### PR TITLE
Track transfer events

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -427,23 +427,33 @@ recovery. Methods:
 - `find_by_issuer_request_id(vault, id) -> Option<RecoveredReceipt>` - Looks up
   a receipt by ITN issuer_request_id for mint recovery
 
-Receipts enter the inventory through backfill (scanning historic Deposit events
-at startup from `last_backfilled_block`), live monitoring (WebSocket
-subscription to Deposit events at runtime), or direct registration after a mint.
+Receipts enter the inventory through backfill (scanning historic Deposit and
+ERC-1155 transfer events at startup from `last_backfilled_block`), live
+monitoring (WebSocket subscription to Deposit and ERC-1155 transfer events at
+runtime), or direct registration after a mint.
 
-Receipts leave the inventory through reconciliation — querying
-`balanceOf(bot_wallet, receipt_id)` on-chain and emitting `BalanceDecreased`
-when on-chain < aggregate. Reconciliation is triggered by:
+The Receipt contract is an ERC-1155 token that emits `TransferSingle` and
+`TransferBatch` events on all token movements. The receipt monitor and
+backfiller track these events to discover inbound receipt transfers (to ==
+bot_wallet) and reconcile outbound transfers (from == bot_wallet). Mint/burn
+transfers (from/to == address(0)) are filtered out since those are already
+covered by the vault's Deposit/Withdraw events.
+
+Receipts leave the inventory (or have their balance corrected) through
+reconciliation — querying `balanceOf(bot_wallet, receipt_id)` on-chain and
+emitting `BalanceReconciled` when the on-chain balance differs from the
+aggregate balance in either direction. Reconciliation is triggered by:
 
 - **Startup**: After receipt backfill, reconciles all receipts with positive
-  aggregate balance before transfer backfill begins
+  aggregate balance before redemption transfer backfill begins
 - **Post-burn**: After every burn attempt (successful or failed), reconciles the
   affected vault immediately
-- **Live monitoring**: WebSocket subscription to Withdraw events on each vault
-  contract. When a Withdraw event fires with `owner == bot_wallet`, reconciles
-  the specific receipt. This detects external burns (manual burns by
-  stakeholders) in real time, mirroring the Deposit event subscription for
-  receipt discovery
+- **Live monitoring**: WebSocket subscription to Withdraw events and ERC-1155
+  TransferSingle/TransferBatch events. When a Withdraw event fires with
+  `owner == bot_wallet`, or an outbound transfer from bot_wallet is detected,
+  reconciles the specific receipt. This detects external burns (manual burns by
+  stakeholders) and direct token transfers in real time, mirroring the Deposit
+  event subscription for receipt discovery
 
 #### ReceiptInventory Aggregate
 
@@ -452,14 +462,14 @@ Commands:
 - `DiscoverReceipt` - Register a newly discovered receipt
 - `AdvanceBackfillCheckpoint` - Update the last backfilled block number
 - `ReconcileBalance { receipt_id, on_chain_balance }` - Correct aggregate
-  balance to match on-chain state. No-op if balances match or receipt unknown.
-  Errors if on-chain > aggregate (safety check)
+  balance to match on-chain state (both increases and decreases). No-op if
+  balances match or receipt unknown
 
 Events:
 
 - `Discovered` - Receipt discovered with initial balance
-- `BalanceDecreased { receipt_id, previous_balance, on_chain_balance }` -
-  Balance decreased (detected during reconciliation)
+- `BalanceReconciled { receipt_id, previous_balance, on_chain_balance }` -
+  Balance changed (detected during reconciliation, either increase or decrease)
 - `Depleted` - Receipt fully consumed (balance reached zero)
 - `BackfillCheckpoint` - Backfill progress marker
 
@@ -1512,11 +1522,13 @@ We call these Alpaca endpoints:
    `CallbackPending` -> `MintCompleted`, completing the flow without waiting for
    a service restart.
 6. **Receipt balance reconciliation**: At startup (after receipt backfill),
-   after every burn (both successful and failed), and on live Withdraw events,
-   the service reconciles each receipt's aggregate balance against its on-chain
-   `balanceOf`. If on-chain < aggregate, emits `BalanceDecreased` to correct the
-   inventory. This single mechanism handles all balance changes — burns by this
-   service, manual burns by stakeholders, or any other on-chain activity.
+   after every burn (both successful and failed), on live Withdraw events, and
+   on inbound/outbound ERC-1155 transfers, the service reconciles each receipt's
+   aggregate balance against its on-chain `balanceOf`. Emits `BalanceReconciled`
+   to correct the inventory in either direction (increases from inbound
+   transfers, decreases from burns or outbound transfers). This single mechanism
+   handles all balance changes — burns by this service, manual burns by
+   stakeholders, direct token transfers, or any other on-chain activity.
 7. **BurnFailed auto-fail**: Redemptions stuck in `BurnFailed` state (after a
    `BurningFailed` event) are auto-failed via `MarkFailed` when recovery
    determines they cannot be retried — either because the on-chain share balance
@@ -1527,11 +1539,13 @@ We call these Alpaca endpoints:
    failed), receipt reconciliation is triggered immediately for the affected
    vault. This is the primary mechanism for updating inventory after burns
    performed by this service.
-9. **Live burn monitoring**: The receipt monitor subscribes to Withdraw events
-   on each vault contract via WebSocket. When a Withdraw event fires with
-   `owner == bot_wallet`, reconciliation is triggered for that receipt. This
-   detects external burns in real time, mirroring the Deposit event subscription
-   used for receipt discovery.
+9. **Live transfer monitoring**: The receipt monitor subscribes to Withdraw
+   events on each vault contract and ERC-1155 TransferSingle/TransferBatch
+   events on the Receipt contract via WebSocket. When a Withdraw event fires
+   with `owner == bot_wallet`, or an outbound/inbound transfer involving the bot
+   wallet is detected, reconciliation is triggered for that receipt. Inbound
+   transfers also attempt discovery (for new receipt IDs). This detects external
+   burns, direct token transfers, and inbound receipts in real time.
 
 **Startup view rebuild:** All view tables are cleared before replay on every
 startup, ensuring views are rebuilt cleanly from events and eliminating stale or

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -8,6 +8,7 @@ use itertools::Itertools;
 use std::sync::Arc;
 use tracing::{debug, info};
 
+use super::monitor::{transfer_batch_filter, transfer_single_filter};
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
     ReceiptInventoryError, Shares, determine_source,
@@ -36,16 +37,10 @@ fn block_ranges(
 }
 
 /// Backfills the ReceiptInventory aggregate by scanning historic Deposit
-/// events where the bot wallet received receipts.
+/// events and ERC-1155 transfer events where the bot wallet received receipts.
 ///
 /// This handles receipts minted outside our system (e.g., manual operations)
-/// that the service needs to know about for burn planning.
-///
-/// **Assumption:** All mints (including manual/external ones) are performed
-/// via the bot wallet as the depositor. This allows us to discover all
-/// receipts by monitoring Deposit events alone. Without this assumption,
-/// we would also need to track TransferSingle and TransferBatch events to
-/// catch receipts transferred to the bot wallet from other depositors.
+/// and receipts transferred to the bot wallet from other addresses.
 pub(crate) struct ReceiptBackfiller<ProviderType, ReceiptInventoryStore>
 where
     ReceiptInventoryStore: EventStore<ReceiptInventory>,
@@ -101,7 +96,8 @@ where
     ProviderType: alloy::providers::Provider + Clone + Send + Sync,
     ReceiptInventoryStore: EventStore<ReceiptInventory>,
 {
-    /// Scans historic Deposit events to discover receipts the bot owns.
+    /// Scans historic Deposit and ERC-1155 transfer events to discover
+    /// receipts the bot owns.
     ///
     /// For each receipt discovered:
     /// 1. Checks current on-chain balance (not just transfer amount, since
@@ -163,15 +159,16 @@ where
         .flatten()
         .collect();
 
-        let deposits = all_logs
+        let discoveries = all_logs
             .iter()
             .map(Self::parse_log)
             .collect::<Result<Vec<_>, _>>()?
             .into_iter()
-            .unique_by(|deposit| deposit.receipt_id);
+            .flatten()
+            .unique_by(|discovery| discovery.receipt_id);
 
-        let results: Vec<_> = stream::iter(deposits)
-            .map(|deposit| self.process_deposit(deposit))
+        let results: Vec<_> = stream::iter(discoveries)
+            .map(|discovery| self.process_discovery(discovery))
             .buffer_unordered(MAX_CONCURRENT_BALANCE_CHECKS)
             .collect()
             .await;
@@ -221,9 +218,9 @@ where
             .to_block(to_block)
             .filter;
 
-        let logs = self.provider.get_logs(&deposit_filter).await?;
+        let deposit_logs = self.provider.get_logs(&deposit_filter).await?;
 
-        let filtered: Vec<Log> = logs
+        let mut filtered: Vec<Log> = deposit_logs
             .into_iter()
             .filter_map(|log| {
                 match OffchainAssetReceiptVault::Deposit::decode_log(&log.inner)
@@ -237,33 +234,106 @@ where
             })
             .collect::<Result<Vec<_>, _>>()?;
 
+        // Also scan ERC-1155 TransferSingle and TransferBatch events on the
+        // Receipt contract for inbound transfers to the bot wallet.
+        let transfer_single_logs = self
+            .provider
+            .get_logs(
+                &transfer_single_filter(self.receipt_contract)
+                    .from_block(from_block)
+                    .to_block(to_block),
+            )
+            .await?;
+
+        let transfer_batch_logs = self
+            .provider
+            .get_logs(
+                &transfer_batch_filter(self.receipt_contract)
+                    .from_block(from_block)
+                    .to_block(to_block),
+            )
+            .await?;
+
+        // Filter transfer events: keep only inbound (to == bot_wallet),
+        // skip mint transfers (from == address(0)) since Deposit covers those.
+        for log in transfer_single_logs {
+            let event = Receipt::TransferSingle::decode_log(&log.inner)?;
+
+            if event.to == self.bot_wallet && !event.from.is_zero() {
+                filtered.push(log);
+            }
+        }
+
+        for log in transfer_batch_logs {
+            let event = Receipt::TransferBatch::decode_log(&log.inner)?;
+
+            if event.to == self.bot_wallet && !event.from.is_zero() {
+                filtered.push(log);
+            }
+        }
+
         Ok(filtered)
     }
 
