### PR TITLE
feat: add tokenization_request_id and timestamp to /admin/stuck endpoint

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -41,8 +41,11 @@ pub(crate) struct ReprocessResponse {
 pub(crate) struct StuckAggregate {
     aggregate_type: AggregateKind,
     aggregate_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tokenization_request_id: Option<String>,
     state: String,
     detail: String,
+    timestamp: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize)]
@@ -615,21 +618,31 @@ pub(crate) async fn list_stuck(
     })?;
 
     for (id, view) in stuck_redemptions {
-        let (state, detail) = match &view {
-            RedemptionView::Failed { reason, .. } => {
-                ("Failed".to_string(), reason.clone())
+        let (tokenization_request_id, state, detail, timestamp) = match &view {
+            RedemptionView::Failed { reason, failed_at, .. } => {
+                (None, "Failed".to_string(), reason.clone(), *failed_at)
             }
-            RedemptionView::BurnFailed { error, .. } => {
-                ("BurnFailed".to_string(), error.clone())
-            }
+            RedemptionView::BurnFailed {
+                tokenization_request_id,
+                error,
+                failed_at,
+                ..
+            } => (
+                Some(tokenization_request_id.0.clone()),
+                "BurnFailed".to_string(),
+                error.clone(),
+                *failed_at,
+            ),
             _ => continue,
         };
 
         stuck.push(StuckAggregate {
             aggregate_type: AggregateKind::Redemption,
             aggregate_id: id.to_string(),
+            tokenization_request_id,
             state,
             detail,
+            timestamp,
         });
     }
 
@@ -641,20 +654,47 @@ pub(crate) async fn list_stuck(
         })?;
 
     for (id, view) in recoverable_mints {
-        let (state, detail) = match &view {
-            MintView::JournalConfirmed { .. } => (
+        let (tokenization_request_id, state, detail, timestamp) = match &view {
+            MintView::JournalConfirmed {
+                tokenization_request_id,
+                journal_confirmed_at,
+                ..
+            } => (
+                Some(tokenization_request_id.0.clone()),
                 "JournalConfirmed".to_string(),
                 "Waiting for deposit".to_string(),
+                *journal_confirmed_at,
             ),
-            MintView::Minting { .. } => {
-                ("Minting".to_string(), "Deposit in progress".to_string())
-            }
-            MintView::MintingFailed { error, .. } => {
-                ("MintingFailed".to_string(), error.clone())
-            }
-            MintView::CallbackPending { .. } => (
+            MintView::Minting {
+                tokenization_request_id,
+                minting_started_at,
+                ..
+            } => (
+                Some(tokenization_request_id.0.clone()),
+                "Minting".to_string(),
+                "Deposit in progress".to_string(),
+                *minting_started_at,
+            ),
+            MintView::MintingFailed {
+                tokenization_request_id,
+                error,
+                failed_at,
+                ..
+            } => (
+                Some(tokenization_request_id.0.clone()),
+                "MintingFailed".to_string(),
+                error.clone(),
+                *failed_at,
+            ),
+            MintView::CallbackPending {
+                tokenization_request_id,
+                minted_at,
+                ..
+            } => (
+                Some(tokenization_request_id.0.clone()),
                 "CallbackPending".to_string(),
                 "Waiting for callback".to_string(),
+                *minted_at,
             ),
             _ => continue,
         };
@@ -662,8 +702,10 @@ pub(crate) async fn list_stuck(
         stuck.push(StuckAggregate {
             aggregate_type: AggregateKind::Mint,
             aggregate_id: id.to_string(),
+            tokenization_request_id,
             state,
             detail,
+            timestamp,
         });
     }
 


### PR DESCRIPTION
Closes [RAI-369](https://linear.app/makeitrain/issue/RAI-369)

## Motivation

The `/admin/stuck` endpoint returns stuck/failed aggregates but lacks enough
context for operators to quickly triage them. Without a tokenization request ID,
cross-referencing with Alpaca requires looking up each aggregate manually. Without
a timestamp, there's no way to tell how long an aggregate has been stuck.

## Solution

Add two fields to the `StuckAggregate` response in `src/admin.rs`:

- **`tokenization_request_id`** (`Option<String>`, omitted from JSON when `None`) —
  extracted from the relevant `MintView` or `RedemptionView` variant. Present for
  all mint states (`JournalConfirmed`, `Minting`, `MintingFailed`, `CallbackPending`)
  and for `BurnFailed` redemptions. `None` for `RedemptionView::Failed` which doesn't
  have a tokenization request ID.
- **`timestamp`** (`DateTime<Utc>`) — the time the aggregate entered its current state
  (e.g., `failed_at`, `minting_started_at`, `journal_confirmed_at`, `minted_at`).

No new dependencies or schema changes — the data was already available in the view
variants, just not surfaced in the API response.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced admin stuck items view with additional tracking information: tokenization request identifiers are now displayed when available, and timestamps indicate when each stuck item occurred, improving visibility into stuck redemptions and mint operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->