### PR TITLE
feat: resilient mint recovery

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -42,7 +42,7 @@ pub(crate) struct StuckAggregate {
     aggregate_type: AggregateKind,
     aggregate_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tokenization_request_id: Option<String>,
+    tokenization_request_id: Option<TokenizationRequestId>,
     state: String,
     detail: String,
     timestamp: DateTime<Utc>,
@@ -557,7 +557,9 @@ pub(crate) async fn reprocess_mint(
         Ok(Some(view)) => {
             let state = match &view {
                 MintView::NotFound => return Err(Status::NotFound),
-                MintView::Completed { .. } => return Err(Status::Conflict),
+                MintView::Completed { .. } | MintView::Closed { .. } => {
+                    return Err(Status::Conflict);
+                }
                 MintView::Initiated { .. } => "Initiated",
                 MintView::JournalConfirmed { .. } => "JournalConfirmed",
                 MintView::JournalRejected { .. } => "JournalRejected",
@@ -603,6 +605,56 @@ pub(crate) async fn reprocess_mint(
     }))
 }
 
+#[derive(Debug, Deserialize)]
+pub(crate) struct CloseMintRequest {
+    reason: String,
+}
+
+/// Admin endpoint to close a mint that cannot be automatically recovered.
+///
+/// Valid from any non-terminal state. Closed mints do not appear in stuck queries.
+#[tracing::instrument(skip(_auth, cqrs))]
+#[post("/admin/close/mint/<aggregate_id>", format = "json", data = "<body>")]
+pub(crate) async fn close_mint(
+    _auth: InternalAuth,
+    cqrs: &rocket::State<MintCqrs>,
+    aggregate_id: &str,
+    body: Json<CloseMintRequest>,
+) -> Result<Json<ReprocessResponse>, Status> {
+    let issuer_request_id: IssuerMintRequestId = aggregate_id
+        .parse::<uuid::Uuid>()
+        .map(IssuerMintRequestId::new)
+        .map_err(|_| Status::BadRequest)?;
+
+    cqrs.execute(
+        aggregate_id,
+        MintCommand::CloseMint {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: body.into_inner().reason,
+        },
+    )
+    .await
+    .map_err(|err| {
+        error!(target: "admin", aggregate_id = %aggregate_id,
+            error = %err,
+            "Failed to close mint"
+        );
+        match err {
+            AggregateError::UserError(_) => Status::UnprocessableEntity,
+            _ => Status::InternalServerError,
+        }
+    })?;
+
+    info!(target: "admin", aggregate_id = %aggregate_id, "Mint closed");
+
+    Ok(Json(ReprocessResponse {
+        aggregate_type: AggregateKind::Mint,
+        aggregate_id: aggregate_id.to_string(),
+        previous_state: "Unknown".to_string(),
+        message: "Mint closed by admin".to_string(),
+    }))
+}
+
 #[tracing::instrument(skip(_auth, pool))]
 #[get("/admin/stuck")]
 pub(crate) async fn list_stuck(
@@ -628,7 +680,7 @@ pub(crate) async fn list_stuck(
                 failed_at,
                 ..
             } => (
-                Some(tokenization_request_id.0.clone()),
+                Some(tokenization_request_id.clone()),
                 "BurnFailed".to_string(),
                 error.clone(),
                 *failed_at,
@@ -660,7 +712,7 @@ pub(crate) async fn list_stuck(
                 journal_confirmed_at,
                 ..
             } => (
-                Some(tokenization_request_id.0.clone()),
+                Some(tokenization_request_id.clone()),
                 "JournalConfirmed".to_string(),
                 "Waiting for deposit".to_string(),
                 *journal_confirmed_at,
@@ -670,7 +722,7 @@ pub(crate) async fn list_stuck(
                 minting_started_at,
                 ..
             } => (
-                Some(tokenization_request_id.0.clone()),
+                Some(tokenization_request_id.clone()),
                 "Minting".to_string(),
                 "Deposit in progress".to_string(),
                 *minting_started_at,
@@ -681,7 +733,7 @@ pub(crate) async fn list_stuck(
                 failed_at,
                 ..
             } => (
-                Some(tokenization_request_id.0.clone()),
+                Some(tokenization_request_id.clone()),
                 "MintingFailed".to_string(),
                 error.clone(),
                 *failed_at,
@@ -691,7 +743,7 @@ pub(crate) async fn list_stuck(
                 minted_at,
                 ..
             } => (
-                Some(tokenization_request_id.0.clone()),
+                Some(tokenization_request_id.clone()),
                 "CallbackPending".to_string(),
                 "Waiting for callback".to_string(),
                 *minted_at,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -452,6 +452,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 admin::recover_redemption,
                 admin::close_redemption,
                 admin::reprocess_mint,
+                admin::close_mint,
                 admin::list_stuck,
             ],
         )

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -54,6 +54,15 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
     },
 
+    /// Admin-closes a mint that cannot be automatically recovered.
+    ///
+    /// Valid from any non-terminal state. Closed mints are excluded from
+    /// recovery and stuck queries.
+    CloseMint {
+        issuer_request_id: IssuerMintRequestId,
+        reason: String,
+    },
+
     /// Recovers a mint that failed during transaction submission but whose
     /// on-chain transaction actually succeeded, as evidenced by a receipt
     /// discovered by the receipt monitor.

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -61,6 +61,14 @@ pub(crate) enum MintEvent {
         block_number: u64,
         recovered_at: DateTime<Utc>,
     },
+    /// Admin-closed mint that cannot be automatically recovered.
+    /// Terminal state — closed mints do not appear in stuck queries.
+    MintClosed {
+        issuer_request_id: IssuerMintRequestId,
+        reason: String,
+        closed_at: DateTime<Utc>,
+    },
+
     /// Indicates that a mint retry has started during recovery.
     MintRetryStarted {
         issuer_request_id: IssuerMintRequestId,
@@ -96,6 +104,7 @@ impl DomainEvent for MintEvent {
             Self::ExistingMintRecovered { .. } => {
                 "MintEvent::ExistingMintRecovered".to_string()
             }
+            Self::MintClosed { .. } => "MintEvent::MintClosed".to_string(),
             Self::MintRetryStarted { .. } => {
                 "MintEvent::MintRetryStarted".to_string()
             }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -194,6 +194,11 @@ pub(crate) enum Mint {
         minted_at: DateTime<Utc>,
         completed_at: DateTime<Utc>,
     },
+    Closed {
+        issuer_request_id: IssuerMintRequestId,
+        reason: String,
+        closed_at: DateTime<Utc>,
+    },
 }
 
 impl Default for Mint {
@@ -213,6 +218,7 @@ impl Mint {
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
             Self::Completed { .. } => "Completed",
+            Self::Closed { .. } => "Closed",
         }
     }
 
@@ -240,7 +246,7 @@ impl Mint {
             | Self::Completed { tokenization_request_id, .. } => {
                 Some(tokenization_request_id)
             }
-            Self::Uninitialized => None,
+            Self::Uninitialized | Self::Closed { .. } => None,
         }
     }
 
@@ -1048,6 +1054,27 @@ impl Mint {
             minting_started_at: started_at,
         };
     }
+    fn handle_close_mint(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+        reason: String,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
+            Self::Completed { .. } | Self::Closed { .. } => {
+                Err(MintError::NotRecoverable {
+                    current_state: self.state_name().to_string(),
+                })
+            }
+            Self::Uninitialized => Err(MintError::NotRecoverable {
+                current_state: self.state_name().to_string(),
+            }),
+            _ => Ok(vec![MintEvent::MintClosed {
+                issuer_request_id,
+                reason,
+                closed_at: Utc::now(),
+            }]),
+        }
+    }
 }
 
 #[async_trait]
@@ -1119,6 +1146,9 @@ impl Aggregate for Mint {
                     tx_hash,
                 )
                 .await
+            }
+            MintCommand::CloseMint { issuer_request_id, reason } => {
+                self.handle_close_mint(issuer_request_id, reason)
             }
         }
     }
