### PR TITLE
fix: checkpoint issuance backfills before serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,13 @@ endpoints.
 3. We poll for journal completion
 4. We burn tokens on-chain via `vault.withdraw()`
 
+Receipt and redemption transfer backfills use durable per-vault checkpoints.
+Periodic receipt backfill keeps receipt checkpoints current during long uptime,
+and live receipt monitoring processes new events without advancing the durable
+checkpoint out of block order. Redemption transfer backfill runs as background
+startup work. Restarts resume after the last successfully processed block
+instead of rescanning the full configured historical range.
+
 ## Configuration
 
 Configuration is managed through environment variables. See `.env.example` for

--- a/SPEC.md
+++ b/SPEC.md
@@ -428,9 +428,18 @@ recovery. Methods:
   a receipt by ITN issuer_request_id for mint recovery
 
 Receipts enter the inventory through backfill (scanning historic Deposit and
-ERC-1155 transfer events at startup from `last_backfilled_block`), live
-monitoring (WebSocket subscription to Deposit and ERC-1155 transfer events at
-runtime), or direct registration after a mint.
+ERC-1155 transfer events at startup from the block after
+`last_backfilled_block`), live monitoring (WebSocket subscription to Deposit and
+ERC-1155 transfer events at runtime), or direct registration after a mint. After
+startup backfill succeeds, periodic receipt backfill safely scans the small
+runtime range from the durable checkpoint to the current block and advances
+`last_backfilled_block` only after ordered range processing succeeds. Live
+monitoring processes observed logs opportunistically but does not advance the
+durable checkpoint, because WebSocket logs can arrive out of order within or
+across blocks. This prevents long-running services from restarting with a stale
+receipt checkpoint that forces a large historical scan before Rocket can serve
+requests without allowing one live log to checkpoint past another unprocessed
+log in the same block.
 
 The Receipt contract is an ERC-1155 token that emits `TransferSingle` and
 `TransferBatch` events on all token movements. The receipt monitor and
@@ -445,7 +454,7 @@ emitting `BalanceReconciled` when the on-chain balance differs from the
 aggregate balance in either direction. Reconciliation is triggered by:
 
 - **Startup**: After receipt backfill, reconciles all receipts with positive
-  aggregate balance before redemption transfer backfill begins
+  aggregate balance before redemption recovery and live monitoring begin
 - **Post-burn**: After every burn attempt (successful or failed), reconciles the
   affected vault immediately
 - **Live monitoring**: WebSocket subscription to Withdraw events and ERC-1155
@@ -1153,21 +1162,23 @@ tokenized asset.
 
 **Transfer Backfilling:**
 
-At startup, before spawning live monitors, the service scans historic Transfer
-events on **each vault independently** to detect any redemption transfers that
-occurred while the service was down. This ensures no redemptions are silently
-missed due to downtime.
+At startup, the service starts historic Transfer backfill in the background so
+HTTP serving and health checks are not blocked by avoidable chain catch-up work.
+The backfiller scans Transfer events on **each vault independently** to detect
+any redemption transfers that occurred while the service was down. This ensures
+no redemptions are silently missed due to downtime.
 
-Each vault is backfilled separately: the backfiller scans from the configured
-`backfill_start_block` to the current block for each vault contract. Idempotency
-is guaranteed by the `IssuerRedemptionRequestId` derived from each transaction
-hash — the Redemption aggregate rejects duplicate detections, so re-scanning
-already-processed blocks is safe.
+Each vault is backfilled separately. The configured `backfill_start_block` is
+only the first-run seed; after a successful range, the service persists a
+per-vault `redemption_backfill_checkpoints` row and the next startup resumes at
+`last_processed_block + 1`. The checkpoint advances only after the requested
+range succeeds, and writes are monotonic so a shorter later range cannot move
+progress backward. Idempotency is still guaranteed by the
+`IssuerRedemptionRequestId` derived from each transaction hash — the Redemption
+aggregate rejects duplicate detections.
 
 This mirrors the receipt backfill pattern, where per-vault checkpoints are
 tracked via the `ReceiptInventory` aggregate's `last_backfilled_block` state.
-Transfer backfill currently relies on idempotency rather than per-vault
-checkpoint tracking.
 
 **Note:** The bot's wallet serves as the redemption destination. When users send
 shares to this wallet, they're initiating a redemption. Since the bot already

--- a/migrations/20260428084837_create_redemption_backfill_checkpoints.sql
+++ b/migrations/20260428084837_create_redemption_backfill_checkpoints.sql
@@ -1,0 +1,5 @@
+CREATE TABLE redemption_backfill_checkpoints (
+    vault TEXT PRIMARY KEY,
+    last_processed_block INTEGER NOT NULL CHECK (last_processed_block >= 0),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,8 @@ use sqlite_es::{
     SqliteCqrs, SqliteEventRepository, SqliteViewRepository, sqlite_cqrs,
 };
 use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
+use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, warn};
 use url::Url;
 
