### PR TITLE
refactor: reclassify tracing log levels and add domain categories

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,4 +92,4 @@ rsa = "0.9.10"
 rust_decimal_macros = "1.40.0"
 tempfile = "3.23.0"
 tokio = { version = "1.48.0", features = ["macros"] }
-tracing-test = "0.2.6"
+tracing-test = { version = "0.2.6", features = ["no-env-filter"] }

--- a/src/account/api.rs
+++ b/src/account/api.rs
@@ -58,7 +58,7 @@ impl<'r> Responder<'r, 'static> for ApiError {
         };
 
         let message = self.to_string();
-        error!("{message}");
+        error!(target: "account", "{message}");
 
         rocket::Response::build()
             .status(status)
@@ -122,7 +122,7 @@ fn map_cqrs_error_to_status(
         AggregateError::UserError(_) => Status::BadRequest,
         AggregateError::AggregateConflict => Status::Conflict,
         _ => {
-            error!("CQRS execute error: {err}");
+            error!(target: "account", "CQRS execute error: {err}");
             Status::InternalServerError
         }
     }

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -219,8 +219,7 @@ impl Aggregate for Account {
                 let Self::Registered { client_id, email, registered_at } =
                     self.clone()
                 else {
-                    error!(
-                        event = "LinkedToAlpaca",
+                    error!(target: "account", event = "LinkedToAlpaca",
                         alpaca_account = %alpaca_account.0,
                         state = ?self,
                         "event applied to non-Registered state"
@@ -241,8 +240,7 @@ impl Aggregate for Account {
             AccountEvent::WalletWhitelisted { wallet, .. } => {
                 let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self
                 else {
-                    error!(
-                        event = "WalletWhitelisted",
+                    error!(target: "account", event = "WalletWhitelisted",
                         wallet = %wallet,
                         state = ?self,
                         "event applied to non-LinkedToAlpaca state"
@@ -256,8 +254,7 @@ impl Aggregate for Account {
             AccountEvent::WalletUnwhitelisted { wallet, .. } => {
                 let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self
                 else {
-                    error!(
-                        event = "WalletUnwhitelisted",
+                    error!(target: "account", event = "WalletUnwhitelisted",
                         wallet = %wallet,
                         state = ?self,
                         "event applied to non-LinkedToAlpaca state"

--- a/src/account/view.rs
+++ b/src/account/view.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::info;
+use tracing::debug;
 
 use super::{
     Account, AccountError, AccountEvent, AlpacaAccountNumber, ClientId, Email,
@@ -27,7 +27,7 @@ pub(crate) enum AccountViewError {
 pub(crate) async fn replay_account_view(
     pool: Pool<Sqlite>,
 ) -> Result<(), AccountViewError> {
-    info!("Rebuilding account view from events");
+    debug!(target: "account", "Rebuilding account view from events");
 
     sqlx::query!("DELETE FROM account_view").execute(&pool).await?;
 
@@ -42,7 +42,7 @@ pub(crate) async fn replay_account_view(
     let replay = QueryReplay::new(event_repo, query);
     replay.replay_all().await?;
 
-    info!("Account view rebuild complete");
+    debug!(target: "account", "Account view rebuild complete");
 
     Ok(())
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -87,8 +87,7 @@ async fn load_reprocess_context(
 ) -> Result<ReprocessContext, Status> {
     let events =
         event_store.load_events(aggregate_id).await.map_err(|err| {
-            error!(
-                aggregate_id = aggregate_id,
+            error!(target: "admin", aggregate_id = aggregate_id,
                 error = %err,
                 "Failed to load redemption events"
             );
@@ -157,8 +156,7 @@ async fn load_reprocess_context(
     }
 
     let Some(metadata) = metadata else {
-        error!(
-            aggregate_id = aggregate_id,
+        error!(target: "admin", aggregate_id = aggregate_id,
             "No Detected event found in redemption event history"
         );
         return Err(Status::InternalServerError);
@@ -237,16 +235,14 @@ async fn recover_pre_alpaca(
     )
     .await
     .map_err(|err| {
-        error!(
-            aggregate_id = %aggregate_id,
+        error!(target: "admin", aggregate_id = %aggregate_id,
             error = %err,
             "Failed to recover redemption (pre-Alpaca)"
         );
         map_redemption_error(&err)
     })?;
 
-    info!(
-        aggregate_id = %aggregate_id,
+    info!(target: "admin", aggregate_id = %aggregate_id,
         "Redemption recovered from Failed to Detected"
     );
 
@@ -289,8 +285,7 @@ async fn recover_post_alpaca(
         .poll_request_status(&alpaca_data.tokenization_request_id)
         .await
         .map_err(|err| {
-            error!(
-                aggregate_id = %aggregate_id,
+            error!(target: "admin", aggregate_id = %aggregate_id,
                 tokenization_request_id = %alpaca_data.tokenization_request_id.0,
                 error = %err,
                 "Failed to poll Alpaca for journal status"
@@ -317,8 +312,7 @@ async fn recover_post_alpaca(
                 || req_quantity != &alpaca_data.alpaca_quantity
                 || req_wallet != &metadata.wallet
             {
-                error!(
-                    aggregate_id = %aggregate_id,
+                error!(target: "admin", aggregate_id = %aggregate_id,
                     "Alpaca response fields do not match redemption metadata"
                 );
                 return Err(Status::InternalServerError);
@@ -326,8 +320,7 @@ async fn recover_post_alpaca(
             (status, updated_at)
         }
         TokenizationRequest::Mint { .. } => {
-            error!(
-                aggregate_id = %aggregate_id,
+            error!(target: "admin", aggregate_id = %aggregate_id,
                 "Alpaca returned Mint request for a redemption tokenization_request_id"
             );
             return Err(Status::InternalServerError);
@@ -337,16 +330,14 @@ async fn recover_post_alpaca(
     match status {
         RedeemRequestStatus::Completed => {}
         RedeemRequestStatus::Pending => {
-            info!(
-                aggregate_id = %aggregate_id,
+            info!(target: "admin", aggregate_id = %aggregate_id,
                 tokenization_request_id = %alpaca_data.tokenization_request_id.0,
                 "Cannot recover: Alpaca journal still pending"
             );
             return Err(Status::UnprocessableEntity);
         }
         RedeemRequestStatus::Rejected => {
-            info!(
-                aggregate_id = %aggregate_id,
+            info!(target: "admin", aggregate_id = %aggregate_id,
                 tokenization_request_id = %alpaca_data.tokenization_request_id.0,
                 "Cannot recover: Alpaca journal was rejected"
             );
@@ -364,8 +355,7 @@ async fn recover_post_alpaca(
                     block_number,
                 })) => {
                     if bf_data.planned_burns.is_empty() {
-                        warn!(
-                            aggregate_id = %aggregate_id,
+                        warn!(target: "admin", aggregate_id = %aggregate_id,
                             fireblocks_tx_id = %fb_tx_id,
                             tx_hash = ?tx_hash,
                             "Pre-enrichment BurningFailed event has no planned_burns — \
@@ -374,8 +364,7 @@ async fn recover_post_alpaca(
                         );
                     }
 
-                    info!(
-                        aggregate_id = %aggregate_id,
+                    info!(target: "admin", aggregate_id = %aggregate_id,
                         fireblocks_tx_id = %fb_tx_id,
                         tx_hash = ?tx_hash,
                         "Fireblocks tx already completed on-chain, recording existing burn"
@@ -393,8 +382,7 @@ async fn recover_post_alpaca(
                     )
                     .await
                     .map_err(|err| {
-                        error!(
-                            aggregate_id = %aggregate_id,
+                        error!(target: "admin", aggregate_id = %aggregate_id,
                             error = %err,
                             "Failed to record existing burn"
                         );
@@ -411,16 +399,14 @@ async fn recover_post_alpaca(
                     }));
                 }
                 Ok(Some(FireblocksTxStatus::Pending)) => {
-                    info!(
-                        aggregate_id = %aggregate_id,
+                    info!(target: "admin", aggregate_id = %aggregate_id,
                         fireblocks_tx_id = %fb_tx_id,
                         "Fireblocks tx still pending, cannot recover yet"
                     );
                     return Err(Status::UnprocessableEntity);
                 }
                 Ok(Some(FireblocksTxStatus::Failed { status: fb_status })) => {
-                    info!(
-                        aggregate_id = %aggregate_id,
+                    info!(target: "admin", aggregate_id = %aggregate_id,
                         fireblocks_tx_id = %fb_tx_id,
                         fireblocks_status = %fb_status,
                         "Fireblocks tx failed, proceeding with ResumeBurn"
@@ -431,8 +417,7 @@ async fn recover_post_alpaca(
                     // Non-Fireblocks backend, fall through to ResumeBurn
                 }
                 Err(err) => {
-                    error!(
-                        aggregate_id = %aggregate_id,
+                    error!(target: "admin", aggregate_id = %aggregate_id,
                         fireblocks_tx_id = %fb_tx_id,
                         error = %err,
                         "Failed to check Fireblocks tx status"
@@ -444,8 +429,7 @@ async fn recover_post_alpaca(
     }
 
     let Some(alpaca_journal_completed_at) = alpaca_updated_at else {
-        error!(
-            aggregate_id = %aggregate_id,
+        error!(target: "admin", aggregate_id = %aggregate_id,
             "Alpaca returned completed status but updated_at is null"
         );
         return Err(Status::BadGateway);
@@ -466,16 +450,14 @@ async fn recover_post_alpaca(
     )
     .await
     .map_err(|err| {
-        error!(
-            aggregate_id = %aggregate_id,
+        error!(target: "admin", aggregate_id = %aggregate_id,
             error = %err,
             "Failed to recover redemption (post-Alpaca)"
         );
         map_redemption_error(&err)
     })?;
 
-    info!(
-        aggregate_id = %aggregate_id,
+    info!(target: "admin", aggregate_id = %aggregate_id,
         "Redemption recovered from Failed to Burning"
     );
 
@@ -530,16 +512,14 @@ pub(crate) async fn close_redemption(
     )
     .await
     .map_err(|err| {
-        error!(
-            aggregate_id = %aggregate_id,
+        error!(target: "admin", aggregate_id = %aggregate_id,
             error = %err,
             "Failed to close redemption"
         );
         map_redemption_error(&err)
     })?;
 
-    info!(
-        aggregate_id = %aggregate_id,
+    info!(target: "admin", aggregate_id = %aggregate_id,
         "Redemption closed"
     );
 
@@ -565,28 +545,31 @@ pub(crate) async fn reprocess_mint(
         .map_err(|_| Status::BadRequest)?;
 
     // Check current state via view
-    let current_state =
-        match find_by_issuer_request_id(pool.inner(), &issuer_request_id).await
-        {
-            Ok(Some(view)) => {
-                let state = match &view {
-                    MintView::NotFound => return Err(Status::NotFound),
-                    MintView::Completed { .. } => return Err(Status::Conflict),
-                    MintView::Initiated { .. } => "Initiated",
-                    MintView::JournalConfirmed { .. } => "JournalConfirmed",
-                    MintView::JournalRejected { .. } => "JournalRejected",
-                    MintView::Minting { .. } => "Minting",
-                    MintView::CallbackPending { .. } => "CallbackPending",
-                    MintView::MintingFailed { .. } => "MintingFailed",
-                };
-                state.to_string()
-            }
-            Ok(None) => return Err(Status::NotFound),
-            Err(err) => {
-                error!(error = %err, "Failed to query mint view");
-                return Err(Status::InternalServerError);
-            }
-        };
+    let current_state = match find_by_issuer_request_id(
+        pool.inner(),
+        &issuer_request_id,
+    )
+    .await
+    {
+        Ok(Some(view)) => {
+            let state = match &view {
+                MintView::NotFound => return Err(Status::NotFound),
+                MintView::Completed { .. } => return Err(Status::Conflict),
+                MintView::Initiated { .. } => "Initiated",
+                MintView::JournalConfirmed { .. } => "JournalConfirmed",
+                MintView::JournalRejected { .. } => "JournalRejected",
+                MintView::Minting { .. } => "Minting",
+                MintView::CallbackPending { .. } => "CallbackPending",
+                MintView::MintingFailed { .. } => "MintingFailed",
+            };
+            state.to_string()
+        }
+        Ok(None) => return Err(Status::NotFound),
+        Err(err) => {
+            error!(target: "admin", error = %err, "Failed to query mint view");
+            return Err(Status::InternalServerError);
+        }
+    };
 
     cqrs.execute(
         aggregate_id,
@@ -594,8 +577,7 @@ pub(crate) async fn reprocess_mint(
     )
     .await
     .map_err(|err| {
-        error!(
-            aggregate_id = aggregate_id,
+        error!(target: "admin", aggregate_id = aggregate_id,
             error = %err,
             "Failed to reprocess mint"
         );
@@ -605,8 +587,7 @@ pub(crate) async fn reprocess_mint(
         }
     })?;
 
-    info!(
-        aggregate_id = aggregate_id,
+    info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
         "Mint reprocessed successfully"
     );
@@ -629,7 +610,7 @@ pub(crate) async fn list_stuck(
 
     // Stuck redemptions (Failed and BurnFailed)
     let stuck_redemptions = find_stuck(pool.inner()).await.map_err(|err| {
-        error!(error = %err, "Failed to query stuck redemptions");
+        error!(target: "admin", error = %err, "Failed to query stuck redemptions");
         Status::InternalServerError
     })?;
 
@@ -655,7 +636,7 @@ pub(crate) async fn list_stuck(
     // Stuck mints (recoverable states)
     let recoverable_mints =
         find_all_recoverable_mints(pool.inner()).await.map_err(|err| {
-            error!(error = %err, "Failed to query recoverable mints");
+            error!(target: "admin", error = %err, "Failed to query recoverable mints");
             Status::InternalServerError
         })?;
 

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -150,7 +150,7 @@ impl AlpacaService for RealAlpacaService {
             self.account_id
         );
 
-        debug!(%url, method = "POST", "Sending mint callback to Alpaca");
+        debug!(target: "alpaca", %url, method = "POST", "Sending mint callback to Alpaca");
 
         (|| async {
             let response = self
@@ -185,7 +185,8 @@ impl AlpacaService for RealAlpacaService {
         )
         .when(|e: &AlpacaError| e.is_retryable())
         .notify(|err: &AlpacaError, dur: std::time::Duration| {
-            tracing::warn!(
+            tracing::debug!(
+                target: "alpaca",
                 "Alpaca API call failed with {err}, retrying after {dur:?}"
             );
         })
@@ -202,7 +203,7 @@ impl AlpacaService for RealAlpacaService {
             self.account_id
         );
 
-        debug!(%url, method = "POST", "Calling Alpaca redeem endpoint");
+        debug!(target: "alpaca", %url, method = "POST", "Calling Alpaca redeem endpoint");
 
         let response = self
             .client
@@ -221,6 +222,7 @@ impl AlpacaService for RealAlpacaService {
                 let body = response.text().await?;
                 serde_json::from_str(&body).map_err(|e| {
                     tracing::error!(
+                        target: "alpaca",
                         %body,
                         error = %e,
                         "Failed to parse Alpaca redeem response"
@@ -250,7 +252,7 @@ impl AlpacaService for RealAlpacaService {
             self.account_id
         );
 
-        debug!(%url, method = "GET", "Polling Alpaca request status");
+        debug!(target: "alpaca", %url, method = "GET", "Polling Alpaca request status");
 
         (|| async {
             let response = self
@@ -270,6 +272,7 @@ impl AlpacaService for RealAlpacaService {
                     let requests: Vec<TokenizationRequest> =
                         serde_json::from_str(&body).map_err(|e| {
                             tracing::error!(
+                                target: "alpaca",
                                 %body,
                                 error = %e,
                                 "Failed to parse Alpaca requests list response"
@@ -309,7 +312,8 @@ impl AlpacaService for RealAlpacaService {
         )
         .when(|e: &AlpacaError| e.is_retryable())
         .notify(|err: &AlpacaError, dur: std::time::Duration| {
-            tracing::warn!(
+            tracing::debug!(
+                target: "alpaca",
                 "Alpaca poll request status API call failed with {err}, retrying after {dur:?}"
             );
         })

--- a/src/auth/ip_whitelist.rs
+++ b/src/auth/ip_whitelist.rs
@@ -45,8 +45,7 @@ impl FromStr for IpWhitelist {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.trim().is_empty() {
-            warn!(
-                "IP whitelist is empty - all IPs will be allowed. \
+            warn!(target: "auth", "IP whitelist is empty - all IPs will be allowed. \
                  This is NOT RECOMMENDED for production."
             );
             return Ok(Self::AllowAll);

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -9,7 +9,7 @@ use std::io::Cursor;
 use std::net::IpAddr;
 use std::str::FromStr;
 use subtle::ConstantTimeEq;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 use crate::config::Config;
 pub use ip_whitelist::IpWhitelist;
@@ -96,8 +96,7 @@ impl<'r> FromRequest<'r> for IssuerAuth {
     ) -> Outcome<Self, Self::Error> {
         match authenticate_request(request, |auth| &auth.alpaca_ip_ranges) {
             Ok(client_ip) => {
-                info!(
-                    ip = %client_ip,
+                debug!(target: "auth", ip = %client_ip,
                     endpoint = %request.uri(),
                     "Issuer authentication success"
                 );
@@ -122,8 +121,7 @@ impl<'r> FromRequest<'r> for InternalAuth {
     ) -> Outcome<Self, Self::Error> {
         match authenticate_request(request, |auth| &auth.internal_ip_ranges) {
             Ok(client_ip) => {
-                info!(
-                    ip = %client_ip,
+                debug!(target: "auth", ip = %client_ip,
                     endpoint = %request.uri(),
                     "Internal authentication success"
                 );
@@ -159,7 +157,7 @@ fn get_config<'a>(
     request: &'a Request<'_>,
 ) -> Result<&'a Config, (Status, AuthError)> {
     request.rocket().state::<Config>().ok_or_else(|| {
-        warn!("Config not found in Rocket state");
+        warn!(target: "auth", "Config not found in Rocket state");
         (Status::InternalServerError, AuthError::ConfigMissing)
     })
 }
@@ -168,7 +166,7 @@ fn get_rate_limiter<'a>(
     request: &'a Request<'_>,
 ) -> Result<&'a FailedAuthRateLimiter, (Status, AuthError)> {
     request.rocket().state::<FailedAuthRateLimiter>().ok_or_else(|| {
-        warn!("Rate limiter not found in Rocket state");
+        warn!(target: "auth", "Rate limiter not found in Rocket state");
         (Status::InternalServerError, AuthError::ConfigMissing)
     })
 }
@@ -179,8 +177,7 @@ fn check_api_key(
     rate_limiter: &FailedAuthRateLimiter,
 ) -> Result<(), (Status, AuthError)> {
     let Some(api_key) = request.headers().get_one("X-API-KEY") else {
-        warn!(
-            endpoint = %request.uri(),
+        warn!(target: "auth", endpoint = %request.uri(),
             "Missing X-API-KEY header"
         );
         return Err((Status::Unauthorized, AuthError::MissingApiKey));
@@ -195,8 +192,7 @@ fn check_api_key(
         check_rate_limit(request, rate_limiter, &client_ip)?;
     }
 
-    warn!(
-        endpoint = %request.uri(),
+    warn!(target: "auth", endpoint = %request.uri(),
         "Invalid API key"
     );
     Err((Status::Unauthorized, AuthError::InvalidApiKey))
@@ -204,8 +200,7 @@ fn check_api_key(
 
 fn get_client_ip(request: &Request<'_>) -> Result<IpAddr, (Status, AuthError)> {
     extract_client_ip(request).ok_or_else(|| {
-        warn!(
-            endpoint = %request.uri(),
+        warn!(target: "auth", endpoint = %request.uri(),
             "Could not determine client IP"
         );
         (Status::BadRequest, AuthError::NoClientIp)
@@ -226,8 +221,7 @@ fn check_ip_whitelist(
 
     check_rate_limit(request, rate_limiter, &client_ip)?;
 
-    warn!(
-        ip = %client_ip,
+    warn!(target: "auth", ip = %client_ip,
         endpoint = %request.uri(),
         "IP not whitelisted"
     );
@@ -243,8 +237,7 @@ fn check_rate_limit(
         return Ok(());
     }
 
-    warn!(
-        ip = %client_ip,
+    warn!(target: "auth", ip = %client_ip,
         endpoint = %request.uri(),
         "Rate limit exceeded for failed authentication"
     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,9 +276,37 @@ pub enum ConfigError {
     ChainIdMismatch { configured: u64, from_rpc: u64 },
 }
 
+/// Domain target categories used in `target:` on all tracing macros.
+/// The default `EnvFilter` must include these so logs are not silenced.
+const DOMAIN_TARGETS: &[&str] = &[
+    "startup",
+    "mint",
+    "redemption",
+    "receipt",
+    "account",
+    "asset",
+    "alpaca",
+    "auth",
+    "fireblocks",
+    "admin",
+    "vault",
+];
+
+/// Builds a default `EnvFilter` string that includes both the crate module
+/// path and all custom domain targets at the given level.
+pub(crate) fn default_log_filter(level: Level) -> String {
+    let mut parts = vec![format!("st0x_issuance={level}")];
+
+    for target in DOMAIN_TARGETS {
+        parts.push(format!("{target}={level}"));
+    }
+
+    parts.join(",")
+}
+
 pub fn setup_tracing(log_level: &LogLevel) {
     let level: Level = log_level.into();
-    let default_filter = format!("st0x_issuance={level}");
+    let default_filter = default_log_filter(level);
 
     let _ = tracing_subscriber::fmt()
         .with_env_filter(

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -149,8 +149,7 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
         }
         let client = builder.build()?;
 
-        debug!(
-            vault_account_id = %config.vault_account_id.as_str(),
+        debug!(target: "fireblocks", vault_account_id = %config.vault_account_id.as_str(),
             chain_asset_ids = ?config.chain_asset_ids,
             %chain_id,
             "Fireblocks vault service initialized"
@@ -253,8 +252,7 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
                 // the response body which contains the actual error message and
                 // code. Debug preserves the full ResponseContent including the
                 // body and typed error entity.
-                warn!(
-                    error = ?err,
+                warn!(target: "fireblocks", error = ?err,
                     %contract_address,
                     %external_tx_id,
                     "Fireblocks create_transaction failed"
@@ -278,7 +276,7 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
         &self,
         tx_id: &str,
     ) -> Result<B256, FireblocksVaultError> {
-        debug!(fireblocks_tx_id = %tx_id, "Polling Fireblocks CONTRACT_CALL transaction...");
+        debug!(target: "fireblocks", fireblocks_tx_id = %tx_id, "Polling Fireblocks CONTRACT_CALL transaction...");
 
         let result = self
             .client
@@ -287,8 +285,7 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
                 Duration::from_secs(600),
                 Duration::from_millis(500),
                 |tx| {
-                    debug!(
-                        fireblocks_tx_id = %tx_id,
+                    debug!(target: "fireblocks", fireblocks_tx_id = %tx_id,
                         status = ?tx.status,
                         "Polling Fireblocks transaction"
                     );
@@ -298,8 +295,7 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
 
         if result.status != TransactionStatus::Completed {
             if is_still_pending(result.status) {
-                warn!(
-                    fireblocks_tx_id = %tx_id,
+                warn!(target: "fireblocks", fireblocks_tx_id = %tx_id,
                     status = ?result.status,
                     "Polling timed out but transaction may still confirm on-chain"
                 );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use sqlite_es::{
 use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
 use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info, trace, warn};
 use url::Url;
 
 use crate::account::view::replay_account_view;
@@ -257,7 +257,7 @@ pub async fn initialize_rocket(
     let blockchain_setup = config.create_blockchain_setup().await?;
     let alpaca_service = config.alpaca.service()?;
     let bot_wallet = config.signer.address().await?;
-    info!("Bot wallet address: {bot_wallet}");
+    info!(target: "startup", "Bot wallet address: {bot_wallet}");
 
     let vault_service_for_rocket = blockchain_setup.vault_service.clone();
 
@@ -286,7 +286,7 @@ pub async fn initialize_rocket(
     // Reprojections must complete BEFORE recovery runs, so recovery queries
     // up-to-date views. Each replay clears its view table first to remove
     // stale/corrupt data, then rebuilds from the event store.
-    info!("Rebuilding all views from events");
+    debug!(target: "startup", "Rebuilding all views from events");
     replay_account_view(pool.clone()).await?;
     replay_tokenized_asset_view(pool.clone()).await?;
     replay_mint_view(pool.clone()).await?;
@@ -321,7 +321,8 @@ pub async fn initialize_rocket(
     )
     .await
     {
-        warn!(
+        error!(
+            target: "receipt",
             error = %error,
             "Startup reconciliation failed — receipt balances may be stale \
              until the next withdraw event triggers reconciliation"
@@ -633,12 +634,14 @@ fn spawn_all_redemption_detectors(
     bot_wallet: Address,
 ) {
     info!(
+        target: "redemption",
         vault_count = vault_configs.len(),
         "Spawning redemption detectors for all vaults"
     );
 
     for config in vault_configs {
         debug!(
+            target: "redemption",
             vault = %config.vault,
             bot_wallet = %bot_wallet,
             "Spawning redemption detector for vault"
@@ -671,7 +674,7 @@ fn spawn_redemption_detector(
     managers: RedemptionManagers,
     bot_wallet: Address,
 ) {
-    info!(bot_wallet = %bot_wallet, "Spawning WebSocket monitoring task");
+    debug!(target: "redemption", bot_wallet = %bot_wallet, "Spawning WebSocket monitoring task");
 
     let detector_config =
         RedemptionDetectorConfig { rpc_url, vault, bot_wallet };
@@ -692,29 +695,29 @@ fn spawn_redemption_detector(
 }
 
 async fn run_mint_recovery(pool: &Pool<Sqlite>, mint_cqrs: &MintCqrs) {
-    info!("Running mint recovery");
+    info!(target: "mint", "Running mint recovery");
 
     let recoverable_mints = match find_all_recoverable_mints(pool).await {
         Ok(mints) => mints,
         Err(err) => {
-            error!(error = %err, "Failed to query recoverable mints");
+            error!(target: "mint", error = %err, "Failed to query recoverable mints");
             return;
         }
     };
 
     if recoverable_mints.is_empty() {
-        info!("No mints to recover");
+        debug!(target: "mint", "No mints to recover");
         return;
     }
 
     let count = recoverable_mints.len();
-    info!(count, "Recovering mints");
+    debug!(target: "mint", count, "Recovering mints");
 
     for (issuer_request_id, _view) in recoverable_mints {
         recover_mint(mint_cqrs, issuer_request_id).await;
     }
 
-    info!(count, "Mint recovery complete");
+    debug!(target: "mint", count, "Mint recovery complete");
 }
 
 async fn run_redemption_recovery(
@@ -726,7 +729,7 @@ async fn run_redemption_recovery(
     >,
     burn: &BurnManager<PersistedEventStore<SqliteEventRepository, Redemption>>,
 ) {
-    info!("Running redemption recovery");
+    info!(target: "redemption", "Running redemption recovery");
 
     redeem_call.recover_detected_redemptions().await;
     journal.recover_alpaca_called_redemptions().await;
@@ -755,11 +758,12 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
     let assets = list_enabled_assets(pool).await?;
 
     if assets.is_empty() {
-        info!("No enabled tokenized assets found, skipping receipt backfill");
+        info!(target: "receipt", "No enabled tokenized assets found, skipping receipt backfill");
         return Ok(vec![]);
     }
 
     info!(
+        target: "receipt",
         asset_count = assets.len(),
         "Running receipt backfill for all enabled assets"
     );
@@ -814,6 +818,7 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
     )?;
 
     info!(
+        target: "receipt",
         underlying,
         vault = %vault,
         receipt_contract = %receipt_contract,
@@ -833,6 +838,7 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
     let result = backfiller.backfill_receipts(from_block).await?;
 
     info!(
+        target: "receipt",
         underlying,
         vault = %vault,
         processed = result.processed_count,
@@ -872,7 +878,8 @@ async fn run_periodic_receipt_backfill_for_config<P: Provider + Clone>(
         backfill_start_block,
     )?;
 
-    debug!(
+    trace!(
+        target: "receipt",
         vault = %config.vault,
         receipt_contract = %config.receipt_contract,
         from_block,
@@ -889,7 +896,8 @@ async fn run_periodic_receipt_backfill_for_config<P: Provider + Clone>(
 
     let result = backfiller.backfill_receipts(from_block).await?;
 
-    debug!(
+    trace!(
+        target: "receipt",
         vault = %config.vault,
         processed = result.processed_count,
         skipped_zero_balance = result.skipped_zero_balance,
@@ -931,6 +939,7 @@ fn spawn_periodic_receipt_backfills<P>(
                 .await
                 {
                     warn!(
+                        target: "receipt",
                         error = %error,
                         vault = %config.vault,
                         "Periodic receipt backfill failed; next run will resume \
@@ -953,11 +962,12 @@ async fn run_all_transfer_backfills<P: Provider + Clone>(
     backfill_start_block: u64,
 ) -> Result<(), anyhow::Error> {
     if vault_configs.is_empty() {
-        info!("No enabled vaults, skipping transfer backfill");
+        info!(target: "redemption", "No enabled vaults, skipping transfer backfill");
         return Ok(());
     }
 
     info!(
+        target: "redemption",
         vault_count = vault_configs.len(),
         "Running transfer backfill for all vaults"
     );
@@ -973,6 +983,7 @@ async fn run_all_transfer_backfills<P: Provider + Clone>(
             Err(error) => {
                 failed_count += 1;
                 warn!(
+                    target: "redemption",
                     error = %error,
                     vault = %config.vault,
                     "Transfer backfill failed for vault; continuing with \
@@ -983,6 +994,7 @@ async fn run_all_transfer_backfills<P: Provider + Clone>(
         };
 
         debug!(
+            target: "redemption",
             vault = %config.vault,
             detected = result.detected_count,
             skipped_mint = result.skipped_mint,
@@ -1021,6 +1033,7 @@ fn spawn_all_transfer_backfills<P>(
                 Ok(()) => return,
                 Err(error) => {
                     error!(
+                        target: "redemption",
                         error = %error,
                         retry_after_secs =
                             TRANSFER_BACKFILL_RETRY_INTERVAL.as_secs(),
@@ -1048,12 +1061,14 @@ fn spawn_all_receipt_monitors<P, ITN>(
     ITN: ItnReceiptHandler + Clone + 'static,
 {
     info!(
+        target: "receipt",
         vault_count = vault_configs.len(),
         "Spawning receipt monitors for all vaults"
     );
 
     for config in vault_configs {
-        info!(
+        debug!(
+            target: "receipt",
             vault = %config.vault,
             receipt_contract = %config.receipt_contract,
             bot_wallet = %bot_wallet,

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -41,8 +41,7 @@ pub(crate) async fn confirm_journal(
         reason,
     } = request.into_inner();
 
-    info!(
-        "Received journal confirmation for issuer_request_id={}, \
+    info!(target: "mint", "Received journal confirmation for issuer_request_id={}, \
          tokenization_request_id={}, status={:?}",
         issuer_request_id, tokenization_request_id.0, status
     );
@@ -53,8 +52,7 @@ pub(crate) async fn confirm_journal(
     {
         Ok(ctx) => ctx,
         Err(err) => {
-            error!(
-                "Failed to load mint aggregate for issuer_request_id={}: {}",
+            error!(target: "mint", "Failed to load mint aggregate for issuer_request_id={}: {}",
                 issuer_request_id, err
             );
             return rocket::http::Status::InternalServerError;
@@ -65,8 +63,7 @@ pub(crate) async fn confirm_journal(
         mint_ctx.aggregate().tokenization_request_id()
     {
         if &tokenization_request_id != expected_tokenization_id {
-            error!(
-                "Tokenization request ID mismatch for issuer_request_id={}. \
+            error!(target: "mint", "Tokenization request ID mismatch for issuer_request_id={}. \
                  Expected: {}, provided: {}",
                 issuer_request_id,
                 expected_tokenization_id.0,
@@ -88,8 +85,7 @@ pub(crate) async fn confirm_journal(
             if let Err(err) =
                 cqrs.execute(&issuer_request_id.to_string(), command).await
             {
-                error!(
-                    "Failed to execute journal rejection command for \
+                error!(target: "mint", "Failed to execute journal rejection command for \
                      issuer_request_id={}: {}",
                     issuer_request_id, err
                 );
@@ -105,8 +101,7 @@ pub(crate) async fn confirm_journal(
             if let Err(err) =
                 cqrs.execute(&issuer_request_id.to_string(), command).await
             {
-                error!(
-                    "Failed to execute journal confirmation command for \
+                error!(target: "mint", "Failed to execute journal confirmation command for \
                      issuer_request_id={}: {}",
                     issuer_request_id, err
                 );
@@ -140,8 +135,7 @@ async fn process_journal_completion(
         )
         .await
     {
-        error!(
-            issuer_request_id = %issuer_request_id,
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
             error = ?err,
             "Deposit command failed"
         );
@@ -157,8 +151,7 @@ async fn process_journal_completion(
         )
         .await
     {
-        error!(
-            issuer_request_id = %issuer_request_id,
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
             error = ?err,
             "SendCallback command failed"
         );

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -75,7 +75,7 @@ pub(crate) async fn initiate_mint(
 
     cqrs.execute(&issuer_request_id.to_string(), command).await.map_err(
         |error| {
-            error!("Failed to execute mint command: {error}");
+            error!(target: "mint", "Failed to execute mint command: {error}");
             MintApiError::CommandExecutionFailed(Box::new(error))
         },
     )?;
@@ -83,7 +83,7 @@ pub(crate) async fn initiate_mint(
     let mint_view = find_by_issuer_request_id(pool.inner(), &issuer_request_id)
         .await
         .map_err(|error| {
-            error!("Failed to find mint by issuer_request_id: {error}");
+            error!(target: "mint", "Failed to find mint by issuer_request_id: {error}");
             MintApiError::MintViewQueryFailed(error)
         })?
         .ok_or(MintApiError::MintViewNotFound)?;

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -3,7 +3,7 @@ use rocket::http::{ContentType, Status};
 use rocket::response::{self, Responder};
 use rocket::serde::json::Json;
 use serde::{Deserialize, Serialize};
-use tracing::error;
+use tracing::{error, warn};
 
 use super::{
     ClientId, IssuerMintRequestId, Network, TokenSymbol, UnderlyingSymbol,
@@ -96,13 +96,13 @@ impl<'r> Responder<'r, 'static> for MintApiError {
                 Self::handle_query_error(&e, "Failed to query mint view")
             }
             Self::MintViewNotFound => {
-                error!("Mint view not found after creation");
+                error!(target: "mint", "Mint view not found after creation");
                 MintErrorResponse::internal_server_error(
                     "Internal server error",
                 )
             }
             Self::UnexpectedMintState => {
-                error!("Unexpected mint state");
+                error!(target: "mint", "Unexpected mint state");
                 MintErrorResponse::internal_server_error(
                     "Internal server error",
                 )
@@ -117,7 +117,7 @@ impl MintApiError {
     fn handle_command_execution_error(
         e: &(dyn std::error::Error + Send),
     ) -> MintErrorResponse {
-        error!(error = %e, "Failed to execute mint command");
+        error!(target: "mint", error = %e, "Failed to execute mint command");
 
         let error_msg = e.to_string().to_lowercase();
         if error_msg.contains("already") || error_msg.contains("duplicate") {
@@ -133,7 +133,7 @@ impl MintApiError {
         e: &E,
         message: &str,
     ) -> MintErrorResponse {
-        error!(error = %e, "{message}");
+        error!(target: "mint", error = %e, "{message}");
         MintErrorResponse::internal_server_error("Internal server error")
     }
 }
@@ -204,7 +204,7 @@ pub(crate) async fn validate_asset_exists(
     .fetch_one(pool)
     .await
     .map_err(|e| {
-        error!("Failed to query asset: {e}");
+        error!(target: "mint", "Failed to query asset: {e}");
         MintApiError::AssetQueryFailed(e.into())
     })?;
 
@@ -222,7 +222,7 @@ pub(crate) async fn validate_client_eligible(
 ) -> Result<(), MintApiError> {
     let account_view =
         find_by_client_id(pool, client_id).await.map_err(|e| {
-            error!("Failed to find account by client_id: {e}");
+            error!(target: "mint", "Failed to find account by client_id: {e}");
             MintApiError::AccountQueryFailed(e)
         })?;
 
@@ -233,7 +233,8 @@ pub(crate) async fn validate_client_eligible(
     };
 
     if !whitelisted_wallets.contains(wallet) {
-        error!(
+        warn!(
+            target: "mint",
             client_id = %client_id,
             whitelisted_wallet_count = whitelisted_wallets.len(),
             "Wallet not in client's whitelisted wallets"

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -11,7 +11,7 @@ use cqrs_es::Aggregate;
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 use uuid::Uuid;
 
 use crate::account::view::AccountViewError;
@@ -366,6 +366,7 @@ impl Mint {
             }
             Err(err) => {
                 warn!(
+                    target: "mint",
                     issuer_request_id = %issuer_request_id,
                     error = %err,
                     "On-chain deposit failed"
@@ -395,6 +396,7 @@ impl Mint {
         now: DateTime<Utc>,
     ) -> Result<Vec<MintEvent>, MintError> {
         info!(
+            target: "mint",
             issuer_request_id = %issuer_request_id,
             tx_hash = %result.tx_hash,
             receipt_id = %result.receipt_id,
@@ -416,6 +418,7 @@ impl Mint {
             .await
         {
             warn!(
+                target: "mint",
                 issuer_request_id = %issuer_request_id,
                 error = %err,
                 "Failed to register minted receipt \
@@ -473,6 +476,7 @@ impl Mint {
         services.alpaca.send_mint_callback(callback_request).await?;
 
         info!(
+            target: "mint",
             issuer_request_id = %issuer_request_id,
             "Alpaca callback succeeded"
         );
@@ -659,6 +663,7 @@ impl Mint {
         let completion_event = match mint_result {
             Ok(result) => {
                 info!(
+                    target: "mint",
                     issuer_request_id = %issuer_request_id,
                     tx_hash = %result.tx_hash,
                     "Recovery mint succeeded"
@@ -675,6 +680,7 @@ impl Mint {
             }
             Err(err) => {
                 warn!(
+                    target: "mint",
                     issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Recovery mint failed"
@@ -703,11 +709,12 @@ impl Mint {
             .find_by_issuer_request_id(vault, issuer_request_id)
             .await?
         else {
-            info!(issuer_request_id = %issuer_request_id, "No receipt found, retrying mint");
+            debug!(target: "mint", issuer_request_id = %issuer_request_id, "No receipt found, retrying mint");
             return Ok(None);
         };
 
         info!(
+            target: "mint",
             issuer_request_id = %issuer_request_id,
             receipt_id = %receipt.receipt_id,
             "Found existing receipt, recording recovery"

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -82,8 +82,7 @@ async fn drive_recovery<ES>(
 
         match result {
             Ok(()) => {
-                debug!(
-                    issuer_request_id = %issuer_request_id,
+                debug!(target: "mint", issuer_request_id = %issuer_request_id,
                     attempt,
                     "Recovery step succeeded, continuing"
                 );
@@ -91,16 +90,14 @@ async fn drive_recovery<ES>(
             Err(AggregateError::UserError(MintError::NotRecoverable {
                 current_state,
             })) => {
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "mint", issuer_request_id = %issuer_request_id,
                     current_state,
                     "Mint recovery complete"
                 );
                 return;
             }
             Err(err) => {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Mint recovery failed"
                 );
@@ -109,8 +106,7 @@ async fn drive_recovery<ES>(
         }
     }
 
-    error!(
-        issuer_request_id = %issuer_request_id,
+    error!(target: "mint", issuer_request_id = %issuer_request_id,
         aggregate_id,
         max_attempts = MAX_RECOVERY_ATTEMPTS,
         "Mint recovery exceeded maximum attempts without reaching terminal state"

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::info;
+use tracing::debug;
 use uuid::Uuid;
 
 use super::{
@@ -32,7 +32,7 @@ pub(crate) enum MintViewError {
 /// This is used at startup to ensure the view is in sync with events after manual
 /// event store modifications or schema changes.
 pub async fn replay_mint_view(pool: Pool<Sqlite>) -> Result<(), MintViewError> {
-    info!("Rebuilding mint view from events");
+    debug!(target: "mint", "Rebuilding mint view from events");
 
     sqlx::query!("DELETE FROM mint_view").execute(&pool).await?;
 
@@ -46,7 +46,7 @@ pub async fn replay_mint_view(pool: Pool<Sqlite>) -> Result<(), MintViewError> {
     let replay = QueryReplay::new(event_repo, query);
     replay.replay_all().await?;
 
-    info!("Mint view rebuild complete");
+    debug!(target: "mint", "Mint view rebuild complete");
 
     Ok(())
 }

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -6,7 +6,7 @@ use cqrs_es::{AggregateError, CqrsFramework, EventStore};
 use futures::{StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{info, trace};
 
 use super::monitor::{
     TransferDirection, transfer_batch_filter, transfer_single_filter,
@@ -120,8 +120,7 @@ where
         let current_block = self.provider.get_block_number().await?;
 
         if from_block > current_block {
-            info!(
-                from_block,
+            info!(target: "receipt", from_block,
                 current_block,
                 "Backfill skipped: from_block is ahead of current block"
             );
@@ -132,8 +131,7 @@ where
             });
         }
 
-        info!(
-            receipt_contract = %self.receipt_contract,
+        trace!(target: "receipt", receipt_contract = %self.receipt_contract,
             bot_wallet = %self.bot_wallet,
             from_block,
             to_block = current_block,
@@ -147,8 +145,7 @@ where
         ))
         .then(|(chunk_from, chunk_to)| async move {
             let logs = self.fetch_logs_for_range(chunk_from, chunk_to).await?;
-            debug!(
-                chunk_from,
+            trace!(target: "receipt", chunk_from,
                 chunk_to,
                 logs_found = logs.len(),
                 "Processed block range"
@@ -193,8 +190,7 @@ where
             )
             .await?;
 
-        info!(
-            processed_count,
+        trace!(target: "receipt", processed_count,
             skipped_zero_balance,
             checkpoint_block = current_block,
             "Receipt backfill complete"
@@ -388,8 +384,7 @@ where
             )
             .await?;
 
-        debug!(
-            receipt_id = %discovery.receipt_id,
+        trace!(target: "receipt", receipt_id = %discovery.receipt_id,
             balance = %current_balance,
             "Processed receipt"
         );
@@ -555,14 +550,14 @@ mod tests {
         let test = "backfill_discovers_receipt_from_historic_deposit";
         assert!(
             logs_contain_at!(
-                tracing::Level::DEBUG,
+                tracing::Level::TRACE,
                 &[test, "Processed block range"]
             ),
             "Expected DEBUG log for block range processing"
         );
         assert!(
             logs_contain_at!(
-                tracing::Level::DEBUG,
+                tracing::Level::TRACE,
                 &[test, "Processed receipt"]
             ),
             "Expected DEBUG log for processed receipt"
@@ -701,14 +696,14 @@ mod tests {
         let test = "backfill_skips_zero_balance_receipts";
         assert!(
             logs_contain_at!(
-                tracing::Level::DEBUG,
+                tracing::Level::TRACE,
                 &[test, "Processed block range"]
             ),
             "Expected DEBUG log for block range processing"
         );
         assert!(
             !logs_contain_at!(
-                tracing::Level::DEBUG,
+                tracing::Level::TRACE,
                 &[test, "Processed receipt"]
             ),
             "Should NOT log processed receipt when all receipts have zero balance"
@@ -898,7 +893,7 @@ mod tests {
 
         assert!(
             logs_contain_at!(
-                tracing::Level::INFO,
+                tracing::Level::TRACE,
                 &[
                     "backfill_emits_checkpoint_after_processing",
                     "Receipt backfill complete"

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::info;
+use tracing::debug;
 
 use super::{ReceiptId, ReceiptInventoryError, Shares, SharesOverflow};
 use crate::redemption::IssuerRedemptionRequestId;
@@ -210,7 +210,7 @@ pub(crate) fn plan_burn(
 pub(crate) async fn replay_receipt_burns_view(
     pool: Pool<Sqlite>,
 ) -> Result<(), BurnTrackingError> {
-    info!("Rebuilding receipt burns view from events");
+    debug!(target: "receipt", "Rebuilding receipt burns view from events");
 
     sqlx::query!("DELETE FROM receipt_burns_view").execute(&pool).await?;
 
@@ -225,7 +225,7 @@ pub(crate) async fn replay_receipt_burns_view(
     let replay = QueryReplay::new(event_repo, query);
     replay.replay_all().await?;
 
-    info!("Receipt burns view rebuild complete");
+    debug!(target: "receipt", "Receipt burns view rebuild complete");
 
     Ok(())
 }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -371,8 +371,7 @@ pub(crate) fn determine_source(
         match rain_meta::decode_receipt_meta(receipt_information) {
             Ok(bytes) => bytes,
             Err(err) => {
-                warn!(
-                    error = %err,
+                warn!(target: "receipt", error = %err,
                     data_len = receipt_information.len(),
                     data_prefix = %alloy::hex::encode(
                         &receipt_information[..receipt_information.len().min(32)]

--- a/src/receipt_inventory/monitor.rs
+++ b/src/receipt_inventory/monitor.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use cqrs_es::{AggregateError, CqrsFramework, EventStore};
 use futures::StreamExt;
 use std::sync::Arc;
-use tracing::{debug, info, warn};
+use tracing::{debug, error, info, trace, warn};
 
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
@@ -120,7 +120,7 @@ where
     pub(crate) async fn run(&self) {
         loop {
             if let Err(err) = self.monitor_once().await {
-                warn!("Receipt monitor error: {err}. Retrying in 5s...");
+                warn!(target: "receipt", "Receipt monitor error: {err}. Retrying in 5s...");
                 tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
             }
         }
@@ -161,8 +161,7 @@ where
             TransferDirection::Outbound,
         );
 
-        info!(
-            vault = %self.vault,
+        debug!(target: "receipt", vault = %self.vault,
             receipt_contract = %self.receipt_contract,
             bot_wallet = %self.bot_wallet,
             "Subscribing to Deposit, Withdraw, TransferSingle, and TransferBatch events"
@@ -191,13 +190,13 @@ where
         let mut transfer_batch_outbound_stream =
             transfer_batch_outbound_sub.into_stream();
 
-        info!("Receipt monitor WebSocket subscription active");
+        debug!(target: "receipt", "Receipt monitor WebSocket subscription active");
 
         loop {
             tokio::select! {
                 Some(log) = deposit_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed Deposit log (reorg)");
+                        trace!(target: "receipt", "Skipping removed Deposit log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "Deposit", |log| {
@@ -206,7 +205,7 @@ where
                 }
                 Some(log) = withdraw_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed Withdraw log (reorg)");
+                        trace!(target: "receipt", "Skipping removed Withdraw log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "Withdraw", |log| {
@@ -215,7 +214,7 @@ where
                 }
                 Some(log) = transfer_single_inbound_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed TransferSingle log (reorg)");
+                        trace!(target: "receipt", "Skipping removed TransferSingle log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "TransferSingle", |log| {
@@ -224,7 +223,7 @@ where
                 }
                 Some(log) = transfer_single_outbound_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed TransferSingle log (reorg)");
+                        trace!(target: "receipt", "Skipping removed TransferSingle log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "TransferSingle", |log| {
@@ -233,7 +232,7 @@ where
                 }
                 Some(log) = transfer_batch_inbound_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed TransferBatch log (reorg)");
+                        trace!(target: "receipt", "Skipping removed TransferBatch log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "TransferBatch", |log| {
@@ -242,7 +241,7 @@ where
                 }
                 Some(log) = transfer_batch_outbound_stream.next() => {
                     if log.removed {
-                        debug!("Skipping removed TransferBatch log (reorg)");
+                        trace!(target: "receipt", "Skipping removed TransferBatch log (reorg)");
                         continue;
                     }
                     self.process_live_log(&log, "TransferBatch", |log| {
@@ -269,8 +268,7 @@ where
             // Without a block number we cannot prove where this live log fits
             // relative to the durable checkpoint. Skip live processing and let
             // periodic backfill rescan the range in block order.
-            warn!(
-                event_name,
+            warn!(target: "receipt", event_name,
                 "Live receipt log missing block number; periodic backfill will \
                  rescan the range in block order"
             );
@@ -278,16 +276,14 @@ where
         };
 
         if let Err(err) = process(log).await {
-            warn!(
-                event_name,
+            error!(target: "receipt", event_name,
                 block_number,
                 error = %err,
                 "Failed to process live receipt log; periodic backfill will \
                  rescan from the durable checkpoint"
             );
         } else {
-            debug!(
-                event_name,
+            debug!(target: "receipt", event_name,
                 block_number,
                 "Processed live receipt log; periodic backfill owns durable \
                  checkpoint advancement"
@@ -311,8 +307,7 @@ where
             return Ok(());
         }
 
-        info!(
-            receipt_id = %event.id,
+        info!(target: "receipt", receipt_id = %event.id,
             sender = %event.sender,
             owner = %event.owner,
             shares = %event.shares,
@@ -346,8 +341,7 @@ where
 
         let receipt_id = ReceiptId::from(event.id);
 
-        info!(
-            receipt_id = %receipt_id,
+        info!(target: "receipt", receipt_id = %receipt_id,
             sender = %event.sender,
             owner = %event.owner,
             shares = %event.shares,
@@ -372,8 +366,7 @@ where
             )
             .await?;
 
-        info!(
-            receipt_id = %receipt_id,
+        info!(target: "receipt", receipt_id = %receipt_id,
             on_chain_balance = %on_chain_balance,
             "Receipt balance reconciled after withdraw"
         );
@@ -405,8 +398,7 @@ where
         let receipt_id = ReceiptId::from(event.id);
 
         if event.to == self.bot_wallet {
-            debug!(
-                receipt_id = %receipt_id,
+            trace!(target: "receipt", receipt_id = %receipt_id,
                 from = %event.from,
                 value = %event.value,
                 "Inbound TransferSingle detected"
@@ -420,8 +412,7 @@ where
             )
             .await?;
         } else if event.from == self.bot_wallet {
-            debug!(
-                receipt_id = %receipt_id,
+            trace!(target: "receipt", receipt_id = %receipt_id,
                 to = %event.to,
                 value = %event.value,
                 "Outbound TransferSingle detected"
@@ -457,8 +448,7 @@ where
             for receipt_id_raw in &event.ids {
                 let receipt_id = ReceiptId::from(*receipt_id_raw);
 
-                debug!(
-                    receipt_id = %receipt_id,
+                trace!(target: "receipt", receipt_id = %receipt_id,
                     from = %event.from,
                     "Inbound TransferBatch item detected"
                 );
@@ -475,8 +465,7 @@ where
             for receipt_id_raw in &event.ids {
                 let receipt_id = ReceiptId::from(*receipt_id_raw);
 
-                debug!(
-                    receipt_id = %receipt_id,
+                trace!(target: "receipt", receipt_id = %receipt_id,
                     to = %event.to,
                     "Outbound TransferBatch item detected"
                 );
@@ -511,8 +500,7 @@ where
             )
             .await?;
 
-        debug!(
-            receipt_id = %receipt_id,
+        debug!(target: "receipt", receipt_id = %receipt_id,
             on_chain_balance = %on_chain_balance,
             "Receipt balance reconciled after transfer"
         );
@@ -537,8 +525,7 @@ where
             .await?;
 
         if current_balance.is_zero() {
-            info!(
-                receipt_id = %receipt_id,
+            debug!(target: "receipt", receipt_id = %receipt_id,
                 "Receipt has zero balance, skipping"
             );
             return Ok(());
@@ -582,8 +569,7 @@ where
             )
             .await?;
 
-        info!(
-            receipt_id = %receipt_id,
+        info!(target: "receipt", receipt_id = %receipt_id,
             balance = %current_balance,
             "Receipt discovered or reconciled via live monitoring"
         );
@@ -930,7 +916,7 @@ mod tests {
         let context = store.load_aggregate(&vault.to_string()).await.unwrap();
         assert_eq!(context.aggregate().last_backfilled_block(), None);
         assert!(logs_contain_at!(
-            tracing::Level::WARN,
+            tracing::Level::ERROR,
             &[
                 "Failed to process live receipt log",
                 "periodic backfill will rescan from the durable checkpoint",
@@ -1544,7 +1530,7 @@ mod tests {
         monitor.process_transfer_single(&transfer_log).await.unwrap();
 
         assert!(logs_contain_at!(
-            tracing::Level::DEBUG,
+            tracing::Level::TRACE,
             &["Inbound TransferSingle detected"]
         ));
 
@@ -1654,7 +1640,7 @@ mod tests {
         monitor.process_transfer_single(&transfer_log).await.unwrap();
 
         assert!(logs_contain_at!(
-            tracing::Level::DEBUG,
+            tracing::Level::TRACE,
             &["Outbound TransferSingle detected", "receipt_id=171"]
         ));
         assert!(logs_contain_at!(
@@ -1978,7 +1964,7 @@ mod tests {
         for (receipt_id, _) in &deposits {
             assert!(
                 logs_contain_at!(
-                    tracing::Level::DEBUG,
+                    tracing::Level::TRACE,
                     &[
                         "Inbound TransferBatch item detected",
                         &format!("receipt_id={receipt_id}")
@@ -2108,11 +2094,11 @@ mod tests {
         monitor.process_transfer_batch(&batch_log).await.unwrap();
 
         assert!(logs_contain_at!(
-            tracing::Level::DEBUG,
+            tracing::Level::TRACE,
             &["Outbound TransferBatch item detected", "receipt_id=30"]
         ));
         assert!(logs_contain_at!(
-            tracing::Level::DEBUG,
+            tracing::Level::TRACE,
             &["Outbound TransferBatch item detected", "receipt_id=31"]
         ));
 

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -3,7 +3,7 @@ use alloy::providers::Provider;
 use cqrs_es::{AggregateContext, AggregateError, CqrsFramework, EventStore};
 use futures::{StreamExt, stream};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
@@ -84,8 +84,7 @@ where
             return Ok(ReconcileResult { checked: 0, mismatches: 0 });
         }
 
-        info!(
-            receipt_count = receipts.len(),
+        info!(target: "receipt", receipt_count = receipts.len(),
             vault = %self.vault,
             "Reconciling receipt balances with on-chain state"
         );
@@ -112,8 +111,7 @@ where
                     checked += 1;
                 }
                 Err(err) => {
-                    debug!(
-                        vault = %self.vault,
+                    debug!(target: "receipt", vault = %self.vault,
                         error = %err,
                         "Failed to reconcile receipt"
                     );
@@ -122,8 +120,7 @@ where
             }
         }
 
-        info!(
-            checked,
+        info!(target: "receipt", checked,
             mismatches,
             errors,
             vault = %self.vault,
@@ -150,16 +147,14 @@ where
         let on_chain_shares = Shares::from(on_chain_balance);
 
         if on_chain_shares == aggregate_balance {
-            debug!(
-                receipt_id = %receipt_id,
+            trace!(target: "receipt", receipt_id = %receipt_id,
                 balance = %aggregate_balance,
                 "Receipt balance matches on-chain"
             );
             return Ok(false);
         }
 
-        debug!(
-            receipt_id = %receipt_id,
+        trace!(target: "receipt", receipt_id = %receipt_id,
             aggregate_balance = %aggregate_balance,
             on_chain_balance = %on_chain_shares,
             "Balance mismatch detected"
@@ -222,8 +217,7 @@ pub(crate) async fn run_startup_reconciliation<
                 total_mismatches += result.mismatches;
 
                 if result.mismatches > 0 {
-                    debug!(
-                        vault = %vault,
+                    debug!(target: "receipt", vault = %vault,
                         checked = result.checked,
                         mismatches = result.mismatches,
                         "Receipt reconciliation found mismatches"
@@ -231,8 +225,7 @@ pub(crate) async fn run_startup_reconciliation<
                 }
             }
             Err(err) => {
-                debug!(
-                    vault = %vault,
+                debug!(target: "receipt", vault = %vault,
                     receipt_contract = %receipt_contract,
                     error = %err,
                     "Receipt reconciliation failed for vault"
@@ -244,8 +237,7 @@ pub(crate) async fn run_startup_reconciliation<
     }
 
     if total_mismatches > 0 || failed_vaults > 0 {
-        info!(
-            total_checked,
+        info!(target: "receipt", total_checked,
             total_mismatches, failed_vaults, "Receipt reconciliation complete"
         );
     }

--- a/src/redemption/backfill.rs
+++ b/src/redemption/backfill.rs
@@ -5,7 +5,7 @@ use alloy::transports::{RpcError, TransportErrorKind};
 use cqrs_es::{CqrsFramework, EventStore};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{debug, info};
+use tracing::{debug, info, trace};
 
 use super::{
     Redemption,
@@ -92,8 +92,7 @@ where
         .await?;
 
         if from_block > current_block {
-            info!(
-                %vault,
+            info!(target: "redemption", %vault,
                 from_block,
                 current_block,
                 "Transfer backfill skipped: from_block is ahead of current block"
@@ -106,8 +105,7 @@ where
             });
         }
 
-        info!(
-            %vault,
+        debug!(target: "redemption", %vault,
             bot_wallet = %self.bot_wallet,
             from_block,
             to_block = current_block,
@@ -124,8 +122,7 @@ where
             let logs =
                 self.fetch_transfer_logs(vault, chunk_from, chunk_to).await?;
 
-            debug!(
-                chunk_from,
+            trace!(target: "redemption", chunk_from,
                 chunk_to,
                 logs_found = logs.len(),
                 "Processed block range"
@@ -170,8 +167,7 @@ where
 
         save_backfill_checkpoint(&self.pool, vault, current_block).await?;
 
-        info!(
-            %vault,
+        debug!(target: "redemption", %vault,
             detected_count,
             skipped_mint,
             skipped_no_account,
@@ -490,11 +486,11 @@ mod tests {
         assert_eq!(result.skipped_no_account, 0);
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Starting transfer backfill"]
         ));
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Transfer backfill complete", "detected_count=1"]
         ));
     }
@@ -532,11 +528,11 @@ mod tests {
         assert_eq!(result.skipped_mint, 1);
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Starting transfer backfill"]
         ));
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Transfer backfill complete", "skipped_mint=1"]
         ));
     }
@@ -591,7 +587,7 @@ mod tests {
         );
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Transfer backfill complete"]
         ));
     }
@@ -631,7 +627,7 @@ mod tests {
         assert_eq!(result.skipped_no_account, 1);
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Transfer backfill complete", "skipped_no_account=1"]
         ));
     }
@@ -779,11 +775,11 @@ mod tests {
         );
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Starting transfer backfill", "from_block=50", "to_block=200"]
         ));
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Transfer backfill complete", "checkpoint_block=200"]
         ));
     }

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -81,18 +81,17 @@ where
         let stuck_redemptions = match find_burning(&self.view_pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
-                error!(error = %err, "Failed to query for stuck Burning redemptions");
+                error!(target: "redemption", error = %err, "Failed to query for stuck Burning redemptions");
                 return;
             }
         };
 
         if stuck_redemptions.is_empty() {
-            info!("No Burning redemptions to recover");
+            debug!(target: "redemption", "No Burning redemptions to recover");
             return;
         }
 
-        info!(
-            count = stuck_redemptions.len(),
+        info!(target: "redemption", count = stuck_redemptions.len(),
             "Recovering stuck Burning redemptions"
         );
 
@@ -100,8 +99,7 @@ where
             if let Err(err) =
                 self.recover_single_burning(&issuer_request_id).await
             {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Failed to recover Burning redemption"
                 );
@@ -117,18 +115,17 @@ where
         let failed_redemptions = match find_burn_failed(&self.view_pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
-                error!(error = %err, "Failed to query for BurnFailed redemptions");
+                error!(target: "redemption", error = %err, "Failed to query for BurnFailed redemptions");
                 return;
             }
         };
 
         if failed_redemptions.is_empty() {
-            info!("No BurnFailed redemptions to recover");
+            debug!(target: "redemption", "No BurnFailed redemptions to recover");
             return;
         }
 
-        info!(
-            count = failed_redemptions.len(),
+        info!(target: "redemption", count = failed_redemptions.len(),
             "Recovering BurnFailed redemptions"
         );
 
@@ -136,8 +133,7 @@ where
             if let Err(err) =
                 self.recover_single_burn_failed(&issuer_request_id, &view).await
             {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Failed to recover BurnFailed redemption"
                 );
@@ -158,8 +154,7 @@ where
             ..
         } = view
         else {
-            debug!(
-                issuer_request_id = %issuer_request_id,
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                 "View not in BurnFailed state, skipping"
             );
             return Ok(());
@@ -193,8 +188,7 @@ where
                  balance={on_chain_balance}, required={total_shares}"
             );
 
-            info!(
-                issuer_request_id = %issuer_request_id,
+            info!(target: "redemption", issuer_request_id = %issuer_request_id,
                 on_chain_balance = %on_chain_balance,
                 total_shares = %total_shares,
                 "Auto-failing BurnFailed redemption with insufficient on-chain balance"
@@ -231,8 +225,7 @@ where
             })
             .collect();
 
-        debug!(
-            issuer_request_id = %issuer_request_id,
+        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_shares = %burn_shares,
             dust_shares = %dust_shares,
             num_receipts = burns.len(),
@@ -253,8 +246,7 @@ where
             )
             .await?;
 
-        debug!(
-            issuer_request_id = %issuer_request_id,
+        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             "Successfully retried burn"
         );
 
@@ -277,8 +269,7 @@ where
             ..
         } = aggregate
         else {
-            debug!(
-                issuer_request_id = %issuer_request_id,
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                 "Redemption no longer in Burning state, skipping"
             );
             return Ok(());
@@ -309,8 +300,7 @@ where
             .await?;
 
         if on_chain_balance < total_shares_needed {
-            warn!(
-                issuer_request_id = %issuer_request_id,
+            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                 on_chain_balance = %on_chain_balance,
                 burn_shares = %burn_shares,
                 dust_shares = %dust_shares,
@@ -322,8 +312,7 @@ where
             return Ok(());
         }
 
-        debug!(
-            issuer_request_id = %issuer_request_id,
+        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             "Recovering Burning redemption - resuming burn"
         );
 
@@ -384,8 +373,7 @@ where
                 metadata.underlying
             );
 
-            warn!(
-                issuer_request_id = %issuer_request_id,
+            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                 underlying = %metadata.underlying,
                 "{error_msg}"
             );
@@ -411,8 +399,7 @@ where
         let burn_shares = alpaca_quantity.to_u256_with_18_decimals()?;
         let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
 
-        info!(
-            issuer_request_id = %issuer_request_id,
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
             underlying = %metadata.underlying,
             alpaca_quantity = %alpaca_quantity,
             dust_quantity = %dust_quantity,
@@ -452,8 +439,7 @@ where
 
         match plan {
             Ok(plan) => {
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     num_receipts = plan.allocations.len(),
                     total_burn = %plan.total_burn,
                     dust = %plan.dust,
@@ -488,8 +474,7 @@ where
             "Insufficient balance for {underlying}: required {required}, available {available}"
         );
 
-        warn!(
-            issuer_request_id = %issuer_request_id,
+        warn!(target: "redemption", issuer_request_id = %issuer_request_id,
             %required,
             %available,
             underlying = %underlying,
@@ -508,8 +493,7 @@ where
             )
             .await?;
 
-        info!(
-            issuer_request_id = %issuer_request_id,
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
             "RecordBurnFailure command executed successfully"
         );
 
@@ -559,8 +543,7 @@ where
 
         match burn_result {
             Ok(()) => {
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "BurnTokens command executed successfully"
                 );
 
@@ -569,8 +552,7 @@ where
             Err(AggregateError::UserError(RedemptionError::Vault(err))) => {
                 let fireblocks_tx_id = extract_fireblocks_tx_id(&err);
 
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     fireblocks_tx_id = ?fireblocks_tx_id,
                     "On-chain burning failed"
@@ -588,8 +570,7 @@ where
                     )
                     .await?;
 
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "RecordBurnFailure command recorded"
                 );
 

--- a/src/redemption/detector.rs
+++ b/src/redemption/detector.rs
@@ -5,7 +5,7 @@ use cqrs_es::{CqrsFramework, EventStore};
 use futures::StreamExt;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 use url::Url;
 
 use super::{
@@ -93,8 +93,7 @@ where
     pub(crate) async fn run(&self) {
         loop {
             if let Err(err) = self.monitor_once().await {
-                warn!(
-                    "WebSocket monitoring error: {err}. Reconnecting in 5s..."
+                warn!(target: "redemption", "WebSocket monitoring error: {err}. Reconnecting in 5s..."
                 );
                 tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
             }
@@ -105,7 +104,7 @@ where
     ///
     /// Returns an error if the connection fails, subscription fails, or the stream ends.
     async fn monitor_once(&self) -> Result<(), RedemptionMonitorError> {
-        info!("Connecting to WebSocket at {}", self.rpc_url);
+        debug!(target: "redemption", "Connecting to WebSocket at {}", self.rpc_url);
 
         let provider =
             ProviderBuilder::new().connect(self.rpc_url.as_str()).await?;
@@ -115,8 +114,7 @@ where
 
         let filter = vault.Transfer_filter().topic2(self.bot_wallet).filter;
 
-        info!(
-            "Subscribing to Transfer events for bot wallet {}",
+        debug!(target: "redemption", "Subscribing to Transfer events for bot wallet {}",
             self.bot_wallet
         );
 
@@ -124,11 +122,11 @@ where
 
         let mut stream = sub.into_stream();
 
-        info!("WebSocket subscription active, monitoring for redemptions");
+        debug!(target: "redemption", "WebSocket subscription active, monitoring for redemptions");
 
         while let Some(log) = stream.next().await {
             if let Err(err) = self.process_transfer_log(&log).await {
-                warn!("Failed to process transfer log: {err}");
+                warn!(target: "redemption", "Failed to process transfer log: {err}");
             }
         }
 

--- a/src/redemption/journal_manager.rs
+++ b/src/redemption/journal_manager.rs
@@ -49,18 +49,17 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
         let stuck_redemptions = match find_alpaca_called(&self.pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
-                error!(error = %err, "Failed to query for stuck AlpacaCalled redemptions");
+                error!(target: "redemption", error = %err, "Failed to query for stuck AlpacaCalled redemptions");
                 return;
             }
         };
 
         if stuck_redemptions.is_empty() {
-            info!("No AlpacaCalled redemptions to recover");
+            debug!(target: "redemption", "No AlpacaCalled redemptions to recover");
             return;
         }
 
-        info!(
-            count = stuck_redemptions.len(),
+        info!(target: "redemption", count = stuck_redemptions.len(),
             "Recovering stuck AlpacaCalled redemptions"
         );
 
@@ -69,8 +68,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
                 .recover_single_alpaca_called(&issuer_request_id, &view)
                 .await
             {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Failed to recover AlpacaCalled redemption"
                 );
@@ -89,8 +87,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
             ..
         } = view
         else {
-            debug!(
-                issuer_request_id = %issuer_request_id,
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                 "Redemption no longer in AlpacaCalled state, skipping"
             );
             return Ok(());
@@ -98,8 +95,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
 
         let alpaca_account = self.lookup_account_for_recovery(wallet).await?;
 
-        info!(
-            issuer_request_id = %issuer_request_id,
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
             "Recovering AlpacaCalled redemption - resuming polling"
         );
 
@@ -139,8 +135,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
         issuer_request_id: IssuerRedemptionRequestId,
         tokenization_request_id: TokenizationRequestId,
     ) -> Result<(), JournalManagerError> {
-        info!(
-            issuer_request_id = %issuer_request_id,
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
             tokenization_request_id = %tokenization_request_id,
             "Starting journal polling for redemption"
         );
@@ -157,8 +152,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
                     .await;
             }
 
-            debug!(
-                issuer_request_id = %issuer_request_id,
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                 tokenization_request_id = %tokenization_request_id.0,
                 poll_interval = ?poll_interval,
                 elapsed = ?start_time.elapsed(),
@@ -315,8 +309,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
         issuer_request_id: &IssuerRedemptionRequestId,
         elapsed: Duration,
     ) -> Result<(), JournalManagerError> {
-        warn!(
-            issuer_request_id = %issuer_request_id,
+        warn!(target: "redemption", issuer_request_id = %issuer_request_id,
             elapsed = ?elapsed,
             max_duration = ?self.max_duration,
             "Polling timeout reached, marking redemption as failed"
@@ -358,8 +351,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
 
                 match status {
                     RedeemRequestStatus::Completed => {
-                        info!(
-                            issuer_request_id = %issuer_request_id,
+                        info!(target: "redemption", issuer_request_id = %issuer_request_id,
                             tokenization_request_id = %tokenization_request_id,
                             elapsed = ?elapsed,
                             "Alpaca journal completed, confirming completion"
@@ -375,16 +367,14 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
                             )
                             .await?;
 
-                        info!(
-                            issuer_request_id = %issuer_request_id,
+                        info!(target: "redemption", issuer_request_id = %issuer_request_id,
                             "ConfirmAlpacaComplete command executed successfully"
                         );
 
                         Ok(false)
                     }
                     RedeemRequestStatus::Rejected => {
-                        warn!(
-                            issuer_request_id = %issuer_request_id,
+                        warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                             tokenization_request_id = %tokenization_request_id,
                             "Alpaca journal rejected, marking redemption as failed"
                         );
@@ -406,8 +396,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
                         })
                     }
                     RedeemRequestStatus::Pending => {
-                        info!(
-                            issuer_request_id = %issuer_request_id,
+                        info!(target: "redemption", issuer_request_id = %issuer_request_id,
                             tokenization_request_id = %tokenization_request_id,
                             status = "pending",
                             next_poll_in = ?poll_interval,
@@ -418,8 +407,7 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
                 }
             }
             Err(err) => {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     tokenization_request_id = %tokenization_request_id,
                     error = %err,
                     next_poll_in = ?poll_interval,

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -38,18 +38,17 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
         let stuck_redemptions = match find_detected(&self.pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
-                error!(error = %err, "Failed to query for stuck Detected redemptions");
+                error!(target: "redemption", error = %err, "Failed to query for stuck Detected redemptions");
                 return;
             }
         };
 
         if stuck_redemptions.is_empty() {
-            info!("No Detected redemptions to recover");
+            debug!(target: "redemption", "No Detected redemptions to recover");
             return;
         }
 
-        info!(
-            count = stuck_redemptions.len(),
+        info!(target: "redemption", count = stuck_redemptions.len(),
             "Recovering stuck Detected redemptions"
         );
 
@@ -77,23 +76,20 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
                         .execute(&issuer_request_id.to_string(), command)
                         .await
                     {
-                        debug!(
-                            issuer_request_id = %issuer_request_id,
+                        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                             error = %err,
                             "Failed to mark unrecoverable Detected redemption as failed"
                         );
                         failed += 1;
                     } else {
-                        debug!(
-                            issuer_request_id = %issuer_request_id,
+                        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                             "Auto-failed Detected redemption with no linked account"
                         );
                         auto_failed += 1;
                     }
                 }
                 Err(err) => {
-                    debug!(
-                        issuer_request_id = %issuer_request_id,
+                    debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                         error = %err,
                         "Failed to recover Detected redemption"
                     );
@@ -102,8 +98,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
             }
         }
 
-        info!(
-            total = stuck_redemptions.len(),
+        info!(target: "redemption", total = stuck_redemptions.len(),
             recovered,
             auto_failed,
             failed,
@@ -123,8 +118,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
         let aggregate = aggregate_ctx.aggregate();
 
         let Redemption::Detected { metadata } = aggregate else {
-            debug!(
-                issuer_request_id = %issuer_request_id,
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                 "Redemption no longer in Detected state, skipping"
             );
             return Ok(());
@@ -136,8 +130,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
         let network =
             self.lookup_network_for_asset(&metadata.underlying).await?;
 
-        debug!(
-            issuer_request_id = %issuer_request_id,
+        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             "Recovering Detected redemption - calling Alpaca"
         );
 
@@ -215,8 +208,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
         let (alpaca_quantity, dust_quantity) =
             metadata.quantity.truncate_for_alpaca()?;
 
-        info!(
-            issuer_request_id = %issuer_request_id,
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
             underlying = %metadata.underlying,
             original_quantity = %metadata.quantity.0,
             alpaca_quantity = %alpaca_quantity.0,
@@ -238,8 +230,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
 
         match self.alpaca_service.call_redeem_endpoint(request).await {
             Ok(response) => {
-                info!(
-                    issuer_request_id = %response.issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %response.issuer_request_id,
                     tokenization_request_id = %response.tokenization_request_id.0,
                     r#type = ?response.r#type,
                     status = ?response.status,
@@ -268,16 +259,14 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
                     )
                     .await?;
 
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "RecordAlpacaCall command executed successfully"
                 );
 
                 Ok(())
             }
             Err(err) => {
-                warn!(
-                    issuer_request_id = %issuer_request_id,
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Alpaca redeem API call failed"
                 );
@@ -292,8 +281,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
                     )
                     .await?;
 
-                info!(
-                    issuer_request_id = %issuer_request_id,
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "RecordAlpacaFailure command executed successfully"
                 );
 

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -70,8 +70,7 @@ where
         bindings::OffchainAssetReceiptVault::Transfer::decode_log(&log.inner)?;
 
     if transfer_event.from == Address::ZERO {
-        debug!(
-            to = %transfer_event.to,
+        debug!(target: "redemption", to = %transfer_event.to,
             value = %transfer_event.value,
             "Skipping mint event (from=0x0)"
         );
@@ -89,8 +88,7 @@ where
     let Some(AccountView::LinkedToAlpaca { client_id, alpaca_account, .. }) =
         account_view
     else {
-        debug!(
-            from = %transfer_event.from,
+        debug!(target: "redemption", from = %transfer_event.from,
             tx_hash = %tx_hash,
             "Skipping transfer from unknown/unlinked wallet"
         );
@@ -115,8 +113,7 @@ where
     match cqrs.execute(&issuer_request_id.to_string(), command).await {
         Ok(()) => {}
         Err(AggregateError::UserError(_)) => {
-            debug!(
-                %issuer_request_id,
+            debug!(target: "redemption", %issuer_request_id,
                 "Transfer already detected"
             );
             return Ok(TransferOutcome::AlreadyDetected);
@@ -124,8 +121,7 @@ where
         Err(err) => return Err(err.into()),
     }
 
-    info!(
-        %issuer_request_id,
+    info!(target: "redemption", %issuer_request_id,
         from = %transfer_event.from,
         "Redemption transfer detected"
     );
@@ -169,8 +165,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
     {
         Ok(ctx) => ctx,
         Err(err) => {
-            warn!(
-                %issuer_request_id,
+            warn!(target: "redemption", %issuer_request_id,
                 error = ?err,
                 "Failed to load aggregate after detection"
             );
@@ -189,8 +184,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
         )
         .await
     {
-        warn!(
-            %issuer_request_id,
+        warn!(target: "redemption", %issuer_request_id,
             error = ?err,
             "handle_redemption_detected failed"
         );
@@ -204,8 +198,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
     {
         Ok(ctx) => ctx,
         Err(err) => {
-            warn!(
-                %issuer_request_id,
+            warn!(target: "redemption", %issuer_request_id,
                 error = ?err,
                 "Failed to load aggregate after redeem call"
             );
@@ -216,8 +209,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
     let Redemption::AlpacaCalled { tokenization_request_id, .. } =
         aggregate_ctx.aggregate()
     else {
-        debug!(
-            %issuer_request_id,
+        debug!(target: "redemption", %issuer_request_id,
             aggregate_state = ?aggregate_ctx.aggregate(),
             "Aggregate not in AlpacaCalled state after redeem call"
         );
@@ -236,8 +228,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
             )
             .await
         {
-            warn!(
-                %issuer_request_id,
+            warn!(target: "redemption", %issuer_request_id,
                 error = ?err,
                 "handle_alpaca_called (journal polling) failed"
             );
@@ -251,8 +242,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
         {
             Ok(ctx) => ctx,
             Err(err) => {
-                warn!(
-                    %issuer_request_id,
+                warn!(target: "redemption", %issuer_request_id,
                     error = ?err,
                     "Failed to load aggregate after journal completion"
                 );
@@ -269,15 +259,13 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
                 )
                 .await
             {
-                warn!(
-                    %issuer_request_id,
+                warn!(target: "redemption", %issuer_request_id,
                     error = ?err,
                     "handle_burning_started failed"
                 );
             }
         } else {
-            debug!(
-                %issuer_request_id,
+            debug!(target: "redemption", %issuer_request_id,
                 aggregate_state = ?aggregate_ctx.aggregate(),
                 "Aggregate not in Burning state after journal completion"
             );

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -7,7 +7,7 @@ use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::info;
+use tracing::debug;
 
 use super::IssuerRedemptionRequestId;
 use crate::mint::{Quantity, TokenizationRequestId};
@@ -391,7 +391,7 @@ pub(crate) enum RedemptionViewError {
 pub async fn replay_redemption_view(
     pool: Pool<Sqlite>,
 ) -> Result<(), RedemptionViewError> {
-    info!("Rebuilding redemption view from events");
+    debug!(target: "redemption", "Rebuilding redemption view from events");
 
     sqlx::query!("DELETE FROM redemption_view").execute(&pool).await?;
 
@@ -406,7 +406,7 @@ pub async fn replay_redemption_view(
     let replay = QueryReplay::new(event_repo, query);
     replay.replay_all().await?;
 
-    info!("Redemption view rebuild complete");
+    debug!(target: "redemption", "Redemption view rebuild complete");
 
     Ok(())
 }

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -132,7 +132,7 @@ impl HyperDxConfig {
         let telemetry_layer =
             tracing_opentelemetry::layer().with_tracer(tracer);
 
-        let default_filter = format!("st0x_issuance={}", self.log_level);
+        let default_filter = crate::config::default_log_filter(self.log_level);
 
         let fmt_filter = tracing_subscriber::EnvFilter::try_from_default_env()
             .unwrap_or_else(|_| default_filter.clone().into());

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -811,8 +811,40 @@ impl LocalEvm {
     }
 }
 
+/// Maps `module_path!()` to the domain target used in `target:` on
+/// tracing macros. Falls back to the module path itself for modules
+/// that don't use custom targets.
+#[cfg(test)]
+pub(crate) fn domain_target_for_module(module: &str) -> &'static str {
+    let module = module.strip_suffix("::tests").unwrap_or(module);
+
+    if module.contains("::mint") {
+        "mint"
+    } else if module.contains("::redemption") {
+        "redemption"
+    } else if module.contains("::receipt_inventory") {
+        "receipt"
+    } else if module.contains("::account") {
+        "account"
+    } else if module.contains("::tokenized_asset") {
+        "asset"
+    } else if module.contains("::alpaca") {
+        "alpaca"
+    } else if module.contains("::auth") {
+        "auth"
+    } else if module.contains("::fireblocks") {
+        "fireblocks"
+    } else if module.contains("::admin") {
+        "admin"
+    } else if module.contains("::vault") {
+        "vault"
+    } else {
+        "startup"
+    }
+}
+
 /// Checks whether any log line at the given level, scoped to the
-/// caller's module, contains all snippets.
+/// caller's domain target, contains all snippets.
 #[cfg(test)]
 macro_rules! logs_contain_at {
     ($level:expr, $snippets:expr) => {
@@ -821,7 +853,7 @@ macro_rules! logs_contain_at {
 }
 
 /// Counts log lines at the given level, scoped to the caller's
-/// module, that contain all snippets.
+/// domain target, that contain all snippets.
 #[cfg(test)]
 macro_rules! log_count_at {
     ($level:expr, $snippets:expr) => {{
@@ -829,8 +861,8 @@ macro_rules! log_count_at {
             let buf = tracing_test::internal::global_buf().lock().unwrap();
             String::from_utf8_lossy(&buf).into_owned()
         };
-        let scope = module_path!();
-        let scope = scope.strip_suffix("::tests").unwrap_or(scope);
+        let target =
+            $crate::test_utils::domain_target_for_module(module_path!());
         let level_str = match $level {
             tracing::Level::TRACE => "TRACE",
             tracing::Level::DEBUG => "DEBUG",
@@ -841,7 +873,7 @@ macro_rules! log_count_at {
         let snippets: &[&str] = $snippets;
         logs.lines()
             .filter(|line| {
-                line.contains(scope)
+                line.contains(target)
                     && line.contains(level_str)
                     && snippets.iter().all(|snippet| line.contains(snippet))
             })

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -37,7 +37,7 @@ pub(crate) async fn get_tokenized_asset(
     )
     .await
     .map_err(|err| {
-        error!(error = %err, "Failed to load tokenized asset");
+        error!(target: "asset", error = %err, "Failed to load tokenized asset");
         Status::InternalServerError
     })?;
 
@@ -80,7 +80,7 @@ pub(crate) async fn list_tokenized_assets(
 ) -> Result<Json<TokenizedAssetsListResponse>, rocket::http::Status> {
     let views =
         super::view::list_enabled_assets(pool.inner()).await.map_err(|e| {
-            error!("Failed to list enabled assets: {e}");
+            error!(target: "asset", "Failed to list enabled assets: {e}");
             rocket::http::Status::InternalServerError
         })?;
 
@@ -140,7 +140,7 @@ pub(crate) async fn add_tokenized_asset(
             _ => Err(err),
         })
         .map_err(|err| {
-            error!("Failed to add tokenized asset: {err}");
+            error!(target: "asset", "Failed to add tokenized asset: {err}");
             Status::InternalServerError
         })?;
 

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -106,15 +106,13 @@ impl Aggregate for TokenizedAsset {
                 Self::Added { vault: current_vault, .. }
                     if *current_vault == vault =>
                 {
-                    tracing::debug!(
-                        underlying = %underlying.0,
+                    tracing::debug!(target: "asset", underlying = %underlying.0,
                         "Asset already added with same vault, skipping"
                     );
                     Ok(vec![])
                 }
                 Self::Added { vault: current_vault, .. } => {
-                    tracing::info!(
-                        underlying = %underlying.0,
+                    tracing::info!(target: "asset", underlying = %underlying.0,
                         previous_vault = %current_vault,
                         new_vault = %vault,
                         "Updating vault address for asset"
@@ -126,8 +124,7 @@ impl Aggregate for TokenizedAsset {
                     }])
                 }
                 Self::NotAdded => {
-                    tracing::info!(
-                        underlying = %underlying.0,
+                    tracing::info!(target: "asset", underlying = %underlying.0,
                         vault = %vault,
                         "Adding new tokenized asset"
                     );

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::info;
+use tracing::debug;
 
 use super::{
     Network, TokenSymbol, TokenizedAsset, TokenizedAssetError,
@@ -36,7 +36,7 @@ pub(crate) enum TokenizedAssetViewError {
 pub(crate) async fn replay_tokenized_asset_view(
     pool: Pool<Sqlite>,
 ) -> Result<(), TokenizedAssetViewError> {
-    info!(view = "tokenized_asset_view", "Rebuilding view from events");
+    debug!(target: "asset", view = "tokenized_asset_view", "Rebuilding view from events");
 
     sqlx::query!("DELETE FROM tokenized_asset_view").execute(&pool).await?;
 
@@ -53,7 +53,7 @@ pub(crate) async fn replay_tokenized_asset_view(
     let replay = QueryReplay::new(event_repo, query);
     replay.replay_all().await?;
 
-    info!(view = "tokenized_asset_view", "View rebuild complete");
+    debug!(target: "asset", view = "tokenized_asset_view", "View rebuild complete");
 
     Ok(())
 }
@@ -476,11 +476,11 @@ mod tests {
         }
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["Rebuilding view from events", "tokenized_asset_view"]
         ));
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            tracing::Level::DEBUG,
             &["View rebuild complete", "tokenized_asset_view"]
         ));
     }

--- a/src/vault/rain_meta.rs
+++ b/src/vault/rain_meta.rs
@@ -356,6 +356,7 @@ impl OaSchemaCache {
             Err(error) => {
                 // Don't cache transient failures — allow retry on next call
                 warn!(
+                    target: "vault",
                     %vault,
                     %error,
                     "failed to fetch OA schema hash from subgraph, \


### PR DESCRIPTION
## Motivation

Closes [RAI-314](https://linear.app/makeitrain/issue/RAI-314/reclassify-tracing-log-levels-and-add-domain-categories).

Log levels were inconsistently assigned — `info` was used for per-iteration polling messages that fire every few seconds, `warn` was used for expected retry behavior, and there was no way to filter logs by business domain (e.g., "show me only mint logs") since everything used the default module path target.

Production log analysis (1500 lines over 17 minutes) showed that **90% of all log output was periodic receipt backfill noise** (75 lines/minute at INFO/DEBUG), with only 11 WARN/ERROR lines in the entire window. Startup alone dumped ~150 INFO lines for per-vault spawn/subscribe messages.

Mirrors the approach from st0x.liquidity [PR #611](https://github.com/ST0x-Technology/st0x.liquidity/pull/611).

## Solution

Systematic audit and reclassification of every tracing call across the codebase (~233 call sites in 35 files), plus the introduction of domain-based `target:` categories on all log macros for operator-friendly filtering.

### Level discipline applied

- **error** — operator must investigate; money or availability at risk
- **warn** — degraded but not broken; should not fire continuously
- **info** — high-level milestones; should not fire >1x/min in steady state
- **debug** — step-by-step troubleshooting narrative
- **trace** — per-item/per-iteration firehose

### Key level changes

- **info → trace**: Periodic receipt backfill start/complete logs (75 lines/min → silent at default level)
- **info → debug**: Per-vault startup spawn logs, view rebuilds, recovery "nothing to do" messages, auth per-request success, WebSocket subscription messages
- **debug → trace**: Per-chunk backfill block ranges, per-receipt transfer processing, reconciliation detail
- **warn → error**: Startup reconciliation failure (receipt balances at risk), live receipt log processing failure
- **warn → debug**: Alpaca retry notifications (expected behavior; error after exhaustion is sufficient)

### Domain categories (11 total)

| Category | Scope |
|---|---|
| `mint` | Mint lifecycle: initiation, journal confirm, on-chain minting, callback, recovery |
| `redemption` | Redemption lifecycle: detection, Alpaca call, journal polling, burn |
| `receipt` | Receipt inventory: backfill, monitoring, reconciliation, burn tracking |
| `account` | Account linking, wallet whitelisting |
| `asset` | Tokenized asset management |
| `alpaca` | Alpaca API client: callbacks, redeem calls, polling |
| `auth` | Authentication, IP whitelisting, rate limiting |
| `fireblocks` | Fireblocks vault service, signing |
| `startup` | App lifecycle: init, config, view rebuilds, backfills, spawning |
| `admin` | Admin/reprocessing endpoints |
| `vault` | Rain contract interactions, rain meta |

Operators can now filter with `RUST_LOG=mint=debug,redemption=warn`.

### Other changes

- Updated default `EnvFilter` in both `setup_tracing()` and `TelemetryConfig::setup_telemetry()` to include all custom domain targets (`src/config.rs`, `src/telemetry.rs`)
- Enabled `no-env-filter` feature on `tracing-test` so test log capture works with custom target overrides
- Replaced module-path scoping in `logs_contain_at!` / `log_count_at!` test macros with domain-target scoping via `domain_target_for_module()` (`src/test_utils.rs`)
- Updated all test log assertions to match new levels

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized logging throughout the application with domain-specific targets (`mint`, `redemption`, `receipt`, `account`, `asset`, `alpaca`, `auth`, `fireblocks`, `admin`, `vault`, `startup`) for better log filtering and organization.
  * Adjusted logging verbosity by downgrading verbose operational messages from info to debug/trace level.
  * Enhanced structured logging with named fields for improved observability.
  * Updated logging infrastructure to support environment-based filter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->