### PR TITLE
fix: switch fireblocks-sdk to fork that treats Confirming as non-terminal

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->
+
+## Motivation
+
+<!--
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? In some cases there is not a problem and this can be
+thought of as being the motivation for your change.
+-->
+
+## Solution
+
+<!--
+Summarize the solution and provide any necessary context needed to understand
+the code change.
+-->
+
+## Checks
+
+<!-- It's important you've done these, or your PR will not be considered for review -->
+
+By submitting this for review, I'm confirming I've done the following:
+
+- [ ] added comprehensive test coverage for any changes in logic
+- [ ] made this PR as small as possible
+- [ ] linked any relevant issues or PRs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2069,8 +2069,7 @@ checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 [[package]]
 name = "fireblocks-sdk"
 version = "2025.10.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc844aaedb912fb065fe82763b95ddb366d58c18d07374c9b389fc63f4b26f26"
+source = "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix%2Fconfirming-not-terminal#8cf2bf3813b7184df8819b50c76b1c44e4bfcdf9"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ base64 = "0.22.1"
 ipnetwork = "0.21.1"
 subtle = "2.6.1"
 governor = "0.10.2"
-fireblocks-sdk = "2025.10.17"
+fireblocks-sdk = { git = "https://github.com/0xgleb/fireblocks-sdk-rs.git", branch = "fix/confirming-not-terminal" }
 
 [lints]
 workspace = true

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -679,7 +679,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
 
 #[cfg(test)]
 mod tests {
-    use std::sync::LazyLock;
+    use std::sync::{Arc, LazyLock};
 
     use httpmock::MockServer;
     use rsa::RsaPrivateKey;
@@ -1039,5 +1039,73 @@ mod tests {
         assert!(!is_still_pending(Cancelled));
         assert!(!is_still_pending(Blocked));
         assert!(!is_still_pending(Rejected));
+    }
+
+    /// The Fireblocks SDK must treat `Confirming` as a non-terminal status and
+    /// keep polling. A transaction that is `Confirming` will eventually become
+    /// `Completed` — stopping early causes a spurious `TransactionFailed` error.
+    ///
+    /// This test simulates a transaction that reports `CONFIRMING` for its first
+    /// two polls, then transitions to `COMPLETED`. With a correct SDK,
+    /// `wait_for_completion` polls through the `Confirming` state and succeeds.
+    /// With a buggy SDK that treats `Confirming` as terminal, the poll loop
+    /// exits early and returns `TransactionFailed { status: Confirming }`.
+    #[tokio::test]
+    async fn wait_for_completion_polls_through_confirming_status() {
+        use std::sync::atomic::{AtomicU32, Ordering};
+
+        let server = MockServer::start();
+        let call_count = Arc::new(AtomicU32::new(0));
+        let counter = Arc::clone(&call_count);
+
+        let expected_tx_hash = "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+        let tx_hash = expected_tx_hash.to_string();
+
+        server.mock(|when, then| {
+            when.method("GET").path("/transactions/tx-confirming-123");
+            then.respond_with(move |_req: &httpmock::HttpMockRequest| {
+                let call = counter.fetch_add(1, Ordering::SeqCst);
+
+                let status = if call < 2 { "CONFIRMING" } else { "COMPLETED" };
+
+                httpmock::HttpMockResponse::builder()
+                    .status(200)
+                    .header("content-type", "application/json")
+                    .body(
+                        serde_json::json!({
+                            "id": "tx-confirming-123",
+                            "status": status,
+                            "txHash": tx_hash,
+                        })
+                        .to_string(),
+                    )
+                    .build()
+            });
+        });
+
+        let service = build_test_service(mock_client(&server));
+
+        let result = service.wait_for_completion("tx-confirming-123").await;
+
+        assert!(
+            result.is_ok(),
+            "wait_for_completion should succeed after polling through \
+             Confirming status, but got: {result:?}"
+        );
+
+        let hash = result.unwrap();
+        assert_eq!(
+            hash,
+            expected_tx_hash.parse::<B256>().unwrap(),
+            "Should return the on-chain transaction hash"
+        );
+
+        let total_calls = call_count.load(Ordering::SeqCst);
+        assert!(
+            total_calls >= 3,
+            "SDK should have polled past Confirming status \
+             (expected >= 3 calls, got {total_calls})"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

The upstream `fireblocks-sdk` crate (`2025.10.17`) treats `Confirming` as a terminal transaction status in `poll_transaction()`. This causes the SDK to stop polling when a transaction enters the `CONFIRMING` state (which is a normal intermediate state before `COMPLETED`), leading to spurious `TransactionFailed { status: Confirming }` errors.

## Solution

- Switch `fireblocks-sdk` dependency to [our fork](https://github.com/0xgleb/fireblocks-sdk-rs/tree/fix/confirming-not-terminal) which removes `Confirming` from the terminal status match arm in `poll_transaction()`
- Add a mock-server integration test (`wait_for_completion_polls_through_confirming_status`) that verifies `wait_for_completion` polls through `Confirming` status to reach `Completed`
- Add `.github/PULL_REQUEST_TEMPLATE.md`

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction polling to correctly handle cases where transactions remain in confirming state for extended periods before reaching completion status.

* **Tests**
  * Added test coverage verifying proper handling of transaction confirmation flows with extended confirming state scenarios.

* **Chores**
  * Updated core dependencies to enhance transaction processing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->