@@ -1204,6 +1234,9 @@ impl Aggregate for Mint {
                 ..
             } => {
                 self.apply_mint_retry_started(started_at);
+            }
+            MintEvent::MintClosed { issuer_request_id, reason, closed_at } => {
+                *self = Self::Closed { issuer_request_id, reason, closed_at };
             }
         }
     }
@@ -1475,7 +1508,8 @@ pub(crate) mod tests {
                     | MintEvent::MintingFailed { .. }
                     | MintEvent::MintCompleted { .. }
                     | MintEvent::ExistingMintRecovered { .. }
-                    | MintEvent::MintRetryStarted { .. } => {
+                    | MintEvent::MintRetryStarted { .. }
+                    | MintEvent::MintClosed { .. } => {
                         panic!(
                             "Expected MintInitiated event, got {:?}",
                             &events[0]

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -154,6 +154,11 @@ pub(crate) enum MintView {
         minted_at: DateTime<Utc>,
         completed_at: DateTime<Utc>,
     },
+    Closed {
+        issuer_request_id: IssuerMintRequestId,
+        reason: String,
+        closed_at: DateTime<Utc>,
+    },
 }
 
 impl Default for MintView {
@@ -174,6 +179,7 @@ impl MintView {
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
             Self::Completed { .. } => "Completed",
+            Self::Closed { .. } => "Closed",
         }
     }
 
@@ -536,6 +542,13 @@ impl View<Mint> for MintView {
             }
             MintEvent::MintRetryStarted { started_at, .. } => {
                 self.handle_mint_retry_started(*started_at);
+            }
+            MintEvent::MintClosed { issuer_request_id, reason, closed_at } => {
+                *self = Self::Closed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    reason: reason.clone(),
+                    closed_at: *closed_at,
+                };
             }
         }
     }

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -117,7 +117,8 @@ impl View<Mint> for ReceiptInventoryView {
             | MintEvent::MintingFailed { .. }
             | MintEvent::MintCompleted { .. }
             | MintEvent::ExistingMintRecovered { .. }
-            | MintEvent::MintRetryStarted { .. } => {}
+            | MintEvent::MintRetryStarted { .. }
+            | MintEvent::MintClosed { .. } => {}
         }
     }
 }