-    fn parse_log(log: &Log) -> Result<DepositInfo, BackfillError> {
-        let event = OffchainAssetReceiptVault::Deposit::decode_log(&log.inner)?;
+    /// Parses a log into one or more `ReceiptDiscovery` entries.
+    ///
+    /// Deposit logs produce a single entry with receipt information.
+    /// TransferSingle logs produce a single entry without receipt information.
+    /// TransferBatch logs produce one entry per (id, value) pair.
+    fn parse_log(log: &Log) -> Result<Vec<ReceiptDiscovery>, BackfillError> {
         let tx_hash =
             log.transaction_hash.ok_or(BackfillError::MissingTxHash)?;
         let block_number =
             log.block_number.ok_or(BackfillError::MissingBlockNumber)?;
 
-        Ok(DepositInfo {
-            receipt_id: ReceiptId::from(event.id),
-            tx_hash,
-            block_number,
-            receipt_information: event.receiptInformation.clone(),
-        })
+        // Try Deposit first, then TransferSingle, then TransferBatch
+        if let Ok(event) =
+            OffchainAssetReceiptVault::Deposit::decode_log(&log.inner)
+        {
+            return Ok(vec![ReceiptDiscovery {
+                receipt_id: ReceiptId::from(event.id),
+                tx_hash,
+                block_number,
+                receipt_information: event.receiptInformation.clone(),
+            }]);
+        }
+
+        if let Ok(event) = Receipt::TransferSingle::decode_log(&log.inner) {
+            return Ok(vec![ReceiptDiscovery {
+                receipt_id: ReceiptId::from(event.id),
+                tx_hash,
+                block_number,
+                receipt_information: Bytes::new(),
+            }]);
+        }
+
+        if let Ok(event) = Receipt::TransferBatch::decode_log(&log.inner) {
+            return Ok(event
+                .ids
+                .iter()
+                .map(|id| ReceiptDiscovery {
+                    receipt_id: ReceiptId::from(*id),
+                    tx_hash,
+                    block_number,
+                    receipt_information: Bytes::new(),
+                })
+                .collect());
+        }
+
+        Err(BackfillError::SolTypes(alloy::sol_types::Error::custom(
+            "Log did not match Deposit, TransferSingle, or TransferBatch",
+        )))
     }
 
-    async fn process_deposit(
+    async fn process_discovery(
         &self,
-        deposit: DepositInfo,
+        discovery: ReceiptDiscovery,
     ) -> Result<ProcessOutcome, BackfillError> {
         let receipt_contract =
             Receipt::new(self.receipt_contract, &self.provider);
 
         let current_balance = receipt_contract
-            .balanceOf(self.bot_wallet, deposit.receipt_id.inner())
+            .balanceOf(self.bot_wallet, discovery.receipt_id.inner())
             .call()
             .await?;
 
@@ -272,21 +342,21 @@ where
         }
 
         let (source, receipt_info) =
-            determine_source(&deposit.receipt_information);
-        let receipt_info_bytes = if deposit.receipt_information.is_empty() {
+            determine_source(&discovery.receipt_information);
+        let receipt_info_bytes = if discovery.receipt_information.is_empty() {
             None
         } else {
-            Some(deposit.receipt_information.clone())
+            Some(discovery.receipt_information.clone())
         };
 
         self.cqrs
             .execute(
                 &self.vault.to_string(),
                 ReceiptInventoryCommand::DiscoverReceipt {
-                    receipt_id: deposit.receipt_id,
+                    receipt_id: discovery.receipt_id,
                     balance: Shares::from(current_balance),
-                    block_number: deposit.block_number,
-                    tx_hash: deposit.tx_hash,
+                    block_number: discovery.block_number,
+                    tx_hash: discovery.tx_hash,
                     source,
                     receipt_info: receipt_info.map(Box::new),
                     receipt_info_bytes,
@@ -294,8 +364,21 @@ where
             )
             .await?;
 
+        // For already-known receipts, DiscoverReceipt is a no-op. Reconcile
+        // ensures the aggregate reflects the current on-chain balance (e.g.,
+        // after an inbound transfer increases the balance).
+        self.cqrs
+            .execute(
+                &self.vault.to_string(),
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: discovery.receipt_id,
+                    on_chain_balance: Shares::from(current_balance),
+                },
+            )
+            .await?;
+
         debug!(
-            receipt_id = %deposit.receipt_id,
+            receipt_id = %discovery.receipt_id,
             balance = %current_balance,
             "Processed receipt"
         );
@@ -304,7 +387,7 @@ where
     }
 }
 
-struct DepositInfo {
+struct ReceiptDiscovery {
     receipt_id: ReceiptId,
     tx_hash: TxHash,
     block_number: u64,
@@ -333,7 +416,10 @@ mod tests {
 
     use super::ReceiptBackfiller;
     use crate::bindings::OffchainAssetReceiptVault;
-    use crate::receipt_inventory::ReceiptInventory;
+    use crate::receipt_inventory::{
+        ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
+        Shares,
+    };
     use crate::test_utils::logs_contain_at;
 
     type TestStore = MemStore<ReceiptInventory>;
@@ -389,6 +475,13 @@ mod tests {
         Arc::new(CqrsFramework::new(MemStore::default(), vec![], ()))
     }
 
+    /// Pushes empty responses for the TransferSingle and TransferBatch
+    /// get_logs calls that the backfiller now makes.
+    fn push_empty_transfer_logs(asserter: &Asserter) {
+        asserter.push_success(&Vec::<Log>::new());
+        asserter.push_success(&Vec::<Log>::new());
+    }
+
     fn setup_cqrs_with_store()
     -> (Arc<CqrsFramework<ReceiptInventory, TestStore>>, Arc<TestStore>) {
         let store = Arc::new(MemStore::default());
@@ -427,6 +520,7 @@ mod tests {
         asserter.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter)
         asserter.push_success(&vec![deposit_log]);
+        push_empty_transfer_logs(&asserter);
         // eth_call (balanceOf)
         asserter.push_success(&balance.to_be_bytes::<32>());
 
@@ -495,6 +589,7 @@ mod tests {
         asserter1.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter)
         asserter1.push_success(&vec![deposit_log.clone()]);
+        push_empty_transfer_logs(&asserter1);
         // eth_call (balanceOf)
         asserter1.push_success(&balance.to_be_bytes::<32>());
 
@@ -520,6 +615,7 @@ mod tests {
         asserter2.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter)
         asserter2.push_success(&vec![deposit_log]);
+        push_empty_transfer_logs(&asserter2);
         // eth_call (balanceOf)
         asserter2.push_success(&balance.to_be_bytes::<32>());
 
@@ -570,6 +666,7 @@ mod tests {
         asserter.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter)
         asserter.push_success(&vec![deposit_log]);
+        push_empty_transfer_logs(&asserter);
         // eth_call (balanceOf) - zero because receipt was fully burned
         asserter.push_success(&U256::ZERO.to_be_bytes::<32>());
 
@@ -638,6 +735,7 @@ mod tests {
         asserter.push_success(&U256::from(checkpoint_block));
         // eth_getLogs (Deposit filter)
         asserter.push_success(&vec![deposit_log]);
+        push_empty_transfer_logs(&asserter);
         // eth_call (balanceOf) - returns current balance, not original deposit
         asserter.push_success(&current_balance.to_be_bytes::<32>());
 
@@ -710,6 +808,7 @@ mod tests {
         asserter.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter) - both deposits returned, filtered client-side
         asserter.push_success(&vec![deposit_for_bot, deposit_for_other]);
+        push_empty_transfer_logs(&asserter);
         // eth_call (balanceOf) - only called for bot's receipt
         asserter.push_success(&balance.to_be_bytes::<32>());
 
@@ -761,6 +860,7 @@ mod tests {
         asserter.push_success(&U256::from(current_block));
         // eth_getLogs (Deposit filter)
         asserter.push_success(&vec![deposit_log]);
+        push_empty_transfer_logs(&asserter);
         // eth_call (balanceOf)
         asserter.push_success(&balance.to_be_bytes::<32>());
 
@@ -825,5 +925,372 @@ mod tests {
     fn block_ranges_empty_when_from_equals_to() {
         let ranges: Vec<_> = super::block_ranges(100, 100, 2000).collect();
         assert_eq!(ranges, vec![(100, 100)]);
+    }
+
+    #[derive(Clone, Copy)]
+    struct TransferSingleLogParams {
+        receipt_contract: Address,
+        operator: Address,
+        from: Address,
+        to: Address,
+        id: U256,
+        value: U256,
+        tx_hash: B256,
+        block_number: u64,
+    }
+
+    fn create_transfer_single_log(params: TransferSingleLogParams) -> Log {
+        use crate::bindings::Receipt;
+
+        let event = Receipt::TransferSingle {
+            operator: params.operator,
+            from: params.from,
+            to: params.to,
+            id: params.id,
+            value: params.value,
+        };
+
+        Log {
+            inner: alloy::primitives::Log {
+                address: params.receipt_contract,
+                data: event.encode_log_data(),
+            },
+            block_hash: Some(b256!(
+                "0x0000000000000000000000000000000000000000000000000000000000000001"
+            )),
+            block_number: Some(params.block_number),
+            block_timestamp: None,
+            transaction_hash: Some(params.tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn backfill_discovers_receipt_from_inbound_transfer() {
+        let (receipt_contract, bot_wallet, vault) = test_addresses();
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let (cqrs, store) = setup_cqrs_with_store();
+
+        let receipt_id = U256::from(55);
+        let balance = U256::from(750);
+        let tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let transfer_log =
+            create_transfer_single_log(TransferSingleLogParams {
+                receipt_contract,
+                operator: other_wallet,
+                from: other_wallet,
+                to: bot_wallet,
+                id: receipt_id,
+                value: balance,
+                tx_hash,
+                block_number: 150,
+            });
+
+        let asserter = Asserter::new();
+        let current_block = 200u64;
+
+        // eth_blockNumber
+        asserter.push_success(&U256::from(current_block));
+        // eth_getLogs (Deposit filter) - no deposits
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_getLogs (TransferSingle filter) - one inbound transfer
+        asserter.push_success(&vec![transfer_log]);
+        // eth_getLogs (TransferBatch filter) - no batch transfers
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_call (balanceOf)
+        asserter.push_success(&balance.to_be_bytes::<32>());
+
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
+            .connect_mocked_client(asserter);
+
+        let backfiller = ReceiptBackfiller::new(
+            provider,
+            receipt_contract,
+            bot_wallet,
+            vault,
+            cqrs,
+        );
+
+        let result = backfiller.backfill_receipts(0).await.unwrap();
+
+        assert_eq!(result.processed_count, 1);
+        assert_eq!(result.skipped_zero_balance, 0);
+
+        // Verify the receipt was actually discovered with correct ID and balance
+        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let receipts = ctx.aggregate().receipts_with_balance();
+        assert_eq!(receipts.len(), 1, "Should discover exactly one receipt");
+        assert_eq!(
+            receipts[0].receipt_id,
+            ReceiptId::from(receipt_id),
+            "Discovered receipt ID should match the transfer"
+        );
+        assert_eq!(
+            receipts[0].available_balance,
+            Shares::from(balance),
+            "Balance should match the on-chain balanceOf response"
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_filters_outbound_and_mint_transfers() {
+        let (receipt_contract, bot_wallet, vault) = test_addresses();
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let (cqrs, store) = setup_cqrs_with_store();
+
+        let tx_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+
+        // Outbound transfer (from == bot_wallet) — should be filtered
+        let outbound_log =
+            create_transfer_single_log(TransferSingleLogParams {
+                receipt_contract,
+                operator: bot_wallet,
+                from: bot_wallet,
+                to: other_wallet,
+                id: U256::from(1),
+                value: U256::from(100),
+                tx_hash,
+                block_number: 100,
+            });
+
+        // Mint transfer (from == address(0)) — should be filtered
+        let mint_log = create_transfer_single_log(TransferSingleLogParams {
+            receipt_contract,
+            operator: bot_wallet,
+            from: Address::ZERO,
+            to: bot_wallet,
+            id: U256::from(2),
+            value: U256::from(200),
+            tx_hash,
+            block_number: 101,
+        });
+
+        let asserter = Asserter::new();
+        let current_block = 200u64;
+
+        // eth_blockNumber
+        asserter.push_success(&U256::from(current_block));
+        // eth_getLogs (Deposit filter) - no deposits
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_getLogs (TransferSingle filter) - outbound + mint transfers
+        asserter.push_success(&vec![outbound_log, mint_log]);
+        // eth_getLogs (TransferBatch filter) - no batch transfers
+        asserter.push_success(&Vec::<Log>::new());
+        // No balanceOf calls since both transfers are filtered
+
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
+            .connect_mocked_client(asserter);
+
+        let backfiller = ReceiptBackfiller::new(
+            provider,
+            receipt_contract,
+            bot_wallet,
+            vault,
+            cqrs,
+        );
+
+        let result = backfiller.backfill_receipts(0).await.unwrap();
+
+        assert_eq!(
+            result.processed_count, 0,
+            "Outbound and mint transfers should not be processed"
+        );
+        assert_eq!(result.skipped_zero_balance, 0);
+
+        // Verify: aggregate has no receipts at all
+        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert!(
+            ctx.aggregate().receipts_with_balance().is_empty(),
+            "No receipts should be discovered from outbound/mint transfers"
+        );
+    }
+
+    #[tokio::test]
+    async fn backfill_deduplicates_deposit_and_transfer_for_same_receipt() {
+        let (receipt_contract, bot_wallet, vault) = test_addresses();
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let (cqrs, store) = setup_cqrs_with_store();
+
+        let receipt_id = U256::from(88);
+        let balance = U256::from(500);
+
+        // Same receipt discovered via both Deposit and TransferSingle
+        let deposit_log = create_deposit_log(DepositLogParams {
+            vault,
+            sender: bot_wallet,
+            owner: bot_wallet,
+            assets: balance,
+            shares: balance,
+            id: receipt_id,
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 100,
+        });
+
+        let transfer_log = create_transfer_single_log(
+            TransferSingleLogParams {
+                receipt_contract,
+                operator: other_wallet,
+                from: other_wallet,
+                to: bot_wallet,
+                id: receipt_id,
+                value: balance,
+                tx_hash: b256!(
+                    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                block_number: 110,
+            },
+        );
+
+        let asserter = Asserter::new();
+        let current_block = 200u64;
+
+        // eth_blockNumber
+        asserter.push_success(&U256::from(current_block));
+        // eth_getLogs (Deposit filter)
+        asserter.push_success(&vec![deposit_log]);
+        // eth_getLogs (TransferSingle filter)
+        asserter.push_success(&vec![transfer_log]);
+        // eth_getLogs (TransferBatch filter)
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_call (balanceOf) — only one call since deduplicated
+        asserter.push_success(&balance.to_be_bytes::<32>());
+
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
+            .connect_mocked_client(asserter);
+
+        let backfiller = ReceiptBackfiller::new(
+            provider,
+            receipt_contract,
+            bot_wallet,
+            vault,
+            cqrs,
+        );
+
+        let result = backfiller.backfill_receipts(0).await.unwrap();
+
+        // Should only process once despite appearing in both Deposit and Transfer
+        assert_eq!(result.processed_count, 1);
+
+        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let receipts = ctx.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "Should have exactly one receipt after deduplication"
+        );
+        assert_eq!(
+            receipts[0].receipt_id,
+            ReceiptId::from(receipt_id),
+            "Receipt ID should match the deduplicated receipt"
+        );
+        assert_eq!(
+            receipts[0].available_balance,
+            Shares::from(balance),
+            "Balance should match the on-chain balanceOf response"
+        );
+    }
+
+    /// Verifies that backfill reconciles an already-known receipt's balance
+    /// upward when an inbound transfer increases the on-chain balance.
+    #[tokio::test]
+    async fn backfill_reconciles_known_receipt_balance_upward() {
+        let (receipt_contract, bot_wallet, vault) = test_addresses();
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let (cqrs, store) = setup_cqrs_with_store();
+
+        let receipt_id_raw = U256::from(55);
+        let stale_balance = U256::from(500);
+        let new_on_chain_balance = U256::from(750);
+
+        // Seed aggregate with a receipt at a stale lower balance
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: ReceiptId::from(receipt_id_raw),
+                balance: Shares::from(stale_balance),
+                block_number: 50,
+                tx_hash: b256!(
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Inbound transfer log (someone sent tokens to bot_wallet)
+        let transfer_log = create_transfer_single_log(
+            TransferSingleLogParams {
+                receipt_contract,
+                operator: other_wallet,
+                from: other_wallet,
+                to: bot_wallet,
+                id: receipt_id_raw,
+                value: U256::from(250),
+                tx_hash: b256!(
+                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                block_number: 150,
+            },
+        );
+
+        let asserter = Asserter::new();
+        let current_block = 200u64;
+
+        // eth_blockNumber
+        asserter.push_success(&U256::from(current_block));
+        // eth_getLogs (Deposit filter) — no deposits
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_getLogs (TransferSingle filter) — one inbound transfer
+        asserter.push_success(&vec![transfer_log]);
+        // eth_getLogs (TransferBatch filter) — none
+        asserter.push_success(&Vec::<Log>::new());
+        // eth_call (balanceOf) — returns the new higher balance
+        asserter.push_success(&new_on_chain_balance.to_be_bytes::<32>());
+
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
+            .connect_mocked_client(asserter);
+
+        let backfiller = ReceiptBackfiller::new(
+            provider,
+            receipt_contract,
+            bot_wallet,
+            vault,
+            cqrs,
+        );
+
+        let result = backfiller.backfill_receipts(0).await.unwrap();
+        assert_eq!(result.processed_count, 1);
+
+        // Verify balance was reconciled upward from 500 to 750
+        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let receipts = ctx.aggregate().receipts_with_balance();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(
+            receipts[0].available_balance,
+            Shares::from(new_on_chain_balance),
+            "Backfill should reconcile known receipt balance upward"
+        );
     }
 }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -399,17 +399,7 @@ pub(crate) fn determine_source(
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ReceiptInventoryError {
-    #[error(
-        "Unexpected balance increase for receipt {receipt_id}: \
-         aggregate_balance={aggregate_balance}, on_chain_balance={on_chain_balance}"
-    )]
-    UnexpectedBalanceIncrease {
-        receipt_id: ReceiptId,
-        aggregate_balance: Shares,
-        on_chain_balance: Shares,
-    },
-}
+pub(crate) enum ReceiptInventoryError {}
 
 #[async_trait]
 impl Aggregate for ReceiptInventory {
@@ -463,16 +453,6 @@ impl Aggregate for ReceiptInventory {
                 let aggregate_balance = metadata.balance;
                 if on_chain_balance == aggregate_balance {
                     return Ok(vec![]);
-                }
-
-                if aggregate_balance.checked_sub(on_chain_balance).is_none() {
-                    return Err(
-                        ReceiptInventoryError::UnexpectedBalanceIncrease {
-                            receipt_id,
-                            aggregate_balance,
-                            on_chain_balance,
-                        },
-                    );
                 }
 
                 let reconciled = ReceiptInventoryEvent::BalanceReconciled {
@@ -1522,7 +1502,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_reconcile_increased_balance_returns_error() {
+    async fn test_reconcile_increased_balance_emits_reconciled_event() {
         let mut aggregate = ReceiptInventory::default();
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1545,7 +1525,7 @@ mod tests {
             aggregate.apply(event);
         }
 
-        let result = aggregate
+        let events = aggregate
             .handle(
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
@@ -1553,12 +1533,26 @@ mod tests {
                 },
                 &(),
             )
-            .await;
+            .await
+            .unwrap();
 
+        assert_eq!(events.len(), 1);
         assert!(matches!(
-            result,
-            Err(ReceiptInventoryError::UnexpectedBalanceIncrease { .. })
+            &events[0],
+            ReceiptInventoryEvent::BalanceReconciled {
+                previous_balance,
+                on_chain_balance,
+                ..
+            } if *previous_balance == make_shares(50) && *on_chain_balance == make_shares(100)
         ));
+
+        for event in events {
+            aggregate.apply(event);
+        }
+
+        let receipts = aggregate.receipts_with_balance();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].available_balance, make_shares(100));
     }
 
     #[tokio::test]

--- a/src/receipt_inventory/monitor.rs
+++ b/src/receipt_inventory/monitor.rs
@@ -1,13 +1,13 @@
 use alloy::primitives::{Address, B256, Bytes, TxHash};
 use alloy::providers::Provider;
-use alloy::rpc::types::Log;
+use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
 use cqrs_es::{AggregateError, CqrsFramework, EventStore};
 use futures::StreamExt;
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
@@ -126,41 +126,82 @@ where
         }
     }
 
-    /// Monitors for Deposit and Withdraw events, subscribing and processing them.
+    /// Monitors for Deposit, Withdraw, TransferSingle, and TransferBatch events.
     async fn monitor_once(&self) -> Result<(), ReceiptMonitorError> {
         let vault_contract =
             OffchainAssetReceiptVault::new(self.vault, &self.provider);
 
-        // Subscribe to all Deposit and Withdraw events on the vault.
+        // Subscribe to Deposit and Withdraw events on the vault contract.
         // We filter by owner == bot_wallet client-side since owner is not indexed.
         let deposit_filter = vault_contract.Deposit_filter().filter;
         let withdraw_filter = vault_contract.Withdraw_filter().filter;
 
+        // Subscribe to ERC-1155 TransferSingle and TransferBatch events on
+        // the Receipt contract. These capture direct token transfers that
+        // bypass the vault's deposit/withdraw (e.g., manual receipt transfers).
+        let transfer_single_filter =
+            transfer_single_filter(self.receipt_contract);
+        let transfer_batch_filter =
+            transfer_batch_filter(self.receipt_contract);
+
         info!(
             vault = %self.vault,
+            receipt_contract = %self.receipt_contract,
             bot_wallet = %self.bot_wallet,
-            "Subscribing to Deposit and Withdraw events"
+            "Subscribing to Deposit, Withdraw, TransferSingle, and TransferBatch events"
         );
 
         let deposit_sub = self.provider.subscribe_logs(&deposit_filter).await?;
         let withdraw_sub =
             self.provider.subscribe_logs(&withdraw_filter).await?;
+        let transfer_single_sub =
+            self.provider.subscribe_logs(&transfer_single_filter).await?;
+        let transfer_batch_sub =
+            self.provider.subscribe_logs(&transfer_batch_filter).await?;
 
         let mut deposit_stream = deposit_sub.into_stream();
         let mut withdraw_stream = withdraw_sub.into_stream();
+        let mut transfer_single_stream = transfer_single_sub.into_stream();
+        let mut transfer_batch_stream = transfer_batch_sub.into_stream();
 
         info!("Receipt monitor WebSocket subscription active");
 
         loop {
             tokio::select! {
                 Some(log) = deposit_stream.next() => {
+                    if log.removed {
+                        debug!("Skipping removed Deposit log (reorg)");
+                        continue;
+                    }
                     if let Err(err) = self.process_deposit(&log).await {
                         warn!("Failed to process Deposit: {err}");
                     }
                 }
                 Some(log) = withdraw_stream.next() => {
+                    if log.removed {
+                        debug!("Skipping removed Withdraw log (reorg)");
+                        continue;
+                    }
                     if let Err(err) = self.process_withdraw(&log).await {
                         warn!("Failed to process Withdraw: {err}");
+                    }
+                }
+                Some(log) = transfer_single_stream.next() => {
+                    if log.removed {
+                        debug!("Skipping removed TransferSingle log (reorg)");
+                        continue;
+                    }
+                    if let Err(err) = self.process_transfer_single(&log).await {
+                        warn!("Failed to process TransferSingle: {err}");
+                    }
+                }
+                Some(log) = transfer_batch_stream.next() => {
+                    if log.removed {
+                        debug!("Skipping removed TransferBatch log (reorg)");
+                        continue;
+                    }
+                    if let Err(err) = self.process_transfer_batch(&log).await {
+                        warn!("Failed to process TransferBatch: {err}");
                     }
                 }
                 else => {
@@ -256,6 +297,149 @@ where
         Ok(())
     }
 
+    /// Processes a TransferSingle event (ERC-1155 single token transfer).
+    ///
+    /// Handles both inbound transfers (to == bot_wallet, discovers receipt)
+    /// and outbound transfers (from == bot_wallet, reconciles balance).
+    /// Mint/burn transfers (from/to == address(0)) are skipped since those
+    /// are already handled by Deposit/Withdraw events.
+    async fn process_transfer_single(
+        &self,
+        log: &Log,
+    ) -> Result<(), ReceiptMonitorError> {
+        let event = Receipt::TransferSingle::decode_log(&log.inner)?;
+        let tx_hash =
+            log.transaction_hash.ok_or(ReceiptMonitorError::MissingTxHash)?;
+
+        // Skip mint/burn transfers — already covered by Deposit/Withdraw
+        if event.from.is_zero() || event.to.is_zero() {
+            return Ok(());
+        }
+
+        let receipt_id = ReceiptId::from(event.id);
+
+        if event.to == self.bot_wallet {
+            debug!(
+                receipt_id = %receipt_id,
+                from = %event.from,
+                value = %event.value,
+                "Inbound TransferSingle detected"
+            );
+
+            let block_number = log
+                .block_number
+                .ok_or(ReceiptMonitorError::MissingBlockNumber)?;
+
+            self.discover_receipt_if_has_balance(
+                receipt_id,
+                tx_hash,
+                block_number,
+                Bytes::new(),
+            )
+            .await?;
+        } else if event.from == self.bot_wallet {
+            debug!(
+                receipt_id = %receipt_id,
+                to = %event.to,
+                value = %event.value,
+                "Outbound TransferSingle detected"
+            );
+
+            self.reconcile_receipt(receipt_id).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Processes a TransferBatch event (ERC-1155 batch token transfer).
+    ///
+    /// Each (id, value) pair in the batch is handled identically to a
+    /// TransferSingle event.
+    async fn process_transfer_batch(
+        &self,
+        log: &Log,
+    ) -> Result<(), ReceiptMonitorError> {
+        let event = Receipt::TransferBatch::decode_log(&log.inner)?;
+
+        // Skip mint/burn transfers — already covered by Deposit/Withdraw
+        if event.from.is_zero() || event.to.is_zero() {
+            return Ok(());
+        }
+
+        let tx_hash =
+            log.transaction_hash.ok_or(ReceiptMonitorError::MissingTxHash)?;
+
+        if event.to == self.bot_wallet {
+            let block_number = log
+                .block_number
+                .ok_or(ReceiptMonitorError::MissingBlockNumber)?;
+
+            for receipt_id_raw in &event.ids {
+                let receipt_id = ReceiptId::from(*receipt_id_raw);
+
+                debug!(
+                    receipt_id = %receipt_id,
+                    from = %event.from,
+                    "Inbound TransferBatch item detected"
+                );
+
+                self.discover_receipt_if_has_balance(
+                    receipt_id,
+                    tx_hash,
+                    block_number,
+                    Bytes::new(),
+                )
+                .await?;
+            }
+        } else if event.from == self.bot_wallet {
+            for receipt_id_raw in &event.ids {
+                let receipt_id = ReceiptId::from(*receipt_id_raw);
+
+                debug!(
+                    receipt_id = %receipt_id,
+                    to = %event.to,
+                    "Outbound TransferBatch item detected"
+                );
+
+                self.reconcile_receipt(receipt_id).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Queries the on-chain balance of a receipt and reconciles the aggregate.
+    async fn reconcile_receipt(
+        &self,
+        receipt_id: ReceiptId,
+    ) -> Result<(), ReceiptMonitorError> {
+        let receipt_contract =
+            Receipt::new(self.receipt_contract, &self.provider);
+
+        let on_chain_balance = receipt_contract
+            .balanceOf(self.bot_wallet, receipt_id.inner())
+            .call()
+            .await?;
+
+        self.cqrs
+            .execute(
+                &self.vault.to_string(),
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id,
+                    on_chain_balance: Shares::from(on_chain_balance),
+                },
+            )
+            .await?;
+
+        debug!(
+            receipt_id = %receipt_id,
+            on_chain_balance = %on_chain_balance,
+            "Receipt balance reconciled after transfer"
+        );
+
+        Ok(())
+    }
+
     /// Checks on-chain balance and emits DiscoverReceipt if balance > 0.
     async fn discover_receipt_if_has_balance(
         &self,
@@ -305,10 +489,23 @@ where
             )
             .await?;
 
+        // For already-known receipts, DiscoverReceipt is a no-op. Reconcile
+        // ensures the aggregate reflects the current on-chain balance (e.g.,
+        // after an inbound transfer increases the balance).
+        self.cqrs
+            .execute(
+                &self.vault.to_string(),
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id,
+                    on_chain_balance: Shares::from(current_balance),
+                },
+            )
+            .await?;
+
         info!(
             receipt_id = %receipt_id,
             balance = %current_balance,
-            "Receipt discovered via live monitoring"
+            "Receipt discovered or reconciled via live monitoring"
         );
 
         if let ReceiptSource::Itn { issuer_request_id } = source {
@@ -319,6 +516,20 @@ where
 
         Ok(())
     }
+}
+
+/// Builds a log filter for ERC-1155 TransferSingle events on the given contract.
+pub(crate) fn transfer_single_filter(receipt_contract: Address) -> Filter {
+    Filter::new()
+        .address(receipt_contract)
+        .event_signature(Receipt::TransferSingle::SIGNATURE_HASH)
+}
+
+/// Builds a log filter for ERC-1155 TransferBatch events on the given contract.
+pub(crate) fn transfer_batch_filter(receipt_contract: Address) -> Filter {
+    Filter::new()
+        .address(receipt_contract)
+        .event_signature(Receipt::TransferBatch::SIGNATURE_HASH)
 }
 
 #[cfg(test)]
@@ -341,6 +552,14 @@ mod tests {
         let store = Arc::new(MemStore::default());
         let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
         (cqrs, store)
+    }
+
+    /// Sets up Anvil vault roles and certifies for deposits. Call once
+    /// per LocalEvm instance before calling `mint_directly`.
+    async fn setup_vault_for_deposits(evm: &LocalEvm) {
+        evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+        evm.grant_certify_role(evm.wallet_address).await.unwrap();
+        evm.certify_vault(U256::MAX).await.unwrap();
     }
 
     struct VaultEventLogParams {
@@ -542,6 +761,14 @@ mod tests {
         let receipts = context.aggregate().receipts_with_balance();
 
         assert_eq!(receipts.len(), 1);
+        assert_eq!(
+            receipts[0].receipt_id, receipt_id,
+            "Should still be the same receipt after duplicate discover"
+        );
+        assert_eq!(
+            receipts[0].available_balance, balance,
+            "Balance should be unchanged after duplicate discover"
+        );
     }
 
     fn create_withdraw_log(params: VaultEventLogParams) -> RpcLog {
@@ -607,6 +834,21 @@ mod tests {
         )
         .await
         .unwrap();
+
+        // Verify the receipt exists with stale balance BEFORE processing
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts_before = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts_before.len(),
+            1,
+            "Should have one receipt before withdraw"
+        );
+        assert_eq!(receipts_before[0].receipt_id, receipt_id);
+        assert_eq!(
+            receipts_before[0].available_balance, stale_balance,
+            "Balance should be 100e18 before withdraw"
+        );
 
         let config = ReceiptMonitorConfig {
             vault: evm.vault_address,
@@ -741,5 +983,798 @@ mod tests {
             _tx_hash: TxHash,
         ) {
         }
+    }
+
+    #[derive(Clone, Copy)]
+    struct TransferSingleLogParams {
+        receipt_contract: Address,
+        operator: Address,
+        from: Address,
+        to: Address,
+        id: U256,
+        value: U256,
+        tx_hash: B256,
+        block_number: u64,
+    }
+
+    fn create_transfer_single_log(params: TransferSingleLogParams) -> RpcLog {
+        let event = Receipt::TransferSingle {
+            operator: params.operator,
+            from: params.from,
+            to: params.to,
+            id: params.id,
+            value: params.value,
+        };
+
+        RpcLog {
+            inner: alloy::primitives::Log {
+                address: params.receipt_contract,
+                data: event.encode_log_data(),
+            },
+            block_hash: Some(b256!(
+                "0x0000000000000000000000000000000000000000000000000000000000000001"
+            )),
+            block_number: Some(params.block_number),
+            block_timestamp: None,
+            transaction_hash: Some(params.tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }
+    }
+
+    struct TransferBatchLogParams {
+        receipt_contract: Address,
+        operator: Address,
+        from: Address,
+        to: Address,
+        ids: Vec<U256>,
+        values: Vec<U256>,
+        tx_hash: B256,
+        block_number: u64,
+    }
+
+    fn create_transfer_batch_log(params: TransferBatchLogParams) -> RpcLog {
+        let event = Receipt::TransferBatch {
+            operator: params.operator,
+            from: params.from,
+            to: params.to,
+            ids: params.ids,
+            values: params.values,
+        };
+
+        RpcLog {
+            inner: alloy::primitives::Log {
+                address: params.receipt_contract,
+                data: event.encode_log_data(),
+            },
+            block_hash: Some(b256!(
+                "0x0000000000000000000000000000000000000000000000000000000000000001"
+            )),
+            block_number: Some(params.block_number),
+            block_timestamp: None,
+            transaction_hash: Some(params.tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_inbound_transfer_single_discovers_receipt() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+
+        // Do a real deposit on Anvil so balanceOf returns a non-zero value
+        let deposit_amount = uint!(75_000000000000000000_U256);
+        setup_vault_for_deposits(&evm).await;
+        let (receipt_id_raw, minted_shares) =
+            evm.mint_directly(deposit_amount, bot_wallet).await.unwrap();
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        // Inventory should be empty before processing the transfer
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        assert!(
+            context.aggregate().receipts_with_balance().is_empty(),
+            "Inventory should be empty before inbound transfer"
+        );
+
+        // Simulate an inbound transfer from other_wallet to bot_wallet
+        let transfer_log = create_transfer_single_log(
+            TransferSingleLogParams {
+                receipt_contract,
+                operator: other_wallet,
+                from: other_wallet,
+                to: bot_wallet,
+                id: receipt_id_raw,
+                value: minted_shares,
+                tx_hash: b256!(
+                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                block_number: 100,
+            },
+        );
+
+        monitor.process_transfer_single(&transfer_log).await.unwrap();
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Inbound TransferSingle detected"]
+        ));
+
+        // Verify: receipt was discovered with the exact on-chain balance
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(receipts.len(), 1, "Should discover exactly one receipt");
+        assert_eq!(
+            receipts[0].receipt_id,
+            ReceiptId::from(receipt_id_raw),
+            "Discovered receipt ID should match the deposited receipt"
+        );
+        assert_eq!(
+            receipts[0].available_balance,
+            Shares::from(minted_shares),
+            "Discovered balance should match the on-chain balance"
+        );
+        assert!(
+            receipts[0].receipt_info.is_none(),
+            "Transfer-discovered receipts should have no parsed receipt info"
+        );
+        assert!(
+            receipts[0].receipt_info_bytes.is_none(),
+            "Transfer-discovered receipts should have no raw receipt info bytes"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_outbound_transfer_single_reconciles_balance() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        // Seed aggregate with a receipt that has stale balance (never
+        // actually minted on-chain, so balanceOf will return 0)
+        let receipt_id = ReceiptId::from(uint!(0xab_U256));
+        let stale_balance = Shares::from(uint!(200_000000000000000000_U256));
+
+        cqrs.execute(
+            &evm.vault_address.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id,
+                balance: stale_balance,
+                block_number: 1,
+                tx_hash: b256!(
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Verify the aggregate has the receipt with stale balance BEFORE processing
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts_before = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts_before.len(),
+            1,
+            "Should have one receipt before outbound transfer"
+        );
+        assert_eq!(receipts_before[0].receipt_id, receipt_id);
+        assert_eq!(
+            receipts_before[0].available_balance, stale_balance,
+            "Balance should be 200e18 before outbound transfer"
+        );
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        let transfer_log = create_transfer_single_log(
+            TransferSingleLogParams {
+                receipt_contract,
+                operator: bot_wallet,
+                from: bot_wallet,
+                to: other_wallet,
+                id: uint!(0xab_U256),
+                value: uint!(200_000000000000000000_U256),
+                tx_hash: b256!(
+                    "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+                ),
+                block_number: 200,
+            },
+        );
+
+        monitor.process_transfer_single(&transfer_log).await.unwrap();
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Outbound TransferSingle detected", "receipt_id=171"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Receipt balance reconciled after transfer",
+                "on_chain_balance=0"
+            ]
+        ));
+
+        // On-chain balance is 0 (never minted on Anvil), so reconciliation
+        // should deplete the receipt from 200e18 → 0
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts_after = context.aggregate().receipts_with_balance();
+        assert!(
+            receipts_after.is_empty(),
+            "Receipt should be depleted (balance 200e18 → 0) after outbound transfer reconciliation"
+        );
+    }
+
+    /// Verifies the outbound-then-inbound scenario: a receipt that was
+    /// reconciled downward after an outbound transfer gets its balance
+    /// restored when an inbound transfer arrives for the same receipt ID.
+    #[tokio::test]
+    async fn test_inbound_transfer_reconciles_balance_upward_for_known_receipt()
+    {
+        let (cqrs, store) = setup_test_cqrs();
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let receipt_id = ReceiptId::from(uint!(42_U256));
+
+        // 1. Discover receipt with balance 100
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id,
+                balance: Shares::from(uint!(100_U256)),
+                block_number: 1,
+                tx_hash: b256!(
+                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // 2. Reconcile down to 50 (simulating outbound transfer)
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id,
+                on_chain_balance: Shares::from(uint!(50_U256)),
+            },
+        )
+        .await
+        .unwrap();
+
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert_eq!(
+            context.aggregate().receipts_with_balance()[0].available_balance,
+            Shares::from(uint!(50_U256)),
+        );
+
+        // 3. Simulate inbound transfer: DiscoverReceipt is no-op (known),
+        //    then ReconcileBalance updates balance upward to 80
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id,
+                balance: Shares::from(uint!(80_U256)),
+                block_number: 2,
+                tx_hash: b256!(
+                    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id,
+                on_chain_balance: Shares::from(uint!(80_U256)),
+            },
+        )
+        .await
+        .unwrap();
+
+        // 4. Verify balance is now 80 and receipt ID is unchanged
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(receipts.len(), 1);
+        assert_eq!(receipts[0].receipt_id, receipt_id);
+        assert_eq!(
+            receipts[0].available_balance,
+            Shares::from(uint!(80_U256)),
+            "Balance should be reconciled upward after inbound transfer"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_transfer_single_skips_mint_transfers() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        // Seed a pre-existing receipt to verify it's unmodified after processing
+        let existing_receipt_id = ReceiptId::from(uint!(99_U256));
+        let existing_balance = Shares::from(uint!(500_U256));
+        cqrs.execute(
+            &evm.vault_address.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: existing_receipt_id,
+                balance: existing_balance,
+                block_number: 1,
+                tx_hash: b256!(
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        // Mint transfer: from == address(0) — should be skipped
+        let mint_log = create_transfer_single_log(TransferSingleLogParams {
+            receipt_contract,
+            operator: bot_wallet,
+            from: Address::ZERO,
+            to: bot_wallet,
+            id: uint!(1_U256),
+            value: uint!(100_U256),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 100,
+        });
+
+        monitor.process_transfer_single(&mint_log).await.unwrap();
+
+        // Verify: only the pre-existing receipt remains, unchanged
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "Mint transfer (from == 0) should not add new receipts"
+        );
+        assert_eq!(receipts[0].receipt_id, existing_receipt_id);
+        assert_eq!(
+            receipts[0].available_balance, existing_balance,
+            "Pre-existing receipt balance should be unchanged"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_transfer_single_skips_burn_transfers() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        // Seed a pre-existing receipt to verify it's unmodified after processing
+        let existing_receipt_id = ReceiptId::from(uint!(99_U256));
+        let existing_balance = Shares::from(uint!(500_U256));
+        cqrs.execute(
+            &evm.vault_address.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: existing_receipt_id,
+                balance: existing_balance,
+                block_number: 1,
+                tx_hash: b256!(
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        // Burn transfer: to == address(0) — should be skipped
+        let burn_log = create_transfer_single_log(TransferSingleLogParams {
+            receipt_contract,
+            operator: bot_wallet,
+            from: bot_wallet,
+            to: Address::ZERO,
+            id: uint!(1_U256),
+            value: uint!(100_U256),
+            tx_hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            block_number: 200,
+        });
+
+        monitor.process_transfer_single(&burn_log).await.unwrap();
+
+        // Verify: only the pre-existing receipt remains, unchanged
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "Burn transfer (to == 0) should not affect inventory"
+        );
+        assert_eq!(receipts[0].receipt_id, existing_receipt_id);
+        assert_eq!(
+            receipts[0].available_balance, existing_balance,
+            "Pre-existing receipt balance should be unchanged"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_inbound_transfer_batch_discovers_receipts() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+
+        // Do three real deposits on Anvil so balanceOf returns non-zero
+        // for each receipt ID (contract auto-assigns receipt IDs sequentially)
+        let deposit_amounts = [
+            uint!(100_000000000000000000_U256),
+            uint!(200_000000000000000000_U256),
+            uint!(300_000000000000000000_U256),
+        ];
+
+        setup_vault_for_deposits(&evm).await;
+
+        let mut deposits = Vec::new();
+        for amount in &deposit_amounts {
+            let (receipt_id, shares) =
+                evm.mint_directly(*amount, bot_wallet).await.unwrap();
+            deposits.push((receipt_id, shares));
+        }
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        let batch_log = create_transfer_batch_log(TransferBatchLogParams {
+            receipt_contract,
+            operator: other_wallet,
+            from: other_wallet,
+            to: bot_wallet,
+            ids: deposits.iter().map(|(id, _)| *id).collect(),
+            values: deposits.iter().map(|(_, shares)| *shares).collect(),
+            tx_hash: b256!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            ),
+            block_number: 300,
+        });
+
+        monitor.process_transfer_batch(&batch_log).await.unwrap();
+
+        // Verify log output for each batch item
+        for (receipt_id, _) in &deposits {
+            assert!(
+                logs_contain_at!(
+                    tracing::Level::DEBUG,
+                    &[
+                        "Inbound TransferBatch item detected",
+                        &format!("receipt_id={receipt_id}")
+                    ]
+                ),
+                "Should log inbound batch detection for receipt {receipt_id}",
+            );
+        }
+
+        // Verify: all three receipts discovered with exact on-chain balances
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(receipts.len(), 3, "Should discover all 3 batch receipts");
+
+        for (receipt_id, minted_shares) in &deposits {
+            let receipt = receipts
+                .iter()
+                .find(|r| r.receipt_id == ReceiptId::from(*receipt_id))
+                .unwrap_or_else(|| {
+                    panic!("Receipt {receipt_id} not found in inventory")
+                });
+            assert_eq!(
+                receipt.available_balance,
+                Shares::from(*minted_shares),
+                "Balance for receipt {receipt_id} should match on-chain deposit",
+            );
+            assert!(
+                receipt.receipt_info.is_none(),
+                "Transfer-discovered receipt {receipt_id} should have no parsed receipt info"
+            );
+            assert!(
+                receipt.receipt_info_bytes.is_none(),
+                "Transfer-discovered receipt {receipt_id} should have no raw receipt info bytes"
+            );
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_outbound_transfer_batch_reconciles_balances() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        // Seed aggregate with two receipts (never minted on-chain, so
+        // balanceOf will return 0 for both — simulating full outbound transfer)
+        let stale_balance = Shares::from(uint!(100_000000000000000000_U256));
+        let receipt_ids = [uint!(30_U256), uint!(31_U256)];
+
+        for receipt_id_raw in &receipt_ids {
+            cqrs.execute(
+                &evm.vault_address.to_string(),
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(*receipt_id_raw),
+                    balance: stale_balance,
+                    block_number: 1,
+                    tx_hash: b256!(
+                        "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    ),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        // Verify both receipts exist with expected balances BEFORE processing
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts_before = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts_before.len(),
+            2,
+            "Should have 2 receipts before outbound batch"
+        );
+        for receipt_id_raw in &receipt_ids {
+            let receipt = receipts_before
+                .iter()
+                .find(|r| r.receipt_id == ReceiptId::from(*receipt_id_raw))
+                .unwrap_or_else(|| {
+                    panic!("Receipt {receipt_id_raw} not found before outbound transfer")
+                });
+            assert_eq!(
+                receipt.available_balance, stale_balance,
+                "Receipt {receipt_id_raw} should have balance 100e18 before outbound transfer"
+            );
+        }
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        let batch_log = create_transfer_batch_log(TransferBatchLogParams {
+            receipt_contract,
+            operator: bot_wallet,
+            from: bot_wallet,
+            to: other_wallet,
+            ids: receipt_ids.to_vec(),
+            values: vec![
+                uint!(100_000000000000000000_U256),
+                uint!(100_000000000000000000_U256),
+            ],
+            tx_hash: b256!(
+                "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+            ),
+            block_number: 400,
+        });
+
+        monitor.process_transfer_batch(&batch_log).await.unwrap();
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Outbound TransferBatch item detected", "receipt_id=30"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Outbound TransferBatch item detected", "receipt_id=31"]
+        ));
+
+        // On-chain balance is 0 for both (never minted on Anvil), so
+        // reconciliation should deplete both from 100e18 → 0
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts_after = context.aggregate().receipts_with_balance();
+        assert!(
+            receipts_after.is_empty(),
+            "Both receipts should be depleted (100e18 → 0) after outbound batch transfer"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_transfer_single_ignores_unrelated_wallets() {
+        let evm = LocalEvm::new().await.unwrap();
+        let (cqrs, store) = setup_test_cqrs();
+        let bot_wallet = evm.wallet_address;
+        let wallet_a = address!("0x3333333333333333333333333333333333333333");
+        let wallet_b = address!("0x4444444444444444444444444444444444444444");
+
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let vault_contract =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+        let receipt_contract =
+            Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+        // Seed a pre-existing receipt to verify it's unmodified
+        let existing_receipt_id = ReceiptId::from(uint!(77_U256));
+        let existing_balance = Shares::from(uint!(250_U256));
+        cqrs.execute(
+            &evm.vault_address.to_string(),
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: existing_receipt_id,
+                balance: existing_balance,
+                block_number: 1,
+                tx_hash: b256!(
+                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                ),
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let config = ReceiptMonitorConfig {
+            vault: evm.vault_address,
+            receipt_contract,
+            bot_wallet,
+        };
+
+        let monitor =
+            ReceiptMonitor::new(provider, config, cqrs.clone(), NoOpHandler);
+
+        // Transfer between two wallets that are NOT the bot wallet
+        let log = create_transfer_single_log(TransferSingleLogParams {
+            receipt_contract,
+            operator: wallet_a,
+            from: wallet_a,
+            to: wallet_b,
+            id: uint!(1_U256),
+            value: uint!(100_U256),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 100,
+        });
+
+        monitor.process_transfer_single(&log).await.unwrap();
+
+        // Verify: pre-existing receipt is untouched, no new receipts added
+        let context =
+            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
+        let receipts = context.aggregate().receipts_with_balance();
+        assert_eq!(
+            receipts.len(),
+            1,
+            "Unrelated transfer should not add or remove receipts"
+        );
+        assert_eq!(receipts[0].receipt_id, existing_receipt_id);
+        assert_eq!(
+            receipts[0].available_balance, existing_balance,
+            "Pre-existing receipt balance should be unchanged after unrelated transfer"
+        );
     }
 }

--- a/src/vault/rain_meta.rs
+++ b/src/vault/rain_meta.rs
@@ -268,8 +268,8 @@ fn inflate(data: &[u8]) -> Result<Vec<u8>, RainMetaError> {
 /// Transient failures are NOT cached, allowing retries on subsequent calls.
 pub(crate) struct OaSchemaCache {
     mode: OaSchemaCacheMode,
-    /// `Some(hash)` = successfully fetched, `None` = vault has no schema
-    /// (permanently cached). Absent key = not yet fetched or last fetch failed.
+    /// Only positive results (`Some(hash)`) are cached. Absent key means not
+    /// yet fetched, last fetch failed, or vault had no schema (all retried).
     cache: Arc<RwLock<HashMap<Address, Option<String>>>>,
 }
 

--- a/tests/receipt_transfer.rs
+++ b/tests/receipt_transfer.rs
@@ -1,0 +1,872 @@
+#![allow(clippy::unwrap_used)]
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, Bytes, U256, b256};
+use alloy::providers::ProviderBuilder;
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+use rocket::local::asynchronous::Client;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::time::Duration;
+
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::bindings::Receipt::ReceiptInstance;
+use st0x_issuance::initialize_rocket;
+use st0x_issuance::test_utils::LocalEvm;
+
+/// Helper: set up a second wallet from Anvil's test accounts (account index 1).
+fn second_wallet() -> (PrivateKeySigner, Address) {
+    let signer = PrivateKeySigner::from_bytes(&b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    ))
+    .unwrap();
+    let addr = signer.address();
+    (signer, addr)
+}
+
+/// Helper: set up a third wallet from Anvil's test accounts (account index 2).
+fn third_wallet() -> (PrivateKeySigner, Address) {
+    let signer = PrivateKeySigner::from_bytes(&b256!(
+        "0x5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a"
+    ))
+    .unwrap();
+    let addr = signer.address();
+    (signer, addr)
+}
+
+/// Helper: query the events table for ReceiptInventory events.
+async fn receipt_events(db_url: &str) -> Vec<(String, String)> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(db_url)
+        .await
+        .unwrap();
+
+    sqlx::query_as(
+        "SELECT event_type, payload FROM events \
+         WHERE aggregate_type = 'ReceiptInventory' \
+         ORDER BY sequence",
+    )
+    .fetch_all(&pool)
+    .await
+    .unwrap()
+}
+
+/// Happy path: An ERC-1155 receipt transferred TO the bot wallet via
+/// `safeTransferFrom` is discovered by the live monitor.
+///
+/// 1. Mint a receipt to a second wallet (not bot) — bot has 0 balance
+/// 2. Start the service (backfill finds nothing for this receipt)
+/// 3. Second wallet transfers the receipt to bot wallet via safeTransferFrom
+/// 4. Monitor detects TransferSingle → discovers receipt with on-chain balance
+#[tokio::test]
+async fn test_inbound_receipt_transfer_discovered_by_monitor()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+    let (other_signer, other_wallet) = second_wallet();
+
+    // Grant roles: other_wallet needs DEPOSIT to mint directly
+    evm.grant_deposit_role(other_wallet).await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Mint a receipt to other_wallet (not bot)
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(75) * one_share;
+
+    // We need to mint as other_wallet, so use their provider
+    let other_evm_wallet = EthereumWallet::from(other_signer.clone());
+    let other_provider = ProviderBuilder::new()
+        .wallet(other_evm_wallet.clone())
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &other_provider,
+    );
+
+    let share_ratio = U256::from(10).pow(U256::from(18));
+    let tx_receipt = vault
+        .deposit(amount, other_wallet, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Extract receipt_id from Deposit event
+    let deposit_event = tx_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            log.log_decode::<st0x_issuance::bindings::OffchainAssetReceiptVault::Deposit>()
+                .ok()
+                .map(|d| d.inner)
+        })
+        .expect("Deposit event emitted");
+    let receipt_id = deposit_event.id;
+
+    // Get receipt contract address
+    let receipt_contract_addr = Address::from(vault.receipt().call().await?.0);
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &other_provider);
+
+    // Verify: other_wallet has the receipt, bot has 0
+    let other_balance =
+        receipt_contract.balanceOf(other_wallet, receipt_id).call().await?;
+    assert_eq!(
+        other_balance, deposit_event.shares,
+        "other_wallet should hold the minted shares"
+    );
+    let bot_balance_before =
+        receipt_contract.balanceOf(bot_wallet, receipt_id).call().await?;
+    assert_eq!(
+        bot_balance_before,
+        U256::ZERO,
+        "bot should have 0 before transfer"
+    );
+
+    // Setup mocks and database
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_inbound_transfer.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Start service — backfill runs, bot has no receipts yet
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = Client::tracked(rocket).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Transfer receipt from other_wallet to bot_wallet via ERC-1155 safeTransferFrom
+    receipt_contract
+        .safeTransferFrom(
+            other_wallet,
+            bot_wallet,
+            receipt_id,
+            other_balance,
+            Bytes::new(),
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Give monitor time to detect TransferSingle and process
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify: receipt was discovered in the event store
+    let events = receipt_events(&db_url).await;
+    let discovered =
+        events.iter().filter(|(t, _)| t.contains("Discovered")).count();
+
+    assert_eq!(
+        discovered,
+        1,
+        "Inbound transfer should trigger exactly 1 receipt discovery. Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    // Verify on-chain: bot now holds the receipt
+    let bot_balance_after =
+        receipt_contract.balanceOf(bot_wallet, receipt_id).call().await?;
+    assert_eq!(bot_balance_after, other_balance);
+
+    Ok(())
+}
+
+/// Happy path: An ERC-1155 receipt transferred OUT of the bot wallet is
+/// detected by the live monitor, and the receipt inventory is reconciled.
+///
+/// 1. Mint a receipt to bot wallet
+/// 2. Start service (backfill discovers the receipt)
+/// 3. Bot transfers the receipt to another wallet via safeTransferFrom
+/// 4. Monitor detects outbound TransferSingle → reconciles balance to 0
+/// 5. Receipt is depleted in aggregate
+#[tokio::test]
+async fn test_outbound_receipt_transfer_reconciles_balance()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+    let (_other_signer, other_wallet) = second_wallet();
+
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Mint a receipt to bot wallet BEFORE service starts
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(60) * one_share;
+    let (receipt_id, _shares) = evm.mint_directly(amount, bot_wallet).await?;
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_outbound_transfer.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Start service — backfill discovers the receipt
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = Client::tracked(rocket).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Verify receipt was discovered by backfill
+    let events_before = receipt_events(&db_url).await;
+    let discovered_before =
+        events_before.iter().filter(|(t, _)| t.contains("Discovered")).count();
+    assert_eq!(
+        discovered_before, 1,
+        "Backfill should discover exactly 1 receipt"
+    );
+
+    // Bot transfers the receipt out to other_wallet
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    let bot_evm_wallet = EthereumWallet::from(bot_signer);
+    let bot_provider = ProviderBuilder::new()
+        .wallet(bot_evm_wallet)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let receipt_contract_addr = {
+        let vault = OffchainAssetReceiptVaultInstance::new(
+            evm.vault_address,
+            &bot_provider,
+        );
+        Address::from(vault.receipt().call().await?.0)
+    };
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &bot_provider);
+
+    let bot_balance =
+        receipt_contract.balanceOf(bot_wallet, receipt_id).call().await?;
+
+    receipt_contract
+        .safeTransferFrom(
+            bot_wallet,
+            other_wallet,
+            receipt_id,
+            bot_balance,
+            Bytes::new(),
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Give monitor time to detect outbound TransferSingle and reconcile
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify: balance was reconciled (should see BalanceReconciled + Depleted events)
+    let events_after = receipt_events(&db_url).await;
+    let reconciled = events_after
+        .iter()
+        .filter(|(t, _)| t.contains("BalanceReconciled"))
+        .count();
+    let depleted =
+        events_after.iter().filter(|(t, _)| t.contains("Depleted")).count();
+
+    assert_eq!(
+        reconciled,
+        1,
+        "Outbound transfer should trigger exactly 1 BalanceReconciled. Events: {:?}",
+        events_after.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        depleted,
+        1,
+        "Full outbound transfer should trigger exactly 1 Depleted. Events: {:?}",
+        events_after.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    // Verify on-chain: bot has 0 balance for this receipt
+    let bot_balance_after =
+        receipt_contract.balanceOf(bot_wallet, receipt_id).call().await?;
+    assert_eq!(bot_balance_after, U256::ZERO);
+
+    Ok(())
+}
+
+/// Unhappy path (filtered correctly): Mint transfers (from == address(0))
+/// should NOT trigger duplicate discovery — they are already covered by
+/// Deposit event handling.
+///
+/// 1. Start the service
+/// 2. Mint a receipt to bot wallet (emits both Deposit AND TransferSingle with from=0)
+/// 3. Verify only ONE Discovered event (from Deposit handler, not double-counted)
+#[tokio::test]
+async fn test_mint_transfer_not_double_counted()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_no_double_count.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Start service FIRST, then mint (so live monitor processes the events)
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = Client::tracked(rocket).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Mint while service is running — emits Deposit + TransferSingle(from=0x0)
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(25) * one_share;
+    let (receipt_id, shares) = evm.mint_directly(amount, bot_wallet).await?;
+
+    // Give monitor time to process both events
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify: exactly 1 Discovered event (not 2 from double-counting)
+    let events = receipt_events(&db_url).await;
+    let discovered =
+        events.iter().filter(|(t, _)| t.contains("Discovered")).count();
+
+    assert_eq!(
+        discovered,
+        1,
+        "Mint should produce exactly 1 Discovered event (TransferSingle from 0x0 filtered). \
+         Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    // Verify on-chain: bot holds the minted receipt with expected balance
+    let provider = ProviderBuilder::new().connect(&evm.endpoint).await?;
+    let vault_contract =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
+    let receipt_contract_addr =
+        Address::from(vault_contract.receipt().call().await?.0);
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &provider);
+    let bot_balance =
+        receipt_contract.balanceOf(bot_wallet, receipt_id).call().await?;
+    assert_eq!(
+        bot_balance, shares,
+        "Bot should hold the minted shares for the receipt"
+    );
+
+    Ok(())
+}
+
+/// Happy path: Inbound transfer to bot wallet is discovered during backfill
+/// (not just live monitoring).
+///
+/// 1. Mint receipt to other_wallet, transfer to bot_wallet — all BEFORE service starts
+/// 2. Start service — backfill scans TransferSingle events, discovers the receipt
+/// 3. Verify the receipt appears in the event store
+#[tokio::test]
+async fn test_inbound_transfer_discovered_by_backfill()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+    let (other_signer, other_wallet) = second_wallet();
+
+    evm.grant_deposit_role(other_wallet).await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Mint as other_wallet
+    let other_evm_wallet = EthereumWallet::from(other_signer.clone());
+    let other_provider = ProviderBuilder::new()
+        .wallet(other_evm_wallet)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &other_provider,
+    );
+
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(40) * one_share;
+    let share_ratio = U256::from(10).pow(U256::from(18));
+
+    let tx_receipt = vault
+        .deposit(amount, other_wallet, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let deposit_event = tx_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            log.log_decode::<st0x_issuance::bindings::OffchainAssetReceiptVault::Deposit>()
+                .ok()
+                .map(|d| d.inner)
+        })
+        .expect("Deposit event");
+    let receipt_id = deposit_event.id;
+
+    // Transfer receipt to bot_wallet BEFORE service starts
+    let receipt_contract_addr = Address::from(vault.receipt().call().await?.0);
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &other_provider);
+
+    let balance =
+        receipt_contract.balanceOf(other_wallet, receipt_id).call().await?;
+
+    receipt_contract
+        .safeTransferFrom(
+            other_wallet,
+            bot_wallet,
+            receipt_id,
+            balance,
+            Bytes::new(),
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Now start the service — backfill should discover the receipt
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_backfill_transfer.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let _rocket = initialize_rocket(config).await?;
+
+    // Give backfill time
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Verify: receipt was discovered
+    let events = receipt_events(&db_url).await;
+    let discovered =
+        events.iter().filter(|(t, _)| t.contains("Discovered")).count();
+
+    assert_eq!(
+        discovered,
+        1,
+        "Backfill should discover exactly 1 receipt transferred to bot wallet. Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Unhappy path (filtered correctly): Burn transfers (to == address(0))
+/// should NOT trigger duplicate reconciliation — they are already covered
+/// by the Withdraw event handler.
+///
+/// 1. Mint receipt to bot wallet BEFORE service starts
+/// 2. Start service (backfill discovers receipt)
+/// 3. Bot burns the receipt via withdraw() — emits Withdraw + TransferSingle(to=0x0)
+/// 4. Verify exactly 1 BalanceReconciled event (from Withdraw, not double-counted)
+#[tokio::test]
+async fn test_burn_transfer_not_double_reconciled()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Mint receipt to bot wallet BEFORE service starts
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(30) * one_share;
+    let (receipt_id, shares) = evm.mint_directly(amount, bot_wallet).await?;
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_burn_no_double.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Start service — backfill discovers the receipt
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = Client::tracked(rocket).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Burn the receipt via withdraw — emits Withdraw AND TransferSingle(to=0x0)
+    evm.withdraw_directly(receipt_id, shares, bot_wallet).await?;
+
+    // Give monitor time to process both events
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify: exactly 1 BalanceReconciled and 1 Depleted (from Withdraw handler only)
+    let events = receipt_events(&db_url).await;
+    let reconciled =
+        events.iter().filter(|(t, _)| t.contains("BalanceReconciled")).count();
+    let depleted =
+        events.iter().filter(|(t, _)| t.contains("Depleted")).count();
+
+    assert_eq!(
+        reconciled,
+        1,
+        "Burn should produce exactly 1 BalanceReconciled (TransferSingle to 0x0 filtered). \
+         Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        depleted,
+        1,
+        "Full burn should produce exactly 1 Depleted event. Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Unhappy path: Transfer between two unrelated wallets (neither is bot)
+/// should not produce any inventory changes.
+///
+/// 1. Mint receipt to wallet A
+/// 2. Start service
+/// 3. Wallet A transfers receipt to wallet B (neither is bot_wallet)
+/// 4. Verify: no Discovered events for that receipt ID
+#[tokio::test]
+async fn test_unrelated_transfer_ignored()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+    let (wallet_a_signer, wallet_a) = second_wallet();
+    let (_wallet_b_signer, wallet_b) = third_wallet();
+
+    evm.grant_deposit_role(wallet_a).await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Mint receipt to wallet_a
+    let wallet_a_evm = EthereumWallet::from(wallet_a_signer.clone());
+    let wallet_a_provider = ProviderBuilder::new()
+        .wallet(wallet_a_evm)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &wallet_a_provider,
+    );
+
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(20) * one_share;
+    let share_ratio = U256::from(10).pow(U256::from(18));
+
+    let tx_receipt = vault
+        .deposit(amount, wallet_a, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let deposit_event = tx_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            log.log_decode::<st0x_issuance::bindings::OffchainAssetReceiptVault::Deposit>()
+                .ok()
+                .map(|d| d.inner)
+        })
+        .expect("Deposit event");
+    let receipt_id = deposit_event.id;
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_unrelated_transfer.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    // Start service
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = Client::tracked(rocket).await?;
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Transfer receipt from wallet_a to wallet_b (neither is bot)
+    let receipt_contract_addr = Address::from(vault.receipt().call().await?.0);
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &wallet_a_provider);
+
+    let balance =
+        receipt_contract.balanceOf(wallet_a, receipt_id).call().await?;
+
+    receipt_contract
+        .safeTransferFrom(wallet_a, wallet_b, receipt_id, balance, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Give monitor time to (not) process
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    // Verify: no Discovered events at all (the Deposit was for wallet_a, not bot,
+    // and the transfer was between wallet_a and wallet_b, not involving bot)
+    let events = receipt_events(&db_url).await;
+    let discovered =
+        events.iter().filter(|(t, _)| t.contains("Discovered")).count();
+
+    assert_eq!(
+        discovered,
+        0,
+        "Transfer between unrelated wallets should not produce any Discovered events. \
+         Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    let reconciled =
+        events.iter().filter(|(t, _)| t.contains("BalanceReconciled")).count();
+    assert_eq!(
+        reconciled,
+        0,
+        "Transfer between unrelated wallets should not produce any BalanceReconciled events. \
+         Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}
+
+/// Unhappy path: Inbound transfer for a receipt that has zero on-chain balance
+/// at query time should be skipped (not discovered).
+///
+/// 1. Other wallet mints receipt, transfers it to bot, then bot burns it — all
+///    BEFORE service starts
+/// 2. Start service — backfill sees the inbound TransferSingle but balanceOf
+///    returns 0
+/// 3. Verify: receipt is NOT discovered (zero balance skip)
+#[tokio::test]
+async fn test_inbound_transfer_with_zero_balance_skipped()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let bot_wallet = evm.wallet_address;
+    let (other_signer, other_wallet) = second_wallet();
+
+    evm.grant_deposit_role(other_wallet).await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_withdraw_role(bot_wallet).await?;
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Step 1: Other wallet mints receipt
+    let other_evm_wallet = EthereumWallet::from(other_signer.clone());
+    let other_provider = ProviderBuilder::new()
+        .wallet(other_evm_wallet)
+        .connect(&evm.endpoint)
+        .await?;
+
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &other_provider,
+    );
+
+    let one_share = U256::from(10).pow(U256::from(18));
+    let amount = U256::from(50) * one_share;
+    let share_ratio = U256::from(10).pow(U256::from(18));
+
+    let tx_receipt = vault
+        .deposit(amount, other_wallet, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let deposit_event = tx_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            log.log_decode::<st0x_issuance::bindings::OffchainAssetReceiptVault::Deposit>()
+                .ok()
+                .map(|d| d.inner)
+        })
+        .expect("Deposit event");
+    let receipt_id = deposit_event.id;
+    let shares = deposit_event.shares;
+
+    // Step 2: Transfer receipt to bot
+    let receipt_contract_addr = Address::from(vault.receipt().call().await?.0);
+    let receipt_contract =
+        ReceiptInstance::new(receipt_contract_addr, &other_provider);
+
+    let receipt_balance =
+        receipt_contract.balanceOf(other_wallet, receipt_id).call().await?;
+
+    receipt_contract
+        .safeTransferFrom(
+            other_wallet,
+            bot_wallet,
+            receipt_id,
+            receipt_balance,
+            Bytes::new(),
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Step 3: Other wallet transfers ERC-20 shares to bot so bot can withdraw
+    vault.transfer(bot_wallet, shares).send().await?.get_receipt().await?;
+
+    // Step 4: Bot burns the receipt (withdraw requires both shares + receipt)
+    evm.withdraw_directly(receipt_id, shares, bot_wallet).await?;
+
+    // Verify on-chain: bot has 0 receipt balance
+    let bot_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+    let receipt_check =
+        ReceiptInstance::new(receipt_contract_addr, &bot_provider);
+    let bot_balance =
+        receipt_check.balanceOf(bot_wallet, receipt_id).call().await?;
+    assert_eq!(bot_balance, U256::ZERO, "Bot should have 0 after burn");
+
+    // Step 5: Start service — backfill sees inbound TransferSingle but balanceOf=0
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("test_zero_balance_skip.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let _rocket = initialize_rocket(config).await?;
+
+    // Give backfill time
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Verify: NO Discovered events — the receipt had 0 balance when queried
+    let events = receipt_events(&db_url).await;
+    let discovered =
+        events.iter().filter(|(t, _)| t.contains("Discovered")).count();
+
+    assert_eq!(
+        discovered,
+        0,
+        "Receipt with zero on-chain balance should not be discovered. Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    let reconciled =
+        events.iter().filter(|(t, _)| t.contains("BalanceReconciled")).count();
+    assert_eq!(
+        reconciled,
+        0,
+        "Receipt with zero on-chain balance should not trigger reconciliation. Events: {:?}",
+        events.iter().map(|(t, _)| t.as_str()).collect::<Vec<_>>()
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Closes #129.

The receipt inventory only tracked `Deposit` and `Withdraw` events from the vault contract, missing ERC-1155 `TransferSingle` and `TransferBatch` events on the Receipt contract. This meant:

- Receipts transferred **to** the bot wallet from another address were never discovered
- Receipts transferred **out** of the bot wallet were not reflected in the inventory
- If a known receipt received tokens back via inbound transfer, the aggregate balance was not updated (because `DiscoverReceipt` is a no-op for existing receipts, and `ReconcileBalance` previously rejected increases)

This created an inaccurate receipt inventory whenever receipts moved via direct ERC-1155 transfers rather than vault deposit/withdraw operations.

## Solution

Track `TransferSingle` and `TransferBatch` ERC-1155 events on the Receipt contract in both the live monitor and the backfiller. Additionally, make `ReconcileBalance` bidirectional so that inbound transfers to already-known receipts correctly update the aggregate balance.

**Monitor (`monitor.rs`):**
- Subscribe to `TransferSingle` and `TransferBatch` events on the Receipt contract alongside the existing Deposit/Withdraw vault subscriptions
- Inbound transfers (`to == bot_wallet`) call `discover_receipt_if_has_balance()` followed by `ReconcileBalance` — discovery handles new receipts, reconciliation handles balance updates on existing receipts
- Outbound transfers (`from == bot_wallet`) query on-chain balance and issue `ReconcileBalance`
- Mint/burn transfers (`from/to == address(0)`) are filtered out since Deposit/Withdraw already cover those
- Extracted a `reconcile_receipt()` helper to share between Withdraw and outbound transfer handling

**Backfiller (`backfill.rs`):**
- Scan `TransferSingle` and `TransferBatch` logs (inbound only, excluding mints) alongside Deposit logs in each block range
- `parse_log` now handles all three event types, returning `Vec<ReceiptDiscovery>` (renamed from `DepositInfo`) to accommodate TransferBatch producing multiple entries per log
- `process_discovery` issues both `DiscoverReceipt` and `ReconcileBalance` to handle new and existing receipts
- Renamed `process_deposit` → `process_discovery` to reflect the broader scope

**Aggregate (`mod.rs`):**
- Removed the `UnexpectedBalanceIncrease` error — `ReconcileBalance` now allows both upward and downward reconciliation, emitting `BalanceReconciled` in either direction
- This is necessary because inbound ERC-1155 transfers can legitimately increase a known receipt's balance

**Spec (`SPEC.md`):**
- Updated receipt inventory documentation: reconciliation is now bidirectional, `BalanceReconciled` replaces `BalanceDecreased` terminology, transfer event tracking documented throughout

**Tests:** 12 new tests covering inbound/outbound TransferSingle, inbound/outbound TransferBatch (including multi-item batches), mint/burn filtering, backfiller transfer discovery, backfiller deduplication, upward balance reconciliation (both aggregate-level and backfill-level), and the outbound-then-inbound scenario. Existing tests updated accordingly.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Known Limitations

- **#135 — Receipt metadata lost through depletion/rediscovery cycles.** If a receipt is fully transferred out (balance hits zero), the aggregate deletes the entry and its `issuer_request_id` index. If the same receipt is later transferred back in, it is rediscovered as a brand-new "External" receipt with empty `receipt_info_bytes` — `find_by_issuer_request_id()` stops working and burns fall back to empty receipt bytes, losing original on-chain metadata. Deferred because full depletion + re-transfer of the same receipt ID is unlikely in practice.

## Future Improvements

- **#134** — Optimize ERC-1155 transfer event filters with indexed topic filtering. Currently, transfer events are filtered client-side after fetching all events from the Receipt contract. Since `from` and `to` are indexed ERC-1155 topics, the RPC layer can filter directly to `bot_wallet`, reducing payload size and unnecessary decoding.