### PR TITLE
create GET /tokenized-assets endpoint stub

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@
 extern crate rocket;
 
 mod account;
+mod tokenized_asset;
 
 use clap::Parser;
 use cqrs_es::persist::GenericQuery;
@@ -59,10 +60,13 @@ async fn rocket() -> _ {
     let account_cqrs =
         sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
 
-    rocket::build()
-        .manage(account_cqrs)
-        .manage(pool)
-        .mount("/", routes![account::connect_account])
+    rocket::build().manage(account_cqrs).manage(pool).mount(
+        "/",
+        routes![
+            account::connect_account,
+            tokenized_asset::list_tokenized_assets
+        ],
+    )
 }
 
 async fn create_pool(config: &Config) -> Result<Pool<Sqlite>, sqlx::Error> {

--- a/src/tokenized_asset/endpoint.rs
+++ b/src/tokenized_asset/endpoint.rs
@@ -1,0 +1,104 @@
+use rocket::serde::json::Json;
+use serde::{Deserialize, Serialize};
+
+use super::{Network, TokenSymbol, UnderlyingSymbol};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TokenizedAsset {
+    pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) token: TokenSymbol,
+    pub(crate) network: Network,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TokenizedAssetsResponse {
+    pub(crate) assets: Vec<TokenizedAsset>,
+}
+
+#[get("/tokenized-assets")]
+pub(crate) async fn list_tokenized_assets() -> Json<TokenizedAssetsResponse> {
+    let assets = vec![
+        TokenizedAsset {
+            underlying: UnderlyingSymbol("AAPL".to_string()),
+            token: TokenSymbol("stAAPL".to_string()),
+            network: Network("base".to_string()),
+        },
+        TokenizedAsset {
+            underlying: UnderlyingSymbol("TSLA".to_string()),
+            token: TokenSymbol("stTSLA".to_string()),
+            network: Network("base".to_string()),
+        },
+        TokenizedAsset {
+            underlying: UnderlyingSymbol("NVDA".to_string()),
+            token: TokenSymbol("stNVDA".to_string()),
+            network: Network("base".to_string()),
+        },
+    ];
+
+    Json(TokenizedAssetsResponse { assets })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rocket::http::Status;
+
+    #[tokio::test]
+    async fn test_list_tokenized_assets_returns_hardcoded_list() {
+        let rocket = rocket::build().mount("/", routes![list_tokenized_assets]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client.get("/tokenized-assets").dispatch().await;
+
+        assert_eq!(response.status(), Status::Ok);
+
+        let response_body: TokenizedAssetsResponse = serde_json::from_str(
+            &response.into_string().await.expect("valid response body"),
+        )
+        .expect("valid JSON response");
+
+        assert_eq!(response_body.assets.len(), 3);
+
+        assert_eq!(
+            response_body.assets[0].underlying,
+            UnderlyingSymbol("AAPL".to_string())
+        );
+        assert_eq!(
+            response_body.assets[0].token,
+            TokenSymbol("stAAPL".to_string())
+        );
+        assert_eq!(
+            response_body.assets[0].network,
+            Network("base".to_string())
+        );
+
+        assert_eq!(
+            response_body.assets[1].underlying,
+            UnderlyingSymbol("TSLA".to_string())
+        );
+        assert_eq!(
+            response_body.assets[1].token,
+            TokenSymbol("stTSLA".to_string())
+        );
+        assert_eq!(
+            response_body.assets[1].network,
+            Network("base".to_string())
+        );
+
+        assert_eq!(
+            response_body.assets[2].underlying,
+            UnderlyingSymbol("NVDA".to_string())
+        );
+        assert_eq!(
+            response_body.assets[2].token,
+            TokenSymbol("stNVDA".to_string())
+        );
+        assert_eq!(
+            response_body.assets[2].network,
+            Network("base".to_string())
+        );
+    }
+}

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -1,0 +1,14 @@
+mod endpoint;
+
+use serde::{Deserialize, Serialize};
+
+pub(crate) use endpoint::list_tokenized_assets;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct UnderlyingSymbol(pub(crate) String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct TokenSymbol(pub(crate) String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct Network(pub(crate) String);


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Define the REST API endpoint interface for GET /tokenized-assets endpoint

## Solution

Create a endpoint stub without a real implementation. Real implementation in next PR


## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a change to a front-end or a dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve available tokenized assets, including their underlying symbols, token symbols, and network information.

* **Tests**
  * Added integration tests to verify the new tokenized assets endpoint functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->