### PR DESCRIPTION
## Motivation

Mints can get stuck in non-terminal states (Initiated, JournalConfirmed, MintingFailed, etc.) where automatic recovery isn't possible — e.g. an Alpaca-side issue that won't resolve, or a mint that needs manual off-chain intervention. There was no way to mark these as permanently resolved, so they kept appearing in `/admin/stuck` queries and recovery loops.

Closes RAI-374

## Solution

Add a `POST /admin/close/mint/<aggregate_id>` endpoint that transitions a mint to a new terminal `Closed` state from any non-terminal state.

**New domain concepts:**
- `MintCommand::CloseMint { issuer_request_id, reason }` — accepted from any state except `Completed`, `Closed`, and `Uninitialized` (which return `MintError::NotRecoverable`)
- `MintEvent::MintClosed { issuer_request_id, reason, closed_at }` — new terminal event
- `Mint::Closed` aggregate variant and `MintView::Closed` view variant

**Endpoint behavior (`src/admin.rs`):**
- Requires `InternalAuth`
- Accepts a JSON body with a `reason` string
- Returns `422 Unprocessable Entity` for invalid state transitions, `500` for framework errors
- Reuses the existing `ReprocessResponse` struct for the response

**Integration with existing code:**
- `reprocess_mint` now treats `Closed` the same as `Completed` (returns `409 Conflict`)
- `ReceiptInventoryView` ignores `MintClosed` events (no receipt impact)
- `Mint::tokenization_request_id()` returns `None` for `Closed` state

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [ ] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin operation to close mints with a specified reason. Closed mints are excluded from automatic recovery and reprocessing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->