### PR TITLE
feat: dynamic asset monitoring without a restart

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use sqlx::sqlite::{
     SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions,
 };
 use sqlx::{Pool, Sqlite};
+use std::collections::HashMap;
 use std::str::FromStr;
 use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
@@ -363,7 +364,6 @@ pub async fn initialize_rocket(
     spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
         pool: pool.clone(),
         provider: blockchain_setup.http_provider.clone(),
-        vault_configs: vault_configs.clone(),
         receipt_inventory_store: receipt_inventory_store.clone(),
         bot_wallet,
         backfill_start_block: config.backfill_start_block,
@@ -374,14 +374,13 @@ pub async fn initialize_rocket(
     {
         info!(
             target: "redemption",
-            vault_count = vaults.len(),
-            "Spawning transfer poller (eth_getLogs across all vaults)"
+            "Spawning transfer poller (re-reads enabled vaults each pass, so \
+             runtime-added assets are covered without a restart)"
         );
 
         let poller = TransferPoller::new(TransferPollerConfig {
             provider: blockchain_setup.http_provider,
             bot_wallet,
-            vaults,
             backfill_start_block: config.backfill_start_block,
             store: redemption_store.clone(),
             pool: pool.clone(),
@@ -1032,7 +1031,6 @@ where
 struct PeriodicBackfillSpawn<P, H> {
     pool: Pool<Sqlite>,
     provider: P,
-    vault_configs: Vec<VaultBackfillConfig>,
     receipt_inventory_store: Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
     backfill_start_block: u64,
@@ -1040,6 +1038,11 @@ struct PeriodicBackfillSpawn<P, H> {
     handler: H,
 }
 
+/// Spawns the periodic receipt-backfill reconciliation loop. Each pass re-reads
+/// the enabled vault set from the tokenized-asset view, so an asset added or
+/// re-pointed at runtime is reconciled without a restart. Receipt-contract
+/// addresses are resolved once per vault and cached, since a vault's receipt
+/// contract is immutable on-chain.
 fn spawn_periodic_receipt_backfills<P, H>(spawn: PeriodicBackfillSpawn<P, H>)
 where
     P: Provider + Clone + Send + Sync + 'static,
@@ -1048,23 +1051,12 @@ where
     let PeriodicBackfillSpawn {
         pool,
         provider,
-        vault_configs,
         receipt_inventory_store,
         bot_wallet,
         backfill_start_block,
         receipt_poll_interval,
         handler,
     } = spawn;
-
-    // With no vaults there is nothing to reconcile, so avoid spawning a task
-    // that would fetch the chain head every interval for no work.
-    if vault_configs.is_empty() {
-        debug!(
-            target: "receipt",
-            "No vaults configured; skipping periodic receipt backfill"
-        );
-        return;
-    }
 
     tokio::spawn(async move {
         let ctx = PeriodicBackfillCtx {
@@ -1076,6 +1068,11 @@ where
             handler: &handler,
         };
 
+        let mut receipt_contracts: HashMap<
+            VaultAddress,
+            ReceiptContractAddress,
+        > = HashMap::new();
+
         let mut interval = tokio::time::interval(receipt_poll_interval);
         interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
         // Skip the first tick (fires immediately) — the startup backfill
@@ -1085,6 +1082,27 @@ where
 
         loop {
             interval.tick().await;
+
+            // Re-read the enabled vault set each pass so runtime-added assets
+            // are reconciled without a restart.
+            let assets = match list_enabled_assets(&pool).await {
+                Ok(assets) => assets,
+                Err(error) => {
+                    warn!(
+                        target: "receipt",
+                        error = %error,
+                        "Failed to list enabled assets; skipping receipt \
+                         backfill pass"
+                    );
+                    continue;
+                }
+            };
+
+            // With no enabled assets there is nothing to reconcile, so skip the
+            // chain-head fetch entirely.
+            if assets.is_empty() {
+                continue;
+            }
 
             // Fetch the chain head once per pass and reuse it for every vault.
             // The receipt backfill scans the same block range across all
@@ -1103,23 +1121,106 @@ where
                 }
             };
 
-            for config in &vault_configs {
-                if let Err(error) = run_periodic_receipt_backfill_for_config(
-                    &ctx, *config, head_block,
+            // Per-vault failures log at DEBUG (loop-body rule); the pass emits a
+            // single WARN summary below if any vault failed.
+            let mut failed_vaults: Vec<Address> = Vec::new();
+
+            for asset in &assets {
+                let receipt_contract = match cached_receipt_contract(
+                    &provider,
+                    VaultAddress(asset.vault),
+                    &mut receipt_contracts,
                 )
                 .await
                 {
-                    warn!(
+                    Ok(receipt_contract) => receipt_contract,
+                    Err(error) => {
+                        debug!(
+                            target: "receipt",
+                            error = %error,
+                            vault = %asset.vault,
+                            "Failed to resolve receipt contract; skipping vault \
+                             this pass"
+                        );
+                        failed_vaults.push(asset.vault);
+                        continue;
+                    }
+                };
+
+                let config = VaultBackfillConfig {
+                    vault: asset.vault,
+                    receipt_contract: receipt_contract.0,
+                };
+
+                if let Err(error) = run_periodic_receipt_backfill_for_config(
+                    &ctx, config, head_block,
+                )
+                .await
+                {
+                    debug!(
                         target: "receipt",
                         error = %error,
-                        vault = %config.vault,
+                        vault = %asset.vault,
                         "Periodic receipt backfill failed; next run will resume \
                          from the last checkpoint"
                     );
+                    failed_vaults.push(asset.vault);
                 }
+            }
+
+            if !failed_vaults.is_empty() {
+                warn!(
+                    target: "receipt",
+                    failed_vault_count = failed_vaults.len(),
+                    failed_vaults = ?failed_vaults,
+                    total_vaults = assets.len(),
+                    "Receipt backfill pass completed with vault failures; each \
+                     resumes from its checkpoint next pass"
+                );
             }
         }
     });
+}
+
+/// A vault's own address, as opposed to the address of the ERC-1155 receipt
+/// contract it deploys. Distinct newtypes keep the receipt-contract cache
+/// from silently mixing the two address spaces up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct VaultAddress(Address);
+
+/// The address of the ERC-1155 receipt contract a vault deploys. See
+/// [`VaultAddress`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ReceiptContractAddress(Address);
+
+/// Resolves a vault's ERC-1155 receipt contract, caching the result by vault
+/// address.
+///
+/// The cache is never evicted, and does not need to be: a vault's receipt
+/// contract is immutable on-chain, so a cached entry stays correct even after an
+/// asset is re-pointed away from a vault and later re-pointed back to it. Keying
+/// by vault ADDRESS (not by asset/underlying) is what makes a re-point safe — a
+/// re-pointed asset resolves a brand-new vault address, which is a cache miss
+/// that resolves fresh, so the old vault's contract is never served. The map
+/// grows by at most one entry per distinct vault ever seen, bounded by the
+/// operator-controlled asset set.
+async fn cached_receipt_contract<P: Provider>(
+    provider: &P,
+    vault: VaultAddress,
+    cache: &mut HashMap<VaultAddress, ReceiptContractAddress>,
+) -> Result<ReceiptContractAddress, anyhow::Error> {
+    if let Some(receipt_contract) = cache.get(&vault) {
+        return Ok(*receipt_contract);
+    }
+
+    let vault_contract =
+        bindings::OffchainAssetReceiptVault::new(vault.0, provider);
+    let receipt_contract = ReceiptContractAddress(Address::from(
+        vault_contract.receipt().call().await?.0,
+    ));
+    cache.insert(vault, receipt_contract);
+
+    Ok(receipt_contract)
 }
 
 async fn create_pool(config: &Config) -> Result<Pool<Sqlite>, sqlx::Error> {
@@ -1225,14 +1326,57 @@ fn spawn_mint_recovery_worker(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{U256, uint};
+    use alloy::primitives::{U256, address, uint};
+    use alloy::providers::ProviderBuilder;
+    use alloy::providers::mock::Asserter;
     use rust_decimal::Decimal;
+    use std::collections::HashMap;
     use std::str::FromStr;
 
     use super::{
-        Environment, Quantity, QuantityConversionError, mount_api_docs,
+        Environment, Quantity, QuantityConversionError, ReceiptContractAddress,
+        VaultAddress, cached_receipt_contract, mount_api_docs,
         next_receipt_backfill_block,
     };
+
+    /// The receipt-contract cache must resolve once on-chain and serve every
+    /// subsequent call from memory — a receipt contract is immutable per vault,
+    /// so a second RPC is wasted. Here the mock provider is given exactly one
+    /// `eth_call` response; the second call must hit the cache (an RPC would
+    /// fail against the now-empty mock).
+    #[tokio::test]
+    async fn cached_receipt_contract_resolves_once_then_serves_from_cache() {
+        let vault = VaultAddress(address!(
+            "0x1234567890abcdef1234567890abcdef12345678"
+        ));
+        let receipt_contract = ReceiptContractAddress(address!(
+            "0x00000000000000000000000000000000beefbeef"
+        ));
+
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt_contract.0.into_word());
+        let provider = ProviderBuilder::new().connect_mocked_client(asserter);
+
+        let mut cache = HashMap::new();
+
+        let first = cached_receipt_contract(&provider, vault, &mut cache)
+            .await
+            .unwrap();
+        assert_eq!(first, receipt_contract, "miss must resolve on-chain");
+        assert_eq!(
+            cache.get(&vault),
+            Some(&receipt_contract),
+            "resolved contract must be cached"
+        );
+
+        let second = cached_receipt_contract(&provider, vault, &mut cache)
+            .await
+            .unwrap();
+        assert_eq!(
+            second, receipt_contract,
+            "second call must serve from cache without an RPC"
+        );
+    }
 
     #[test]
     fn api_docs_mounted_only_outside_production() {

--- a/src/poll_checkpoint.rs
+++ b/src/poll_checkpoint.rs
@@ -11,8 +11,21 @@
 use alloy::primitives::Address;
 use sqlx::{Pool, Sqlite};
 
-/// Checkpoint name for the global transfer poller.
+/// Legacy global transfer-poll checkpoint. Superseded by the per-vault
+/// [`transfer_poll_name`] checkpoints; retained only as the seed source that
+/// [`crate::redemption::poller::TransferPoller`] migrates existing vaults from
+/// at startup, so a deploy does not re-scan every vault from
+/// `backfill_start_block`.
 pub(crate) const TRANSFER_POLL: &str = "transfer_poll";
+
+/// Checkpoint name for the transfer poller for a given vault. Per-vault (rather
+/// than one global cursor) so a vault added or re-pointed at runtime is scanned
+/// from `backfill_start_block` on first appearance instead of inheriting a
+/// global checkpoint that is already past its on-chain history — which would
+/// silently drop the redemptions on that vault below the global checkpoint.
+pub(crate) fn transfer_poll_name(vault: Address) -> String {
+    format!("transfer_poll:{vault:#x}")
+}
 
 /// Checkpoint name for the receipt backfiller for a given vault.
 pub(crate) fn receipt_backfill_name(vault: Address) -> String {
@@ -59,6 +72,23 @@ pub(crate) async fn advance(
     .bind(block_signed)
     .execute(pool)
     .await?;
+
+    Ok(())
+}
+
+/// Deletes the checkpoint row for `name`.
+///
+/// Used by one-time migrations that must not leave their source checkpoint
+/// behind: a later restart would re-apply it to rows that did not exist at
+/// migration time.
+pub(crate) async fn remove(
+    pool: &Pool<Sqlite>,
+    name: &str,
+) -> Result<(), CheckpointError> {
+    sqlx::query("DELETE FROM poll_checkpoints WHERE name = ?")
+        .bind(name)
+        .execute(pool)
+        .await?;
 
     Ok(())
 }

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -7,7 +7,7 @@ use event_sorcery::Store;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{debug, trace, warn};
+use tracing::{debug, error, trace, warn};
 
 use super::{
     Redemption,
@@ -21,6 +21,10 @@ use super::{
 };
 use crate::bindings;
 use crate::poll_checkpoint::{self, CheckpointError, TRANSFER_POLL};
+use crate::tokenized_asset::TokenizedAssetView;
+use crate::tokenized_asset::view::{
+    TokenizedAssetViewError, list_enabled_assets,
+};
 
 /// Interval between polling cycles when the poller is caught up to the chain
 /// head. 5 seconds is a reasonable trade-off: negligible latency (downstream
@@ -34,6 +38,13 @@ const BLOCK_CHUNK_SIZE: u64 = 2000;
 /// Interval between retries when a polling pass fails (e.g., RPC error).
 const RETRY_INTERVAL: Duration = Duration::from_secs(10);
 
+/// Consecutive failed poll passes before the per-pass WARN escalates to an ERROR
+/// alarm. A single transient failure retries quietly; sustained failures mean
+/// redemption detection is offline and must be operator-visible rather than
+/// hidden among routine WARNs. At `RETRY_INTERVAL` (10s) this is ~30s of
+/// continuous failure.
+const MAX_POLL_FAILURES_BEFORE_ALARM: usize = 3;
+
 /// Continuously polls `eth_getLogs` for Transfer events across all vaults.
 ///
 /// Replaces the old dual architecture of per-vault `eth_subscribe` detectors
@@ -46,15 +57,20 @@ const RETRY_INTERVAL: Duration = Duration::from_secs(10);
 /// - Fails visibly (if the call fails, we know and retry)
 /// - Persists progress to the `poll_checkpoints` SQL table
 ///
-/// **Operational note — adding new vaults:** The global checkpoint means a
-/// newly-added vault will only be scanned from the current checkpoint
-/// forward, not from `backfill_start_block`. When adding a new vault,
-/// either reset the checkpoint manually or restart with a lower
-/// `backfill_start_block` to cover historic blocks.
+/// **Dynamic vaults:** the monitored set is re-read from the tokenized-asset
+/// view on every pass (see [`enabled_vaults`]), so an asset added or
+/// re-pointed at runtime is covered on the next poll without a restart. Each
+/// vault carries its OWN checkpoint ([`poll_checkpoint::transfer_poll_name`]),
+/// so a vault appearing for the first time — a runtime add, or a re-point to a
+/// vault that already has on-chain history — is scanned from
+/// `backfill_start_block`, catching every redemption on it rather than
+/// inheriting a global cursor already past its history (which would silently
+/// drop those redemptions). Vaults already monitored under the legacy global
+/// checkpoint are seeded from it once at startup (see
+/// [`Self::seed_per_vault_checkpoints`]) so a deploy does not re-scan them.
 pub(crate) struct TransferPoller<P> {
     provider: P,
     bot_wallet: Address,
-    vaults: Vec<Address>,
     backfill_start_block: u64,
     store: Arc<Store<Redemption>>,
     pool: Pool<Sqlite>,
@@ -67,7 +83,6 @@ pub(crate) struct TransferPoller<P> {
 pub(crate) struct TransferPollerConfig<P> {
     pub(crate) provider: P,
     pub(crate) bot_wallet: Address,
-    pub(crate) vaults: Vec<Address>,
     pub(crate) backfill_start_block: u64,
     pub(crate) store: Arc<Store<Redemption>>,
     pub(crate) pool: Pool<Sqlite>,
@@ -81,7 +96,6 @@ impl<P> TransferPoller<P> {
         Self {
             provider: config.provider,
             bot_wallet: config.bot_wallet,
-            vaults: config.vaults,
             backfill_start_block: config.backfill_start_block,
             store: config.store,
             pool: config.pool,
@@ -104,6 +118,10 @@ pub(crate) enum TransferPollError {
     Checkpoint(#[from] CheckpointError),
     #[error("Checkpoint overflow: last_processed_block={last_processed_block}")]
     CheckpointOverflow { last_processed_block: u64 },
+    #[error("Tokenized asset view error: {0}")]
+    TokenizedAssetView(#[from] TokenizedAssetViewError),
+    #[error("all {total} vaults failed the poll pass")]
+    AllVaultsFailed { total: usize },
 }
 
 impl<P> TransferPoller<P>
@@ -112,34 +130,179 @@ where
 {
     /// Runs the polling loop forever. Never returns under normal operation.
     ///
-    /// On error, logs the failure and retries after `RETRY_INTERVAL`. The
-    /// cursor is persisted, so no blocks are re-scanned unnecessarily.
+    /// On error, logs the failure and retries after `RETRY_INTERVAL`. Each
+    /// vault's cursor is persisted, so no blocks are re-scanned unnecessarily.
     pub(crate) async fn run(&self) {
+        // One-time migration from the legacy global checkpoint to per-vault
+        // checkpoints. Non-fatal: without it a vault simply re-scans from
+        // `backfill_start_block`, which is safe (redemption detection is
+        // idempotent), just slower on the first deploy.
+        if let Err(error) = self.seed_per_vault_checkpoints().await {
+            warn!(
+                target: "redemption",
+                error = %error,
+                "Failed to seed per-vault transfer checkpoints; affected vaults \
+                 will re-scan from backfill_start_block"
+            );
+        }
+
+        // A single transient poll failure is WARN-level — the loop retries from
+        // the last checkpoint. But a sustained failure keeps all redemption
+        // detection offline, so once failures persist past
+        // `MAX_POLL_FAILURES_BEFORE_ALARM` escalate to ERROR; otherwise a long
+        // outage is indistinguishable from a single blip in the logs.
+        let mut consecutive_failures = 0_usize;
         loop {
             if let Err(error) = self.poll_once().await {
-                warn!(
-                    target: "redemption",
-                    error = %error,
-                    retry_after_secs = RETRY_INTERVAL.as_secs(),
-                    "Transfer poll pass failed; will retry from last checkpoint"
-                );
+                consecutive_failures += 1;
+                log_poll_failure(&error, consecutive_failures);
                 tokio::time::sleep(RETRY_INTERVAL).await;
                 continue;
             }
 
+            consecutive_failures = 0;
             tokio::time::sleep(POLL_INTERVAL).await;
         }
     }
 
-    /// Runs a single poll pass: scan from cursor to chain head, process logs,
-    /// advance checkpoint.
+    /// Seeds the per-vault transfer checkpoints from the legacy global
+    /// [`TRANSFER_POLL`] checkpoint, for the legacy vaults the old single-cursor
+    /// poller scanned up to that block, CONSUMING the legacy row so the
+    /// migration runs at most once. Runs at startup so a deploy resumes from
+    /// the global block instead of re-scanning every vault from
+    /// `backfill_start_block`.
+    ///
+    /// Consuming the legacy row is what makes this a one-shot migration:
+    /// without it, a vault added at runtime and killed before its first
+    /// per-vault checkpoint write would be mistaken for a legacy vault on the
+    /// next startup and seeded to the global block, silently skipping every
+    /// transfer between `backfill_start_block` and that block. A crash between
+    /// the delete and the seeds only costs the legacy vaults a re-scan from
+    /// `backfill_start_block`, which is safe (detection is idempotent) but
+    /// slower.
+    ///
+    /// No-op when the global checkpoint is unset (a fresh deploy, or a prior
+    /// run already consumed it). Only seeds a vault that has NO per-vault
+    /// checkpoint yet; a vault that already holds one — a runtime-added vault
+    /// mid-scan — is skipped, so its (possibly partial) checkpoint is never
+    /// jumped forward to the global block, which would silently drop the
+    /// redemptions in between.
+    async fn seed_per_vault_checkpoints(
+        &self,
+    ) -> Result<(), TransferPollError> {
+        let Some(global) =
+            poll_checkpoint::load(&self.pool, TRANSFER_POLL).await?
+        else {
+            return Ok(());
+        };
+
+        let assets = list_enabled_assets(&self.pool).await?;
+
+        // Delete the legacy row BEFORE seeding: once it is gone, no later
+        // startup can re-apply the migration to vaults that did not exist at
+        // migration time.
+        poll_checkpoint::remove(&self.pool, TRANSFER_POLL).await?;
+
+        for vault in enabled_vaults(&assets) {
+            let name = poll_checkpoint::transfer_poll_name(vault);
+            // Only migrate vaults with NO per-vault checkpoint yet — the legacy
+            // vaults the old single-cursor poller scanned under the global. A
+            // vault that already holds its own checkpoint (a runtime-added vault
+            // mid-scan) must be left untouched: it may carry a PARTIAL
+            // checkpoint below the legacy global, and `advance`'s monotonic
+            // forward-jump would silently skip every redemption between its
+            // cursor and the global block.
+            if poll_checkpoint::load(&self.pool, &name).await?.is_some() {
+                continue;
+            }
+
+            poll_checkpoint::advance(&self.pool, &name, global).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Runs a single poll pass: re-read the enabled asset set, then scan each
+    /// of its vaults from its own checkpoint to the chain head.
+    ///
+    /// The asset list is loaded ONCE per pass and that same snapshot drives
+    /// both the vault set and per-log asset attribution
+    /// ([`super::transfer::detect_transfer`]): one snapshot per pass means a
+    /// re-point mid-pass cannot turn an already-fetched log into a
+    /// non-transient skip (the vault its log came from is always present in
+    /// the snapshot the pass was built from).
     async fn poll_once(&self) -> Result<(), TransferPollError> {
-        if self.vaults.is_empty() {
+        // Re-read the monitored asset set every pass so assets added or
+        // re-pointed at runtime are covered without a restart.
+        let assets = list_enabled_assets(&self.pool).await?;
+        let vaults = enabled_vaults(&assets);
+        if vaults.is_empty() {
             return Ok(());
         }
 
+        // One `head` for the whole pass so every vault scans to a consistent
+        // block.
+        let head = self.provider.get_block_number().await?;
+
+        // A per-vault failure must not starve the other vaults: each vault owns
+        // its checkpoint, so a failed vault simply resumes from where it left
+        // off next pass. Log per-vault failures at DEBUG and emit a single WARN
+        // summary — the same resilience the receipt-backfill loop uses. But a
+        // pass where EVERY vault failed is indistinguishable from redemption
+        // detection being offline, so it propagates as a pass failure and
+        // counts toward the WARN→ERROR escalation and `RETRY_INTERVAL` backoff
+        // in `run()`. (Pass-level failures above — the view read and the head
+        // fetch — still propagate, since they block every vault.)
+        let mut failed_vaults: Vec<Address> = Vec::new();
+        let total_vaults = vaults.len();
+
+        for vault in vaults {
+            if let Err(error) = self.poll_vault(&assets, vault, head).await {
+                debug!(
+                    target: "redemption",
+                    %vault,
+                    error = %error,
+                    "Failed to poll vault; will retry next pass from its \
+                     checkpoint"
+                );
+                failed_vaults.push(vault);
+            }
+        }
+
+        if !failed_vaults.is_empty() {
+            warn!(
+                target: "redemption",
+                failed_vault_count = failed_vaults.len(),
+                failed_vaults = ?failed_vaults,
+                total_vaults,
+                "Transfer poll pass completed with vault failures; each resumes \
+                 from its checkpoint next pass"
+            );
+
+            if failed_vaults.len() == total_vaults {
+                return Err(TransferPollError::AllVaultsFailed {
+                    total: total_vaults,
+                });
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Scans one vault from its per-vault checkpoint (or `backfill_start_block`
+    /// when it has none — a runtime-added or re-pointed vault) up to `head`,
+    /// processing each Transfer and advancing the vault's checkpoint per chunk.
+    /// Per-vault checkpoints are why a first-seen vault scans its full history
+    /// instead of inheriting a global cursor already past it.
+    async fn poll_vault(
+        &self,
+        assets: &[TokenizedAssetView],
+        vault: Address,
+        head: u64,
+    ) -> Result<(), TransferPollError> {
+        let checkpoint_name = poll_checkpoint::transfer_poll_name(vault);
         let last_processed =
-            poll_checkpoint::load(&self.pool, TRANSFER_POLL).await?;
+            poll_checkpoint::load(&self.pool, &checkpoint_name).await?;
 
         let cursor = match last_processed {
             None => self.backfill_start_block,
@@ -153,33 +316,34 @@ where
             }
         };
 
-        let head = self.provider.get_block_number().await?;
-
         if cursor > head {
             trace!(
                 target: "redemption",
+                %vault,
                 cursor,
                 head,
-                "Transfer poller caught up; sleeping"
+                "Vault caught up; skipping"
             );
             return Ok(());
         }
 
         debug!(
             target: "redemption",
+            %vault,
             from_block = cursor,
             to_block = head,
-            vault_count = self.vaults.len(),
-            "Polling for transfer events"
+            "Polling vault for transfer events"
         );
 
         for (chunk_from, chunk_to) in
             block_ranges(cursor, head, BLOCK_CHUNK_SIZE)
         {
-            let logs = self.fetch_transfer_logs(chunk_from, chunk_to).await?;
+            let logs =
+                self.fetch_transfer_logs(vault, chunk_from, chunk_to).await?;
 
             trace!(
                 target: "redemption",
+                %vault,
                 chunk_from,
                 chunk_to,
                 logs_found = logs.len(),
@@ -187,26 +351,25 @@ where
             );
 
             for log in &logs {
-                self.process_log(log).await?;
+                self.process_log(assets, log).await?;
             }
 
-            poll_checkpoint::advance(&self.pool, TRANSFER_POLL, chunk_to)
+            poll_checkpoint::advance(&self.pool, &checkpoint_name, chunk_to)
                 .await?;
         }
 
         Ok(())
     }
 
-    /// Fetches Transfer logs for all vaults in a single RPC call.
+    /// Fetches Transfer logs for one vault where topic2 (to) == bot_wallet.
     async fn fetch_transfer_logs(
         &self,
+        vault: Address,
         from_block: u64,
         to_block: u64,
     ) -> Result<Vec<Log>, TransferPollError> {
-        // Build a filter matching Transfer events across all vault addresses
-        // where topic2 (to) == bot_wallet.
         let filter = alloy::rpc::types::Filter::new()
-            .address(self.vaults.clone())
+            .address(vault)
             .event_signature(
                 bindings::OffchainAssetReceiptVault::Transfer::SIGNATURE_HASH,
             )
@@ -226,11 +389,17 @@ where
     /// succeed on retry). Non-transient failures (decode errors, missing
     /// fields, no matching asset) are logged and skipped — retrying them
     /// would freeze the checkpoint permanently.
-    async fn process_log(&self, log: &Log) -> Result<(), TransferPollError> {
+    async fn process_log(
+        &self,
+        assets: &[TokenizedAssetView],
+        log: &Log,
+    ) -> Result<(), TransferPollError> {
         let vault = log.address();
 
         let outcome =
-            match detect_transfer(log, vault, &self.store, &self.pool).await {
+            match detect_transfer(log, vault, assets, &self.store, &self.pool)
+                .await
+            {
                 Ok(outcome) => outcome,
                 Err(err) if err.is_non_transient() => {
                     warn!(
@@ -273,6 +442,47 @@ where
     }
 }
 
+/// Extracts the deduped vault addresses from a per-pass asset snapshot.
+/// Frozen assets stay in the set so in-flight redemptions on them are still
+/// detected. Deduped so a vault shared by two enabled assets is polled once,
+/// not once per asset. (Sharing a vault is a misconfiguration that
+/// `find_matching_asset` rejects, but avoid the duplicate `eth_getLogs` work
+/// regardless.)
+fn enabled_vaults(assets: &[TokenizedAssetView]) -> Vec<Address> {
+    let mut vaults: Vec<Address> =
+        assets.iter().map(|asset| asset.vault).collect();
+    vaults.sort_unstable();
+    vaults.dedup();
+    vaults
+}
+
+/// Emits the log for a failed poll pass: WARN while the failure may still be
+/// a blip (the loop retries from the last checkpoint), escalating to ERROR
+/// once `consecutive_failures` reaches [`MAX_POLL_FAILURES_BEFORE_ALARM`] —
+/// sustained failure means redemption detection is offline and must be
+/// operator-visible rather than hidden among routine WARNs.
+fn log_poll_failure(error: &TransferPollError, consecutive_failures: usize) {
+    if consecutive_failures >= MAX_POLL_FAILURES_BEFORE_ALARM {
+        error!(
+            target: "redemption",
+            error = %error,
+            consecutive_failures,
+            retry_after_secs = RETRY_INTERVAL.as_secs(),
+            "Transfer poll pass has failed repeatedly; redemption \
+             detection is offline until it recovers"
+        );
+    } else {
+        warn!(
+            target: "redemption",
+            error = %error,
+            consecutive_failures,
+            retry_after_secs = RETRY_INTERVAL.as_secs(),
+            "Transfer poll pass failed; will retry from last \
+             checkpoint"
+        );
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Block range chunking
 // ---------------------------------------------------------------------------
@@ -300,11 +510,12 @@ mod tests {
     use alloy::providers::mock::Asserter;
     use alloy::rpc::types::Log;
     use alloy::signers::local::PrivateKeySigner;
-    use event_sorcery::{Store, test_store};
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use sqlx::SqlitePool;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
+    use super::TransferPollError;
     use crate::alpaca::mock::MockAlpacaService;
     use crate::poll_checkpoint::{self, TRANSFER_POLL};
     use crate::receipt_inventory::{
@@ -314,7 +525,11 @@ mod tests {
     use crate::redemption::test_utils::{
         create_transfer_log, setup_test_db_with_asset,
     };
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{log_count_at, logs_contain_at};
+    use crate::tokenized_asset::{
+        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
+    };
     use crate::vault::mock::MockVaultService;
 
     /// `pool` must already have migrations applied — the stores write to the
@@ -347,11 +562,10 @@ mod tests {
         backfill_start_block: u64,
     ) -> TestPollerSetup<impl alloy::providers::Provider + Clone> {
         let pool = setup_test_db_with_asset(vault, ap_wallet).await;
-        build_poller(vault, bot_wallet, asserter, backfill_start_block, pool)
+        build_poller(bot_wallet, asserter, backfill_start_block, pool)
     }
 
     fn build_poller(
-        vault: Address,
         bot_wallet: Address,
         asserter: &Asserter,
         backfill_start_block: u64,
@@ -393,7 +607,6 @@ mod tests {
         let poller = super::TransferPoller::new(super::TransferPollerConfig {
             provider,
             bot_wallet,
-            vaults: vec![vault],
             backfill_start_block,
             store,
             pool: pool.clone(),
@@ -403,6 +616,29 @@ mod tests {
         });
 
         TestPollerSetup { poller, pool }
+    }
+
+    /// Adds a second enabled asset (MSFT/tMSFT) bound to `vault`, alongside
+    /// the AAPL asset `setup_test_db_with_asset` seeds.
+    async fn add_second_asset(pool: &SqlitePool, vault: Address) {
+        let (asset_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        let msft = UnderlyingSymbol::new("MSFT");
+        asset_store
+            .send(
+                &msft,
+                TokenizedAssetCommand::Add {
+                    underlying: msft.clone(),
+                    token: TokenSymbol::new("tMSFT"),
+                    network: Network::Base,
+                    vault,
+                },
+            )
+            .await
+            .unwrap();
     }
 
     // -----------------------------------------------------------------------
@@ -472,13 +708,18 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
             Some(200)
         );
 
         assert!(logs_contain_at!(
             tracing::Level::DEBUG,
-            &["Polling for transfer events"]
+            &["Polling vault for transfer events"]
         ));
     }
 
@@ -513,13 +754,18 @@ mod tests {
 
         // Checkpoint still advances even with no detections
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
             Some(200)
         );
 
         assert!(logs_contain_at!(
             tracing::Level::DEBUG,
-            &["Polling for transfer events"]
+            &["Polling vault for transfer events"]
         ));
     }
 
@@ -536,18 +782,19 @@ mod tests {
         let setup =
             setup_test_poller(vault, bot_wallet, None, &asserter, 50).await;
 
-        // Pre-seed checkpoint at 200
-        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
-            .await
-            .unwrap();
+        // Pre-seed the vault's checkpoint at 200
+        poll_checkpoint::advance(
+            &setup.pool,
+            &poll_checkpoint::transfer_poll_name(vault),
+            200,
+        )
+        .await
+        .unwrap();
 
         // Should skip since cursor (201) > head (200)
         setup.poller.poll_once().await.unwrap();
 
-        assert!(logs_contain_at!(
-            tracing::Level::TRACE,
-            &["Transfer poller caught up"]
-        ));
+        assert!(logs_contain_at!(tracing::Level::TRACE, &["Vault caught up"]));
     }
 
     #[traced_test]
@@ -582,7 +829,12 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
             Some(200)
         );
     }
@@ -592,60 +844,57 @@ mod tests {
     async fn poll_no_op_with_empty_vaults() {
         let asserter = Asserter::new();
         let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
-        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let pool = setup_test_db_with_asset(vault, None).await;
+        // No tokenized asset is seeded, so the dynamic vault lookup finds none
+        // and the pass short-circuits before any RPC call.
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 
-        let (store, receipt_service) = setup_test_store(&pool);
+        let setup = build_poller(bot_wallet, &asserter, 0, pool);
 
-        let alpaca_service = Arc::new(MockAlpacaService::new_success())
-            as Arc<dyn crate::alpaca::AlpacaService>;
-        let redeem_call_manager = Arc::new(
-            crate::redemption::redeem_call_manager::RedeemCallManager::new(
-                alpaca_service.clone(),
-                store.clone(),
-                pool.clone(),
-            ),
-        );
-        let journal_manager =
-            Arc::new(crate::redemption::journal_manager::JournalManager::new(
-                alpaca_service,
-                store.clone(),
-                pool.clone(),
-            ));
-        let vault_service = Arc::new(MockVaultService::new_success())
-            as Arc<dyn crate::vault::VaultService>;
-        let burn_manager =
-            Arc::new(crate::redemption::burn_manager::BurnManager::new(
-                vault_service,
-                pool.clone(),
-                store.clone(),
-                receipt_service,
-                bot_wallet,
-            ));
+        setup.poller.poll_once().await.unwrap();
 
-        let provider = ProviderBuilder::new()
-            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
-            .connect_mocked_client(asserter);
-
-        let poller = super::TransferPoller::new(super::TransferPollerConfig {
-            provider,
-            bot_wallet,
-            vaults: vec![],
-            backfill_start_block: 0,
-            store,
-            pool: pool.clone(),
-            redeem_call_manager,
-            journal_manager,
-            burn_manager,
-        });
-
-        poller.poll_once().await.unwrap();
-
-        // No checkpoint saved, no RPC calls made
+        // No checkpoint advanced — assert the whole table is empty, not just the
+        // dead global key (which is vacuously None regardless of what poll_once
+        // did, since nothing writes it anymore).
+        let checkpoint_rows = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM poll_checkpoints",
+        )
+        .fetch_one(&setup.pool)
+        .await
+        .unwrap();
         assert_eq!(
-            poll_checkpoint::load(&pool, TRANSFER_POLL).await.unwrap(),
-            None
+            checkpoint_rows, 0,
+            "an empty-vault pass must not advance any per-vault checkpoint"
+        );
+    }
+
+    /// A failed enabled-vault view read aborts the whole pass with
+    /// `TokenizedAssetView` — the outer `run` loop then WARNs and retries — so it
+    /// must surface as that error, never be swallowed or panic. Dropping the view
+    /// table makes the read fail the way a corrupt or unavailable DB would.
+    #[tokio::test]
+    async fn poll_once_errors_when_the_asset_view_read_fails() {
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let asserter = Asserter::new();
+        let pool = SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        // The enabled-vault read targets tokenized_asset_view; dropping it makes
+        // list_enabled_assets fail like a corrupt or unavailable database.
+        sqlx::query("DROP TABLE tokenized_asset_view")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let setup = build_poller(bot_wallet, &asserter, 0, pool);
+
+        let result = setup.poller.poll_once().await;
+
+        assert!(
+            matches!(result, Err(TransferPollError::TokenizedAssetView(_))),
+            "a failed asset-view read must abort the pass with \
+             TokenizedAssetView, got: {result:?}"
         );
     }
 
@@ -665,13 +914,22 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
             Some(200)
         );
 
         assert!(logs_contain_at!(
             tracing::Level::DEBUG,
-            &["Polling for transfer events", "from_block=50", "to_block=200"]
+            &[
+                "Polling vault for transfer events",
+                "from_block=50",
+                "to_block=200"
+            ]
         ));
     }
 
@@ -691,13 +949,308 @@ mod tests {
 
         // No checkpoint saved since we skipped
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
             None
         );
 
+        assert!(logs_contain_at!(tracing::Level::TRACE, &["Vault caught up"]));
+    }
+
+    /// A vault with no per-vault checkpoint scans from `backfill_start_block`,
+    /// NOT from the legacy global checkpoint — this is what makes a re-pointed
+    /// or late-attached vault catch its pre-checkpoint redemption history
+    /// instead of silently skipping it.
+    #[traced_test]
+    #[tokio::test]
+    async fn poll_vault_scans_from_backfill_start_ignoring_global_checkpoint() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(300u64));
+        asserter.push_success(&Vec::<Log>::new());
+
+        let setup =
+            setup_test_poller(vault, bot_wallet, None, &asserter, 50).await;
+
+        // A leftover global checkpoint from before the per-vault migration.
+        // The vault has no per-vault checkpoint, so poll_once must ignore the
+        // global value and scan from backfill_start_block (50).
+        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
+            .await
+            .unwrap();
+
+        setup.poller.poll_once().await.unwrap();
+
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Polling vault for transfer events", "from_block=50"]
+            ),
+            "a first-seen vault must scan from backfill_start_block, not the \
+             global checkpoint"
+        );
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
+            Some(300)
+        );
+    }
+
+    /// The startup seed migrates a vault already monitored under the legacy
+    /// global checkpoint to its per-vault checkpoint, so a deploy resumes from
+    /// the global block rather than re-scanning from `backfill_start_block`.
+    #[tokio::test]
+    async fn seed_migrates_existing_vault_from_global_checkpoint() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        // Seed (run()'s migration step) makes no RPC calls.
+        let asserter = Asserter::new();
+        let setup =
+            setup_test_poller(vault, bot_wallet, None, &asserter, 0).await;
+
+        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
+            .await
+            .unwrap();
+
+        setup.poller.seed_per_vault_checkpoints().await.unwrap();
+
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
+            Some(200),
+            "an existing vault must inherit the global checkpoint, not re-scan"
+        );
+    }
+
+    /// Regression for the silent-redemption-loss bug: a vault that already holds
+    /// its OWN partial checkpoint (a runtime-added vault that scanned partway,
+    /// then the service restarted) must NOT be advanced to the legacy global.
+    /// Seeding it forward would skip every redemption between its partial cursor
+    /// and the global block, since `advance` only ever moves a checkpoint
+    /// forward.
+    #[tokio::test]
+    async fn seed_does_not_advance_a_vault_with_an_existing_checkpoint() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asserter = Asserter::new();
+        let setup =
+            setup_test_poller(vault, bot_wallet, None, &asserter, 0).await;
+
+        // The vault scanned partway (block 100) before the restart...
+        poll_checkpoint::advance(
+            &setup.pool,
+            &poll_checkpoint::transfer_poll_name(vault),
+            100,
+        )
+        .await
+        .unwrap();
+        // ...and a stale legacy global sits far ahead at block 5000.
+        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 5000)
+            .await
+            .unwrap();
+
+        setup.poller.seed_per_vault_checkpoints().await.unwrap();
+
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault),
+            )
+            .await
+            .unwrap(),
+            Some(100),
+            "a vault with an existing partial checkpoint must NOT be jumped \
+             forward to the legacy global — that would drop redemptions in the \
+             gap"
+        );
+    }
+
+    /// A per-vault failure (here a failing `eth_getLogs`) must NOT abort the
+    /// pass — `poll_once` records it and continues, so a single flaky vault does
+    /// not starve the others: the healthy vault still advances its checkpoint
+    /// to head, while the failed vault keeps no checkpoint advance and simply
+    /// retries next pass from where it left off.
+    #[traced_test]
+    #[tokio::test]
+    async fn poll_once_continues_past_a_failing_vault() {
+        let vault_a = address!("0x1111111111111111111111111111111111111111");
+        let vault_b = address!("0x2222222222222222222222222222222222222222");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(300u64));
+        // Vaults are polled in sorted address order: vault_a's `eth_getLogs`
+        // fails, vault_b's succeeds.
+        asserter.push_failure_msg("simulated eth_getLogs failure");
+        asserter.push_success(&Vec::<Log>::new());
+
+        let setup =
+            setup_test_poller(vault_a, bot_wallet, None, &asserter, 0).await;
+        add_second_asset(&setup.pool, vault_b).await;
+
+        // The failing vault must not propagate — the pass completes Ok.
+        setup.poller.poll_once().await.unwrap();
+
         assert!(logs_contain_at!(
-            tracing::Level::TRACE,
-            &["Transfer poller caught up"]
+            tracing::Level::WARN,
+            &["Transfer poll pass completed with vault failures"]
         ));
+
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault_b),
+            )
+            .await
+            .unwrap(),
+            Some(300),
+            "the healthy vault must advance its checkpoint to head"
+        );
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault_a),
+            )
+            .await
+            .unwrap(),
+            None,
+            "a failed vault must not advance its checkpoint"
+        );
+    }
+
+    /// A pass where EVERY vault failed is indistinguishable from redemption
+    /// detection being offline, so `poll_once` must propagate it as a pass
+    /// failure — feeding `run()`'s WARN→ERROR escalation and RETRY_INTERVAL
+    /// backoff — instead of quietly returning Ok.
+    #[traced_test]
+    #[tokio::test]
+    async fn poll_once_fails_when_every_vault_fails() {
+        let vault_a = address!("0x1111111111111111111111111111111111111111");
+        let vault_b = address!("0x2222222222222222222222222222222222222222");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(300u64));
+        asserter.push_failure_msg("simulated eth_getLogs failure for vault_a");
+        asserter.push_failure_msg("simulated eth_getLogs failure for vault_b");
+
+        let setup =
+            setup_test_poller(vault_a, bot_wallet, None, &asserter, 0).await;
+        add_second_asset(&setup.pool, vault_b).await;
+
+        let result = setup.poller.poll_once().await;
+
+        assert!(
+            matches!(
+                result,
+                Err(TransferPollError::AllVaultsFailed { total: 2 })
+            ),
+            "a pass where every vault failed must fail the pass, got: \
+             {result:?}"
+        );
+    }
+
+    /// The escalation policy for consecutive pass failures: WARN below
+    /// `MAX_POLL_FAILURES_BEFORE_ALARM` (the loop retries quietly), ERROR at
+    /// the threshold (redemption detection is offline and must be
+    /// operator-visible).
+    #[traced_test]
+    #[test]
+    fn log_poll_failure_escalates_from_warn_to_error_at_the_alarm_threshold() {
+        let error = TransferPollError::AllVaultsFailed { total: 1 };
+
+        super::log_poll_failure(&error, 1);
+        super::log_poll_failure(&error, 2);
+
+        assert_eq!(
+            log_count_at!(
+                tracing::Level::WARN,
+                &["will retry from last checkpoint"]
+            ),
+            2,
+            "each below-threshold failure must WARN"
+        );
+        assert!(
+            !logs_contain_at!(tracing::Level::ERROR, &["failed repeatedly"]),
+            "no ERROR before the alarm threshold is reached"
+        );
+
+        super::log_poll_failure(&error, 3);
+
+        assert!(
+            logs_contain_at!(tracing::Level::ERROR, &["failed repeatedly"]),
+            "the third consecutive failure must escalate to ERROR"
+        );
+    }
+
+    /// Regression for the one-shot-migration guarantee: seeding must CONSUME
+    /// the legacy global checkpoint. A vault enabled AFTER the migration ran —
+    /// e.g. added at runtime and killed before its first per-vault checkpoint
+    /// write — must NOT be mistaken for a legacy vault on the next startup and
+    /// seeded to the global block; it must scan from `backfill_start_block`.
+    #[tokio::test]
+    async fn seed_consumes_the_global_checkpoint() {
+        let vault_a = address!("0x1111111111111111111111111111111111111111");
+        let vault_b = address!("0x2222222222222222222222222222222222222222");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asserter = Asserter::new();
+        let setup =
+            setup_test_poller(vault_a, bot_wallet, None, &asserter, 0).await;
+
+        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
+            .await
+            .unwrap();
+
+        setup.poller.seed_per_vault_checkpoints().await.unwrap();
+
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault_a),
+            )
+            .await
+            .unwrap(),
+            Some(200),
+            "the legacy vault must inherit the global checkpoint"
+        );
+        assert_eq!(
+            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            None,
+            "the migration must consume the legacy global row"
+        );
+
+        // The crash-window case: a vault enabled after the first seeding run,
+        // then a restart re-runs the seed.
+        add_second_asset(&setup.pool, vault_b).await;
+        setup.poller.seed_per_vault_checkpoints().await.unwrap();
+
+        assert_eq!(
+            poll_checkpoint::load(
+                &setup.pool,
+                &poll_checkpoint::transfer_poll_name(vault_b),
+            )
+            .await
+            .unwrap(),
+            None,
+            "a vault added after the migration must have no checkpoint — it \
+             scans from backfill_start_block, not the stale global block"
+        );
     }
 }

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -14,9 +14,6 @@ use super::{
 use crate::account::view::{AccountViewError, find_by_wallet};
 use crate::account::{AccountView, AlpacaAccountNumber, ClientId};
 use crate::bindings;
-use crate::tokenized_asset::view::{
-    TokenizedAssetViewError, list_enabled_assets,
-};
 use crate::tokenized_asset::{
     Network, TokenSymbol, TokenizedAssetView, UnderlyingSymbol,
 };
@@ -49,10 +46,13 @@ pub(crate) enum TransferProcessingError {
     Aggregate(Box<AggregateError<LifecycleError<Redemption>>>),
     #[error("Account view error: {0}")]
     AccountView(#[from] AccountViewError),
-    #[error("Tokenized asset view error: {0}")]
-    TokenizedAssetView(#[from] TokenizedAssetViewError),
     #[error("No asset found for vault {vault}")]
     NoMatchingAsset { vault: Address },
+    #[error(
+        "Multiple enabled assets are bound to vault {vault}; refusing to \
+         attribute its redemptions to an arbitrary underlying"
+    )]
+    AmbiguousVault { vault: Address },
 }
 
 // `AggregateError<LifecycleError<Redemption>>` is large (it can carry a full
@@ -81,12 +81,14 @@ impl TransferProcessingError {
     }
 }
 
-/// Decodes a Transfer log, looks up account and asset, and executes
-/// `RedemptionCommand::Detect`. Idempotent — returns `AlreadyDetected` on
-/// duplicate.
+/// Decodes a Transfer log, looks up the account view and the asset (from the
+/// caller's per-pass snapshot, so attribution is consistent with the vault set
+/// the pass was built from), and executes `RedemptionCommand::Detect`.
+/// Idempotent — returns `AlreadyDetected` on duplicate.
 pub(crate) async fn detect_transfer(
     log: &alloy::rpc::types::Log,
     vault: Address,
+    assets: &[TokenizedAssetView],
     store: &Store<Redemption>,
     pool: &Pool<Sqlite>,
 ) -> Result<TransferOutcome, TransferProcessingError> {
@@ -119,7 +121,7 @@ pub(crate) async fn detect_transfer(
         return Ok(TransferOutcome::SkippedNoAccount);
     };
 
-    let (underlying, token, network) = find_matching_asset(pool, vault).await?;
+    let (underlying, token, network) = find_matching_asset(assets, vault)?;
 
     let issuer_request_id = IssuerRedemptionRequestId::new(tx_hash);
     let quantity = Quantity::from_u256_with_18_decimals(transfer_event.value)?;
@@ -293,26 +295,37 @@ pub(crate) async fn drive_redemption_flow(
     });
 }
 
-async fn find_matching_asset(
-    pool: &Pool<Sqlite>,
+/// Attributes a vault to its enabled asset from the caller's per-pass asset
+/// snapshot.
+fn find_matching_asset(
+    assets: &[TokenizedAssetView],
     vault: Address,
 ) -> Result<(UnderlyingSymbol, TokenSymbol, Network), TransferProcessingError> {
-    let assets = list_enabled_assets(pool).await?;
+    let mut matching = assets.iter().filter(|asset| asset.vault == vault);
 
-    assets
-        .into_iter()
-        .find_map(
-            |TokenizedAssetView {
-                 underlying,
-                 token,
-                 network,
-                 vault: addr,
-                 ..
-             }| {
-                (addr == vault).then_some((underlying, token, network))
-            },
-        )
-        .ok_or(TransferProcessingError::NoMatchingAsset { vault })
+    let first = matching
+        .next()
+        .ok_or(TransferProcessingError::NoMatchingAsset { vault })?;
+
+    // Two enabled assets bound to the same vault is a misconfiguration: neither
+    // this lookup nor the per-vault checkpoint can disambiguate them, so picking
+    // an arbitrary one would silently journal the redemption against the wrong
+    // underlying at Alpaca. Fail loudly instead — `AmbiguousVault` is transient
+    // (deliberately not in `is_non_transient`), so the vault's checkpoint
+    // freezes and the failure recurs until an operator removes the duplicate,
+    // rather than dropping or misrouting the redemption.
+    if matching.next().is_some() {
+        warn!(
+            target: "redemption",
+            %vault,
+            "Two enabled assets share this vault; refusing to attribute the \
+             redemption to an arbitrary underlying"
+        );
+        return Err(TransferProcessingError::AmbiguousVault { vault });
+    }
+
+    let TokenizedAssetView { underlying, token, network, .. } = first.clone();
+    Ok((underlying, token, network))
 }
 
 #[cfg(test)]
@@ -329,8 +342,10 @@ mod tests {
         create_transfer_log, setup_test_db_with_asset,
     };
     use crate::test_utils::logs_contain_at;
+    use crate::tokenized_asset::view::list_enabled_assets;
     use crate::tokenized_asset::{
-        TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
+        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
 
@@ -360,7 +375,8 @@ mod tests {
             vault, ap_wallet, bot_wallet, value, tx_hash, 12345,
         );
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         let outcome = result.expect("Expected success");
         assert!(
@@ -415,7 +431,8 @@ mod tests {
             vault, ap_wallet, bot_wallet, value, tx_hash, 12345,
         );
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         let outcome = result.expect("Expected success");
         assert!(
@@ -461,7 +478,8 @@ mod tests {
             12345,
         );
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         assert!(
             matches!(result, Ok(TransferOutcome::SkippedMint)),
@@ -495,7 +513,8 @@ mod tests {
         );
         log.transaction_hash = None;
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         assert!(
             matches!(result, Err(TransferProcessingError::MissingTxHash)),
@@ -524,7 +543,8 @@ mod tests {
         );
         log.block_number = None;
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         assert!(
             matches!(result, Err(TransferProcessingError::MissingBlockNumber)),
@@ -557,7 +577,8 @@ mod tests {
             12345,
         );
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         assert!(
             matches!(
@@ -566,6 +587,70 @@ mod tests {
             ),
             "Expected NoMatchingAsset, got {result:?}"
         );
+    }
+
+    /// Two enabled assets bound to the same vault is a misconfiguration that
+    /// `find_matching_asset` must reject with `AmbiguousVault` rather than
+    /// silently attributing the redemption to an arbitrary underlying at Alpaca.
+    #[traced_test]
+    #[tokio::test]
+    async fn detect_transfer_ambiguous_vault_when_two_assets_share_one() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let ap_wallet = address!("0x9999999999999999999999999999999999999999");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        // `setup_test_db_with_asset` seeds AAPL on `vault`; add a SECOND asset
+        // (TSLA) bound to the SAME vault to create the ambiguity.
+        let pool = setup_test_db_with_asset(vault, Some(ap_wallet)).await;
+        let store = setup_test_store(&pool);
+
+        let (asset_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        let tsla = UnderlyingSymbol::new("TSLA");
+        asset_store
+            .send(
+                &tsla,
+                TokenizedAssetCommand::Add {
+                    underlying: tsla.clone(),
+                    token: TokenSymbol::new("tTSLA"),
+                    network: Network::Base,
+                    vault,
+                },
+            )
+            .await
+            .unwrap();
+
+        let value = U256::from_str_radix("100000000000000000000", 10).unwrap();
+        let log = create_transfer_log(
+            vault,
+            ap_wallet,
+            bot_wallet,
+            value,
+            b256!(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            ),
+            12345,
+        );
+
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(TransferProcessingError::AmbiguousVault { .. })
+            ),
+            "two assets sharing a vault must fail loudly, not misroute: \
+             got {result:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Two enabled assets share this vault"]
+        ));
     }
 
     #[traced_test]
@@ -592,7 +677,8 @@ mod tests {
             12345,
         );
 
-        let result = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(&log, vault, &assets, &store, &pool).await;
 
         assert!(
             matches!(result, Ok(TransferOutcome::SkippedNoAccount)),
@@ -624,13 +710,14 @@ mod tests {
             vault, ap_wallet, bot_wallet, value, tx_hash, 12345,
         );
 
-        let first = detect_transfer(&log, vault, &store, &pool).await;
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let first = detect_transfer(&log, vault, &assets, &store, &pool).await;
         assert!(
             matches!(first, Ok(TransferOutcome::Detected { .. })),
             "First detection should succeed, got {first:?}"
         );
 
-        let second = detect_transfer(&log, vault, &store, &pool).await;
+        let second = detect_transfer(&log, vault, &assets, &store, &pool).await;
         assert!(
             matches!(second, Ok(TransferOutcome::AlreadyDetected)),
             "Second detection should return AlreadyDetected, got {second:?}"

--- a/tests/dynamic_asset.rs
+++ b/tests/dynamic_asset.rs
@@ -1,0 +1,252 @@
+#![allow(clippy::unwrap_used)]
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{U256, b256};
+use alloy::providers::ProviderBuilder;
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::initialize_rocket;
+use st0x_issuance::test_utils::LocalEvm;
+
+/// Tests that adding a new tokenized asset at runtime is picked up by the
+/// receipt backfill loop and the transfer poller on their next polling pass,
+/// without requiring a service restart.
+///
+/// Scenario:
+/// 1. Start service with AAPL pre-seeded
+/// 2. Deploy a new vault for MSFT on Anvil
+/// 3. POST /tokenized-assets to add MSFT
+/// 4. Mint on MSFT vault — the receipt backfill loop should detect the receipt
+/// 5. Transfer shares to bot wallet — the transfer poller should detect it
+#[tokio::test]
+async fn test_new_asset_triggers_backfills_and_monitors()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+
+    // Deploy a second vault for MSFT
+    let (vault2_address, vault2_authorizer) =
+        evm.deploy_additional_vault().await?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_dynamic_asset.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    // Pre-seed only AAPL — MSFT will be added at runtime via API
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    // Grant roles on vault2 (MSFT)
+    harness::setup_roles_on_vault(
+        &evm,
+        vault2_authorizer,
+        vault2_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
+
+    // Add MSFT via API at runtime — the pollers pick it up on their next
+    // polling pass
+    harness::seed_tokenized_asset_with(
+        &client,
+        vault2_address,
+        "MSFT",
+        "tMSFT",
+    )
+    .await;
+
+    // Setup account
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    // Mint on MSFT vault — this tests that:
+    // 1. The receipt backfill loop is covering MSFT (mint completes via
+    //    callback)
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        &link_body.client_id.to_string(),
+        "alp-mint-msft",
+        "25.0",
+        "MSFT",
+        "tMSFT",
+    )
+    .await?;
+
+    // Setup user provider for transfers
+    let user_wallet_instance = EthereumWallet::from(user_signer);
+    let user_provider = ProviderBuilder::new()
+        .wallet(user_wallet_instance)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault2 =
+        OffchainAssetReceiptVaultInstance::new(vault2_address, &user_provider);
+
+    // Wait for shares on MSFT vault
+    let msft_shares = harness::wait_for_shares(&vault2, user_wallet).await?;
+    assert!(msft_shares > U256::ZERO, "Should have MSFT shares after mint");
+
+    // Transfer shares to bot wallet — tests that the transfer poller is
+    // covering MSFT
+    vault2
+        .transfer(bot_wallet, msft_shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Wait for burn to complete — proves the transfer poller is monitoring MSFT
+    harness::wait_for_burn(&vault2, bot_wallet).await?;
+
+    assert_eq!(
+        vault2.balanceOf(user_wallet).call().await?,
+        U256::ZERO,
+        "User should have no MSFT shares after redemption"
+    );
+
+    Ok(())
+}
+
+/// Tests that changing a vault address at runtime is picked up on the next
+/// poll pass — no monitor restart — so the pollers detect activity on the new
+/// address (read from the tokenized asset view).
+///
+/// Scenario:
+/// 1. Start service with vault A for AAPL
+/// 2. Deploy a new vault A' on Anvil
+/// 3. POST /tokenized-assets with AAPL pointing to vault A'
+/// 4. Mint on vault A' — the receipt backfill loop should detect it
+/// 5. Transfer shares on vault A' — the transfer poller should detect it
+#[tokio::test]
+async fn test_address_change_picked_up_on_next_pass()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+
+    // Deploy a second vault (this will become the "new" AAPL vault)
+    let (vault_b_address, vault_b_authorizer) =
+        evm.deploy_additional_vault().await?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_addr_change.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    // Pre-seed AAPL with vault A (the original)
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    // Grant roles on vault B (the new AAPL vault)
+    harness::setup_roles_on_vault(
+        &evm,
+        vault_b_authorizer,
+        vault_b_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
+
+    // Update AAPL to point to vault B — the pollers pick it up on the next pass
+    harness::seed_tokenized_asset_with(
+        &client,
+        vault_b_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await;
+
+    // Setup account
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    // Mint on vault B (the new AAPL vault) — tests that the pollers picked up
+    // the new address
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        &link_body.client_id.to_string(),
+        "alp-mint-aapl-new",
+        "25.0",
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Setup user provider for transfers
+    let user_wallet_instance = EthereumWallet::from(user_signer);
+    let user_provider = ProviderBuilder::new()
+        .wallet(user_wallet_instance)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault_b =
+        OffchainAssetReceiptVaultInstance::new(vault_b_address, &user_provider);
+
+    // Wait for shares on vault B
+    let shares = harness::wait_for_shares(&vault_b, user_wallet).await?;
+    assert!(shares > U256::ZERO, "Should have shares on new vault");
+
+    // Transfer shares to bot wallet — tests the transfer poller on the new
+    // vault
+    vault_b.transfer(bot_wallet, shares).send().await?.get_receipt().await?;
+
+    // Wait for burn — proves the transfer poller is monitoring vault B
+    harness::wait_for_burn(&vault_b, bot_wallet).await?;
+
+    assert_eq!(
+        vault_b.balanceOf(user_wallet).call().await?,
+        U256::ZERO,
+        "User should have no shares after redemption on new vault"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Adding a tokenized asset (or re-pointing one at a new vault) at runtime via
`POST /tokenized-assets` did not start monitoring its vault: the transfer poller
and the periodic receipt backfill both captured a fixed vault list at startup,
so a new vault's redemptions and receipts were ignored until the next restart.

This branch is a **from-scratch reconciliation**. The apalis job-orchestration
half of the original PR now lives in #118; this PR is just the
dynamic-asset-monitoring half, re-implemented against `main`'s polling
architecture (the original built it on the WebSocket monitors `main` has since
deleted).

## Solution

The poll loops re-read the enabled vault set from the tokenized-asset view on
every pass — no event wiring or monitor restarts:

- `TransferPoller` reads the enabled (and frozen) vaults each poll instead of
  holding a fixed list, so a runtime-added or re-pointed vault is covered on the
  next pass.
- `spawn_periodic_receipt_backfills` likewise re-reads the enabled assets each
  pass and resolves their receipt contracts (cached, since a receipt contract is
  immutable on-chain).

The global transfer checkpoint is correct for runtime additions, whose on-chain
activity is always after the asset is added.

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

`tests/dynamic_asset.rs` covers a new asset and a vault-address change, each
minting + redeeming on the new vault with no restart. Stacked on #118.