@@ -121,6 +122,9 @@ impl std::fmt::Display for Quantity {
 /// Maximum decimal places supported by Alpaca's tokenization API.
 /// Quantities with more decimals must be truncated before sending to Alpaca.
 pub(crate) const ALPACA_MAX_DECIMALS: u32 = 9;
+
+const RECEIPT_BACKFILL_REFRESH_INTERVAL: Duration = Duration::from_secs(60);
+const TRANSFER_BACKFILL_RETRY_INTERVAL: Duration = Duration::from_secs(60);
 
 impl Quantity {
     pub(crate) const fn new(value: Decimal) -> Self {
@@ -321,9 +325,6 @@ pub async fn initialize_rocket(
         );
     }
 
-    // Transfer backfill must run after receipt backfill so that receipt inventory
-    // is available for burn planning, and before live monitoring so that missed
-    // transfers during downtime are detected before new ones come in.
     let transfer_backfiller = TransferBackfiller {
         provider: blockchain_setup.provider.clone(),
         bot_wallet,
@@ -335,15 +336,8 @@ pub async fn initialize_rocket(
         burn_manager: managers.burn.clone(),
     };
 
-    run_all_transfer_backfills(
-        &vault_configs,
-        &transfer_backfiller,
-        config.backfill_start_block,
-    )
-    .await?;
-
     spawn_all_receipt_monitors(
-        blockchain_setup.provider,
+        blockchain_setup.provider.clone(),
         &vault_configs,
         &receipt_inventory.cqrs,
         bot_wallet,
@@ -361,6 +355,21 @@ pub async fn initialize_rocket(
         &managers.burn,
     )
     .await;
+
+    spawn_periodic_receipt_backfills(
+        blockchain_setup.provider.clone(),
+        vault_configs.clone(),
+        receipt_inventory.cqrs.clone(),
+        receipt_inventory.event_store.clone(),
+        bot_wallet,
+        config.backfill_start_block,
+    );
+
+    spawn_all_transfer_backfills(
+        vault_configs.clone(),
+        transfer_backfiller,
+        config.backfill_start_block,
+    );
 
     spawn_all_redemption_detectors(
         &config.rpc_url,
@@ -710,6 +719,7 @@ async fn run_redemption_recovery(
 }
 
 /// Configuration for a single vault, extracted from TokenizedAssetView.
+#[derive(Clone, Copy)]
 struct VaultBackfillConfig {
     vault: Address,
     receipt_contract: Address,
@@ -782,10 +792,10 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
         .load_aggregate(&vault.to_string())
         .await?;
 
-    let from_block = aggregate_context
-        .aggregate()
-        .last_backfilled_block()
-        .unwrap_or(backfill_start_block);
+    let from_block = next_receipt_backfill_block(
+        aggregate_context.aggregate().last_backfilled_block(),
+        backfill_start_block,
+    )?;
 
     info!(
         underlying,
@@ -817,11 +827,110 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
     Ok(VaultBackfillConfig { vault, receipt_contract })
 }
 
-/// Runs transfer backfill for ALL enabled vaults.
+fn next_receipt_backfill_block(
+    last_backfilled_block: Option<u64>,
+    backfill_start_block: u64,
+) -> Result<u64, anyhow::Error> {
+    last_backfilled_block.map_or(Ok(backfill_start_block), |block| {
+        block.checked_add(1).map_or_else(
+            || Err(anyhow::anyhow!("Receipt backfill checkpoint overflow")),
+            |next_block| Ok(next_block.max(backfill_start_block)),
+        )
+    })
+}
+
+async fn run_periodic_receipt_backfill_for_config<P: Provider + Clone>(
+    provider: &P,
+    config: VaultBackfillConfig,
+    receipt_inventory_cqrs: &ReceiptInventoryCqrs,
+    receipt_inventory_event_store: &ReceiptInventoryEventStore,
+    bot_wallet: Address,
+    backfill_start_block: u64,
+) -> Result<(), anyhow::Error> {
+    let aggregate_context = receipt_inventory_event_store
+        .load_aggregate(&config.vault.to_string())
+        .await?;
+
+    let from_block = next_receipt_backfill_block(
+        aggregate_context.aggregate().last_backfilled_block(),
+        backfill_start_block,
+    )?;
+
+    debug!(
+        vault = %config.vault,
+        receipt_contract = %config.receipt_contract,
+        from_block,
+        "Running periodic receipt backfill for vault"
+    );
+
+    let backfiller = ReceiptBackfiller::new(
+        provider.clone(),
+        config.receipt_contract,
+        bot_wallet,
+        config.vault,
+        receipt_inventory_cqrs.clone(),
+    );
+
+    let result = backfiller.backfill_receipts(from_block).await?;
+
+    debug!(
+        vault = %config.vault,
+        processed = result.processed_count,
+        skipped_zero_balance = result.skipped_zero_balance,
+        "Periodic receipt backfill complete for vault"
+    );
+
+    Ok(())
+}
+
+fn spawn_periodic_receipt_backfills<P>(
+    provider: P,
+    vault_configs: Vec<VaultBackfillConfig>,
+    receipt_inventory_cqrs: ReceiptInventoryCqrs,
+    receipt_inventory_event_store: ReceiptInventoryEventStore,
+    bot_wallet: Address,
+    backfill_start_block: u64,
+) where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        tokio::time::sleep(RECEIPT_BACKFILL_REFRESH_INTERVAL).await;
+
+        let mut interval =
+            tokio::time::interval(RECEIPT_BACKFILL_REFRESH_INTERVAL);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        loop {
+            interval.tick().await;
+
+            for config in &vault_configs {
+                if let Err(error) = run_periodic_receipt_backfill_for_config(
+                    &provider,
+                    *config,
+                    &receipt_inventory_cqrs,
+                    &receipt_inventory_event_store,
+                    bot_wallet,
+                    backfill_start_block,
+                )
+                .await
+                {
+                    warn!(
+                        error = %error,
+                        vault = %config.vault,
+                        "Periodic receipt backfill failed; next run will resume \
+                         from the last checkpoint"
+                    );
+                }
+            }
+        }
+    });
+}
+
+/// Runs transfer backfill for all enabled vaults.
 ///
 /// Scans historic Transfer events to detect redemptions that occurred while the
-/// service was down. Must run after receipt backfill (for burn planning) and
-/// before live monitoring (to avoid missing transfers in the gap).
+/// service was down. A failure for one vault is logged and does not prevent
+/// later vaults from being attempted in the same pass.
 async fn run_all_transfer_backfills<P: Provider + Clone>(
     vault_configs: &[VaultBackfillConfig],
     backfiller: &TransferBackfiller<P, SqliteEventStore<Redemption>>,
@@ -837,10 +946,25 @@ async fn run_all_transfer_backfills<P: Provider + Clone>(
         "Running transfer backfill for all vaults"
     );
 
+    let mut failed_count = 0u64;
+
     for config in vault_configs {
-        let result = backfiller
+        let result = match backfiller
             .backfill_transfers(config.vault, backfill_start_block)
-            .await?;
+            .await
+        {
+            Ok(result) => result,
+            Err(error) => {
+                failed_count += 1;
+                warn!(
+                    error = %error,
+                    vault = %config.vault,
+                    "Transfer backfill failed for vault; continuing with \
+                     remaining vaults"
+                );
+                continue;
+            }
+        };
 
         debug!(
             vault = %config.vault,
@@ -851,7 +975,49 @@ async fn run_all_transfer_backfills<P: Provider + Clone>(
         );
     }
 
+    if failed_count > 0 {
+        return Err(anyhow::anyhow!(
+            "transfer backfill failed for {failed_count} vault(s)"
+        ));
+    }
+
     Ok(())
+}
+
+/// Starts transfer backfill in the background so HTTP startup is not blocked by
+/// catch-up scans. Progress is checkpointed per vault by the backfiller.
+fn spawn_all_transfer_backfills<P>(
+    vault_configs: Vec<VaultBackfillConfig>,
+    backfiller: TransferBackfiller<P, SqliteEventStore<Redemption>>,
+    backfill_start_block: u64,
+) where
+    P: Provider + Clone + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        loop {
+            match run_all_transfer_backfills(
+                &vault_configs,
+                &backfiller,
+                backfill_start_block,
+            )
+            .await
+            {
+                Ok(()) => return,
+                Err(error) => {
+                    error!(
+                        error = %error,
+                        retry_after_secs =
+                            TRANSFER_BACKFILL_RETRY_INTERVAL.as_secs(),
+                        "Transfer backfill pass failed; redemption detector \
+                         remains live and the background task will retry from \
+                         the last checkpoint"
+                    );
+                }
+            }
+
+            tokio::time::sleep(TRANSFER_BACKFILL_RETRY_INTERVAL).await;
+        }
+    });
 }
 
 /// Spawns receipt monitors for ALL enabled vaults.
@@ -910,7 +1076,9 @@ mod tests {
     use rust_decimal::Decimal;
     use std::str::FromStr;
 
-    use super::{Quantity, QuantityConversionError};
+    use super::{
+        Quantity, QuantityConversionError, next_receipt_backfill_block,
+    };
 
     #[test]
     fn test_quantity_display() {
@@ -1108,5 +1276,34 @@ mod tests {
 
         // Verify: truncated_u256 + dust_u256 == original_u256
         assert_eq!(truncated_u256 + dust_u256, original_u256);
+    }
+
+    #[test]
+    fn test_next_receipt_backfill_block_fails_on_overflow() {
+        let result = next_receipt_backfill_block(Some(u64::MAX), 50);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_next_receipt_backfill_block_uses_configured_start_without_checkpoint()
+     {
+        let start_block = next_receipt_backfill_block(None, 50).unwrap();
+
+        assert_eq!(start_block, 50);
+    }
+
+    #[test]
+    fn test_next_receipt_backfill_block_resumes_after_checkpoint() {
+        let start_block = next_receipt_backfill_block(Some(80), 50).unwrap();
+
+        assert_eq!(start_block, 81);
+    }
+
+    #[test]
+    fn test_next_receipt_backfill_block_respects_configured_floor() {
+        let start_block = next_receipt_backfill_block(Some(20), 50).unwrap();
+
+        assert_eq!(start_block, 50);
     }
 }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -470,9 +470,18 @@ impl Aggregate for ReceiptInventory {
 
             ReceiptInventoryCommand::AdvanceBackfillCheckpoint {
                 block_number,
-            } => Ok(vec![ReceiptInventoryEvent::BackfillCheckpoint {
-                block_number,
-            }]),
+            } => {
+                if self
+                    .last_backfilled_block
+                    .is_some_and(|last_block| block_number <= last_block)
+                {
+                    return Ok(vec![]);
+                }
+
+                Ok(vec![ReceiptInventoryEvent::BackfillCheckpoint {
+                    block_number,
+                }])
+            }
         }
     }
 
@@ -694,6 +703,38 @@ mod tests {
             &events[0],
             ReceiptInventoryEvent::BackfillCheckpoint { block_number: 100 }
         ));
