### PR TITLE
fix /tokenized-assets response

### DIFF
--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -124,10 +124,8 @@ mod tests {
 
         assert_eq!(response.status(), Status::Ok);
 
-        let response_body: TokenizedAssetsListResponse = serde_json::from_str(
-            &response.into_string().await.expect("valid response body"),
-        )
-        .expect("valid JSON response");
+        let response_body: TokenizedAssetsListResponse =
+            response.into_json().await.expect("valid JSON response");
 
         assert_eq!(response_body.tokens.len(), 1);
         assert_eq!(
@@ -163,10 +161,8 @@ mod tests {
 
         assert_eq!(response.status(), Status::Ok);
 
-        let response_body: TokenizedAssetsListResponse = serde_json::from_str(
-            &response.into_string().await.expect("valid response body"),
-        )
-        .expect("valid JSON response");
+        let response_body: TokenizedAssetsListResponse =
+            response.into_json().await.expect("valid JSON response");
 
         assert!(response_body.tokens.is_empty());
     }


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Alpaca asked to change the response from this

```
curl --location '164.90.135.211:8000/tokenized-assets'
[
    {
        "underlying": "AAPL",
        "token": "tAAPL",
        "network": "base"
    }
]
```

to this

```
curl --location '164.90.135.211:8000/tokenized-assets'
{
    "tokens": [
        {
            "underlying": "AAPL",
            "token": "tAAPL",
            "network": "base"
        }
    ]
}
```

## Solution

Make the change

## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->
By submitting this for review, I'm confirming I've done the following:
- [x] made this PR as small as possible
- [x] unit-tested any new functionality
- [x] linked any relevant issues or PRs
- [x] included screenshots (if this involves a change to a front-end or a dashboard)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * The tokenized-assets endpoint response payload is now an object containing a "tokens" array instead of a bare array. This standardizes the response shape, improves consistency and extensibility, and may require minor client-side updates to read the new object-wrapped format.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->