### PR TITLE
fix: prevent duplicate Alpaca mint callbacks from receipt monitor race

### DIFF
--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -58,10 +58,10 @@ pub(crate) enum MintCommand {
     /// on-chain transaction actually succeeded, as evidenced by a receipt
     /// discovered by the receipt monitor.
     ///
-    /// Only accepts `MintingFailed` and `CallbackPending` states. Unlike
-    /// `Recover`, this rejects `JournalConfirmed` and `Minting` because
-    /// receipt discovery only justifies recovery when the mint was marked
-    /// as failed after submission.
+    /// Only accepts `MintingFailed` state (with `Minting` predecessor).
+    /// When recovery succeeds, atomically sends the Alpaca callback in the
+    /// same command execution to avoid racing with the normal flow's
+    /// `SendCallback` command.
     RecoverFromReceipt {
         issuer_request_id: IssuerMintRequestId,
         tx_hash: TxHash,

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -508,8 +508,17 @@ impl Mint {
 
     /// Handles recovery triggered by receipt discovery. Only accepts
     /// `MintingFailed` when the non-failed predecessor was `Minting`
-    /// (meaning a tx was actually submitted), and `CallbackPending`
-    /// (subsequent step after recovering from `MintingFailed`).
+    /// (meaning a tx was actually submitted).
+    ///
+    /// Unlike `handle_recover`, this does NOT accept `CallbackPending`
+    /// because receipt discovery also fires during the normal mint flow
+    /// (when the deposit creates a new on-chain receipt). Handling
+    /// `CallbackPending` here would race with the normal flow's
+    /// `SendCallback` command, causing duplicate Alpaca callbacks.
+    ///
+    /// Instead, when the deposit recovery succeeds and the mint moves to
+    /// `CallbackPending`, this handler immediately sends the callback in
+    /// the same command execution, atomically advancing to `Completed`.
     async fn handle_recover_from_receipt(
         &self,
         services: &MintServices,
@@ -523,15 +532,42 @@ impl Mint {
                     Self::Minting { .. }
                 ) =>
             {
-                self.handle_recover_incomplete(
-                    services,
-                    issuer_request_id,
-                    Some(tx_hash),
-                )
-                .await
-            }
-            Self::CallbackPending { .. } => {
-                self.handle_send_callback(services, issuer_request_id).await
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        Some(tx_hash),
+                    )
+                    .await?;
+
+                // If the deposit failed, return early with just the failure
+                // event — no callback should be sent.
+                let deposit_succeeded = deposit_events.iter().any(|event| {
+                    matches!(
+                        event,
+                        MintEvent::TokensMinted { .. }
+                            | MintEvent::ExistingMintRecovered { .. }
+                    )
+                });
+
+                if !deposit_succeeded {
+                    return Ok(deposit_events);
+                }
+
+                // Construct intermediate state to send callback from.
+                let mut intermediate = self.clone();
+                for event in &deposit_events {
+                    intermediate.apply(event.clone());
+                }
+
+                let callback_events = intermediate
+                    .handle_send_callback(services, issuer_request_id)
+                    .await?;
+
+                let all_events =
+                    deposit_events.into_iter().chain(callback_events).collect();
+
+                Ok(all_events)
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),


### PR DESCRIPTION
## Summary
- Removes `CallbackPending` from `handle_recover_from_receipt` to prevent the receipt monitor from racing with the normal flow's `SendCallback` command
- When recovering from `MintingFailed`, the callback is now sent atomically in the same command execution, advancing directly to `Completed`
- Startup recovery (`Recover` command) still handles `CallbackPending` since it runs synchronously before the server — no race possible

## Problem
The deploy CI `test_tokenization_flow` failed with `left: 2, right: 1` — the Alpaca mint callback was sent twice.

**Root cause:** During normal mint flow, both `process_journal_completion` (spawned task from confirm_journal) and `MintRecoveryHandler` (receipt monitor) can send the Alpaca callback concurrently. After `Deposit` succeeds (mint → `CallbackPending`), the receipt monitor detects the on-chain receipt and starts `drive_recovery` with `RecoverFromReceipt`, which also calls `handle_send_callback` — racing with the normal flow's `SendCallback`. The HTTP side effect fires inside the command handler before event persistence, so CQRS optimistic locking can't prevent the duplicate.

**Timeline:** The bug was introduced in PR #112 (`fix/resume-failed-mints-on-receipt`, merged Feb 18) when `MintRecoveryHandler` was added. It's a timing-dependent race that only manifests when Docker's resource contention makes the normal flow slow enough for the receipt monitor to observe `CallbackPending` before `SendCallback` completes. Deploy CI history shows the flakiness:

| Commit | Deploy CI | PR |
|--------|-----------|-----|
| `205a978` | pass | run recovery synchronously (#133) |
| `ca77277` | pass | Receipt metadata encoding (#130) |
| `ced92a7` | pass | Track transfer events (#131) |
| `f5b379b` | **fail** | Optimize event filtering (#136) |
| `6901d03` | pass | flaky nonce fix (#139) — manual dispatch |
| `9df71e6` | **fail** | Same fix merged to main (#139) |

**Fix:** `handle_recover_from_receipt` no longer handles `CallbackPending` as a separate loop step. Instead, when recovering from `MintingFailed`, it atomically performs both the deposit recovery AND callback in one command execution — clone + apply intermediate events in memory, then send callback, returning all events together. The receipt monitor can no longer observe `CallbackPending` as a recoverable state, eliminating the race.

## Test plan
- [x] All 594 tests pass (`cargo test --workspace`)
- [x] Clippy clean
- [x] Deploy CI (Docker) passes — manually triggered on this branch
- [x] `recover_from_receipt` and recovery tests pass (17 tests)

Closes RAI-216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of mint recovery operations by ensuring callback processing occurs atomically as part of the recovery command, eliminating potential race conditions that could occur when callbacks were handled in separate steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->