### PR TITLE
fix: MintView drops recovery events from MintingFailed state

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,9 +246,10 @@ Bug fixes and improvements that don't fit into the original phases.
       Fireblocks integration uses OneTimeAddress instead of whitelisted contract
       wallets
   - **PR:** [#125](https://github.com/ST0x-Technology/st0x.issuance/pull/125)
-- [ ] [#126](https://github.com/ST0x-Technology/st0x.issuance/issues/126) -
+- [x] [#126](https://github.com/ST0x-Technology/st0x.issuance/issues/126) -
       MintView silently drops ExistingMintRecovered and MintCompleted events
       from MintingFailed state
+  - **PR:** [#127](https://github.com/ST0x-Technology/st0x.issuance/pull/127)
 - [ ] [#88](https://github.com/ST0x-Technology/st0x.issuance/issues/88) - Add
       automatic recovery for burns detected as already completed on-chain
 - [ ] [#110](https://github.com/ST0x-Technology/st0x.issuance/issues/110) -

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,6 +246,10 @@ Bug fixes and improvements that don't fit into the original phases.
       Fireblocks integration uses OneTimeAddress instead of whitelisted contract
       wallets
   - **PR:** [#125](https://github.com/ST0x-Technology/st0x.issuance/pull/125)
+- [x] [#126](https://github.com/ST0x-Technology/st0x.issuance/issues/126) -
+      MintView silently drops ExistingMintRecovered and MintCompleted events
+      from MintingFailed state
+  - **PR:** [#127](https://github.com/ST0x-Technology/st0x.issuance/pull/127)
 - [ ] [#88](https://github.com/ST0x-Technology/st0x.issuance/issues/88) - Add
       automatic recovery for burns detected as already completed on-chain
 - [ ] [#110](https://github.com/ST0x-Technology/st0x.issuance/issues/110) -

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -246,6 +246,9 @@ Bug fixes and improvements that don't fit into the original phases.
       Fireblocks integration uses OneTimeAddress instead of whitelisted contract
       wallets
   - **PR:** [#125](https://github.com/ST0x-Technology/st0x.issuance/pull/125)
+- [ ] [#126](https://github.com/ST0x-Technology/st0x.issuance/issues/126) -
+      MintView silently drops ExistingMintRecovered and MintCompleted events
+      from MintingFailed state
 - [ ] [#88](https://github.com/ST0x-Technology/st0x.issuance/issues/88) - Add
       automatic recovery for burns detected as already completed on-chain
 - [ ] [#110](https://github.com/ST0x-Technology/st0x.issuance/issues/110) -

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -443,16 +443,14 @@ async fn recover_post_alpaca(
         }
     }
 
-    let alpaca_journal_completed_at = match alpaca_updated_at {
-        Some(ts) => *ts,
-        None => {
-            error!(
-                aggregate_id = %aggregate_id,
-                "Alpaca returned completed status but updated_at is null"
-            );
-            return Err(Status::BadGateway);
-        }
+    let Some(alpaca_journal_completed_at) = alpaca_updated_at else {
+        error!(
+            aggregate_id = %aggregate_id,
+            "Alpaca returned completed status but updated_at is null"
+        );
+        return Err(Status::BadGateway);
     };
+    let alpaca_journal_completed_at = *alpaca_journal_completed_at;
 
     cqrs.execute(
         &aggregate_id,

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -312,7 +312,7 @@ impl MintView {
         block_number: u64,
         minted_at: DateTime<Utc>,
     ) {
-        let Self::Minting {
+        let (Self::Minting {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -324,7 +324,20 @@ impl MintView {
             initiated_at,
             journal_confirmed_at,
             ..
-        } = self.clone()
+        }
+        | Self::MintingFailed {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }) = self.clone()
         else {
             return;
         };
@@ -1544,6 +1557,187 @@ mod tests {
         view.handle_mint_retry_started(Utc::now());
 
         assert_eq!(view, original_view);
+    }
+
+    #[test]
+    fn test_handle_tokens_minted_from_minting_failed_transitions_to_callback_pending()
+     {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-recover-1");
+        let quantity = Quantity::new(Decimal::from(100));
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let network = Network::new("base");
+        let client_id = ClientId::new();
+        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let initiated_at = Utc::now();
+        let journal_confirmed_at = Utc::now();
+
+        let mut view = MintView::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            error: "Transaction reverted".to_string(),
+            failed_at: Utc::now(),
+        };
+
+        let tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let receipt_id = uint!(42_U256);
+        let shares_minted = uint!(100_000000000000000000_U256);
+        let block_number = 2000;
+        let recovered_at = Utc::now();
+
+        let event = MintEvent::ExistingMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash,
+            receipt_id,
+            shares_minted,
+            block_number,
+            recovered_at,
+        };
+
+        let envelope = EventEnvelope {
+            aggregate_id: issuer_request_id.to_string(),
+            sequence: 4,
+            payload: event,
+            metadata: HashMap::new(),
+        };
+
+        view.update(&envelope);
+
+        let MintView::CallbackPending {
+            issuer_request_id: view_iss,
+            tokenization_request_id: view_tok,
+            quantity: view_qty,
+            underlying: view_und,
+            token: view_tok_sym,
+            network: view_net,
+            client_id: view_client,
+            wallet: view_wallet,
+            initiated_at: view_init,
+            journal_confirmed_at: view_jc,
+            tx_hash: view_tx,
+            receipt_id: view_receipt,
+            shares_minted: view_shares,
+            gas_used: view_gas,
+            block_number: view_block,
+            minted_at: view_minted,
+        } = view
+        else {
+            panic!("Expected CallbackPending variant, got {view:?}");
+        };
+
+        assert_eq!(view_iss, issuer_request_id);
+        assert_eq!(view_tok, tokenization_request_id);
+        assert_eq!(view_qty, quantity);
+        assert_eq!(view_und, underlying);
+        assert_eq!(view_tok_sym, token);
+        assert_eq!(view_net, network);
+        assert_eq!(view_client, client_id);
+        assert_eq!(view_wallet, wallet);
+        assert_eq!(view_init, initiated_at);
+        assert_eq!(view_jc, journal_confirmed_at);
+        assert_eq!(view_tx, tx_hash);
+        assert_eq!(view_receipt, receipt_id);
+        assert_eq!(view_shares, shares_minted);
+        assert_eq!(view_gas, None);
+        assert_eq!(view_block, block_number);
+        assert_eq!(view_minted, recovered_at);
+    }
+
+    #[test]
+    fn test_recovery_from_minting_failed_reaches_completed() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-recover-2");
+        let quantity = Quantity::new(Decimal::from(50));
+        let underlying = UnderlyingSymbol::new("TSLA");
+        let token = TokenSymbol::new("tTSLA");
+        let network = Network::new("base");
+        let client_id = ClientId::new();
+        let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let initiated_at = Utc::now();
+        let journal_confirmed_at = Utc::now();
+
+        let tx_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+        let receipt_id = uint!(99_U256);
+        let shares_minted = uint!(50_000000000000000000_U256);
+        let block_number = 3000;
+        let recovered_at = Utc::now();
+
+        let mut view = MintView::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            error: "Gas estimation failed".to_string(),
+            failed_at: Utc::now(),
+        };
+
+        let recover_event = MintEvent::ExistingMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash,
+            receipt_id,
+            shares_minted,
+            block_number,
+            recovered_at,
+        };
+
+        view.update(&EventEnvelope {
+            aggregate_id: issuer_request_id.to_string(),
+            sequence: 4,
+            payload: recover_event,
+            metadata: HashMap::new(),
+        });
+
+        let completed_at = Utc::now();
+        let complete_event = MintEvent::MintCompleted {
+            issuer_request_id: issuer_request_id.clone(),
+            completed_at,
+        };
+
+        view.update(&EventEnvelope {
+            aggregate_id: issuer_request_id.to_string(),
+            sequence: 5,
+            payload: complete_event,
+            metadata: HashMap::new(),
+        });
+
+        let MintView::Completed {
+            issuer_request_id: view_iss,
+            tx_hash: view_tx,
+            receipt_id: view_receipt,
+            shares_minted: view_shares,
+            completed_at: view_completed,
+            ..
+        } = view
+        else {
+            panic!("Expected Completed variant, got {view:?}");
+        };
+
+        assert_eq!(view_iss, issuer_request_id);
+        assert_eq!(view_tx, tx_hash);
+        assert_eq!(view_receipt, receipt_id);
+        assert_eq!(view_shares, shares_minted);
+        assert_eq!(view_completed, completed_at);
     }
 
     fn test_mint_fields() -> TestMintFields {

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -103,7 +103,7 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
 
     let shares_minted = harness::wait_for_shares(&vault, user_wallet).await?;
     assert!(shares_minted > U256::ZERO, "First mint should succeed");
-    mint_callback_mock.assert();
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     // Step 2: Unwhitelist the wallet
     let unwhitelist_response = client

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -96,7 +96,7 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
 
     let shares_minted = harness::wait_for_shares(&vault, user_wallet).await?;
     assert!(shares_minted > U256::ZERO, "First mint should succeed");
-    mint_callback_mock.assert();
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     // Step 2: Unwhitelist the wallet
     let unwhitelist_response = client


### PR DESCRIPTION
## Motivation

`MintView::handle_tokens_minted` only accepted `Self::Minting` as a valid source state. When a mint recovered from `MintingFailed` via `ExistingMintRecovered`, the view ignored the event and stayed stuck in `MintingFailed` — even though the aggregate correctly transitioned to `CallbackPending` and then `Completed`.

This caused `/admin/stuck` to report mints as `MintingFailed` when their aggregates had already recovered. Discovered during the [RAI-280](https://linear.app/makeitrain/issue/RAI-280/alpaca-redemption-journaling-error-stuck-issuance-hedge-bot) investigation: all 29 stuck mints auto-recovered on restart, but the view never updated.

Closes #126 / [RAI-235](https://linear.app/makeitrain/issue/RAI-235/issuance-mintview-drops-recovery-events-from-mintingfailed-state)

## Solution

Add `Self::MintingFailed` as an accepted source state in `handle_tokens_minted` (`src/mint/view.rs:315`) using an or-pattern, matching the aggregate's `apply_existing_mint_recorded` which already handled both states. This lets the view follow the recovery path: `MintingFailed` → `CallbackPending` → `Completed`.

Also fixes a flaky assertion in `tests/unwhitelist.rs` — replaces a synchronous `mint_callback_mock.assert()` with `harness::wait_for_mock_hit()` to handle timing races.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where mint recovery events were silently dropped during failed mint operations, allowing successful recovery and transition to completion.

* **Tests**
  * Added coverage for recovery from failed mint states and adjusted tests to wait for the mint callback before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->