### PR TITLE
fix: isolate WSS subscriptions, use HTTP for RPC calls, recovery timeout (RAI-416)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ async-trait.workspace = true
 clap = { version = "4.5.49", features = ["derive", "env"] }
 alloy = { version = "1.0.41", features = [
   "provider-ws",
+  "provider-http",
   "pubsub",
   "node-bindings",
   "rand",

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,9 +15,12 @@ use crate::telemetry::HyperDxConfig;
 use crate::vault::rain_meta::OaSchemaCache;
 use crate::vault::{VaultService, service::RealBlockchainService};
 
-pub(crate) struct BlockchainSetup<P> {
+pub(crate) struct BlockchainSetup<HttpP> {
     pub(crate) vault_service: Arc<dyn VaultService>,
-    pub(crate) provider: P,
+    /// HTTP provider — used for all non-subscription RPC calls (backfill,
+    /// reconciliation, vault service balance checks, etc.). Receipt monitors
+    /// and redemption detectors create their own WSS connections.
+    pub(crate) http_provider: HttpP,
 }
 
 /// Default chain ID (Base mainnet)
@@ -49,20 +52,20 @@ impl Config {
         env.into_config()
     }
 
-    /// Creates the blockchain provider and vault service.
+    /// Creates the HTTP provider and vault service.
     ///
-    /// Initializes a single provider connection and builds the appropriate
-    /// VaultService (local signer or Fireblocks). The provider is returned
-    /// for reuse by other components (backfill, monitor) to avoid multiple
-    /// connections to the same RPC endpoint.
+    /// Initializes an HTTP provider for non-subscription RPC calls (backfill,
+    /// reconciliation, vault service) and builds the appropriate VaultService
+    /// (local signer or Fireblocks). Receipt monitors and redemption detectors
+    /// create their own WSS connections independently.
     pub(crate) async fn create_blockchain_setup(
         &self,
     ) -> Result<BlockchainSetup<impl Provider + Clone + use<>>, ConfigError>
     {
-        let provider =
-            ProviderBuilder::new().connect(self.rpc_url.as_str()).await?;
+        let http_url = wss_to_http(&self.rpc_url)?;
+        let http_provider = ProviderBuilder::new().connect_http(http_url);
 
-        let rpc_chain_id = provider.get_chain_id().await?;
+        let rpc_chain_id = http_provider.get_chain_id().await?;
         if rpc_chain_id != self.chain_id {
             return Err(ConfigError::ChainIdMismatch {
                 configured: self.chain_id,
@@ -80,21 +83,20 @@ impl Config {
 
                 let signing_provider = ProviderBuilder::new()
                     .wallet(resolved.wallet)
-                    .connect(self.rpc_url.as_str())
-                    .await?;
+                    .connect_http(wss_to_http(&self.rpc_url)?);
 
                 Arc::new(RealBlockchainService::new(
                     signing_provider,
-                    oa_schema_cache.clone(),
+                    oa_schema_cache,
                 ))
             }
 
             SignerConfig::Fireblocks(env) => {
                 let service = FireblocksVaultService::new(
                     env,
-                    provider.clone(),
+                    http_provider.clone(),
                     self.chain_id,
-                    oa_schema_cache.clone(),
+                    oa_schema_cache,
                 )
                 .map_err(|err| ConfigError::FireblocksVault(Box::new(err)))?;
 
@@ -102,7 +104,7 @@ impl Config {
             }
         };
 
-        Ok(BlockchainSetup { vault_service, provider })
+        Ok(BlockchainSetup { vault_service, http_provider })
     }
 }
 
@@ -274,6 +276,27 @@ pub enum ConfigError {
         "Chain ID mismatch: configured {configured}, RPC returned {from_rpc}"
     )]
     ChainIdMismatch { configured: u64, from_rpc: u64 },
+    #[error("Cannot derive HTTP URL from RPC URL: {0}")]
+    InvalidRpcScheme(String),
+}
+
+/// Derives an HTTP URL from a WebSocket URL by replacing the scheme.
+///
+/// `wss://` → `https://`, `ws://` → `http://`. Leaves HTTP URLs unchanged.
+fn wss_to_http(url: &Url) -> Result<Url, ConfigError> {
+    let new_scheme = match url.scheme() {
+        "wss" => "https",
+        "ws" => "http",
+        "http" | "https" => return Ok(url.clone()),
+        other => return Err(ConfigError::InvalidRpcScheme(other.to_string())),
+    };
+
+    let mut http_url = url.clone();
+    http_url.set_scheme(new_scheme).map_err(|()| {
+        ConfigError::InvalidRpcScheme(url.scheme().to_string())
+    })?;
+
+    Ok(http_url)
 }
 
 /// Domain target categories used in `target:` on all tracing macros.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::{Address, U256};
-use alloy::providers::Provider;
+use alloy::providers::{Provider, ProviderBuilder};
 use cqrs_es::persist::{GenericQuery, PersistedEventStore};
 use cqrs_es::{AggregateContext, EventStore};
 use futures::stream::{self, StreamExt, TryStreamExt};
@@ -297,7 +297,7 @@ pub async fn initialize_rocket(
     // receipt inventory to detect already-minted receipts (prevents double-mints).
     let vault_configs = run_all_receipt_backfills(
         &pool,
-        blockchain_setup.provider.clone(),
+        blockchain_setup.http_provider.clone(),
         &receipt_inventory.cqrs,
         &receipt_inventory.event_store,
         bot_wallet,
@@ -313,7 +313,7 @@ pub async fn initialize_rocket(
         .collect();
 
     if let Err(error) = run_startup_reconciliation(
-        blockchain_setup.provider.clone(),
+        blockchain_setup.http_provider.clone(),
         &vault_receipt_pairs,
         &receipt_inventory.cqrs,
         receipt_inventory.event_store.as_ref(),
@@ -330,7 +330,7 @@ pub async fn initialize_rocket(
     }
 
     let transfer_backfiller = TransferBackfiller {
-        provider: blockchain_setup.provider.clone(),
+        provider: blockchain_setup.http_provider.clone(),
         bot_wallet,
         cqrs: redemption_cqrs.clone(),
         event_store: redemption_event_store.clone(),
@@ -341,27 +341,21 @@ pub async fn initialize_rocket(
     };
 
     spawn_all_receipt_monitors(
-        blockchain_setup.provider.clone(),
+        &config.rpc_url,
         &vault_configs,
         &receipt_inventory.cqrs,
         bot_wallet,
         &MintRecoveryHandler::new(mint.cqrs.clone()),
     );
 
-    // Recovery runs AFTER reprojections and backfill so it can query accurate state.
-    // Recovery must complete BEFORE the HTTP server starts accepting requests to
-    // prevent race conditions between recovery and incoming confirm/redeem requests
-    // that could cause duplicate side effects (e.g., duplicate Alpaca callbacks).
-    run_mint_recovery(&pool, &mint.cqrs).await;
-    run_redemption_recovery(
-        &managers.redeem_call,
-        &managers.journal,
-        &managers.burn,
-    )
-    .await;
+    // Recovery runs with a timeout before the HTTP server starts. If it
+    // completes within the timeout, there is no race with incoming requests.
+    // If it hangs (e.g., Fireblocks call), it is cancelled and stuck
+    // aggregates are left for manual admin intervention.
+    run_recovery_with_timeout(&pool, &mint.cqrs, &managers).await;
 
     spawn_periodic_receipt_backfills(
-        blockchain_setup.provider.clone(),
+        blockchain_setup.http_provider,
         vault_configs.clone(),
         receipt_inventory.cqrs.clone(),
         receipt_inventory.event_store.clone(),
@@ -738,6 +732,50 @@ async fn run_redemption_recovery(
     burn.recover_burn_failed_redemptions().await;
 }
 
+/// Maximum time to wait for recovery before starting the HTTP server.
+///
+/// Recovery runs as a background task with a timeout. If it completes within
+/// this window, no race condition is possible (recovery is done before any
+/// HTTP request arrives). If it hangs (e.g., Fireblocks call), the task is
+/// **cancelled** — not left running — so no concurrent side effects can
+/// race with incoming HTTP requests. Stuck aggregates that weren't recovered
+/// in time require manual intervention via `/admin/recover` or `/admin/close`.
+const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Runs mint and redemption recovery with a timeout, then starts the HTTP
+/// server. Recovery that completes within [`RECOVERY_TIMEOUT`] runs to
+/// completion before Rocket serves requests. Recovery that hangs is
+/// cancelled to prevent concurrent side effects.
+async fn run_recovery_with_timeout(
+    pool: &Pool<Sqlite>,
+    mint_cqrs: &MintCqrs,
+    managers: &RedemptionManagers,
+) {
+    let recovery = async {
+        run_mint_recovery(pool, mint_cqrs).await;
+        run_redemption_recovery(
+            &managers.redeem_call,
+            &managers.journal,
+            &managers.burn,
+        )
+        .await;
+    };
+
+    match tokio::time::timeout(RECOVERY_TIMEOUT, recovery).await {
+        Ok(()) => {
+            info!(target: "startup", "Recovery complete");
+        }
+        Err(_) => {
+            warn!(
+                target: "startup",
+                timeout_secs = RECOVERY_TIMEOUT.as_secs(),
+                "Recovery timed out — remaining stuck aggregates require \
+                 manual recovery via /admin/recover or /admin/close endpoints"
+            );
+        }
+    }
+}
+
 /// Configuration for a single vault, extracted from TokenizedAssetView.
 #[derive(Clone, Copy)]
 struct VaultBackfillConfig {
@@ -1050,21 +1088,23 @@ fn spawn_all_transfer_backfills<P>(
     });
 }
 
-/// Spawns receipt monitors for ALL enabled vaults.
-fn spawn_all_receipt_monitors<P, ITN>(
-    provider: P,
+/// Spawns one receipt monitor per vault, each with its own WebSocket
+/// connection. This avoids hitting per-connection subscription limits
+/// (each monitor creates 6 subscriptions) regardless of how many assets
+/// are added.
+fn spawn_all_receipt_monitors<ITN>(
+    rpc_url: &Url,
     vault_configs: &[VaultBackfillConfig],
     receipt_inventory_cqrs: &ReceiptInventoryCqrs,
     bot_wallet: Address,
     handler: &ITN,
 ) where
-    P: Provider + Clone + Send + Sync + 'static,
     ITN: ItnReceiptHandler + Clone + 'static,
 {
     info!(
         target: "receipt",
         vault_count = vault_configs.len(),
-        "Spawning receipt monitors for all vaults"
+        "Spawning receipt monitors (one WSS connection per vault)"
     );
 
     for config in vault_configs {
@@ -1076,21 +1116,51 @@ fn spawn_all_receipt_monitors<P, ITN>(
             "Spawning receipt monitor for vault"
         );
 
+        let rpc_url = rpc_url.clone();
+        let cqrs = receipt_inventory_cqrs.clone();
+        let handler = handler.clone();
         let monitor_config = ReceiptMonitorConfig {
             vault: config.vault,
             receipt_contract: config.receipt_contract,
             bot_wallet,
         };
 
-        let monitor = ReceiptMonitor::new(
-            provider.clone(),
-            monitor_config,
-            receipt_inventory_cqrs.clone(),
-            handler.clone(),
-        );
-
         tokio::spawn(async move {
-            monitor.run().await;
+            loop {
+                let provider = match ProviderBuilder::new()
+                    .connect(rpc_url.as_str())
+                    .await
+                {
+                    Ok(provider) => provider,
+                    Err(err) => {
+                        warn!(
+                            target: "receipt",
+                            vault = %monitor_config.vault,
+                            error = %err,
+                            "Failed to connect WSS for receipt monitor, retrying in 5s"
+                        );
+                        tokio::time::sleep(Duration::from_secs(5)).await;
+                        continue;
+                    }
+                };
+
+                let monitor = ReceiptMonitor::new(
+                    provider,
+                    monitor_config,
+                    cqrs.clone(),
+                    handler.clone(),
+                );
+
+                monitor.run().await;
+
+                warn!(
+                    target: "receipt",
+                    vault = %monitor_config.vault,
+                    retry_after_secs = 5,
+                    "Receipt monitor exited; reconnecting after backoff"
+                );
+                tokio::time::sleep(Duration::from_secs(5)).await;
+            }
         });
     }
 }


### PR DESCRIPTION
## Motivation

Production incident on 2026-05-07: adding 3 new assets (QQQM, VWO, ARKK) pushed receipt monitor subscriptions from 90 to 108 on a single WebSocket connection. dRPC's per-connection subscription limit (~60) triggered an infinite reconnect loop — alloy's pubsub service reconnected immediately with no backoff, re-subscribing all 108 subscriptions each cycle. This:

1. **Blocked all RPC calls** — `eth_call`, `get_logs`, and balance checks shared the same WSS connection, so the reconnect storm prevented burn recovery, backfill, and reconciliation from completing.
2. **Burned 4M+ `eth_subscribe` credits** in minutes, exhausting the dRPC account.
3. **Hung the bot indefinitely** — startup recovery (mint + redemption) runs synchronously before Rocket starts, so a stuck Fireblocks or RPC call prevented the HTTP server from ever serving.

Closes RAI-416. Related: [RAI-415](https://linear.app/makeitrain/issue/RAI-415) (validate RPC URL scheme at startup).

## Solution

Three changes:

**1. HTTP provider for non-subscription RPC calls (`src/config.rs`)**

Derive an `https://` URL from the configured `wss://` URL via `wss_to_http()`. Create a separate HTTP provider for all read-only RPC calls (backfill, reconciliation, vault service balance checks, transfer backfiller). The WSS provider is no longer shared — receipt monitors and redemption detectors create their own connections.

- `BlockchainSetup` now holds only `http_provider` (the shared WSS `provider` field is removed)
- `FireblocksVaultService` and `RealBlockchainService` receive the HTTP provider
- `wss_to_http()` handles `wss→https`, `ws→http`, passes `http/https` unchanged, rejects other schemes

**2. One WSS connection per receipt monitor (`src/lib.rs`)**

`spawn_all_receipt_monitors` now takes `rpc_url: &Url` instead of a shared provider. Each vault's monitor spawns its own `tokio::spawn` task that:
- Creates a dedicated WSS provider via `ProviderBuilder::new().connect()`
- Retries connection failures with a 5-second backoff (previously, a failed connect permanently killed the monitor)
- Runs the monitor loop with that provider

With 18 assets × 6 subscriptions = 108 total, spread across 18 independent connections (6 subs each), well under any per-connection limit.

**3. Recovery with timeout (`src/lib.rs`)**

`run_recovery_with_timeout` replaces the old blocking `run_mint_recovery` + `run_redemption_recovery` sequence. Recovery runs with a 30-second timeout:
- If it completes in time: no race condition possible (recovery is done before Rocket serves)
- If it hangs (e.g., Fireblocks call): recovery is **cancelled** (not left running in background), so no concurrent side effects can race with incoming HTTP requests. Stuck aggregates are left for manual admin intervention via `/admin/recover` or `/admin/close`

This avoids both the old problem (bot hangs forever) and the alternative problem (background recovery races with HTTP handlers on external side effects like Alpaca calls or on-chain mints).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recovery operations now run with a timeout to avoid indefinite hangs and emit clear logs on timeout or completion.
  * Receipt monitoring now automatically reconnects and retries after connection failures for improved reliability.
  * Startup sequencing improved to make RPC-based startup checks more robust.

* **Chores**
  * Added support and validation for HTTP(S)-based RPC connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->