+    }
+
+    #[tokio::test]
+    async fn test_advance_backfill_checkpoint_ignores_stale_blocks() {
+        let aggregate = ReceiptInventory {
+            last_backfilled_block: Some(100),
+            ..Default::default()
+        };
+
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::AdvanceBackfillCheckpoint {
+                    block_number: 99,
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(events.is_empty());
+
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::AdvanceBackfillCheckpoint {
+                    block_number: 100,
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(events.is_empty());
     }
 
     #[test]

--- a/src/receipt_inventory/monitor.rs
+++ b/src/receipt_inventory/monitor.rs
@@ -200,59 +200,98 @@ where
                         debug!("Skipping removed Deposit log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_deposit(&log).await {
-                        warn!("Failed to process Deposit: {err}");
-                    }
+                    self.process_live_log(&log, "Deposit", |log| {
+                        Box::pin(self.process_deposit(log))
+                    }).await;
                 }
                 Some(log) = withdraw_stream.next() => {
                     if log.removed {
                         debug!("Skipping removed Withdraw log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_withdraw(&log).await {
-                        warn!("Failed to process Withdraw: {err}");
-                    }
+                    self.process_live_log(&log, "Withdraw", |log| {
+                        Box::pin(self.process_withdraw(log))
+                    }).await;
                 }
                 Some(log) = transfer_single_inbound_stream.next() => {
                     if log.removed {
                         debug!("Skipping removed TransferSingle log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_transfer_single(&log).await {
-                        warn!("Failed to process TransferSingle: {err}");
-                    }
+                    self.process_live_log(&log, "TransferSingle", |log| {
+                        Box::pin(self.process_transfer_single(log))
+                    }).await;
                 }
                 Some(log) = transfer_single_outbound_stream.next() => {
                     if log.removed {
                         debug!("Skipping removed TransferSingle log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_transfer_single(&log).await {
-                        warn!("Failed to process TransferSingle: {err}");
-                    }
+                    self.process_live_log(&log, "TransferSingle", |log| {
+                        Box::pin(self.process_transfer_single(log))
+                    }).await;
                 }
                 Some(log) = transfer_batch_inbound_stream.next() => {
                     if log.removed {
                         debug!("Skipping removed TransferBatch log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_transfer_batch(&log).await {
-                        warn!("Failed to process TransferBatch: {err}");
-                    }
+                    self.process_live_log(&log, "TransferBatch", |log| {
+                        Box::pin(self.process_transfer_batch(log))
+                    }).await;
                 }
                 Some(log) = transfer_batch_outbound_stream.next() => {
                     if log.removed {
                         debug!("Skipping removed TransferBatch log (reorg)");
                         continue;
                     }
-                    if let Err(err) = self.process_transfer_batch(&log).await {
-                        warn!("Failed to process TransferBatch: {err}");
-                    }
+                    self.process_live_log(&log, "TransferBatch", |log| {
+                        Box::pin(self.process_transfer_batch(log))
+                    }).await;
                 }
                 else => {
                     return Err(ReceiptMonitorError::StreamEnded);
                 }
             }
+        }
+    }
+
+    async fn process_live_log<'a, FutureType>(
+        &self,
+        log: &'a Log,
+        event_name: &'static str,
+        process: impl FnOnce(&'a Log) -> FutureType,
+    ) where
+        FutureType:
+            std::future::Future<Output = Result<(), ReceiptMonitorError>>,
+    {
+        let Some(block_number) = log.block_number else {
+            // Without a block number we cannot prove where this live log fits
+            // relative to the durable checkpoint. Skip live processing and let
+            // periodic backfill rescan the range in block order.
+            warn!(
+                event_name,
+                "Live receipt log missing block number; periodic backfill will \
+                 rescan the range in block order"
+            );
+            return;
+        };
+
+        if let Err(err) = process(log).await {
+            warn!(
+                event_name,
+                block_number,
+                error = %err,
+                "Failed to process live receipt log; periodic backfill will \
+                 rescan from the durable checkpoint"
+            );
+        } else {
+            debug!(
+                event_name,
+                block_number,
+                "Processed live receipt log; periodic backfill owns durable \
+                 checkpoint advancement"
+            );
         }
     }
 
@@ -355,6 +394,8 @@ where
         let event = Receipt::TransferSingle::decode_log(&log.inner)?;
         let tx_hash =
             log.transaction_hash.ok_or(ReceiptMonitorError::MissingTxHash)?;
+        let block_number =
+            log.block_number.ok_or(ReceiptMonitorError::MissingBlockNumber)?;
 
         // Skip mint/burn transfers — already covered by Deposit/Withdraw
         if event.from.is_zero() || event.to.is_zero() {
@@ -370,10 +411,6 @@ where
                 value = %event.value,
                 "Inbound TransferSingle detected"
             );
-
-            let block_number = log
-                .block_number
-                .ok_or(ReceiptMonitorError::MissingBlockNumber)?;
 
             self.discover_receipt_if_has_balance(
                 receipt_id,
@@ -405,6 +442,8 @@ where
         log: &Log,
     ) -> Result<(), ReceiptMonitorError> {
         let event = Receipt::TransferBatch::decode_log(&log.inner)?;
+        let block_number =
+            log.block_number.ok_or(ReceiptMonitorError::MissingBlockNumber)?;
 
         // Skip mint/burn transfers — already covered by Deposit/Withdraw
         if event.from.is_zero() || event.to.is_zero() {
@@ -415,10 +454,6 @@ where
             log.transaction_hash.ok_or(ReceiptMonitorError::MissingTxHash)?;
 
         if event.to == self.bot_wallet {
-            let block_number = log
-                .block_number
-                .ok_or(ReceiptMonitorError::MissingBlockNumber)?;
-
             for receipt_id_raw in &event.ids {
                 let receipt_id = ReceiptId::from(*receipt_id_raw);
 
@@ -771,6 +806,318 @@ mod tests {
         assert_eq!(event_for_other.owner, other_wallet);
         assert!(event_for_bot.owner == bot_wallet);
         assert!(event_for_other.owner != bot_wallet);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_live_deposit_does_not_advance_receipt_checkpoint() {
+        let (cqrs, store) = setup_test_cqrs();
+        let vault = address!("0x1111111111111111111111111111111111111111");
+        let bot_wallet = address!("0x2222222222222222222222222222222222222222");
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let receipt_contract =
+            address!("0x5555555555555555555555555555555555555555");
+
+        let provider = ProviderBuilder::new()
+            .connect_mocked_client(alloy::providers::mock::Asserter::new());
+
+        let monitor = ReceiptMonitor::new(
+            provider,
+            ReceiptMonitorConfig { vault, receipt_contract, bot_wallet },
+            cqrs.clone(),
+            NoOpHandler,
+        );
+
+        let log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(42_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 123,
+        });
+
+        monitor
+            .process_live_log(&log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert_eq!(context.aggregate().last_backfilled_block(), None);
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Processed live receipt log",
+                "periodic backfill owns durable checkpoint advancement",
+                "block_number=123"
+            ]
+        ));
+        assert!(
+            context.aggregate().receipts_with_balance().is_empty(),
+            "Non-bot deposit should not register a receipt"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_failed_live_log_does_not_affect_later_live_processing() {
+        let (cqrs, store) = setup_test_cqrs();
+        let vault = address!("0x1111111111111111111111111111111111111111");
+        let bot_wallet = address!("0x2222222222222222222222222222222222222222");
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let receipt_contract =
+            address!("0x5555555555555555555555555555555555555555");
+
+        let provider = ProviderBuilder::new()
+            .connect_mocked_client(alloy::providers::mock::Asserter::new());
+
+        let monitor = ReceiptMonitor::new(
+            provider,
+            ReceiptMonitorConfig { vault, receipt_contract, bot_wallet },
+            cqrs.clone(),
+            NoOpHandler,
+        );
+
+        let mut failed_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(42_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 123,
+        });
+        failed_log.transaction_hash = None;
+
+        monitor
+            .process_live_log(&failed_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let later_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(43_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            block_number: 124,
+        });
+
+        monitor
+            .process_live_log(&later_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert_eq!(context.aggregate().last_backfilled_block(), None);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &[
+                "Failed to process live receipt log",
+                "periodic backfill will rescan from the durable checkpoint",
+                "error=Missing transaction hash in log"
+            ]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Processed live receipt log",
+                "periodic backfill owns durable checkpoint advancement",
+                "block_number=124"
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_periodic_backfill_remains_checkpoint_authority() {
+        let (cqrs, store) = setup_test_cqrs();
+        let vault = address!("0x1111111111111111111111111111111111111111");
+        let bot_wallet = address!("0x2222222222222222222222222222222222222222");
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let receipt_contract =
+            address!("0x5555555555555555555555555555555555555555");
+
+        let provider = ProviderBuilder::new()
+            .connect_mocked_client(alloy::providers::mock::Asserter::new());
+
+        let monitor = ReceiptMonitor::new(
+            provider,
+            ReceiptMonitorConfig { vault, receipt_contract, bot_wallet },
+            cqrs.clone(),
+            NoOpHandler,
+        );
+
+        let mut failed_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(42_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 123,
+        });
+        failed_log.transaction_hash = None;
+
+        monitor
+            .process_live_log(&failed_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::AdvanceBackfillCheckpoint {
+                block_number: 123,
+            },
+        )
+        .await
+        .unwrap();
+
+        let later_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(43_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            block_number: 124,
+        });
+
+        monitor
+            .process_live_log(&later_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert_eq!(context.aggregate().last_backfilled_block(), Some(123));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Processed live receipt log",
+                "periodic backfill owns durable checkpoint advancement",
+                "block_number=124"
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_unpositioned_live_log_does_not_clear_existing_checkpoint() {
+        let (cqrs, store) = setup_test_cqrs();
+        let vault = address!("0x1111111111111111111111111111111111111111");
+        let bot_wallet = address!("0x2222222222222222222222222222222222222222");
+        let other_wallet =
+            address!("0x4444444444444444444444444444444444444444");
+        let receipt_contract =
+            address!("0x5555555555555555555555555555555555555555");
+
+        let provider = ProviderBuilder::new()
+            .connect_mocked_client(alloy::providers::mock::Asserter::new());
+
+        let monitor = ReceiptMonitor::new(
+            provider,
+            ReceiptMonitorConfig { vault, receipt_contract, bot_wallet },
+            cqrs.clone(),
+            NoOpHandler,
+        );
+
+        cqrs.execute(
+            &vault.to_string(),
+            ReceiptInventoryCommand::AdvanceBackfillCheckpoint {
+                block_number: 123,
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut unpositioned_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(42_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            block_number: 123,
+        });
+        unpositioned_log.block_number = None;
+
+        monitor
+            .process_live_log(&unpositioned_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let later_log = create_deposit_log(VaultEventLogParams {
+            vault,
+            sender: other_wallet,
+            owner: other_wallet,
+            assets: uint!(100_U256),
+            shares: uint!(100_U256),
+            id: uint!(43_U256),
+            receipt_information: Bytes::new(),
+            tx_hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            block_number: 124,
+        });
+
+        monitor
+            .process_live_log(&later_log, "Deposit", |log| {
+                Box::pin(monitor.process_deposit(log))
+            })
+            .await;
+
+        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert_eq!(context.aggregate().last_backfilled_block(), Some(123));
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &[
+                "Live receipt log missing block number",
+                "periodic backfill will rescan the range in block order"
+            ]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Processed live receipt log",
+                "periodic backfill owns durable checkpoint advancement",
+                "block_number=124"
+            ]
+        ));
     }
 
     #[tokio::test]

--- a/src/redemption/backfill.rs
+++ b/src/redemption/backfill.rs
@@ -50,6 +50,14 @@ pub(crate) struct TransferBackfillResult {
 pub(crate) enum TransferBackfillError {
     #[error("RPC error: {0}")]
     Rpc(#[from] RpcError<TransportErrorKind>),
+    #[error("Database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("Integer conversion error: {0}")]
+    IntConversion(#[from] std::num::TryFromIntError),
+    #[error(
+        "Backfill checkpoint overflow for vault {vault}: {last_processed_block}"
+    )]
+    CheckpointOverflow { vault: Address, last_processed_block: u64 },
     #[error("Transfer processing error: {0}")]
     TransferProcessing(#[from] TransferProcessingError),
 }
@@ -73,12 +81,19 @@ where
     pub(crate) async fn backfill_transfers(
         &self,
         vault: Address,
-        from_block: u64,
+        backfill_start_block: u64,
     ) -> Result<TransferBackfillResult, TransferBackfillError> {
         let current_block = self.provider.get_block_number().await?;
+        let from_block = backfill_start_block_for_vault(
+            &self.pool,
+            vault,
+            backfill_start_block,
+        )
+        .await?;
 
         if from_block > current_block {
             info!(
+                %vault,
                 from_block,
                 current_block,
                 "Transfer backfill skipped: from_block is ahead of current block"
@@ -153,9 +168,15 @@ where
             }
         }
 
+        save_backfill_checkpoint(&self.pool, vault, current_block).await?;
+
         info!(
+            %vault,
             detected_count,
-            skipped_mint, skipped_no_account, "Transfer backfill complete"
+            skipped_mint,
+            skipped_no_account,
+            checkpoint_block = current_block,
+            "Transfer backfill complete"
         );
 
         Ok(TransferBackfillResult {
@@ -187,6 +208,88 @@ where
     }
 }
 
+async fn backfill_start_block_for_vault(
+    pool: &Pool<Sqlite>,
+    vault: Address,
+    configured_start_block: u64,
+) -> Result<u64, TransferBackfillError> {
+    load_backfill_checkpoint(pool, vault).await?.map_or(
+        Ok(configured_start_block),
+        |last_processed_block| {
+            next_transfer_backfill_block(
+                vault,
+                last_processed_block,
+                configured_start_block,
+            )
+        },
+    )
+}
+
+fn next_transfer_backfill_block(
+    vault: Address,
+    last_processed_block: u64,
+    configured_start_block: u64,
+) -> Result<u64, TransferBackfillError> {
+    let next_unprocessed_block = last_processed_block.checked_add(1).ok_or(
+        TransferBackfillError::CheckpointOverflow {
+            vault,
+            last_processed_block,
+        },
+    )?;
+
+    Ok(next_unprocessed_block.max(configured_start_block))
+}
+
+async fn load_backfill_checkpoint(
+    pool: &Pool<Sqlite>,
+    vault: Address,
+) -> Result<Option<u64>, TransferBackfillError> {
+    let row = sqlx::query_as::<_, (i64,)>(
+        "
+        SELECT last_processed_block
+        FROM redemption_backfill_checkpoints
+        WHERE vault = ?
+        ",
+    )
+    .bind(vault.to_string())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(|(last_processed_block,)| u64::try_from(last_processed_block))
+        .transpose()
+        .map_err(TransferBackfillError::IntConversion)
+}
+
+async fn save_backfill_checkpoint(
+    pool: &Pool<Sqlite>,
+    vault: Address,
+    last_processed_block: u64,
+) -> Result<(), TransferBackfillError> {
+    let last_processed_block = i64::try_from(last_processed_block)?;
+
+    sqlx::query(
+        "
+        INSERT INTO redemption_backfill_checkpoints (
+            vault,
+            last_processed_block
+        )
+        VALUES (?, ?)
+        ON CONFLICT(vault) DO UPDATE SET
+            last_processed_block = MAX(
+                excluded.last_processed_block,
+                redemption_backfill_checkpoints.last_processed_block
+            ),
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        ",
+    )
+    .bind(vault.to_string())
+    .bind(last_processed_block)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 /// Maximum number of blocks to query in a single get_logs call.
 const BLOCK_CHUNK_SIZE: u64 = 2000;
 
@@ -213,10 +316,15 @@ mod tests {
     use alloy::providers::mock::Asserter;
     use alloy::signers::local::PrivateKeySigner;
     use cqrs_es::{CqrsFramework, mem_store::MemStore};
+    use sqlx::SqlitePool;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    use super::TransferBackfiller;
+    use super::{
+        TransferBackfillError, TransferBackfiller,
+        backfill_start_block_for_vault, load_backfill_checkpoint,
+        next_transfer_backfill_block, save_backfill_checkpoint,
+    };
     use crate::alpaca::mock::MockAlpacaService;
     use crate::receipt_inventory::{
         CqrsReceiptService, ReceiptInventory, ReceiptService,
@@ -266,8 +374,21 @@ mod tests {
         from_block: u64,
     ) -> Result<super::TransferBackfillResult, super::TransferBackfillError>
     {
-        let (cqrs, store, receipt_service) = setup_test_cqrs();
         let pool = setup_test_db_with_asset(vault, ap_wallet).await;
+
+        run_backfill_with_pool(vault, bot_wallet, asserter, from_block, pool)
+            .await
+    }
+
+    async fn run_backfill_with_pool(
+        vault: Address,
+        bot_wallet: Address,
+        asserter: &Asserter,
+        from_block: u64,
+        pool: SqlitePool,
+    ) -> Result<super::TransferBackfillResult, super::TransferBackfillError>
+    {
+        let (cqrs, store, receipt_service) = setup_test_cqrs();
 
         let alpaca_service = Arc::new(MockAlpacaService::new_success())
             as Arc<dyn crate::alpaca::AlpacaService>;
@@ -315,6 +436,23 @@ mod tests {
         };
 
         backfiller.backfill_transfers(vault, from_block).await
+    }
+
+    async fn load_backfill_checkpoint_updated_at(
+        pool: &SqlitePool,
+        vault: Address,
+    ) -> Option<String> {
+        sqlx::query_scalar::<_, String>(
+            "
+            SELECT updated_at
+            FROM redemption_backfill_checkpoints
+            WHERE vault = ?
+            ",
+        )
+        .bind(vault.to_string())
+        .fetch_optional(pool)
+        .await
+        .unwrap()
     }
 
     #[traced_test]
@@ -519,6 +657,173 @@ mod tests {
         assert!(logs_contain_at!(
             tracing::Level::INFO,
             &["Transfer backfill skipped", "from_block is ahead"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn backfill_start_block_uses_configured_start_without_checkpoint() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        let start_block =
+            backfill_start_block_for_vault(&pool, vault, 50).await.unwrap();
+
+        assert_eq!(start_block, 50);
+    }
+
+    #[tokio::test]
+    async fn backfill_start_block_resumes_after_checkpoint() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        save_backfill_checkpoint(&pool, vault, 80).await.unwrap();
+
+        let start_block =
+            backfill_start_block_for_vault(&pool, vault, 50).await.unwrap();
+
+        assert_eq!(start_block, 81);
+    }
+
+    #[tokio::test]
+    async fn backfill_start_block_respects_configured_floor() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        save_backfill_checkpoint(&pool, vault, 20).await.unwrap();
+
+        let start_block =
+            backfill_start_block_for_vault(&pool, vault, 50).await.unwrap();
+
+        assert_eq!(start_block, 50);
+    }
+
+    #[tokio::test]
+    async fn backfill_start_block_fails_on_checkpoint_overflow() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let error =
+            next_transfer_backfill_block(vault, u64::MAX, 50).unwrap_err();
+
+        assert!(matches!(
+            error,
+            TransferBackfillError::CheckpointOverflow { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn save_backfill_checkpoint_is_monotonic() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        save_backfill_checkpoint(&pool, vault, 100).await.unwrap();
+        save_backfill_checkpoint(&pool, vault, 80).await.unwrap();
+
+        assert_eq!(
+            load_backfill_checkpoint(&pool, vault).await.unwrap(),
+            Some(100)
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_backfill_does_not_touch_checkpoint_timestamp() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        save_backfill_checkpoint(&pool, vault, 200).await.unwrap();
+        let updated_at_before =
+            load_backfill_checkpoint_updated_at(&pool, vault).await.unwrap();
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(200u64));
+
+        run_backfill_with_pool(vault, bot_wallet, &asserter, 50, pool.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            load_backfill_checkpoint_updated_at(&pool, vault).await.unwrap(),
+            updated_at_before
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn backfill_persists_checkpoint_after_success() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(200u64));
+        asserter.push_success(&Vec::<alloy::rpc::types::Log>::new());
+
+        let result = run_backfill_with_pool(
+            vault,
+            bot_wallet,
+            &asserter,
+            50,
+            pool.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.detected_count, 0);
+        assert_eq!(
+            load_backfill_checkpoint(&pool, vault).await.unwrap(),
+            Some(200)
+        );
+
+        assert_eq!(
+            backfill_start_block_for_vault(&pool, vault, 50).await.unwrap(),
+            201
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Starting transfer backfill", "from_block=50", "to_block=200"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Transfer backfill complete", "checkpoint_block=200"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn backfill_restart_skips_already_checkpointed_range() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let pool = setup_test_db_with_asset(vault, None).await;
+
+        save_backfill_checkpoint(&pool, vault, 200).await.unwrap();
+
+        let asserter = Asserter::new();
+        asserter.push_success(&U256::from(200u64));
+
+        let result = run_backfill_with_pool(
+            vault,
+            bot_wallet,
+            &asserter,
+            50,
+            pool.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.detected_count, 0);
+        assert_eq!(
+            load_backfill_checkpoint(&pool, vault).await.unwrap(),
+            Some(200)
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &[
+                "Transfer backfill skipped",
+                "from_block is ahead",
+                "from_block=201",
+                "current_block=200"
+            ]
         ));
     }
 }


### PR DESCRIPTION
## Motivation

Closes RAI-233.

On restart, the issuer can spend a long time backfilling historical chain ranges before it becomes usable, leaving HTTP endpoints and health checks unavailable. The worst case is not just slow backfill: the service can redo already-processed ranges because progress is derived from stale startup state instead of durable per-range progress.

This follows the checkpoint backfill pattern from `st0x.liquidity` PR #592: persist progress, resume from `checkpoint + 1`, avoid unnecessary reprocessing, and keep avoidable catch-up work out of the critical startup path.

## Solution

- Added a `redemption_backfill_checkpoints` table keyed by vault.
- Updated redemption transfer backfill to:
  - resume from `last_processed_block + 1`
  - use `backfill_start_block` only as the first-run/configured floor
  - persist progress only after the requested range succeeds
  - write checkpoints monotonically with `MAX(...)`
  - log vault/range/checkpoint/detected/skipped counts
- Moved redemption transfer backfill into a background task after startup recovery, so HTTP serving is not blocked by avoidable historical transfer catch-up.
- Updated receipt backfill to start from the block after `ReceiptInventory::last_backfilled_block`, avoiding checkpoint-block reprocessing.
- Added periodic receipt backfill during uptime so receipt checkpoints stay current across long-running processes.
- Added guarded live receipt checkpoint advancement:
  - successful live logs advance the checkpoint
  - stale checkpoint commands are ignored
  - failed or unpositioned live logs block later live checkpoint advancement so restart/periodic backfill cannot skip them
- Updated `SPEC.md` and `README.md` to document checkpointed receipt/redemption backfill behavior.

## Checks

By submitting this for review, I am confirming I have done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Validation run:

- `nix develop -c cargo test -q receipt_inventory`
- `nix develop -c cargo test -q redemption::backfill`
- `nix develop -c cargo test -q --lib`
- `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `nix develop -c cargo check --workspace`
- `git --no-pager diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Durable per-vault checkpoints for receipt and redemption backfills
  * Periodic receipt backfill alongside live monitoring (live events won't advance durable checkpoints)
  * Transfer backfill runs asynchronously in background at startup and retries on failure

* **Behavior Change**
  * Restarts resume from the last successfully processed block; periodic backfills advance durable checkpoints only after ordered success

* **Documentation**
  * Updated backfill, checkpointing, and startup reconciliation descriptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->