### PR TITLE
feat: add GET /admin/fireblocks/tx/<id> endpoint for transaction status lookup

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -408,10 +408,10 @@ async fn recover_post_alpaca(
                     );
                     return Err(Status::UnprocessableEntity);
                 }
-                Ok(Some(FireblocksTxStatus::Failed { status: fb_status })) => {
+                Ok(Some(FireblocksTxStatus::Failed { detail: fb_detail })) => {
                     info!(target: "admin", aggregate_id = %aggregate_id,
                         fireblocks_tx_id = %fb_tx_id,
-                        fireblocks_status = %fb_status,
+                        fireblocks_status = %fb_detail,
                         "Fireblocks tx failed, proceeding with ResumeBurn"
                     );
                     // Fall through to ResumeBurn below
@@ -762,6 +762,50 @@ pub(crate) async fn list_stuck(
     }
 
     Ok(Json(StuckResponse { stuck }))
+}
+
+/// Response for the Fireblocks transaction status lookup endpoint.
+#[derive(Debug, Serialize)]
+pub(crate) struct FireblocksTxResponse {
+    fireblocks_tx_id: String,
+    #[serde(flatten)]
+    status: FireblocksTxStatus,
+}
+
+/// Admin endpoint to look up a Fireblocks transaction status.
+///
+/// Useful for checking orphaned transactions that were submitted but never
+/// recorded in the event store (e.g. due to recovery timeout).
+#[tracing::instrument(skip(_auth, vault_service))]
+#[get("/admin/fireblocks/tx/<fireblocks_tx_id>")]
+pub(crate) async fn check_fireblocks_tx(
+    _auth: InternalAuth,
+    vault_service: &rocket::State<Arc<dyn VaultService>>,
+    fireblocks_tx_id: &str,
+) -> Result<Json<FireblocksTxResponse>, Status> {
+    let result = vault_service
+        .check_fireblocks_tx(fireblocks_tx_id)
+        .await
+        .map_err(|err| {
+            error!(target: "admin",
+                fireblocks_tx_id = %fireblocks_tx_id,
+                error = %err,
+                "Failed to check Fireblocks transaction"
+            );
+            Status::BadGateway
+        })?;
+
+    let Some(fb_status) = result else {
+        // Non-Fireblocks backend — check_fireblocks_tx returns None.
+        return Err(Status::NotFound);
+    };
+
+    let response = FireblocksTxResponse {
+        fireblocks_tx_id: fireblocks_tx_id.to_string(),
+        status: fb_status,
+    };
+
+    Ok(Json(response))
 }
 
 #[cfg(test)]

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -824,7 +824,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
                 // Verify EVM execution succeeded — a mined tx can still be a revert.
                 if !receipt.status() {
                     return Ok(Some(FireblocksTxStatus::Failed {
-                        status: format!(
+                        detail: format!(
                             "EVM reverted (Fireblocks Completed, tx {tx_hash})"
                         ),
                     }));
@@ -834,7 +834,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             }
             status if is_still_pending(status) => FireblocksTxStatus::Pending,
             status => {
-                FireblocksTxStatus::Failed { status: format!("{status:?}") }
+                FireblocksTxStatus::Failed { detail: format!("{status:?}") }
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,6 +448,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 admin::reprocess_mint,
                 admin::close_mint,
                 admin::list_stuck,
+                admin::check_fireblocks_tx,
             ],
         )
         .register("/", catchers::json_catchers())

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -110,14 +110,15 @@ pub(crate) trait VaultService: Send + Sync {
 }
 
 /// Status of a Fireblocks transaction, as returned by `check_fireblocks_tx`.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
 pub(crate) enum FireblocksTxStatus {
     /// Transaction completed on-chain.
     Completed { tx_hash: B256, block_number: u64 },
     /// Transaction is still pending (submitted, confirming, etc.).
     Pending,
     /// Transaction reached a terminal failure status.
-    Failed { status: String },
+    Failed { detail: String },
 }
 
 /// Result of a successful on-chain minting operation.


### PR DESCRIPTION
## Motivation

During the 2026-05-07 incident, Fireblocks transactions were submitted but never recorded in the event store due to recovery timeouts. Diagnosing these orphaned transactions required manually hitting the Fireblocks API. This endpoint gives operators a quick way to check the status of any Fireblocks transaction by ID without leaving the admin API.

## Solution

Add `GET /admin/fireblocks/tx/<fireblocks_tx_id>` to the admin API (`src/admin.rs`). The endpoint:

- Calls `VaultService::check_fireblocks_tx()` (already implemented on `FireblocksVaultService` for the recovery flow in the parent PR)
- Returns JSON with `status` (`completed` / `pending` / `failed`), plus `tx_hash` and `block_number` when completed, or `detail` when failed
- Returns 404 when running against the local (non-Fireblocks) signing backend
- Protected by `InternalAuth`

The route is mounted in `build_rocket()` (`src/lib.rs`).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

---
Linear: RAI-455

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin endpoint to check Fireblocks transaction status by transaction ID. Returns the current status with a 200 response, or appropriate error codes (404 for not found, 502 for service errors).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/148)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->