### PR TITLE
fix: poll for mock callbacks instead of asserting immediately

### DIFF
--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -89,17 +89,30 @@ where
 pub async fn wait_for_mock_hit(
     mock: &Mock<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    wait_for_mock_hits(mock, 1).await
+}
+
+pub async fn wait_for_mock_hits(
+    mock: &Mock<'_>,
+    expected: usize,
+) -> Result<(), Box<dyn std::error::Error>> {
     let start = tokio::time::Instant::now();
     let timeout = tokio::time::Duration::from_secs(5);
     let poll_interval = tokio::time::Duration::from_millis(50);
 
     loop {
-        if mock.calls_async().await > 0 {
+        if mock.calls_async().await >= expected {
             return Ok(());
         }
 
         if start.elapsed() >= timeout {
-            return Err("Timeout waiting for mock to be hit".into());
+            return Err(format!(
+                "Timeout waiting for mock to be hit {expected} time(s) \
+                 (got {} after {}s)",
+                mock.calls_async().await,
+                timeout.as_secs()
+            )
+            .into());
         }
 
         tokio::time::sleep(poll_interval).await;

--- a/tests/mint.rs
+++ b/tests/mint.rs
@@ -273,18 +273,9 @@ async fn test_mint_burn_mint_nonce_synchronization()
         "User should have shares after second mint"
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 2,
-        "Mint callback should be hit at least twice (once per mint)"
-    );
-    assert!(
-        redeem_mock.calls_async().await >= 1,
-        "Redeem endpoint should be hit at least once"
-    );
-    assert!(
-        poll_mock.calls_async().await >= 1,
-        "Poll endpoint should be hit at least once"
-    );
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+    harness::wait_for_mock_hit(&redeem_mock).await?;
+    harness::wait_for_mock_hit(&poll_mock).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The deploy workflow (`deploy.yaml`) has been blocked because the e2e test
`test_mint_burn_mint_nonce_synchronization` fails inside the Docker build.
The test asserts mock call counts immediately after `wait_for_shares`
returns, but the Alpaca callback fires asynchronously *after* the on-chain
deposit succeeds. In the slower Docker-on-GitHub-Actions environment the
callback hasn't arrived yet, causing a flaky assertion failure
([run #24477122041](https://github.com/ST0x-Technology/st0x.issuance/actions/runs/24477122041)).

The primary goal of merging this PR is to unblock the deploy pipeline so
that the **new Alpaca API key** (already configured at the repo secrets
level) reaches production.

Closes RAI-215

## Solution

- Added `wait_for_mock_hits(mock, expected)` helper in
  `tests/harness/mod.rs` that polls (50ms interval, 5s timeout) until the
  mock has been hit at least `expected` times. The existing
  `wait_for_mock_hit` now delegates to it with `expected = 1`.
- Replaced the three immediate `assert!` calls in
  `test_mint_burn_mint_nonce_synchronization` (`tests/mint.rs:276-287`)
  with polling calls: `wait_for_mock_hits(&mint_callback_mock, 2)`,
  `wait_for_mock_hit(&redeem_mock)`, `wait_for_mock_hit(&poll_mock)`.
- Timeout errors now include the actual vs expected call count for easier
  debugging.

## Verification

Triggered the full deploy workflow (Docker build + `cargo test` inside container) on this branch via `workflow_dispatch` — **passed**: [run #24587563273](https://github.com/ST0x-Technology/st0x.issuance/actions/runs/24587563273)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test synchronization infrastructure with improved polling utilities for verifying mock calls.
  * Improved timeout error messages with clearer diagnostic information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->