### PR TITLE
feat: split submit/confirm for idempotent mint/burn recovery (RAI-374)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -185,8 +185,17 @@ initial request through journal confirmation to on-chain minting and callback.
   transfer
 - `RejectJournal { issuer_request_id, reason }` - Alpaca rejected shares journal
   transfer
-- `Deposit { issuer_request_id }` - Execute the on-chain deposit (minting)
-  operation via the vault service
+- `Deposit { issuer_request_id }` - Record intent to mint. Pure state transition
+  from `JournalConfirmed` to `Minting` — no network call. Produces
+  `MintingStarted`. Intent is persisted before the network call so that a crash
+  during submission leaves the aggregate in a recoverable `Minting` state rather
+  than `JournalConfirmed` (which would lose track of the submission)
+- `SubmitMint { issuer_request_id }` - Submit the on-chain deposit to the
+  signing backend. Requires `Minting` state. Produces `FireblocksSubmitted` on
+  success or `MintingFailed` on failure
+- `ConfirmMint { issuer_request_id, fireblocks_tx_id }` - Confirm a previously
+  submitted mint transaction. Polls the signing backend and produces
+  `TokensMinted` or `MintingFailed`
 - `SendCallback { issuer_request_id }` - Send the callback to Alpaca confirming
   mint completion
 - `Recover { issuer_request_id }` - Recover a mint stuck in an incomplete state.
@@ -213,7 +222,9 @@ initial request through journal confirmation to on-chain minting and callback.
 - `Initiated` - Mint request created (carries all request details)
 - `JournalConfirmed` - Alpaca journal transfer confirmed
 - `JournalRejected` - Alpaca journal transfer rejected (terminal)
-- `MintingStarted` - On-chain minting operation started
+- `MintingStarted` - Mint intent recorded (aggregate moves to `Minting`)
+- `FireblocksSubmitted` - Mint transaction submitted to signing backend (carries
+  `external_tx_id` and `fireblocks_tx_id` for crash recovery)
 - `TokensMinted` - On-chain mint succeeded (carries tx details)
 - `MintingFailed` - On-chain mint failed
 - `MintCompleted` - Alpaca callback sent, mint fully completed (terminal)
@@ -228,18 +239,26 @@ initial request through journal confirmation to on-chain minting and callback.
 | `Initiate`           | `Initiated`             | Mint request created                            |
 | `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                               |
 | `RejectJournal`      | `JournalRejected`       | Terminal failure                                |
-| `Deposit`            | See below               | Calls vault service                             |
+| `Deposit`            | `MintingStarted`        | Records intent (no network call)                |
+| `SubmitMint`         | See below               | Submits to signing backend                      |
+| `ConfirmMint`        | See below               | Confirms submitted tx                           |
 | `SendCallback`       | `MintCompleted`         | Calls Alpaca callback                           |
 | `Recover`            | See below               | Checks receipt inventory                        |
 | `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt-triggered recovery from `MintingFailed` |
 
-`Deposit` emits `MintingStarted`, then either `TokensMinted` (success) or
-`MintingFailed` (failure).
+`Deposit` emits only `MintingStarted` (intent). The actual submission is handled
+by `SubmitMint`, which emits either `FireblocksSubmitted` (success) or
+`MintingFailed` (failure). This two-step design persists intent before the
+network call, so a crash during submission leaves the aggregate in `Minting`
+state (recoverable) rather than `JournalConfirmed`.
+
+`ConfirmMint` polls the signing backend for the submitted transaction and emits
+either `TokensMinted` (success) or `MintingFailed` (failure).
 
 `Recover` checks the receipt inventory for a receipt matching the
-`issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found,
-emits `MintRetryStarted` then follows the same path as `Deposit`
-(`MintingStarted`, then `TokensMinted` or `MintingFailed`).
+`issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
+in `Minting` state, submits and emits `FireblocksSubmitted`. If in
+`FireblocksSubmitted` state, confirms the existing transaction.
 
 `RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
 receipt for a mint in `MintingFailed` state (where the predecessor was
@@ -269,8 +288,15 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `RecordAlpacaCall` - Alpaca redeem API called successfully
 - `RecordAlpacaFailure` - Alpaca redeem API call failed
 - `ConfirmAlpacaComplete` - Alpaca journal transfer completed
-- `RecordBurnSuccess` - On-chain burn succeeded
-- `RecordBurnFailure` - On-chain burn failed
+- `BurnTokens` - Submit burn transaction to signing backend. Produces
+  `BurnFireblocksSubmitted` on success
+- `ConfirmBurn { fireblocks_tx_id, dust_shares }` - Confirm a previously
+  submitted burn transaction. Produces `TokensBurned` on success
+- `RecordBurnFailure` - Record on-chain burn failure (from `Burning` or
+  `BurnSubmitted` state). Carries optional `fireblocks_tx_id` and
+  `planned_burns` for recovery
+- `RecordExistingBurn` - Record an existing on-chain burn discovered during
+  recovery via Fireblocks transaction lookup
 - `MarkFailed` - Mark redemption as failed
 - `Reprocess { issuer_request_id, metadata }` - Reset a failed redemption back
   to `Detected` state for reprocessing. Only valid from `Failed` state when no
@@ -296,11 +322,15 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `AlpacaCalled` - Alpaca redeem endpoint called
 - `AlpacaCallFailed` - Alpaca API call failed (terminal)
 - `AlpacaJournalCompleted` - Alpaca confirmed journal transfer
+- `BurnFireblocksSubmitted` - Burn transaction submitted to signing backend
+  (carries `external_tx_id`, `fireblocks_tx_id`, and `planned_burns`)
 - `TokensBurned` - On-chain burn succeeded, redemption complete (terminal
   success). Payload contains `burns: Vec<BurnRecord>` where each `BurnRecord`
   has `receipt_id` and `shares_burned`, supporting multi-receipt burns when a
   single redemption spans multiple ERC-1155 receipts
-- `BurningFailed` - On-chain burn failed (terminal)
+- `BurningFailed` - On-chain burn failed. Carries optional `fireblocks_tx_id`
+  and `planned_burns` for recovery of previously submitted transactions
+- `ExistingBurnRecovered` - Existing on-chain burn discovered during recovery
 - `Reprocessed` - Redemption reset to `Detected` state for reprocessing. Carries
   the original `RedemptionMetadata`, the previous state name, and a timestamp.
   Used for audit trail — shows when and from what state a manual reprocess was
@@ -313,16 +343,18 @@ on-chain transfer through calling Alpaca to burning tokens.
 
 **Command -> Event Mappings:**
 
-| Command                 | Events                   | Notes                                      |
-| ----------------------- | ------------------------ | ------------------------------------------ |
-| `DetectRedemption`      | `RedemptionDetected`     | Transfer detected                          |
-| `RecordAlpacaCall`      | `AlpacaCalled`           | Alpaca API called                          |
-| `RecordAlpacaFailure`   | `AlpacaCallFailed`       | Terminal failure                           |
-| `ConfirmAlpacaComplete` | `AlpacaJournalCompleted` | Journal complete                           |
-| `RecordBurnSuccess`     | `TokensBurned`           | Multi-receipt burn, terminal success       |
-| `RecordBurnFailure`     | `BurningFailed`          | Terminal failure                           |
-| `Reprocess`             | `Reprocessed`            | Reset to Detected for reprocessing         |
-| `ResumeBurn`            | `BurnResumed`            | Resume to Burning for post-Alpaca recovery |
+| Command                 | Events                    | Notes                                      |
+| ----------------------- | ------------------------- | ------------------------------------------ |
+| `DetectRedemption`      | `RedemptionDetected`      | Transfer detected                          |
+| `RecordAlpacaCall`      | `AlpacaCalled`            | Alpaca API called                          |
+| `RecordAlpacaFailure`   | `AlpacaCallFailed`        | Terminal failure                           |
+| `ConfirmAlpacaComplete` | `AlpacaJournalCompleted`  | Journal complete                           |
+| `BurnTokens`            | `BurnFireblocksSubmitted` | Submits to signing backend                 |
+| `ConfirmBurn`           | `TokensBurned`            | Confirms burn, terminal success            |
+| `RecordBurnFailure`     | `BurningFailed`           | Records failure with optional tx metadata  |
+| `RecordExistingBurn`    | `ExistingBurnRecovered`   | Recovery from Failed with known tx         |
+| `Reprocess`             | `Reprocessed`             | Reset to Detected for reprocessing         |
+| `ResumeBurn`            | `BurnResumed`             | Resume to Burning for post-Alpaca recovery |
 
 ### Account Aggregate
 
@@ -1097,11 +1129,13 @@ stateDiagram-v2
     PendingJournal --> JournalConfirmed: ConfirmJournal
     PendingJournal --> JournalRejected: RejectJournal
     JournalConfirmed --> Minting: Deposit (MintingStarted)
-    Minting --> CallbackPending: Deposit (TokensMinted)
-    Minting --> MintingFailed: Deposit (MintingFailed)
-    MintingFailed --> Minting: Recover (MintRetryStarted)
+    Minting --> FireblocksSubmitted: SubmitMint (FireblocksSubmitted)
+    Minting --> MintingFailed: SubmitMint (MintingFailed)
+    FireblocksSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
+    FireblocksSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
+    MintingFailed --> FireblocksSubmitted: Recover (MintRetryStarted + FireblocksSubmitted)
+    MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
     MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
-    Minting --> CallbackPending: Recover (ExistingMintRecovered)
     CallbackPending --> Completed: SendCallback
     JournalRejected --> [*]
     Completed --> [*]

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -6,8 +6,10 @@ use alloy::providers::Provider;
 use alloy::rpc::types::TransactionReceipt;
 use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
+use fireblocks_sdk::apis;
 use fireblocks_sdk::apis::transactions_api::{
     CreateTransactionError, CreateTransactionParams,
+    GetTransactionByExternalIdParams,
 };
 use fireblocks_sdk::apis::whitelisted_contracts_api::GetContractsError;
 use fireblocks_sdk::models::{self, TransactionStatus};
@@ -22,7 +24,7 @@ use crate::bindings::OffchainAssetReceiptVault;
 use crate::vault::rain_meta::OaSchemaCache;
 use crate::vault::{
     MintResult, MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, VaultError, VaultService,
+    ReceiptInformation, SubmittedTx, VaultError, VaultService,
 };
 
 /// Fireblocks-specific errors that can occur during vault operations.
@@ -62,15 +64,10 @@ pub(crate) enum FireblocksVaultError {
     UnknownChain { chain_id: u64 },
     #[error("transaction {tx_hash} has no receipt after confirmation")]
     MissingReceipt { tx_hash: TxHash },
-    /// An error occurred after the Fireblocks transaction was submitted and
-    /// potentially completed on-chain. The `tx_id` is preserved so that
-    /// recovery can look up the transaction on Fireblocks.
-    #[error("post-submit error for Fireblocks tx {tx_id}: {source}")]
-    PostSubmit {
-        tx_id: String,
-        #[source]
-        source: Box<VaultError>,
-    },
+    #[error(
+        "failed to look up existing transaction by externalTxId: {external_tx_id}"
+    )]
+    ExternalTxIdLookupFailed { external_tx_id: String },
 }
 
 /// Fetches the vault account address from Fireblocks.
@@ -242,12 +239,23 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
             .transaction_request(tx_request)
             .build();
 
-        let create_response = self
-            .client
-            .transactions_api()
-            .create_transaction(params)
-            .await
-            .map_err(|err| {
+        let create_response =
+            self.client.transactions_api().create_transaction(params).await;
+
+        match create_response {
+            Ok(response) => {
+                response.id.ok_or(FireblocksVaultError::MissingTransactionId)
+            }
+            Err(ref err) if is_duplicate_external_tx_id_error(err) => {
+                warn!(target: "fireblocks",
+                    %external_tx_id,
+                    original_error = ?err,
+                    "Duplicate externalTxId — looking up existing transaction"
+                );
+
+                self.recover_by_external_tx_id(external_tx_id).await
+            }
+            Err(err) => {
                 // The SDK's Display impl only shows the status code, discarding
                 // the response body which contains the actual error message and
                 // code. Debug preserves the full ResponseContent including the
@@ -257,10 +265,53 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
                     %external_tx_id,
                     "Fireblocks create_transaction failed"
                 );
-                err
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Recovers a Fireblocks transaction ID by looking up the `externalTxId`.
+    ///
+    /// Called when `create_transaction` returns a duplicate `externalTxId`
+    /// rejection (HTTP 409/400). This means we previously submitted a
+    /// transaction with this ID but lost track of it (e.g., crash before
+    /// persisting the Fireblocks tx ID). We look up the existing transaction
+    /// and return its Fireblocks ID so polling can resume.
+    async fn recover_by_external_tx_id(
+        &self,
+        external_tx_id: &str,
+    ) -> Result<String, FireblocksVaultError> {
+        let params = GetTransactionByExternalIdParams {
+            external_tx_id: external_tx_id.to_string(),
+        };
+
+        let tx = self
+            .client
+            .transactions_api()
+            .get_transaction_by_external_id(params)
+            .await
+            .map_err(|err| {
+                warn!(target: "fireblocks",
+                    %external_tx_id,
+                    error = ?err,
+                    "Failed to look up transaction by externalTxId"
+                );
+                // Convert the GetTransactionByExternalIdError into our error type.
+                // The underlying error is an API/network error, so wrap generically.
+                FireblocksVaultError::ExternalTxIdLookupFailed {
+                    external_tx_id: external_tx_id.to_string(),
+                }
             })?;
 
-        create_response.id.ok_or(FireblocksVaultError::MissingTransactionId)
+        let fireblocks_tx_id = tx.id;
+
+        debug!(target: "fireblocks",
+            %external_tx_id,
+            %fireblocks_tx_id,
+            "Recovered existing Fireblocks transaction"
+        );
+
+        Ok(fireblocks_tx_id)
     }
 
     /// Polls a Fireblocks transaction until completion.
@@ -460,20 +511,20 @@ impl std::fmt::Display for VaultOperation {
 }
 
 impl VaultOperation {
-    /// Generates a unique `externalTxId` for Fireblocks transactions.
+    /// Generates a deterministic `externalTxId` for Fireblocks transactions.
     ///
-    /// Format: `{ISO8601_compact}-{operation}-{issuer_request_id}`
-    /// e.g., `20260210T083800Z-mint-5960be2e-a556-42e7-8def-ed3a354b66e6`
+    /// Format: `{operation}-{issuer_request_id}`
+    /// e.g., `mint-5960be2e-a556-42e7-8def-ed3a354b66e6`
     ///
-    /// Each call produces a unique ID (via timestamp), avoiding Fireblocks'
-    /// permanent `externalTxId` rejection on retries. The operation prefix
-    /// and issuer_request_id make the ID searchable in the Fireblocks dashboard.
+    /// The ID is stable across retries so that Fireblocks' duplicate
+    /// `externalTxId` rejection prevents double-submissions. If a retry
+    /// hits HTTP 400 for a duplicate ID, the caller can look up the
+    /// existing transaction and resume polling.
     fn external_tx_id(
         &self,
         issuer_request_id: &(impl std::fmt::Display + ?Sized),
     ) -> String {
-        let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%SZ");
-        format!("{timestamp}-{self}-{issuer_request_id}")
+        format!("{self}-{issuer_request_id}")
     }
 }
 
@@ -500,6 +551,32 @@ const fn is_still_pending(status: TransactionStatus) -> bool {
     }
 }
 
+/// Detects whether a `create_transaction` error is a duplicate `externalTxId`
+/// rejection. Fireblocks returns HTTP 409 (or sometimes 400) when a transaction
+/// with the same `externalTxId` already exists.
+fn is_duplicate_external_tx_id_error(
+    err: &apis::Error<CreateTransactionError>,
+) -> bool {
+    if let apis::Error::ResponseError(apis::ResponseContent {
+        status,
+        content,
+        ..
+    }) = err
+    {
+        // HTTP 409 Conflict is the canonical duplicate response.
+        // HTTP 400 with "externalTxId" in the body is also observed.
+        // For both, verify the body mentions the externalTxId keyword
+        // to avoid false positives from unrelated 409/400 errors.
+        if status.as_u16() == 409 || status.as_u16() == 400 {
+            let lower = content.to_lowercase();
+            return lower.contains("externaltxid")
+                || lower.contains("external_tx_id");
+        }
+    }
+
+    false
+}
+
 /// Parses a transaction hash string (with or without 0x prefix) into B256.
 fn parse_tx_hash(tx_hash_str: &str) -> Result<B256, FireblocksVaultError> {
     let tx_hash_hex = tx_hash_str.strip_prefix("0x").unwrap_or(tx_hash_str);
@@ -521,14 +598,14 @@ fn parse_tx_hash(tx_hash_str: &str) -> Result<B256, FireblocksVaultError> {
 impl<P: Provider + Clone + Send + Sync + 'static> VaultService
     for FireblocksVaultService<P>
 {
-    async fn mint_and_transfer_shares(
+    async fn submit_mint(
         &self,
         vault: Address,
         assets: U256,
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
-    ) -> Result<MintResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
         let oa_schema = self.oa_schema_cache.get(vault).await;
         let receipt_info_bytes = receipt_info.encode(oa_schema.as_deref())?;
 
@@ -566,7 +643,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let external_tx_id = VaultOperation::Mint
             .external_tx_id(&receipt_info.issuer_request_id);
 
-        let tx_id = self
+        let fireblocks_tx_id = self
             .submit_contract_call(
                 vault,
                 &multicall_calldata,
@@ -575,14 +652,21 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             )
             .await?;
 
+        Ok(SubmittedTx { external_tx_id, fireblocks_tx_id })
+    }
+
+    async fn confirm_mint(
+        &self,
+        fireblocks_tx_id: &str,
+    ) -> Result<MintResult, VaultError> {
         // Wait for Fireblocks to complete the transaction
-        let tx_hash = self.wait_for_completion(&tx_id).await?;
+        let tx_hash = self.wait_for_completion(fireblocks_tx_id).await?;
 
         // Fetch the receipt from our RPC provider to parse events
         let receipt = self.fetch_receipt(tx_hash).await?;
 
-        // Parse the Deposit event to get receipt_id and shares_minted
-        let (receipt_id, shares_minted) = receipt
+        // Parse the Deposit event to get receipt_id, shares_minted, and receipt_info_bytes
+        let (receipt_id, shares_minted, receipt_info_bytes) = receipt
             .inner
             .logs()
             .iter()
@@ -590,7 +674,11 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
                 log.log_decode::<OffchainAssetReceiptVault::Deposit>().ok().map(
                     |decoded| {
                         let event_data = decoded.data();
-                        (event_data.id, event_data.shares)
+                        (
+                            event_data.id,
+                            event_data.shares,
+                            event_data.receiptInformation.clone(),
+                        )
                     },
                 )
             })
@@ -610,10 +698,10 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         })
     }
 
-    async fn burn_multiple_receipts(
+    async fn submit_burn(
         &self,
         params: MultiBurnParams,
-    ) -> Result<MultiBurnResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
         let vault_contract =
             OffchainAssetReceiptVault::new(params.vault, &self.read_provider);
 
@@ -681,10 +769,13 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             params.issuer_request_id,
         );
 
+        // DEPLOYMENT NOTE: This format changed from `burn-red-{4_bytes}` to
+        // `burn-0x{full_tx_hash}`. Drain all in-flight burn transactions
+        // before deploying this change to avoid externalTxId mismatches.
         let external_tx_id =
-            VaultOperation::Burn.external_tx_id(&params.issuer_request_id);
+            VaultOperation::Burn.external_tx_id(&params.detected_tx_hash);
 
-        let tx_id = self
+        let fireblocks_tx_id = self
             .submit_contract_call(
                 params.vault,
                 &multicall_calldata,
@@ -693,21 +784,17 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             )
             .await?;
 
-        // Wait for Fireblocks to complete the transaction.
-        // TransactionFailed already carries tx_id, so no wrapping needed.
-        let tx_hash = self.wait_for_completion(&tx_id).await?;
+        Ok(SubmittedTx { external_tx_id, fireblocks_tx_id })
+    }
 
-        // Post-submit: any error after this point means the tx may have
-        // landed on-chain. Wrap errors with PostSubmit to preserve tx_id
-        // for recovery.
-        self.parse_burn_receipt(tx_hash, params.dust_shares).await.map_err(
-            |err| {
-                VaultError::Fireblocks(FireblocksVaultError::PostSubmit {
-                    tx_id,
-                    source: Box::new(err),
-                })
-            },
-        )
+    async fn confirm_burn(
+        &self,
+        fireblocks_tx_id: &str,
+        dust_shares: U256,
+    ) -> Result<MultiBurnResult, VaultError> {
+        let tx_hash = self.wait_for_completion(fireblocks_tx_id).await?;
+
+        self.parse_burn_receipt(tx_hash, dust_shares).await
     }
 
     async fn check_fireblocks_tx(
@@ -1072,37 +1159,35 @@ mod tests {
     }
 
     #[test]
-    fn external_tx_id_contains_operation_and_issuer_request_id() {
+    fn external_tx_id_is_deterministic() {
         let id = VaultOperation::Mint
             .external_tx_id("5960be2e-a556-42e7-8def-ed3a354b66e6");
-        assert!(
-            id.contains("mint-5960be2e-a556-42e7-8def-ed3a354b66e6"),
-            "Expected operation-issuer_request_id suffix, got {id}"
+        assert_eq!(
+            id, "mint-5960be2e-a556-42e7-8def-ed3a354b66e6",
+            "Expected deterministic operation-issuer_request_id format, got {id}"
         );
     }
 
     #[test]
-    fn external_tx_id_starts_with_iso8601_timestamp() {
-        let id =
-            VaultOperation::Burn.external_tx_id(&Uuid::new_v4().to_string());
-        assert!(
-            id.contains('T') && id.contains('Z'),
-            "Expected ISO 8601 compact timestamp, got {id}"
-        );
-        let timestamp_part = id.split('-').next().unwrap();
-        assert!(
-            timestamp_part.ends_with('Z'),
-            "Timestamp should end with Z, got {timestamp_part}"
-        );
-    }
-
-    #[test]
-    fn external_tx_id_is_unique_across_calls() {
+    fn external_tx_id_is_stable_across_calls() {
         let issuer_request_id = Uuid::new_v4().to_string();
         let id1 = VaultOperation::Mint.external_tx_id(&issuer_request_id);
-        std::thread::sleep(std::time::Duration::from_secs(1));
         let id2 = VaultOperation::Mint.external_tx_id(&issuer_request_id);
-        assert_ne!(id1, id2, "Consecutive calls should produce unique IDs");
+        assert_eq!(
+            id1, id2,
+            "Same inputs should produce identical IDs for idempotency"
+        );
+    }
+
+    #[test]
+    fn external_tx_id_differs_by_operation() {
+        let issuer_request_id = "5960be2e-a556-42e7-8def-ed3a354b66e6";
+        let mint_id = VaultOperation::Mint.external_tx_id(issuer_request_id);
+        let burn_id = VaultOperation::Burn.external_tx_id(issuer_request_id);
+        assert_ne!(
+            mint_id, burn_id,
+            "Different operations should produce different IDs"
+        );
     }
 
     #[test]
@@ -1198,6 +1283,91 @@ mod tests {
             total_calls >= 3,
             "SDK should have polled past Confirming status \
              (expected >= 3 calls, got {total_calls})"
+        );
+    }
+
+    fn make_response_error(
+        status: u16,
+        body: &str,
+    ) -> apis::Error<CreateTransactionError> {
+        apis::Error::ResponseError(apis::ResponseContent {
+            status: reqwest::StatusCode::from_u16(status).unwrap(),
+            content: body.to_string(),
+            entity: None,
+        })
+    }
+
+    #[test]
+    fn duplicate_detection_http_409_with_keyword() {
+        let err = make_response_error(
+            409,
+            r#"{"message": "Duplicate externalTxId"}"#,
+        );
+        assert!(
+            is_duplicate_external_tx_id_error(&err),
+            "HTTP 409 with 'externalTxId' should be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_409_without_keyword() {
+        let err = make_response_error(409, "Some other conflict");
+        assert!(
+            !is_duplicate_external_tx_id_error(&err),
+            "HTTP 409 without keyword should not be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_400_with_external_tx_id_keyword() {
+        let err = make_response_error(
+            400,
+            r#"{"message": "A transaction with externalTxId already exists"}"#,
+        );
+        assert!(
+            is_duplicate_external_tx_id_error(&err),
+            "HTTP 400 with 'externalTxId' should be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_400_with_external_tx_id_snake_case() {
+        let err = make_response_error(
+            400,
+            r#"{"message": "Duplicate external_tx_id"}"#,
+        );
+        assert!(
+            is_duplicate_external_tx_id_error(&err),
+            "HTTP 400 with 'external_tx_id' should be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_400_without_keyword() {
+        let err = make_response_error(400, r#"{"message": "Invalid amount"}"#);
+        assert!(
+            !is_duplicate_external_tx_id_error(&err),
+            "HTTP 400 without keyword should not be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_500() {
+        let err = make_response_error(500, "Internal server error");
+        assert!(
+            !is_duplicate_external_tx_id_error(&err),
+            "HTTP 500 should not be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_non_response_error() {
+        let err: apis::Error<CreateTransactionError> = apis::Error::Serde(
+            serde_json::from_str::<String>("!!!").unwrap_err(),
+        );
+        assert!(
+            !is_duplicate_external_tx_id_error(&err),
+            "Non-ResponseError should not be detected as duplicate"
         );
     }
 }

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -1,10 +1,12 @@
 use cqrs_es::{AggregateContext, EventStore};
 use rocket::{State, post, serde::json::Json};
 use serde::Deserialize;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::auth::IssuerAuth;
-use crate::mint::{IssuerMintRequestId, MintCommand, TokenizationRequestId};
+use crate::mint::{
+    IssuerMintRequestId, Mint, MintCommand, TokenizationRequestId,
+};
 use crate::{MintCqrs, MintEventStore};
 
 #[derive(Debug, Deserialize)]
@@ -109,8 +111,10 @@ pub(crate) async fn confirm_journal(
             }
 
             let cqrs = cqrs.inner().clone();
+            let store = event_store.inner().clone();
             rocket::tokio::spawn(process_journal_completion(
                 cqrs,
+                store,
                 issuer_request_id,
             ));
         }
@@ -119,16 +123,23 @@ pub(crate) async fn confirm_journal(
     rocket::http::Status::Ok
 }
 
-#[tracing::instrument(skip(cqrs), fields(
+#[tracing::instrument(skip(cqrs, event_store), fields(
     issuer_request_id = %issuer_request_id
 ))]
 async fn process_journal_completion(
     cqrs: MintCqrs,
+    event_store: MintEventStore,
     issuer_request_id: IssuerMintRequestId,
 ) {
+    let aggregate_id = issuer_request_id.to_string();
+
+    // Step 1: Record mint intent (Deposit → MintingStarted).
+    // Persisted BEFORE the network call so a crash between here and
+    // Step 2 leaves the aggregate in Minting (recoverable) rather
+    // than JournalConfirmed (which would lose track of the submission).
     if let Err(err) = cqrs
         .execute(
-            &issuer_request_id.to_string(),
+            &aggregate_id,
             MintCommand::Deposit {
                 issuer_request_id: issuer_request_id.clone(),
             },
@@ -142,6 +153,84 @@ async fn process_journal_completion(
         return;
     }
 
+    // Step 2: Submit mint transaction (SubmitMint → FireblocksSubmitted).
+    if let Err(err) = cqrs
+        .execute(
+            &aggregate_id,
+            MintCommand::SubmitMint {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+        )
+        .await
+    {
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = ?err,
+            "SubmitMint command failed"
+        );
+        return;
+    }
+
+    // Step 3: Load the fireblocks_tx_id from the aggregate and confirm
+    let context = match event_store.load_aggregate(&aggregate_id).await {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = ?err,
+                "Failed to load aggregate after SubmitMint"
+            );
+            return;
+        }
+    };
+
+    if let Mint::FireblocksSubmitted { fireblocks_tx_id, .. } =
+        context.aggregate()
+    {
+        if let Err(err) = cqrs
+            .execute(
+                &aggregate_id,
+                MintCommand::ConfirmMint {
+                    issuer_request_id: issuer_request_id.clone(),
+                    fireblocks_tx_id: fireblocks_tx_id.clone(),
+                },
+            )
+            .await
+        {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = ?err,
+                "ConfirmMint command failed"
+            );
+            return;
+        }
+    } else {
+        let state = context.aggregate().state_name();
+        match context.aggregate() {
+            Mint::MintingFailed { .. } => {
+                // Submission failed (e.g., transient Fireblocks error).
+                // Recovery runs at startup via run_recovery_with_timeout.
+                // In the current design, no periodic recovery loop exists,
+                // so this mint will remain stuck until the next service restart.
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    %state,
+                    "Mint submission failed — recovery will retry on next restart"
+                );
+            }
+            Mint::CallbackPending { .. } | Mint::Completed { .. } => {
+                info!(target: "mint", issuer_request_id = %issuer_request_id,
+                    %state,
+                    "Aggregate already advanced by concurrent recovery — skipping"
+                );
+            }
+            _ => {
+                error!(target: "mint", issuer_request_id = %issuer_request_id,
+                    %state,
+                    "Unexpected aggregate state after SubmitMint — ConfirmMint skipped"
+                );
+            }
+        }
+        return;
+    }
+
+    // Step 4: Send callback to Alpaca
     if let Err(err) = cqrs
         .execute(
             &issuer_request_id.to_string(),

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -26,12 +26,31 @@ pub(crate) enum MintCommand {
         reason: String,
     },
 
-    /// Executes the on-chain deposit (minting) operation.
+    /// Records the intent to mint, transitioning from `JournalConfirmed` to
+    /// `Minting` state. Pure state transition — no network call or vault lookup.
     ///
-    /// Calls the vault service to deposit, producing `MintingStarted`
-    /// followed by either `TokensMinted` or `MintingFailed`.
+    /// Produces `MintingStarted`. The actual submission to the signing backend
+    /// is handled by the subsequent `SubmitMint` command.
     Deposit {
         issuer_request_id: IssuerMintRequestId,
+    },
+
+    /// Submits the on-chain deposit (minting) transaction to the signing backend.
+    ///
+    /// Requires `Minting` state (set by prior `Deposit` command). Performs vault
+    /// lookup, builds receipt info, and calls `submit_mint()`. Produces
+    /// `FireblocksSubmitted` on success or `MintingFailed` on failure.
+    SubmitMint {
+        issuer_request_id: IssuerMintRequestId,
+    },
+
+    /// Confirms a previously submitted mint transaction.
+    ///
+    /// Polls the signing backend for the transaction identified by
+    /// `fireblocks_tx_id`, then produces `TokensMinted` or `MintingFailed`.
+    ConfirmMint {
+        issuer_request_id: IssuerMintRequestId,
+        fireblocks_tx_id: String,
     },
 
     /// Sends the callback to Alpaca to confirm mint completion.

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -69,6 +69,16 @@ pub(crate) enum MintEvent {
         closed_at: DateTime<Utc>,
     },
 
+    /// Transaction submitted to the signing backend (Fireblocks or local).
+    /// Persists the backend transaction ID so that polling can resume after
+    /// a restart without resubmitting (which would double-mint).
+    FireblocksSubmitted {
+        issuer_request_id: IssuerMintRequestId,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
+        submitted_at: DateTime<Utc>,
+    },
+
     /// Indicates that a mint retry has started during recovery.
     MintRetryStarted {
         issuer_request_id: IssuerMintRequestId,
@@ -105,6 +115,9 @@ impl DomainEvent for MintEvent {
                 "MintEvent::ExistingMintRecovered".to_string()
             }
             Self::MintClosed { .. } => "MintEvent::MintClosed".to_string(),
+            Self::FireblocksSubmitted { .. } => {
+                "MintEvent::FireblocksSubmitted".to_string()
+            }
             Self::MintRetryStarted { .. } => {
                 "MintEvent::MintRetryStarted".to_string()
             }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -23,7 +23,7 @@ use crate::receipt_inventory::{
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
-use crate::vault::{MintResult, ReceiptInformation, VaultService};
+use crate::vault::{ReceiptInformation, VaultService};
 
 pub use api::MintResponse;
 
@@ -139,6 +139,24 @@ pub(crate) enum Mint {
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
     },
+    /// Transaction submitted to signing backend, awaiting on-chain confirmation.
+    /// The `fireblocks_tx_id` enables recovery: on restart, the bot resumes
+    /// polling this transaction instead of resubmitting (which would double-mint).
+    FireblocksSubmitted {
+        issuer_request_id: IssuerMintRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        quantity: Quantity,
+        underlying: UnderlyingSymbol,
+        token: TokenSymbol,
+        network: Network,
+        client_id: ClientId,
+        wallet: Address,
+        initiated_at: DateTime<Utc>,
+        journal_confirmed_at: DateTime<Utc>,
+        minting_started_at: DateTime<Utc>,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
+    },
     CallbackPending {
         issuer_request_id: IssuerMintRequestId,
         tokenization_request_id: TokenizationRequestId,
@@ -207,6 +225,18 @@ impl Default for Mint {
     }
 }
 
+/// Groups mint submission parameters to keep `execute_mint_submission` under
+/// the clippy argument limit.
+struct MintSubmissionInput<'a> {
+    issuer_request_id: IssuerMintRequestId,
+    tokenization_request_id: &'a TokenizationRequestId,
+    quantity: &'a Quantity,
+    underlying: &'a UnderlyingSymbol,
+    wallet: Address,
+    journal_confirmed_at: DateTime<Utc>,
+    receipt_note: Option<&'a str>,
+}
+
 impl Mint {
     const fn state_name(&self) -> &'static str {
         match self {
@@ -215,6 +245,7 @@ impl Mint {
             Self::JournalConfirmed { .. } => "JournalConfirmed",
             Self::JournalRejected { .. } => "JournalRejected",
             Self::Minting { .. } => "Minting",
+            Self::FireblocksSubmitted { .. } => "FireblocksSubmitted",
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
             Self::Completed { .. } => "Completed",
@@ -241,6 +272,7 @@ impl Mint {
             | Self::JournalConfirmed { tokenization_request_id, .. }
             | Self::JournalRejected { tokenization_request_id, .. }
             | Self::Minting { tokenization_request_id, .. }
+            | Self::FireblocksSubmitted { tokenization_request_id, .. }
             | Self::CallbackPending { tokenization_request_id, .. }
             | Self::MintingFailed { tokenization_request_id, .. }
             | Self::Completed { tokenization_request_id, .. } => {
@@ -307,12 +339,36 @@ impl Mint {
         Ok(())
     }
 
-    async fn handle_deposit(
+    /// Records the intent to mint by transitioning from `JournalConfirmed`
+    /// to `Minting` state. Pure state transition — no network call.
+    fn handle_deposit(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let Self::JournalConfirmed { issuer_request_id: expected_id, .. } =
+            self
+        else {
+            return Err(MintError::NotInJournalConfirmedState {
+                current_state: self.state_name().to_string(),
+            });
+        };
+
+        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
+
+        Ok(vec![MintEvent::MintingStarted {
+            issuer_request_id,
+            started_at: Utc::now(),
+        }])
+    }
+
+    /// Submits the on-chain mint transaction to the signing backend.
+    /// Requires `Minting` state (set by prior `Deposit` command).
+    async fn handle_submit_mint(
         &self,
         services: &MintServices,
         issuer_request_id: IssuerMintRequestId,
     ) -> Result<Vec<MintEvent>, MintError> {
-        let Self::JournalConfirmed {
+        let Self::Minting {
             issuer_request_id: expected_id,
             tokenization_request_id,
             quantity,
@@ -322,13 +378,45 @@ impl Mint {
             ..
         } = self
         else {
-            return Err(MintError::NotInJournalConfirmedState {
+            return Err(MintError::NotInMintingState {
                 current_state: self.state_name().to_string(),
             });
         };
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
+        let event = Self::execute_mint_submission(
+            services,
+            MintSubmissionInput {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                wallet: *wallet,
+                journal_confirmed_at: *journal_confirmed_at,
+                receipt_note: None,
+            },
+        )
+        .await?;
+
+        Ok(vec![event])
+    }
+
+    /// Shared submission logic: vault lookup, receipt info, submit_mint call.
+    /// Returns a single `FireblocksSubmitted` or `MintingFailed` event.
+    async fn execute_mint_submission(
+        services: &MintServices,
+        input: MintSubmissionInput<'_>,
+    ) -> Result<MintEvent, MintError> {
+        let MintSubmissionInput {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            wallet,
+            journal_confirmed_at,
+            receipt_note,
+        } = input;
         let vault = find_vault_by_underlying(&services.pool, underlying)
             .await?
             .ok_or_else(|| MintError::AssetNotFound {
@@ -342,111 +430,178 @@ impl Mint {
             issuer_request_id.clone(),
             underlying.clone(),
             quantity.clone(),
-            *journal_confirmed_at,
-            None,
+            journal_confirmed_at,
+            receipt_note.map(String::from),
         );
 
         let now = Utc::now();
 
         match services
             .vault
-            .mint_and_transfer_shares(
-                vault,
-                assets,
-                services.bot,
-                *wallet,
-                receipt_info.clone(),
-            )
+            .submit_mint(vault, assets, services.bot, wallet, receipt_info)
             .await
         {
-            Ok(result) => {
-                Self::on_deposit_success(
-                    services,
-                    vault,
-                    &issuer_request_id,
-                    &result,
-                    receipt_info,
-                    now,
-                )
-                .await
+            Ok(submitted) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    external_tx_id = %submitted.external_tx_id,
+                    fireblocks_tx_id = %submitted.fireblocks_tx_id,
+                    "Mint transaction submitted to signing backend"
+                );
+
+                Ok(MintEvent::FireblocksSubmitted {
+                    issuer_request_id,
+                    external_tx_id: submitted.external_tx_id,
+                    fireblocks_tx_id: submitted.fireblocks_tx_id,
+                    submitted_at: now,
+                })
             }
             Err(err) => {
                 warn!(
                     target: "mint",
                     issuer_request_id = %issuer_request_id,
                     error = %err,
-                    "On-chain deposit failed"
+                    "Mint submission failed"
                 );
 
-                Ok(vec![
-                    MintEvent::MintingStarted {
-                        issuer_request_id: issuer_request_id.clone(),
-                        started_at: now,
-                    },
-                    MintEvent::MintingFailed {
-                        issuer_request_id,
-                        error: err.to_string(),
-                        failed_at: now,
-                    },
-                ])
+                Ok(MintEvent::MintingFailed {
+                    issuer_request_id,
+                    error: err.to_string(),
+                    failed_at: now,
+                })
             }
         }
     }
 
-    async fn on_deposit_success(
+    /// Confirms a previously submitted mint transaction by polling the backend.
+    /// Produces `TokensMinted` on success, or `MintingFailed` on failure.
+    async fn handle_confirm_mint(
+        &self,
         services: &MintServices,
-        vault: Address,
-        issuer_request_id: &IssuerMintRequestId,
-        result: &MintResult,
-        receipt_info: ReceiptInformation,
-        now: DateTime<Utc>,
+        issuer_request_id: IssuerMintRequestId,
+        fireblocks_tx_id: String,
     ) -> Result<Vec<MintEvent>, MintError> {
-        info!(
-            target: "mint",
-            issuer_request_id = %issuer_request_id,
-            tx_hash = %result.tx_hash,
-            receipt_id = %result.receipt_id,
-            shares_minted = %result.shares_minted,
-            "On-chain deposit succeeded"
-        );
+        let Self::FireblocksSubmitted {
+            issuer_request_id: expected_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            journal_confirmed_at,
+            fireblocks_tx_id: stored_tx_id,
+            ..
+        } = self
+        else {
+            return Err(MintError::NotInFireblocksSubmittedState {
+                current_state: self.state_name().to_string(),
+            });
+        };
 
-        if let Err(err) = services
-            .receipts
-            .register_minted_receipt(MintedReceiptParams {
-                vault,
-                receipt_id: ReceiptId::from(result.receipt_id),
-                shares: Shares::from(result.shares_minted),
-                block_number: result.block_number,
-                tx_hash: result.tx_hash,
-                receipt_info,
-                receipt_info_bytes: result.receipt_info_bytes.clone(),
-            })
-            .await
-        {
-            warn!(
-                target: "mint",
-                issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Failed to register minted receipt \
-                 (monitor/backfill will discover it)"
-            );
+        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
+
+        if *stored_tx_id != fireblocks_tx_id {
+            return Err(MintError::FireblocksTxIdMismatch {
+                expected: stored_tx_id.clone(),
+                provided: fireblocks_tx_id,
+            });
         }
 
-        Ok(vec![
-            MintEvent::MintingStarted {
-                issuer_request_id: issuer_request_id.clone(),
-                started_at: now,
-            },
-            MintEvent::TokensMinted {
-                issuer_request_id: issuer_request_id.clone(),
-                tx_hash: result.tx_hash,
-                receipt_id: result.receipt_id,
-                shares_minted: result.shares_minted,
-                gas_used: result.gas_used,
-                block_number: result.block_number,
-                minted_at: now,
-            },
-        ])
+        let now = Utc::now();
+
+        match services.vault.confirm_mint(&fireblocks_tx_id).await {
+            Ok(result) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %result.tx_hash,
+                    receipt_id = %result.receipt_id,
+                    shares_minted = %result.shares_minted,
+                    "On-chain deposit confirmed"
+                );
+
+                // Best-effort receipt registration — vault lookup failure
+                // must not prevent TokensMinted from being emitted.
+                match find_vault_by_underlying(&services.pool, underlying).await
+                {
+                    Ok(Some(vault)) => {
+                        let receipt_info = ReceiptInformation::new(
+                            tokenization_request_id.clone(),
+                            issuer_request_id.clone(),
+                            underlying.clone(),
+                            quantity.clone(),
+                            *journal_confirmed_at,
+                            None,
+                        );
+
+                        if let Err(err) = services
+                            .receipts
+                            .register_minted_receipt(MintedReceiptParams {
+                                vault,
+                                receipt_id: ReceiptId::from(result.receipt_id),
+                                shares: Shares::from(result.shares_minted),
+                                block_number: result.block_number,
+                                tx_hash: result.tx_hash,
+                                receipt_info,
+                                receipt_info_bytes: result
+                                    .receipt_info_bytes
+                                    .clone(),
+                            })
+                            .await
+                        {
+                            warn!(
+                                target: "mint",
+                                issuer_request_id = %issuer_request_id,
+                                error = %err,
+                                "Failed to register minted receipt \
+                                 (monitor/backfill will discover it)"
+                            );
+                        }
+                    }
+                    Ok(None) => {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            underlying = %underlying,
+                            "Vault not found for receipt registration \
+                             (monitor/backfill will discover it)"
+                        );
+                    }
+                    Err(err) => {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            error = %err,
+                            "Vault lookup failed for receipt registration \
+                             (monitor/backfill will discover it)"
+                        );
+                    }
+                }
+
+                Ok(vec![MintEvent::TokensMinted {
+                    issuer_request_id,
+                    tx_hash: result.tx_hash,
+                    receipt_id: result.receipt_id,
+                    shares_minted: result.shares_minted,
+                    gas_used: result.gas_used,
+                    block_number: result.block_number,
+                    minted_at: now,
+                }])
+            }
+            Err(err) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "On-chain deposit confirmation failed"
+                );
+
+                Ok(vec![MintEvent::MintingFailed {
+                    issuer_request_id,
+                    error: err.to_string(),
+                    failed_at: now,
+                }])
+            }
+        }
     }
 
     async fn handle_send_callback(
@@ -500,12 +655,41 @@ impl Mint {
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::JournalConfirmed { .. } => {
-                self.handle_deposit(services, issuer_request_id).await
+                // Emit MintingStarted (intent). drive_recovery will call
+                // Recover again, which hits the Minting arm to submit.
+                self.handle_deposit(issuer_request_id)
             }
-            Self::Minting { .. } | Self::MintingFailed { .. } => {
+            Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                self.handle_confirm_mint(
+                    services,
+                    issuer_request_id,
+                    fireblocks_tx_id.clone(),
+                )
+                .await
+            }
+            Self::MintingFailed { .. } => {
+                // Extract the fireblocks_tx_id from the predecessor if
+                // the tx was already submitted (avoids resubmission).
+                let known_tx_id = match self.non_failed_predecessor() {
+                    Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                        Some(fireblocks_tx_id.clone())
+                    }
+                    _ => None,
+                };
+
                 self.handle_recover_incomplete(
                     services,
                     issuer_request_id,
+                    None,
+                    known_tx_id,
+                )
+                .await
+            }
+            Self::Minting { .. } => {
+                self.handle_recover_incomplete(
+                    services,
+                    issuer_request_id,
+                    None,
                     None,
                 )
                 .await
@@ -542,14 +726,22 @@ impl Mint {
             Self::MintingFailed { .. }
                 if matches!(
                     self.non_failed_predecessor(),
-                    Self::Minting { .. }
+                    Self::Minting { .. } | Self::FireblocksSubmitted { .. }
                 ) =>
             {
+                let known_tx_id = match self.non_failed_predecessor() {
+                    Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                        Some(fireblocks_tx_id.clone())
+                    }
+                    _ => None,
+                };
+
                 let deposit_events = self
                     .handle_recover_incomplete(
                         services,
                         issuer_request_id.clone(),
                         Some(tx_hash),
+                        known_tx_id,
                     )
                     .await?;
 
@@ -593,6 +785,7 @@ impl Mint {
         services: &MintServices,
         issuer_request_id: IssuerMintRequestId,
         receipt_tx_hash: Option<TxHash>,
+        known_fireblocks_tx_id: Option<String>,
     ) -> Result<Vec<MintEvent>, MintError> {
         let (Self::Minting {
             issuer_request_id: expected_id,
@@ -655,53 +848,107 @@ impl Mint {
                 }
             });
 
-        let mint_result = services
-            .vault
-            .mint_and_transfer_shares(
-                vault,
-                quantity.to_u256_with_18_decimals()?,
-                services.bot,
-                *wallet,
-                receipt_info,
-            )
-            .await;
+        if let Some(tx_id) = known_fireblocks_tx_id {
+            // Known tx_id from a prior submission: go straight to confirm.
+            info!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                fireblocks_tx_id = %tx_id,
+                "Resuming confirmation of previously submitted mint"
+            );
 
-        let completion_event = match mint_result {
-            Ok(result) => {
-                info!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    tx_hash = %result.tx_hash,
-                    "Recovery mint succeeded"
-                );
-                MintEvent::TokensMinted {
-                    issuer_request_id,
-                    tx_hash: result.tx_hash,
-                    receipt_id: result.receipt_id,
-                    shares_minted: result.shares_minted,
-                    gas_used: result.gas_used,
-                    block_number: result.block_number,
-                    minted_at: now,
+            return match services.vault.confirm_mint(&tx_id).await {
+                Ok(result) => {
+                    info!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        tx_hash = %result.tx_hash,
+                        "Recovery mint succeeded"
+                    );
+
+                    // Best-effort receipt registration
+                    if let Err(err) = services
+                        .receipts
+                        .register_minted_receipt(MintedReceiptParams {
+                            vault,
+                            receipt_id: ReceiptId::from(result.receipt_id),
+                            shares: Shares::from(result.shares_minted),
+                            block_number: result.block_number,
+                            tx_hash: result.tx_hash,
+                            receipt_info: receipt_info.clone(),
+                            receipt_info_bytes: result
+                                .receipt_info_bytes
+                                .clone(),
+                        })
+                        .await
+                    {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            error = %err,
+                            "Failed to register recovered receipt \
+                             (monitor/backfill will discover it)"
+                        );
+                    }
+
+                    let minted = MintEvent::TokensMinted {
+                        issuer_request_id,
+                        tx_hash: result.tx_hash,
+                        receipt_id: result.receipt_id,
+                        shares_minted: result.shares_minted,
+                        gas_used: result.gas_used,
+                        block_number: result.block_number,
+                        minted_at: now,
+                    };
+
+                    Ok(retry_event
+                        .into_iter()
+                        .chain(std::iter::once(minted))
+                        .collect())
                 }
-            }
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Recovery mint failed"
-                );
-                MintEvent::MintingFailed {
-                    issuer_request_id,
-                    error: err.to_string(),
-                    failed_at: now,
+                Err(err) => {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Recovery mint confirmation failed — \
+                         preserving fireblocks_tx_id for next retry"
+                    );
+
+                    // Do NOT emit MintRetryStarted here — that would
+                    // move the aggregate from MintingFailed to Minting,
+                    // losing the FireblocksSubmitted predecessor and its
+                    // fireblocks_tx_id. Instead, re-emit MintingFailed
+                    // which keeps the existing predecessor chain intact.
+                    Ok(vec![MintEvent::MintingFailed {
+                        issuer_request_id,
+                        error: err.to_string(),
+                        failed_at: now,
+                    }])
                 }
-            }
-        };
+            };
+        }
+
+        // No prior tx_id: submit and persist FireblocksSubmitted.
+        // Don't confirm here — let the next recovery pass handle
+        // ConfirmMint from the FireblocksSubmitted state.
+        let submission_event = Self::execute_mint_submission(
+            services,
+            MintSubmissionInput {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                wallet: *wallet,
+                journal_confirmed_at: *journal_confirmed_at,
+                receipt_note: Some("Recovery mint"),
+            },
+        )
+        .await?;
 
         Ok(retry_event
             .into_iter()
-            .chain(std::iter::once(completion_event))
+            .chain(std::iter::once(submission_event))
             .collect())
     }
 
@@ -833,14 +1080,11 @@ impl Mint {
         };
     }
 
-    fn apply_tokens_minted(
+    fn apply_fireblocks_submitted(
         &mut self,
-        tx_hash: B256,
-        receipt_id: U256,
-        shares_minted: U256,
-        gas_used: Option<u64>,
-        block_number: u64,
-        minted_at: DateTime<Utc>,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
+        _submitted_at: DateTime<Utc>,
     ) {
         let Self::Minting {
             issuer_request_id,
@@ -853,8 +1097,64 @@ impl Mint {
             wallet,
             initiated_at,
             journal_confirmed_at,
-            ..
+            minting_started_at,
         } = self.clone()
+        else {
+            return;
+        };
+
+        *self = Self::FireblocksSubmitted {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            minting_started_at,
+            external_tx_id,
+            fireblocks_tx_id,
+        };
+    }
+
+    fn apply_tokens_minted(
+        &mut self,
+        tx_hash: B256,
+        receipt_id: U256,
+        shares_minted: U256,
+        gas_used: Option<u64>,
+        block_number: u64,
+        minted_at: DateTime<Utc>,
+    ) {
+        let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::FireblocksSubmitted {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }) = self.clone()
         else {
             return;
         };
@@ -886,7 +1186,7 @@ impl Mint {
     ) {
         let failed_from = Box::new(self.clone());
 
-        let Self::Minting {
+        let (Self::Minting {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -898,7 +1198,20 @@ impl Mint {
             initiated_at,
             journal_confirmed_at,
             ..
-        } = self.clone()
+        }
+        | Self::FireblocksSubmitted {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }) = self.clone()
         else {
             return;
         };
@@ -973,6 +1286,19 @@ impl Mint {
         recovered_at: DateTime<Utc>,
     ) {
         let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::FireblocksSubmitted {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -1131,7 +1457,21 @@ impl Aggregate for Mint {
                 self.handle_reject_journal(issuer_request_id, reason)
             }
             MintCommand::Deposit { issuer_request_id } => {
-                self.handle_deposit(services, issuer_request_id).await
+                self.handle_deposit(issuer_request_id)
+            }
+            MintCommand::SubmitMint { issuer_request_id } => {
+                self.handle_submit_mint(services, issuer_request_id).await
+            }
+            MintCommand::ConfirmMint {
+                issuer_request_id,
+                fireblocks_tx_id,
+            } => {
+                self.handle_confirm_mint(
+                    services,
+                    issuer_request_id,
+                    fireblocks_tx_id,
+                )
+                .await
             }
             MintCommand::SendCallback { issuer_request_id } => {
                 self.handle_send_callback(services, issuer_request_id).await
@@ -1228,6 +1568,18 @@ impl Aggregate for Mint {
                 block_number,
                 recovered_at,
             ),
+            MintEvent::FireblocksSubmitted {
+                issuer_request_id: _,
+                external_tx_id,
+                fireblocks_tx_id,
+                submitted_at,
+            } => {
+                self.apply_fireblocks_submitted(
+                    external_tx_id,
+                    fireblocks_tx_id,
+                    submitted_at,
+                );
+            }
             MintEvent::MintRetryStarted {
                 issuer_request_id: _,
                 started_at,
@@ -1259,18 +1611,28 @@ pub(crate) enum MintError {
     )]
     NotInCallbackPendingState { current_state: String },
     #[error(
+        "Mint not in FireblocksSubmitted state. Current state: {current_state}"
+    )]
+    NotInFireblocksSubmittedState { current_state: String },
+    #[error(
         "Issuer request ID mismatch. Expected: {expected}, provided: {provided}"
     )]
     IssuerMintRequestIdMismatch {
         expected: IssuerMintRequestId,
         provided: IssuerMintRequestId,
     },
+    #[error("Mint not in Minting state. Current state: {current_state}")]
+    NotInMintingState { current_state: String },
     #[error(
         "Mint not in Minting or MintingFailed state. Current state: {current_state}"
     )]
     NotInMintingOrMintingFailedState { current_state: String },
     #[error("Mint not in recoverable state. Current state: {current_state}")]
     NotRecoverable { current_state: String },
+    #[error(
+        "Fireblocks tx ID mismatch. Expected: {expected}, provided: {provided}"
+    )]
+    FireblocksTxIdMismatch { expected: String, provided: String },
     #[error("Asset not found for underlying: {underlying}")]
     AssetNotFound { underlying: UnderlyingSymbol },
     #[error("Quantity conversion: {0}")]
@@ -1504,6 +1866,7 @@ pub(crate) mod tests {
                     MintEvent::JournalConfirmed { .. }
                     | MintEvent::JournalRejected { .. }
                     | MintEvent::MintingStarted { .. }
+                    | MintEvent::FireblocksSubmitted { .. }
                     | MintEvent::TokensMinted { .. }
                     | MintEvent::MintingFailed { .. }
                     | MintEvent::MintCompleted { .. }
@@ -2348,10 +2711,49 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
+        // Deposit records intent (emits MintingStarted)
         cqrs.execute(
             &data.issuer_request_id.to_string(),
             MintCommand::Deposit {
                 issuer_request_id: data.issuer_request_id.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // SubmitMint does the network call (emits FireblocksSubmitted)
+        cqrs.execute(
+            &data.issuer_request_id.to_string(),
+            MintCommand::SubmitMint {
+                issuer_request_id: data.issuer_request_id.clone(),
+            },
+        )
+        .await
+        .unwrap();
+
+        // Load the fireblocks_tx_id from the aggregate state
+        let ctx = store
+            .load_aggregate(&data.issuer_request_id.to_string())
+            .await
+            .unwrap();
+
+        let Mint::FireblocksSubmitted { fireblocks_tx_id, .. } =
+            ctx.aggregate()
+        else {
+            panic!(
+                "Expected FireblocksSubmitted state after SubmitMint, got {:?}",
+                ctx.aggregate()
+            );
+        };
+
+        let fb_tx_id = fireblocks_tx_id.clone();
+
+        // ConfirmMint polls the backend (emits TokensMinted)
+        cqrs.execute(
+            &data.issuer_request_id.to_string(),
+            MintCommand::ConfirmMint {
+                issuer_request_id: data.issuer_request_id.clone(),
+                fireblocks_tx_id: fb_tx_id,
             },
         )
         .await
@@ -2382,7 +2784,7 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        assert_eq!(events.len(), 5, "Expected 5 events in the flow");
+        assert_eq!(events.len(), 6, "Expected 6 events in the split flow");
 
         assert!(
             matches!(&events[0].payload, MintEvent::Initiated { .. }),
@@ -2397,12 +2799,16 @@ pub(crate) mod tests {
             "Third event should be MintingStarted"
         );
         assert!(
-            matches!(&events[3].payload, MintEvent::TokensMinted { .. }),
-            "Fourth event should be TokensMinted"
+            matches!(&events[3].payload, MintEvent::FireblocksSubmitted { .. }),
+            "Fourth event should be FireblocksSubmitted"
         );
         assert!(
-            matches!(&events[4].payload, MintEvent::MintCompleted { .. }),
-            "Fifth event should be MintCompleted"
+            matches!(&events[4].payload, MintEvent::TokensMinted { .. }),
+            "Fifth event should be TokensMinted"
+        );
+        assert!(
+            matches!(&events[5].payload, MintEvent::MintCompleted { .. }),
+            "Sixth event should be MintCompleted"
         );
 
         let mut view = MintView::default();

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -540,6 +540,10 @@ impl View<Mint> for MintView {
                     *recovered_at,
                 );
             }
+            MintEvent::FireblocksSubmitted { .. } => {
+                // View stays in Minting — FireblocksSubmitted is an internal
+                // detail that doesn't change the query-facing state.
+            }
             MintEvent::MintRetryStarted { started_at, .. } => {
                 self.handle_mint_retry_started(*started_at);
             }

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -118,7 +118,8 @@ impl View<Mint> for ReceiptInventoryView {
             | MintEvent::MintCompleted { .. }
             | MintEvent::ExistingMintRecovered { .. }
             | MintEvent::MintRetryStarted { .. }
-            | MintEvent::MintClosed { .. } => {}
+            | MintEvent::MintClosed { .. }
+            | MintEvent::FireblocksSubmitted { .. } => {}
         }
     }
 }

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -148,9 +148,18 @@ where
     ) -> Result<(), BurnManagerError> {
         let RedemptionView::BurnFailed {
             underlying,
+            token,
             wallet,
+            quantity,
             alpaca_quantity,
             dust_quantity,
+            tx_hash,
+            block_number,
+            detected_at,
+            called_at,
+            alpaca_journal_completed_at,
+            tokenization_request_id,
+            fireblocks_tx_id,
             ..
         } = view
         else {
@@ -159,6 +168,19 @@ where
             );
             return Ok(());
         };
+
+        // If a Fireblocks tx was already submitted before failure, try to
+        // confirm it instead of resubmitting. This prevents double-burns
+        // when the failure was a transient confirmation error.
+        if let Some(fb_tx_id) = fireblocks_tx_id {
+            return self
+                .recover_burn_failed_with_existing_tx(
+                    issuer_request_id,
+                    fb_tx_id,
+                    dust_quantity,
+                )
+                .await;
+        }
 
         let vault = find_vault_by_underlying(&self.view_pool, underlying)
             .await?
@@ -204,46 +226,46 @@ where
             return Ok(());
         }
 
-        let plan = self
-            .plan_burn(
-                issuer_request_id,
-                vault,
-                underlying,
-                burn_shares,
-                dust_shares,
-            )
-            .await?;
-
-        let burns: Vec<MultiBurnEntry> = plan
-            .allocations
-            .into_iter()
-            .map(|allocation| MultiBurnEntry {
-                receipt_id: allocation.receipt.receipt_id.inner(),
-                burn_shares: allocation.burn_amount.inner(),
-                receipt_info: allocation.receipt.receipt_info,
-                receipt_info_bytes: allocation.receipt.receipt_info_bytes,
-            })
-            .collect();
-
         debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_shares = %burn_shares,
             dust_shares = %dust_shares,
-            num_receipts = burns.len(),
-            "Retrying burn for BurnFailed redemption"
+            "Retrying burn for BurnFailed redemption (no prior submission)"
         );
+
+        // Step 1: Resume the burn (Failed → Burning) so the standard
+        // two-step submit/confirm flow persists the tx ID.
+        let metadata = super::RedemptionMetadata {
+            issuer_request_id: issuer_request_id.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            wallet: *wallet,
+            quantity: quantity.clone(),
+            detected_tx_hash: *tx_hash,
+            block_number: *block_number,
+            detected_at: *detected_at,
+        };
 
         self.cqrs
             .execute(
                 &issuer_request_id.to_string(),
-                RedemptionCommand::RetryBurn {
+                RedemptionCommand::ResumeBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns,
-                    dust_shares: plan.dust.inner(),
-                    owner: self.bot_wallet,
-                    user_wallet: *wallet,
+                    metadata,
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    alpaca_quantity: alpaca_quantity.clone(),
+                    dust_quantity: dust_quantity.clone(),
+                    called_at: *called_at,
+                    alpaca_journal_completed_at: *alpaca_journal_completed_at,
                 },
             )
+            .await?;
+
+        // Step 2: Load the updated aggregate (now in Burning) and use
+        // the standard submit → persist tx ID → confirm flow.
+        let context =
+            self.store.load_aggregate(&issuer_request_id.to_string()).await?;
+
+        self.handle_burning_started(issuer_request_id, context.aggregate())
             .await?;
 
         debug!(target: "redemption", issuer_request_id = %issuer_request_id,
@@ -251,6 +273,91 @@ where
         );
 
         Ok(())
+    }
+
+    /// Recovers a BurnFailed redemption that has a previously submitted Fireblocks
+    /// transaction. Tries to confirm the existing transaction rather than resubmitting.
+    async fn recover_burn_failed_with_existing_tx(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        fireblocks_tx_id: &str,
+        dust_quantity: &crate::Quantity,
+    ) -> Result<(), BurnManagerError> {
+        let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
+
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
+            %fireblocks_tx_id,
+            "BurnFailed recovery — confirming previously submitted Fireblocks transaction"
+        );
+
+        match self
+            .vault_service
+            .confirm_burn(fireblocks_tx_id, dust_shares)
+            .await
+        {
+            Ok(result) => {
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    tx_hash = %result.tx_hash,
+                    "Previously submitted burn confirmed on-chain"
+                );
+
+                // Use actual on-chain burn data, not planned amounts —
+                // the Rain contract's withdraw math may produce slightly
+                // different values than planned (rounding in share ratios).
+                let actual_burns: Vec<super::BurnRecord> = result
+                    .burns
+                    .iter()
+                    .map(|burn| super::BurnRecord {
+                        receipt_id: burn.receipt_id,
+                        shares_burned: burn.shares_burned,
+                    })
+                    .collect();
+
+                // Safe: BurningFailed always transitions the aggregate to
+                // Failed, so RecordExistingBurn (which requires Failed) is valid.
+                self.cqrs
+                    .execute(
+                        &issuer_request_id.to_string(),
+                        RedemptionCommand::RecordExistingBurn {
+                            issuer_request_id: issuer_request_id.clone(),
+                            fireblocks_tx_id: fireblocks_tx_id.to_string(),
+                            tx_hash: result.tx_hash,
+                            planned_burns: actual_burns,
+                            block_number: result.block_number,
+                        },
+                    )
+                    .await?;
+
+                Ok(())
+            }
+            Err(err) => {
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    %fireblocks_tx_id,
+                    error = %err,
+                    "Failed to confirm previously submitted burn — \
+                     marking as failed to prevent infinite retry loop"
+                );
+
+                // Re-mark as failed WITHOUT preserving the fireblocks_tx_id.
+                // This moves the view from BurnFailed to Failed, so the next
+                // recovery pass does not retry the same dead transaction.
+                let reason = format!(
+                    "Fireblocks burn confirmation failed for tx {fireblocks_tx_id}: {err}"
+                );
+
+                self.cqrs
+                    .execute(
+                        &issuer_request_id.to_string(),
+                        RedemptionCommand::MarkFailed {
+                            issuer_request_id: issuer_request_id.clone(),
+                            reason,
+                        },
+                    )
+                    .await?;
+
+                Err(BurnManagerError::Vault(err))
+            }
+        }
     }
 
     async fn recover_single_burning(
@@ -262,61 +369,131 @@ where
 
         let aggregate = context.aggregate();
 
-        let Redemption::Burning {
-            metadata,
-            alpaca_quantity,
-            dust_quantity,
-            ..
-        } = aggregate
-        else {
-            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
-                "Redemption no longer in Burning state, skipping"
-            );
-            return Ok(());
-        };
+        match aggregate {
+            // Already submitted to Fireblocks but never confirmed — resume polling
+            Redemption::BurnSubmitted {
+                fireblocks_tx_id,
+                dust_quantity,
+                planned_burns,
+                ..
+            } => {
+                let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
 
-        let vault =
-            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    fireblocks_tx_id = %fireblocks_tx_id,
+                    "Recovering BurnSubmitted redemption - confirming existing transaction"
+                );
+
+                let confirm_result = self
+                    .cqrs
+                    .execute(
+                        &issuer_request_id.to_string(),
+                        RedemptionCommand::ConfirmBurn {
+                            issuer_request_id: issuer_request_id.clone(),
+                            fireblocks_tx_id: fireblocks_tx_id.clone(),
+                            dust_shares,
+                        },
+                    )
+                    .await;
+
+                match confirm_result {
+                    Ok(()) => {
+                        info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                            "Burn confirmed successfully during recovery"
+                        );
+                        Ok(())
+                    }
+                    Err(AggregateError::UserError(RedemptionError::Vault(
+                        err,
+                    ))) => {
+                        warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                            error = %err,
+                            "Burn confirmation failed during recovery"
+                        );
+
+                        self.cqrs
+                            .execute(
+                                &issuer_request_id.to_string(),
+                                RedemptionCommand::RecordBurnFailure {
+                                    issuer_request_id: issuer_request_id
+                                        .clone(),
+                                    error: err.to_string(),
+                                    fireblocks_tx_id: Some(
+                                        fireblocks_tx_id.clone(),
+                                    ),
+                                    planned_burns: planned_burns.clone(),
+                                },
+                            )
+                            .await?;
+
+                        Err(BurnManagerError::Vault(err))
+                    }
+                    Err(err) => Err(err.into()),
+                }
+            }
+
+            // Still in Burning state — needs full submit + confirm flow
+            Redemption::Burning {
+                metadata,
+                alpaca_quantity,
+                dust_quantity,
+                ..
+            } => {
+                let vault = find_vault_by_underlying(
+                    &self.view_pool,
+                    &metadata.underlying,
+                )
                 .await?
-                .ok_or_else(|| BurnManagerError::AssetNotFound {
-                    underlying: metadata.underlying.clone(),
+                .ok_or_else(|| {
+                    BurnManagerError::AssetNotFound {
+                        underlying: metadata.underlying.clone(),
+                    }
                 })?;
 
-        // We need to burn alpaca_quantity and transfer dust_quantity
-        let burn_shares = alpaca_quantity.to_u256_with_18_decimals()?;
-        let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
-        let total_shares_needed = burn_shares
-            .checked_add(dust_shares)
-            .ok_or(BurnManagerError::SharesOverflow)?;
+                // We need to burn alpaca_quantity and transfer dust_quantity
+                let burn_shares = alpaca_quantity.to_u256_with_18_decimals()?;
+                let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
+                let total_shares_needed = burn_shares
+                    .checked_add(dust_shares)
+                    .ok_or(BurnManagerError::SharesOverflow)?;
 
-        // Check on-chain balance before attempting burn. If the bot has insufficient
-        // shares, the burn likely already succeeded on-chain but we crashed before
-        // recording it. Skip this redemption to avoid recording a false failure.
-        // Manual intervention required to resolve.
-        // TODO: Implement automatic recovery - see #88
-        let on_chain_balance = self
-            .vault_service
-            .get_share_balance(vault, self.bot_wallet)
-            .await?;
+                // Check on-chain balance before attempting burn. If the bot has insufficient
+                // shares, the burn likely already succeeded on-chain but we crashed before
+                // recording it. Skip this redemption to avoid recording a false failure.
+                // Manual intervention required to resolve.
+                // TODO: Implement automatic recovery - see #88
+                let on_chain_balance = self
+                    .vault_service
+                    .get_share_balance(vault, self.bot_wallet)
+                    .await?;
 
-        if on_chain_balance < total_shares_needed {
-            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                on_chain_balance = %on_chain_balance,
-                burn_shares = %burn_shares,
-                dust_shares = %dust_shares,
-                total_shares_needed = %total_shares_needed,
-                "MANUAL INTERVENTION REQUIRED: On-chain balance insufficient for burn recovery. \
-                 Burn likely already succeeded but was not recorded. \
-                 Skipping to avoid recording false failure."
-            );
-            return Ok(());
+                if on_chain_balance < total_shares_needed {
+                    warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        on_chain_balance = %on_chain_balance,
+                        burn_shares = %burn_shares,
+                        dust_shares = %dust_shares,
+                        total_shares_needed = %total_shares_needed,
+                        "MANUAL INTERVENTION REQUIRED: On-chain balance insufficient for burn recovery. \
+                         Burn likely already succeeded but was not recorded. \
+                         Skipping to avoid recording false failure."
+                    );
+                    return Ok(());
+                }
+
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Recovering Burning redemption - resuming burn"
+                );
+
+                self.handle_burning_started(issuer_request_id, aggregate).await
+            }
+
+            _ => {
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Redemption no longer in Burning or BurnSubmitted state, skipping"
+                );
+                Ok(())
+            }
         }
-
-        debug!(target: "redemption", issuer_request_id = %issuer_request_id,
-            "Recovering Burning redemption - resuming burn"
-        );
-
-        self.handle_burning_started(issuer_request_id, aggregate).await
     }
 
     /// Handles a `Burning` state by burning tokens on-chain.
@@ -527,7 +704,10 @@ where
             })
             .collect();
 
-        let burn_result = self
+        let dust_shares = plan.dust.inner();
+
+        // Step 1: Submit the burn transaction (emits BurnFireblocksSubmitted)
+        let submit_result = self
             .cqrs
             .execute(
                 &issuer_request_id.to_string(),
@@ -535,19 +715,17 @@ where
                     issuer_request_id: issuer_request_id.clone(),
                     vault,
                     burns,
-                    dust_shares: plan.dust.inner(),
+                    dust_shares,
                     owner: self.bot_wallet,
                 },
             )
             .await;
 
-        match burn_result {
+        match submit_result {
             Ok(()) => {
-                info!(target: "redemption", issuer_request_id = %issuer_request_id,
-                    "BurnTokens command executed successfully"
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "BurnTokens submitted, confirming..."
                 );
-
-                Ok(())
             }
             Err(AggregateError::UserError(RedemptionError::Vault(err))) => {
                 let fireblocks_tx_id = extract_fireblocks_tx_id(&err);
@@ -555,7 +733,7 @@ where
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %err,
                     fireblocks_tx_id = ?fireblocks_tx_id,
-                    "On-chain burning failed"
+                    "Burn submission failed"
                 );
 
                 self.cqrs
@@ -570,9 +748,64 @@ where
                     )
                     .await?;
 
+                return Err(BurnManagerError::Vault(err));
+            }
+            Err(err) => return Err(err.into()),
+        }
+
+        // Step 2: Load aggregate to get the fireblocks_tx_id from BurnSubmitted state
+        let context =
+            self.store.load_aggregate(&issuer_request_id.to_string()).await?;
+
+        let Redemption::BurnSubmitted { fireblocks_tx_id, .. } =
+            context.aggregate()
+        else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: aggregate_state_name(context.aggregate())
+                    .to_string(),
+            });
+        };
+
+        let fireblocks_tx_id = fireblocks_tx_id.clone();
+
+        // Step 3: Confirm the burn (emits TokensBurned or error)
+        let confirm_result = self
+            .cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                RedemptionCommand::ConfirmBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    fireblocks_tx_id: fireblocks_tx_id.clone(),
+                    dust_shares,
+                },
+            )
+            .await;
+
+        match confirm_result {
+            Ok(()) => {
                 info!(target: "redemption", issuer_request_id = %issuer_request_id,
-                    "RecordBurnFailure command recorded"
+                    "Burn confirmed successfully"
                 );
+
+                Ok(())
+            }
+            Err(AggregateError::UserError(RedemptionError::Vault(err))) => {
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Burn confirmation failed"
+                );
+
+                self.cqrs
+                    .execute(
+                        &issuer_request_id.to_string(),
+                        RedemptionCommand::RecordBurnFailure {
+                            issuer_request_id: issuer_request_id.clone(),
+                            error: err.to_string(),
+                            fireblocks_tx_id: Some(fireblocks_tx_id),
+                            planned_burns,
+                        },
+                    )
+                    .await?;
 
                 Err(BurnManagerError::Vault(err))
             }
@@ -587,6 +820,7 @@ const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
         Redemption::Detected { .. } => "Detected",
         Redemption::AlpacaCalled { .. } => "AlpacaCalled",
         Redemption::Burning { .. } => "Burning",
+        Redemption::BurnSubmitted { .. } => "BurnSubmitted",
         Redemption::Failed { .. } => "Failed",
         Redemption::Completed { .. } => "Completed",
         Redemption::Closed { .. } => "Closed",
@@ -595,17 +829,12 @@ const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
 
 /// Extracts the Fireblocks transaction ID from a `VaultError`, if the error
 /// originated from a Fireblocks error that carries a transaction ID.
-/// Matches both `TransactionFailed` (polling timeout / terminal status) and
-/// `PostSubmit` (errors after a tx was submitted and potentially completed).
 fn extract_fireblocks_tx_id(error: &VaultError) -> Option<String> {
     match error {
         VaultError::Fireblocks(
             crate::fireblocks::FireblocksVaultError::TransactionFailed {
                 tx_id,
                 ..
-            }
-            | crate::fireblocks::FireblocksVaultError::PostSubmit {
-                tx_id, ..
             }
             | crate::fireblocks::FireblocksVaultError::MissingTxHash { tx_id },
         ) => Some(tx_id.clone()),
@@ -1984,5 +2213,98 @@ mod tests {
                 "insufficient on-chain balance"
             ]
         ));
+    }
+
+    /// Tests that recovery from `BurnSubmitted` state (crash between submit
+    /// and confirm) successfully confirms the existing transaction without
+    /// submitting a new one.
+    #[tokio::test]
+    async fn test_recover_burn_submitted_confirms_existing_transaction() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        // Drive redemption to Burning state
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        // Issue BurnTokens directly to stop at BurnSubmitted (simulating
+        // a crash between submit and confirm). This calls submit_burn on
+        // the mock and emits BurnFireblocksSubmitted without confirming.
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::BurnTokens {
+                issuer_request_id: issuer_request_id.clone(),
+                vault,
+                burns: vec![crate::vault::MultiBurnEntry {
+                    receipt_id: uint!(99_U256),
+                    burn_shares: uint!(100_000000000000000000_U256),
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
+                dust_shares: U256::ZERO,
+                owner: TEST_WALLET,
+            },
+        )
+        .await
+        .expect("BurnTokens should succeed");
+
+        // Verify aggregate is in BurnSubmitted state
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(aggregate, Redemption::BurnSubmitted { .. }),
+            "Expected BurnSubmitted state, got {aggregate:?}"
+        );
+
+        // Record submit_burn call count before recovery
+        let submits_before = vault_mock.get_multi_burn_call_count();
+
+        // Recovery should find this redemption (view is Burning, aggregate
+        // is BurnSubmitted) and confirm the existing Fireblocks transaction
+        // without submitting a new burn.
+        manager.recover_burning_redemptions().await;
+
+        // Verify: no new submit_burn calls — recovery confirmed the existing tx
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            submits_before,
+            "Recovery should confirm existing tx, not submit a new burn"
+        );
+
+        // Aggregate should now be Completed
+        let recovered = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(recovered, Redemption::Completed { .. }),
+            "Expected Completed state after recovery, got {recovered:?}"
+        );
     }
 }

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -37,8 +37,8 @@ pub(crate) enum RedemptionCommand {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
     },
-    /// Burns tokens on-chain from one or more receipts, returns dust to user.
-    /// Uses multicall to atomically execute all burns in a single transaction.
+    /// Submits burn transaction to the signing backend.
+    /// Produces `BurnFireblocksSubmitted` on success, or the caller records failure.
     BurnTokens {
         issuer_request_id: IssuerRedemptionRequestId,
         vault: Address,
@@ -48,6 +48,14 @@ pub(crate) enum RedemptionCommand {
         dust_shares: U256,
         owner: Address,
     },
+
+    /// Confirms a previously submitted burn transaction.
+    /// Polls the signing backend and produces `TokensBurned` or error.
+    ConfirmBurn {
+        issuer_request_id: IssuerRedemptionRequestId,
+        fireblocks_tx_id: String,
+        dust_shares: U256,
+    },
     RecordBurnFailure {
         issuer_request_id: IssuerRedemptionRequestId,
         error: String,
@@ -55,19 +63,6 @@ pub(crate) enum RedemptionCommand {
         fireblocks_tx_id: Option<String>,
         /// Planned burns at the time of failure.
         planned_burns: Vec<super::BurnRecord>,
-    },
-    /// Retries a failed burn operation.
-    /// Only valid from Failed state after a BurningFailed event.
-    RetryBurn {
-        issuer_request_id: IssuerRedemptionRequestId,
-        vault: Address,
-        /// Burns to execute (receipt_id + amount for each)
-        burns: Vec<MultiBurnEntry>,
-        /// Dust to return to user
-        dust_shares: U256,
-        owner: Address,
-        /// Wallet to return dust to (from view metadata)
-        user_wallet: Address,
     },
     /// Resets a failed redemption back to Detected state for reprocessing.
     /// Only valid from `Failed` state — post-Alpaca states have dedicated

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -11,7 +11,7 @@ use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 ///
 /// Each burn targets a specific ERC-1155 receipt and burns a portion
 /// (or all) of the shares associated with that receipt.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) struct BurnRecord {
     /// The ERC-1155 receipt ID that was burned from
     pub(crate) receipt_id: U256,
@@ -101,6 +101,17 @@ pub(crate) enum RedemptionEvent {
         previous_state: String,
         reprocessed_at: DateTime<Utc>,
     },
+    /// Burn transaction submitted to the signing backend.
+    /// Persists the backend transaction ID so polling can resume after a restart.
+    BurnFireblocksSubmitted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
+        /// Planned burns at the time of submission (for recovery use).
+        planned_burns: Vec<BurnRecord>,
+        submitted_at: DateTime<Utc>,
+    },
+
     /// Existing on-chain burn discovered during recovery via Fireblocks tx lookup.
     /// Mirrors mint's `ExistingMintRecovered` — the burn already landed on-chain
     /// but the bot failed to record it (e.g., Fireblocks polling timeout).
@@ -170,6 +181,9 @@ impl DomainEvent for RedemptionEvent {
             }
             Self::BurnResumed { .. } => {
                 "RedemptionEvent::BurnResumed".to_string()
+            }
+            Self::BurnFireblocksSubmitted { .. } => {
+                "RedemptionEvent::BurnFireblocksSubmitted".to_string()
             }
             Self::ExistingBurnRecovered { .. } => {
                 "RedemptionEvent::ExistingBurnRecovered".to_string()

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -145,6 +145,18 @@ pub(crate) enum Redemption {
         called_at: DateTime<Utc>,
         alpaca_journal_completed_at: DateTime<Utc>,
     },
+    /// Burn transaction submitted to signing backend, awaiting on-chain confirmation.
+    BurnSubmitted {
+        metadata: RedemptionMetadata,
+        tokenization_request_id: TokenizationRequestId,
+        alpaca_quantity: Quantity,
+        dust_quantity: Quantity,
+        called_at: DateTime<Utc>,
+        alpaca_journal_completed_at: DateTime<Utc>,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
+        planned_burns: Vec<event::BurnRecord>,
+    },
     Completed {
         issuer_request_id: IssuerRedemptionRequestId,
         burn_tx_hash: B256,
@@ -204,17 +216,21 @@ impl Redemption {
         match self {
             Self::Detected { metadata }
             | Self::AlpacaCalled { metadata, .. }
-            | Self::Burning { metadata, .. } => Some(metadata),
+            | Self::Burning { metadata, .. }
+            | Self::BurnSubmitted { metadata, .. } => Some(metadata),
             _ => None,
         }
     }
 
     /// Returns the quantity sent to Alpaca (truncated to 9 decimals).
-    /// Only available in AlpacaCalled and Burning states.
+    /// Only available in AlpacaCalled, Burning, and BurnSubmitted states.
     pub(crate) const fn alpaca_quantity(&self) -> Option<&Quantity> {
         match self {
             Self::AlpacaCalled { alpaca_quantity, .. }
-            | Self::Burning { alpaca_quantity, .. } => Some(alpaca_quantity),
+            | Self::Burning { alpaca_quantity, .. }
+            | Self::BurnSubmitted { alpaca_quantity, .. } => {
+                Some(alpaca_quantity)
+            }
             _ => None,
         }
     }
@@ -225,6 +241,7 @@ impl Redemption {
             Self::Detected { .. } => "Detected",
             Self::AlpacaCalled { .. } => "AlpacaCalled",
             Self::Burning { .. } => "Burning",
+            Self::BurnSubmitted { .. } => "BurnSubmitted",
             Self::Completed { .. } => "Completed",
             Self::Failed { .. } => "Failed",
             Self::Closed { .. } => "Closed",
@@ -305,6 +322,7 @@ impl Redemption {
             Self::Detected { .. }
                 | Self::AlpacaCalled { .. }
                 | Self::Burning { .. }
+                | Self::BurnSubmitted { .. }
                 | Self::Failed { .. }
         ) {
             return Err(RedemptionError::InvalidState {
@@ -321,6 +339,8 @@ impl Redemption {
         }])
     }
 
+    /// Submits the burn transaction to the signing backend.
+    /// Produces `BurnFireblocksSubmitted` on success; failure is propagated to caller.
     async fn handle_burn_tokens(
         &self,
         services: &Arc<dyn VaultService>,
@@ -336,16 +356,61 @@ impl Redemption {
 
         let user_wallet = metadata.wallet;
 
-        let result = services
-            .burn_multiple_receipts(MultiBurnParams {
+        let planned_burns: Vec<BurnRecord> = input
+            .burns
+            .iter()
+            .map(|entry| BurnRecord {
+                receipt_id: entry.receipt_id,
+                shares_burned: entry.burn_shares,
+            })
+            .collect();
+
+        let submitted = services
+            .submit_burn(MultiBurnParams {
                 vault: input.vault,
                 burns: input.burns,
                 dust_shares: input.dust_shares,
                 owner: input.owner,
                 user: user_wallet,
                 issuer_request_id: issuer_request_id.clone(),
+                detected_tx_hash: metadata.detected_tx_hash,
             })
             .await?;
+
+        Ok(vec![RedemptionEvent::BurnFireblocksSubmitted {
+            issuer_request_id,
+            external_tx_id: submitted.external_tx_id,
+            fireblocks_tx_id: submitted.fireblocks_tx_id,
+            planned_burns,
+            submitted_at: Utc::now(),
+        }])
+    }
+
+    /// Confirms a previously submitted burn transaction.
+    async fn handle_confirm_burn(
+        &self,
+        services: &Arc<dyn VaultService>,
+        issuer_request_id: IssuerRedemptionRequestId,
+        fireblocks_tx_id: String,
+        dust_shares: U256,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        let Self::BurnSubmitted { fireblocks_tx_id: stored_tx_id, .. } = self
+        else {
+            return Err(RedemptionError::InvalidState {
+                expected: "BurnSubmitted".to_string(),
+                found: self.state_name().to_string(),
+            });
+        };
+
+        if *stored_tx_id != fireblocks_tx_id {
+            return Err(RedemptionError::FireblocksTxIdMismatch {
+                expected: stored_tx_id.clone(),
+                provided: fireblocks_tx_id,
+            });
+        }
+
+        let result =
+            services.confirm_burn(&fireblocks_tx_id, dust_shares).await?;
 
         let burns = result
             .burns
@@ -374,9 +439,9 @@ impl Redemption {
         fireblocks_tx_id: Option<String>,
         planned_burns: Vec<BurnRecord>,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        if !matches!(self, Self::Burning { .. }) {
+        if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
             return Err(RedemptionError::InvalidState {
-                expected: "Burning".to_string(),
+                expected: "Burning or BurnSubmitted".to_string(),
                 found: self.state_name().to_string(),
             });
         }
@@ -387,51 +452,6 @@ impl Redemption {
             failed_at: Utc::now(),
             fireblocks_tx_id,
             planned_burns,
-        }])
-    }
-
-    async fn handle_retry_burn(
-        &self,
-        services: &Arc<dyn VaultService>,
-        issuer_request_id: IssuerRedemptionRequestId,
-        input: BurnInput,
-        user_wallet: Address,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        if !matches!(self, Self::Failed { .. }) {
-            return Err(RedemptionError::InvalidState {
-                expected: "Failed".to_string(),
-                found: self.state_name().to_string(),
-            });
-        }
-
-        let result = services
-            .burn_multiple_receipts(MultiBurnParams {
-                vault: input.vault,
-                burns: input.burns,
-                dust_shares: input.dust_shares,
-                owner: input.owner,
-                user: user_wallet,
-                issuer_request_id: issuer_request_id.clone(),
-            })
-            .await?;
-
-        let burns = result
-            .burns
-            .into_iter()
-            .map(|b| BurnRecord {
-                receipt_id: b.receipt_id,
-                shares_burned: b.shares_burned,
-            })
-            .collect();
-
-        Ok(vec![RedemptionEvent::TokensBurned {
-            issuer_request_id,
-            tx_hash: result.tx_hash,
-            burns,
-            dust_returned: result.dust_returned,
-            gas_used: result.gas_used,
-            block_number: result.block_number,
-            burned_at: Utc::now(),
         }])
     }
 
@@ -650,6 +670,10 @@ pub(crate) enum RedemptionError {
     AlreadyCompleted { issuer_request_id: IssuerRedemptionRequestId },
     #[error("Vault error: {0}")]
     Vault(#[from] VaultError),
+    #[error(
+        "Fireblocks tx ID mismatch. Expected: {expected}, provided: {provided}"
+    )]
+    FireblocksTxIdMismatch { expected: String, provided: String },
 }
 
 impl PartialEq for RedemptionError {
@@ -668,6 +692,10 @@ impl PartialEq for RedemptionError {
                 Self::InvalidState { expected: e2, found: f2 },
             ) => e1 == e2 && f1 == f2,
             (Self::Vault(a), Self::Vault(b)) => a.to_string() == b.to_string(),
+            (
+                Self::FireblocksTxIdMismatch { expected: e1, provided: p1 },
+                Self::FireblocksTxIdMismatch { expected: e2, provided: p2 },
+            ) => e1 == e2 && p1 == p2,
             _ => false,
         }
     }
@@ -742,6 +770,19 @@ impl Aggregate for Redemption {
                 )
                 .await
             }
+            RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                fireblocks_tx_id,
+                dust_shares,
+            } => {
+                self.handle_confirm_burn(
+                    services,
+                    issuer_request_id,
+                    fireblocks_tx_id,
+                    dust_shares,
+                )
+                .await
+            }
             RedemptionCommand::RecordBurnFailure {
                 issuer_request_id,
                 error,
@@ -753,22 +794,6 @@ impl Aggregate for Redemption {
                 fireblocks_tx_id,
                 planned_burns,
             ),
-            RedemptionCommand::RetryBurn {
-                issuer_request_id,
-                vault,
-                burns,
-                dust_shares,
-                owner,
-                user_wallet,
-            } => {
-                self.handle_retry_burn(
-                    services,
-                    issuer_request_id,
-                    BurnInput { vault, burns, dust_shares, owner },
-                    user_wallet,
-                )
-                .await
-            }
             RedemptionCommand::RecordExistingBurn {
                 issuer_request_id,
                 fireblocks_tx_id,
@@ -890,6 +915,37 @@ impl Aggregate for Redemption {
                     &issuer_request_id,
                     alpaca_journal_completed_at,
                 );
+            }
+            RedemptionEvent::BurnFireblocksSubmitted {
+                issuer_request_id: _,
+                external_tx_id,
+                fireblocks_tx_id,
+                planned_burns,
+                submitted_at: _,
+            } => {
+                let Self::Burning {
+                    metadata,
+                    tokenization_request_id,
+                    alpaca_quantity,
+                    dust_quantity,
+                    called_at,
+                    alpaca_journal_completed_at,
+                } = self.clone()
+                else {
+                    return;
+                };
+
+                *self = Self::BurnSubmitted {
+                    metadata,
+                    tokenization_request_id,
+                    alpaca_quantity,
+                    dust_quantity,
+                    called_at,
+                    alpaca_journal_completed_at,
+                    external_tx_id,
+                    fireblocks_tx_id,
+                    planned_burns,
+                };
             }
             RedemptionEvent::BurnResumed {
                 issuer_request_id,
@@ -1478,21 +1534,22 @@ mod tests {
         let events = validator.inspect_result().unwrap();
         assert_eq!(events.len(), 1);
 
-        let RedemptionEvent::TokensBurned {
+        let RedemptionEvent::BurnFireblocksSubmitted {
             issuer_request_id: event_id,
-            burns,
-            burned_at,
+            planned_burns,
             ..
         } = &events[0]
         else {
-            panic!("Expected TokensBurned event, got {:?}", &events[0]);
+            panic!(
+                "Expected BurnFireblocksSubmitted event, got {:?}",
+                &events[0]
+            );
         };
 
         assert_eq!(event_id, &issuer_request_id);
-        assert_eq!(burns.len(), 1);
-        assert_eq!(burns[0].receipt_id, receipt_id);
-        assert_eq!(burns[0].shares_burned, burn_shares);
-        assert!(burned_at.timestamp() > 0);
+        assert_eq!(planned_burns.len(), 1);
+        assert_eq!(planned_burns[0].receipt_id, receipt_id);
+        assert_eq!(planned_burns[0].shares_burned, burn_shares);
     }
 
     #[test]
@@ -1603,7 +1660,7 @@ mod tests {
                 planned_burns: vec![],
             })
             .then_expect_error(RedemptionError::InvalidState {
-                expected: "Burning".to_string(),
+                expected: "Burning or BurnSubmitted".to_string(),
                 found: "Uninitialized".to_string(),
             });
     }

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -83,6 +83,13 @@ pub(crate) enum RedemptionView {
         alpaca_journal_completed_at: DateTime<Utc>,
         error: String,
         failed_at: DateTime<Utc>,
+        /// Fireblocks transaction ID, if a burn was already submitted before failure.
+        /// Present when the failure occurred during confirmation (after submission).
+        #[serde(default)]
+        fireblocks_tx_id: Option<String>,
+        /// Planned burns at the time of failure.
+        #[serde(default)]
+        planned_burns: Vec<super::BurnRecord>,
     },
     Closed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -176,7 +183,13 @@ impl RedemptionView {
         };
     }
 
-    fn update_burning_failed(&mut self, error: &str, failed_at: DateTime<Utc>) {
+    fn update_burning_failed(
+        &mut self,
+        error: &str,
+        failed_at: DateTime<Utc>,
+        fireblocks_tx_id: Option<&String>,
+        planned_burns: &[super::BurnRecord],
+    ) {
         let Self::Burning {
             issuer_request_id,
             tokenization_request_id,
@@ -212,6 +225,8 @@ impl RedemptionView {
             alpaca_journal_completed_at: *alpaca_journal_completed_at,
             error: error.to_string(),
             failed_at,
+            fireblocks_tx_id: fireblocks_tx_id.cloned(),
+            planned_burns: planned_burns.to_vec(),
         };
     }
 }
@@ -283,8 +298,19 @@ impl View<Redemption> for RedemptionView {
                 };
             }
 
-            RedemptionEvent::BurningFailed { error, failed_at, .. } => {
-                self.update_burning_failed(error, *failed_at);
+            RedemptionEvent::BurningFailed {
+                error,
+                failed_at,
+                fireblocks_tx_id,
+                planned_burns,
+                ..
+            } => {
+                self.update_burning_failed(
+                    error,
+                    *failed_at,
+                    fireblocks_tx_id.as_ref(),
+                    planned_burns,
+                );
             }
 
             RedemptionEvent::AlpacaJournalCompleted {
@@ -355,6 +381,10 @@ impl View<Redemption> for RedemptionView {
                     block_number: *block_number,
                     completed_at: *recovered_at,
                 };
+            }
+            RedemptionEvent::BurnFireblocksSubmitted { .. } => {
+                // View stays in Burning — BurnFireblocksSubmitted is an
+                // internal detail that doesn't change the query-facing state.
             }
             RedemptionEvent::RedemptionClosed {
                 issuer_request_id,
@@ -706,6 +736,7 @@ mod tests {
         }
 
         async fn burn_tokens(&self, id: &IssuerRedemptionRequestId) {
+            // Step 1: Submit
             self.cqrs
                 .execute(
                     &id.to_string(),
@@ -727,7 +758,20 @@ mod tests {
                     },
                 )
                 .await
-                .expect("Failed to burn tokens");
+                .expect("Failed to submit burn");
+
+            // Step 2: Confirm
+            self.cqrs
+                .execute(
+                    &id.to_string(),
+                    RedemptionCommand::ConfirmBurn {
+                        issuer_request_id: id.clone(),
+                        fireblocks_tx_id: "mock-fb-burn".to_string(),
+                        dust_shares: U256::ZERO,
+                    },
+                )
+                .await
+                .expect("Failed to confirm burn");
         }
     }
 

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -1,13 +1,12 @@
-use alloy::primitives::{Address, U256, b256};
+use alloy::primitives::{Address, Bytes, U256, b256};
 use async_trait::async_trait;
 use std::sync::Arc;
-#[cfg(test)]
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{
     MintResult, MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, VaultError, VaultService,
+    ReceiptInformation, SubmittedTx, VaultError, VaultService,
 };
 
 #[cfg(test)]
@@ -28,6 +27,8 @@ enum MockBehavior {
     Success,
     #[cfg(test)]
     Failure,
+    #[cfg(test)]
+    SubmitFailure,
 }
 
 /// Mock blockchain service for testing.
@@ -42,6 +43,10 @@ pub(crate) struct MockVaultService {
     mint_delay_ms: u64,
     call_count: Arc<AtomicUsize>,
     multi_burn_call_count: Arc<AtomicUsize>,
+    /// Cached MintResult from submit_mint for retrieval in confirm_mint.
+    pending_mint_result: Arc<Mutex<Option<MintResult>>>,
+    /// Cached MultiBurnResult from submit_burn for retrieval in confirm_burn.
+    pending_burn_result: Arc<Mutex<Option<MultiBurnResult>>>,
     #[cfg(test)]
     last_call: Arc<Mutex<Option<MintTokensCall>>>,
     #[cfg(test)]
@@ -58,6 +63,8 @@ impl MockVaultService {
             mint_delay_ms: 0,
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             last_call: Arc::new(Mutex::new(None)),
             #[cfg(test)]
@@ -74,6 +81,23 @@ impl MockVaultService {
             mint_delay_ms: 0,
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
+            last_call: Arc::new(Mutex::new(None)),
+            share_balance: Arc::new(Mutex::new(U256::MAX)),
+            last_multi_burn_params: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_submit_failure() -> Self {
+        Self {
+            behavior: MockBehavior::SubmitFailure,
+            mint_delay_ms: 0,
+            call_count: Arc::new(AtomicUsize::new(0)),
+            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
             last_call: Arc::new(Mutex::new(None)),
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
@@ -112,6 +136,8 @@ impl MockVaultService {
         self.call_count.store(0, Ordering::Relaxed);
         self.multi_burn_call_count.store(0, Ordering::Relaxed);
         *self.last_call.lock().unwrap() = None;
+        *self.pending_mint_result.lock().unwrap() = None;
+        *self.pending_burn_result.lock().unwrap() = None;
     }
 
     #[cfg(test)]
@@ -121,17 +147,28 @@ impl MockVaultService {
     }
 }
 
+const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
+    b256!("0x4242424242424242424242424242424242424242424242424242424242424242");
+
+const MOCK_BURN_TX_HASH: alloy::primitives::B256 =
+    b256!("0x4545454545454545454545454545454545454545454545454545454545454545");
+
 #[async_trait]
 impl VaultService for MockVaultService {
     #[cfg_attr(not(test), allow(unused_variables))]
-    async fn mint_and_transfer_shares(
+    async fn submit_mint(
         &self,
         vault: Address,
         assets: U256,
         bot: Address,
         _user: Address,
         receipt_info: ReceiptInformation,
-    ) -> Result<MintResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitFailure) {
+            return Err(VaultError::InvalidReceipt);
+        }
+
         if self.mint_delay_ms > 0 {
             tokio::time::sleep(tokio::time::Duration::from_millis(
                 self.mint_delay_ms,
@@ -151,25 +188,77 @@ impl VaultService for MockVaultService {
             });
         }
 
+        // Pre-compute the MintResult for confirm_mint to return.
+        let receipt_info_bytes = match receipt_info.encode(Some(
+            "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm",
+        )) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                return Err(VaultError::ReceiptEncode(err));
+            }
+        };
+
+        *self
+            .pending_mint_result
+            .lock()
+            .expect("pending_mint_result mutex poisoned") = Some(MintResult {
+            tx_hash: MOCK_MINT_TX_HASH,
+            receipt_id: U256::from(1),
+            shares_minted: assets,
+            gas_used: 21000,
+            block_number: 1000,
+            receipt_info_bytes,
+        });
+
+        Ok(SubmittedTx {
+            external_tx_id: "mock-mint".to_string(),
+            fireblocks_tx_id: "mock-fb-mint".to_string(),
+        })
+    }
+
+    async fn confirm_mint(
+        &self,
+        _fireblocks_tx_id: &str,
+    ) -> Result<MintResult, VaultError> {
         match &self.behavior {
             MockBehavior::Success => {
-                let receipt_info_bytes = receipt_info.encode(Some(
-                    "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm",
-                ))?;
+                let result = self
+                    .pending_mint_result
+                    .lock()
+                    .expect("pending_mint_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(|| MintResult {
+                        tx_hash: MOCK_MINT_TX_HASH,
+                        receipt_id: U256::from(1),
+                        shares_minted: U256::ZERO,
+                        gas_used: 21000,
+                        block_number: 1000,
+                        receipt_info_bytes: Bytes::new(),
+                    });
 
-                Ok(MintResult {
-                    tx_hash: b256!(
-                        "0x4242424242424242424242424242424242424242424242424242424242424242"
-                    ),
-                    receipt_id: U256::from(1),
-                    shares_minted: assets,
-                    gas_used: 21000,
-                    block_number: 1000,
-                    receipt_info_bytes,
-                })
+                Ok(result)
             }
             #[cfg(test)]
             MockBehavior::Failure => Err(VaultError::InvalidReceipt),
+            #[cfg(test)]
+            MockBehavior::SubmitFailure => {
+                // SubmitFailure only affects submit_*, not confirm_*.
+                // If confirm is somehow called, return the cached result.
+                let result = self
+                    .pending_mint_result
+                    .lock()
+                    .expect("pending_mint_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(|| MintResult {
+                        tx_hash: MOCK_MINT_TX_HASH,
+                        receipt_id: U256::from(1),
+                        shares_minted: U256::ZERO,
+                        gas_used: 21000,
+                        block_number: 1000,
+                        receipt_info_bytes: Bytes::new(),
+                    });
+                Ok(result)
+            }
         }
     }
 
@@ -188,10 +277,15 @@ impl VaultService for MockVaultService {
         }
     }
 
-    async fn burn_multiple_receipts(
+    async fn submit_burn(
         &self,
         params: MultiBurnParams,
-    ) -> Result<MultiBurnResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitFailure) {
+            return Err(VaultError::InvalidReceipt);
+        }
+
         self.multi_burn_call_count.fetch_add(1, Ordering::Relaxed);
 
         #[cfg(test)]
@@ -199,29 +293,74 @@ impl VaultService for MockVaultService {
             *self.last_multi_burn_params.lock().unwrap() = Some(params.clone());
         }
 
+        // Pre-compute the MultiBurnResult for confirm_burn to return.
+        let burns = params
+            .burns
+            .into_iter()
+            .map(|entry| MultiBurnResultEntry {
+                receipt_id: entry.receipt_id,
+                shares_burned: entry.burn_shares,
+            })
+            .collect();
+
+        *self
+            .pending_burn_result
+            .lock()
+            .expect("pending_burn_result mutex poisoned") =
+            Some(MultiBurnResult {
+                tx_hash: MOCK_BURN_TX_HASH,
+                burns,
+                dust_returned: params.dust_shares,
+                gas_used: 50000,
+                block_number: 5000,
+            });
+
+        Ok(SubmittedTx {
+            external_tx_id: "mock-burn".to_string(),
+            fireblocks_tx_id: "mock-fb-burn".to_string(),
+        })
+    }
+
+    async fn confirm_burn(
+        &self,
+        _fireblocks_tx_id: &str,
+        dust_shares: U256,
+    ) -> Result<MultiBurnResult, VaultError> {
         match &self.behavior {
             MockBehavior::Success => {
-                let burns = params
-                    .burns
-                    .into_iter()
-                    .map(|entry| MultiBurnResultEntry {
-                        receipt_id: entry.receipt_id,
-                        shares_burned: entry.burn_shares,
-                    })
-                    .collect();
+                let result = self
+                    .pending_burn_result
+                    .lock()
+                    .expect("pending_burn_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(|| MultiBurnResult {
+                        tx_hash: MOCK_BURN_TX_HASH,
+                        burns: vec![],
+                        dust_returned: dust_shares,
+                        gas_used: 50000,
+                        block_number: 5000,
+                    });
 
-                Ok(MultiBurnResult {
-                    tx_hash: b256!(
-                        "0x4545454545454545454545454545454545454545454545454545454545454545"
-                    ),
-                    burns,
-                    dust_returned: params.dust_shares,
-                    gas_used: 50000,
-                    block_number: 5000,
-                })
+                Ok(result)
             }
             #[cfg(test)]
             MockBehavior::Failure => Err(VaultError::InvalidReceipt),
+            #[cfg(test)]
+            MockBehavior::SubmitFailure => {
+                let result = self
+                    .pending_burn_result
+                    .lock()
+                    .expect("pending_burn_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(|| MultiBurnResult {
+                        tx_hash: MOCK_BURN_TX_HASH,
+                        burns: vec![],
+                        dust_returned: dust_shares,
+                        gas_used: 50000,
+                        block_number: 5000,
+                    });
+                Ok(result)
+            }
         }
     }
 }
@@ -262,7 +401,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_new_success_returns_mint_result() {
+    async fn test_submit_and_confirm_mint_success() {
         let mock = MockVaultService::new_success();
         let vault = test_vault();
         let assets = U256::from(1000);
@@ -271,26 +410,24 @@ mod tests {
             address!("0x1111111111111111111111111111111111111111");
         let receipt_info = test_receipt_info();
 
-        let result = mock
-            .mint_and_transfer_shares(
-                vault,
-                assets,
-                bot_wallet,
-                user_wallet,
-                receipt_info,
-            )
-            .await;
+        let submitted = mock
+            .submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
+            .await
+            .unwrap();
 
-        assert!(result.is_ok());
-        let mint_result = result.unwrap();
-        assert_eq!(mint_result.receipt_id, U256::from(1));
-        assert_eq!(mint_result.shares_minted, assets);
-        assert_eq!(mint_result.gas_used, 21000);
-        assert_eq!(mint_result.block_number, 1000);
+        assert_eq!(submitted.external_tx_id, "mock-mint");
+
+        let result =
+            mock.confirm_mint(&submitted.fireblocks_tx_id).await.unwrap();
+
+        assert_eq!(result.receipt_id, U256::from(1));
+        assert_eq!(result.shares_minted, assets);
+        assert_eq!(result.gas_used, 21000);
+        assert_eq!(result.block_number, 1000);
     }
 
     #[tokio::test]
-    async fn test_new_failure_returns_error() {
+    async fn test_confirm_mint_failure() {
         let mock = MockVaultService::new_failure();
         let vault = test_vault();
         let assets = U256::from(1000);
@@ -299,18 +436,15 @@ mod tests {
             address!("0x1111111111111111111111111111111111111111");
         let receipt_info = test_receipt_info();
 
-        let result = mock
-            .mint_and_transfer_shares(
-                vault,
-                assets,
-                bot_wallet,
-                user_wallet,
-                receipt_info,
-            )
-            .await;
+        // Submit always succeeds
+        let submitted = mock
+            .submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
+            .await
+            .unwrap();
 
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), VaultError::InvalidReceipt));
+        // Confirm returns the failure
+        let result = mock.confirm_mint(&submitted.fireblocks_tx_id).await;
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
     }
 
     #[tokio::test]
@@ -324,7 +458,7 @@ mod tests {
 
         assert_eq!(mock.get_call_count(), 0);
 
-        mock.mint_and_transfer_shares(
+        mock.submit_mint(
             vault,
             assets,
             bot_wallet,
@@ -334,17 +468,6 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(mock.get_call_count(), 1);
-
-        mock.mint_and_transfer_shares(
-            vault,
-            assets,
-            bot_wallet,
-            user_wallet,
-            test_receipt_info(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(mock.get_call_count(), 2);
     }
 
     #[tokio::test]
@@ -359,7 +482,7 @@ mod tests {
 
         assert!(mock.get_last_call().is_none());
 
-        mock.mint_and_transfer_shares(
+        mock.submit_mint(
             vault,
             assets,
             bot_wallet,
@@ -394,15 +517,9 @@ mod tests {
         let receipt_info = test_receipt_info();
 
         let start = tokio::time::Instant::now();
-        mock.mint_and_transfer_shares(
-            vault,
-            assets,
-            bot_wallet,
-            user_wallet,
-            receipt_info,
-        )
-        .await
-        .unwrap();
+        mock.submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
+            .await
+            .unwrap();
         let elapsed = start.elapsed();
 
         assert!(elapsed.as_millis() >= u128::from(delay_ms));
@@ -418,7 +535,7 @@ mod tests {
             address!("0x1111111111111111111111111111111111111111");
         let receipt_info = test_receipt_info();
 
-        mock.mint_and_transfer_shares(
+        mock.submit_mint(
             vault,
             assets,
             bot_wallet,
@@ -427,17 +544,8 @@ mod tests {
         )
         .await
         .unwrap();
-        mock.mint_and_transfer_shares(
-            vault,
-            assets,
-            bot_wallet,
-            user_wallet,
-            receipt_info,
-        )
-        .await
-        .unwrap();
 
-        assert_eq!(mock.get_call_count(), 2);
+        assert_eq!(mock.get_call_count(), 1);
         assert!(mock.get_last_call().is_some());
 
         mock.reset();
@@ -447,6 +555,9 @@ mod tests {
     }
 
     fn test_multi_burn_params() -> MultiBurnParams {
+        let detected_tx_hash = b256!(
+            "0xabababababababababababababababababababababababababababababababab"
+        );
         MultiBurnParams {
             vault: test_vault(),
             burns: vec![MultiBurnEntry {
@@ -458,10 +569,25 @@ mod tests {
             dust_shares: U256::from(10),
             owner: test_receiver(),
             user: address!("0x2222222222222222222222222222222222222222"),
-            issuer_request_id: IssuerRedemptionRequestId::new(b256!(
-                "0xabababababababababababababababababababababababababababababababab"
-            )),
+            issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
+            detected_tx_hash,
         }
+    }
+
+    #[tokio::test]
+    async fn test_submit_and_confirm_burn_success() {
+        let mock = MockVaultService::new_success();
+        let params = test_multi_burn_params();
+        let dust = params.dust_shares;
+
+        let submitted = mock.submit_burn(params).await.unwrap();
+        assert_eq!(submitted.external_tx_id, "mock-burn");
+
+        let result =
+            mock.confirm_burn(&submitted.fireblocks_tx_id, dust).await.unwrap();
+
+        assert_eq!(result.burns.len(), 1);
+        assert_eq!(result.dust_returned, dust);
     }
 
     #[tokio::test]
@@ -470,10 +596,10 @@ mod tests {
 
         assert_eq!(mock.get_multi_burn_call_count(), 0);
 
-        mock.burn_multiple_receipts(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params()).await.unwrap();
         assert_eq!(mock.get_multi_burn_call_count(), 1);
 
-        mock.burn_multiple_receipts(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params()).await.unwrap();
         assert_eq!(mock.get_multi_burn_call_count(), 2);
     }
 
@@ -481,13 +607,43 @@ mod tests {
     async fn test_reset_clears_multi_burn_state() {
         let mock = MockVaultService::new_success();
 
-        mock.burn_multiple_receipts(test_multi_burn_params()).await.unwrap();
-        mock.burn_multiple_receipts(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params()).await.unwrap();
 
         assert_eq!(mock.get_multi_burn_call_count(), 2);
 
         mock.reset();
 
         assert_eq!(mock.get_multi_burn_call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_submit_mint_failure() {
+        let mock = MockVaultService::new_submit_failure();
+        let result = mock
+            .submit_mint(
+                test_vault(),
+                U256::from(1000),
+                test_receiver(),
+                address!("0x1111111111111111111111111111111111111111"),
+                test_receipt_info(),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(VaultError::InvalidReceipt)),
+            "Expected InvalidReceipt, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_submit_burn_failure() {
+        let mock = MockVaultService::new_submit_failure();
+        let result = mock.submit_burn(test_multi_burn_params()).await;
+
+        assert!(
+            matches!(result, Err(VaultError::InvalidReceipt)),
+            "Expected InvalidReceipt, got {result:?}"
+        );
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -19,44 +19,36 @@ pub(crate) mod service;
 /// services or mocks for testing.
 #[async_trait]
 pub(crate) trait VaultService: Send + Sync {
-    /// Atomically mints tokens and transfers shares using the vault's multicall() function.
+    /// Submits a mint transaction (deposit + share transfer) to the signing backend.
     ///
-    /// This method implements the receipt custody model by:
-    /// 1. Minting both ERC1155 receipts and ERC20 shares to the bot's wallet
-    /// 2. Immediately transferring the ERC20 shares to the user's wallet
+    /// Encodes the multicall calldata and submits it via the backend (Fireblocks
+    /// CONTRACT_CALL or direct send). Returns a [`SubmittedTx`] whose
+    /// `fireblocks_tx_id` is persisted in a CQRS event so that `confirm_mint`
+    /// can resume polling after a restart.
     ///
-    /// Both operations succeed or fail atomically in a single transaction.
-    ///
-    /// # Arguments
-    ///
-    /// * `vault` - Address of the vault contract to interact with
-    /// * `assets` - Amount of assets to deposit (18-decimal fixed-point)
-    /// * `bot` - Bot's address that will hold the receipts
-    /// * `user` - User's address that will receive the shares
-    /// * `receipt_info` - Metadata about the mint operation for on-chain audit trail
-    ///
-    /// # Returns
-    ///
-    /// On success, returns [`MintResult`] containing transaction hash, receipt ID,
-    /// shares minted, gas used, and block number.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`VaultError`] if the multicall fails, events are missing,
-    /// or RPC communication fails.
-    ///
-    /// # Implementation Note
-    ///
-    /// This relies on the 1:1 share ratio (1 asset = 1 share with 18 decimals).
-    /// The transfer amount can be pre-calculated as equal to assets, allowing
-    /// the multicall to be encoded before execution.
-    async fn mint_and_transfer_shares(
+    /// Uses a deterministic `external_tx_id` so that resubmitting the same mint
+    /// after a crash triggers Fireblocks' duplicate rejection instead of a
+    /// double-mint.
+    async fn submit_mint(
         &self,
         vault: Address,
         assets: U256,
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
+    ) -> Result<SubmittedTx, VaultError>;
+
+    /// Confirms a previously submitted mint transaction.
+    ///
+    /// Polls the signing backend until the transaction reaches a terminal state,
+    /// then fetches the on-chain receipt and parses the Deposit event.
+    ///
+    /// # Arguments
+    ///
+    /// * `fireblocks_tx_id` - Backend transaction ID from [`SubmittedTx`]
+    async fn confirm_mint(
+        &self,
+        fireblocks_tx_id: &str,
     ) -> Result<MintResult, VaultError>;
 
     /// Gets the ERC-20 share balance for an address.
@@ -92,22 +84,28 @@ pub(crate) trait VaultService: Send + Sync {
         Ok(None)
     }
 
-    /// Atomically burns tokens from multiple receipts and returns dust using multicall.
+    /// Submits a multi-receipt burn transaction to the signing backend.
     ///
-    /// This method handles redemptions that require burning from multiple receipts
-    /// when no single receipt has sufficient balance. It uses multicall to atomically:
-    /// 1. Execute N redeem() calls, one for each receipt
-    /// 2. Transfer the dust back to the user's wallet (if dust > 0)
-    ///
-    /// All operations succeed or fail atomically in a single transaction.
-    ///
-    /// # Returns
-    ///
-    /// On success, returns [`MultiBurnResult`] containing transaction details
-    /// and per-receipt burn amounts.
-    async fn burn_multiple_receipts(
+    /// Encodes the multicall calldata (N redeems + optional dust transfer)
+    /// and submits it. Returns a [`SubmittedTx`] for later confirmation.
+    async fn submit_burn(
         &self,
         params: MultiBurnParams,
+    ) -> Result<SubmittedTx, VaultError>;
+
+    /// Confirms a previously submitted burn transaction.
+    ///
+    /// Polls the signing backend until completion, then parses Withdraw events.
+    ///
+    /// # Arguments
+    ///
+    /// * `fireblocks_tx_id` - Backend transaction ID from [`SubmittedTx`]
+    /// * `dust_shares` - Amount of dust to report as returned (passed through
+    ///   from the original request since it cannot be derived from on-chain events)
+    async fn confirm_burn(
+        &self,
+        fireblocks_tx_id: &str,
+        dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError>;
 }
 
@@ -179,6 +177,9 @@ pub(crate) struct MultiBurnParams {
     pub(crate) user: Address,
     /// Redemption's issuer request ID (for Fireblocks notes/externalTxId)
     pub(crate) issuer_request_id: IssuerRedemptionRequestId,
+    /// Full transaction hash that triggered this redemption, used for
+    /// constructing a collision-resistant Fireblocks `externalTxId`.
+    pub(crate) detected_tx_hash: B256,
 }
 
 /// Result of a single burn within a multi-receipt burn operation.
@@ -260,6 +261,22 @@ impl ReceiptInformation {
     }
 }
 
+/// Result of submitting a transaction to the signing backend.
+///
+/// Returned by `submit_mint` and `submit_burn`. The `fireblocks_tx_id` is
+/// persisted in an intermediate CQRS event so that `confirm_mint`/`confirm_burn`
+/// can resume polling after a restart.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub(crate) struct SubmittedTx {
+    /// Deterministic ID used for Fireblocks idempotency (`externalTxId`).
+    /// Format: `{operation}-{issuer_request_id}`.
+    pub(crate) external_tx_id: String,
+    /// Backend-specific transaction identifier.
+    /// For Fireblocks: the Fireblocks transaction ID.
+    /// For local backends: the on-chain transaction hash.
+    pub(crate) fireblocks_tx_id: String,
+}
+
 /// Errors that can occur when encoding receipt information.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum ReceiptEncodeError {
@@ -287,6 +304,12 @@ pub(crate) enum VaultError {
     /// Failed to get transaction receipt
     #[error(transparent)]
     PendingTransaction(#[from] alloy::providers::PendingTransactionError),
+    /// RPC transport error (e.g., fetching receipt by tx hash during recovery)
+    #[error(transparent)]
+    Rpc(
+        #[from]
+        alloy::transports::RpcError<alloy::transports::TransportErrorKind>,
+    ),
     /// Fireblocks vault service error
     #[error(transparent)]
     Fireblocks(#[from] crate::fireblocks::FireblocksVaultError),

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -1,10 +1,17 @@
-use alloy::primitives::{Address, Bytes, U256};
-use alloy::providers::Provider;
-use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 
+use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::Provider;
+use async_trait::async_trait;
+use tokio::sync::Mutex;
+use tracing::debug;
+
 use super::rain_meta::OaSchemaCache;
-use super::{MintResult, ReceiptInformation, VaultError, VaultService};
+use super::{
+    MintResult, MultiBurnResult, MultiBurnResultEntry, ReceiptInformation,
+    SubmittedTx, VaultError, VaultService,
+};
 use crate::bindings::OffchainAssetReceiptVault;
 
 /// Alloy-based blockchain service that interacts with the Rain OffchainAssetReceiptVault
@@ -12,9 +19,24 @@ use crate::bindings::OffchainAssetReceiptVault;
 ///
 /// Generic over the provider type to support both production RPC providers and mock providers
 /// for testing.
+///
+/// Since this backend submits and confirms transactions synchronously (no Fireblocks),
+/// `submit_mint`/`submit_burn` execute the full operation and cache the result for
+/// `confirm_mint`/`confirm_burn` to return. Results are keyed by tx hash to prevent
+/// concurrent operations from overwriting each other.
+///
+/// **Dev/test only.** This backend does not provide crash-safe idempotency:
+/// if the process crashes after the on-chain transaction completes but before
+/// the CQRS event is persisted, recovery will re-submit a new transaction
+/// (no `externalTxId` deduplication). The Fireblocks backend handles this
+/// via deterministic `externalTxId` and duplicate detection.
 pub(crate) struct RealBlockchainService<P> {
     provider: P,
     oa_schema_cache: Arc<OaSchemaCache>,
+    /// Cached results from `submit_mint`, keyed by tx hash string.
+    cached_mints: Arc<Mutex<HashMap<String, MintResult>>>,
+    /// Cached results from `submit_burn`, keyed by tx hash string.
+    cached_burns: Arc<Mutex<HashMap<String, MultiBurnResult>>>,
 }
 
 impl<P: Provider + Clone> RealBlockchainService<P> {
@@ -24,11 +46,16 @@ impl<P: Provider + Clone> RealBlockchainService<P> {
     ///
     /// * `provider` - Alloy provider for blockchain communication
     /// * `oa_schema_cache` - Cache for querying OA schema hashes from the subgraph
-    pub(crate) const fn new(
+    pub(crate) fn new(
         provider: P,
         oa_schema_cache: Arc<OaSchemaCache>,
     ) -> Self {
-        Self { provider, oa_schema_cache }
+        Self {
+            provider,
+            oa_schema_cache,
+            cached_mints: Arc::new(Mutex::new(HashMap::new())),
+            cached_burns: Arc::new(Mutex::new(HashMap::new())),
+        }
     }
 }
 
@@ -36,14 +63,14 @@ impl<P: Provider + Clone> RealBlockchainService<P> {
 impl<P: Provider + Clone + Send + Sync + 'static> VaultService
     for RealBlockchainService<P>
 {
-    async fn mint_and_transfer_shares(
+    async fn submit_mint(
         &self,
         vault: Address,
         assets: U256,
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
-    ) -> Result<MintResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
         let oa_schema = self.oa_schema_cache.get(vault).await;
         let receipt_info_bytes = receipt_info.encode(oa_schema.as_deref())?;
 
@@ -94,12 +121,78 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let block_number =
             receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
 
-        Ok(MintResult {
+        let tx_hash_str = receipt.transaction_hash.to_string();
+
+        let result = MintResult {
             tx_hash: receipt.transaction_hash,
             receipt_id,
             shares_minted,
             gas_used,
             block_number,
+            receipt_info_bytes,
+        };
+
+        self.cached_mints.lock().await.insert(tx_hash_str.clone(), result);
+
+        Ok(SubmittedTx {
+            external_tx_id: format!(
+                "local-mint-{}",
+                receipt_info.issuer_request_id
+            ),
+            fireblocks_tx_id: tx_hash_str,
+        })
+    }
+
+    async fn confirm_mint(
+        &self,
+        fireblocks_tx_id: &str,
+    ) -> Result<MintResult, VaultError> {
+        // Try cache first (normal path when submit and confirm happen in same process)
+        let cached = self.cached_mints.lock().await.remove(fireblocks_tx_id);
+        if let Some(result) = cached {
+            return Ok(result);
+        }
+
+        // Cache empty (process restarted) — re-fetch receipt from chain using tx hash
+        debug!(target: "vault", tx_hash = %fireblocks_tx_id,
+            "Mint cache empty, recovering from chain"
+        );
+
+        let tx_hash: B256 =
+            fireblocks_tx_id.parse().map_err(|_| VaultError::InvalidReceipt)?;
+
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(VaultError::InvalidReceipt)?;
+
+        let (receipt_id, shares_minted, receipt_info_bytes) = receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                log.log_decode::<OffchainAssetReceiptVault::Deposit>().ok().map(
+                    |decoded| {
+                        let event_data = decoded.data();
+                        (
+                            event_data.id,
+                            event_data.shares,
+                            event_data.receiptInformation.clone(),
+                        )
+                    },
+                )
+            })
+            .ok_or_else(|| VaultError::EventNotFound { tx_hash })?;
+
+        Ok(MintResult {
+            tx_hash,
+            receipt_id,
+            shares_minted,
+            gas_used: receipt.gas_used,
+            block_number: receipt
+                .block_number
+                .ok_or(VaultError::InvalidReceipt)?,
             receipt_info_bytes,
         })
     }
@@ -115,10 +208,10 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         Ok(vault_contract.balanceOf(owner).call().await?)
     }
 
-    async fn burn_multiple_receipts(
+    async fn submit_burn(
         &self,
         params: super::MultiBurnParams,
-    ) -> Result<super::MultiBurnResult, VaultError> {
+    ) -> Result<SubmittedTx, VaultError> {
         let vault_contract =
             OffchainAssetReceiptVault::new(params.vault, &self.provider);
 
@@ -205,12 +298,79 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let block_number =
             receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
 
-        Ok(super::MultiBurnResult {
+        let tx_hash_str = receipt.transaction_hash.to_string();
+        let issuer_id = params.issuer_request_id.to_string();
+
+        let result = super::MultiBurnResult {
             tx_hash: receipt.transaction_hash,
             burns,
             dust_returned: params.dust_shares,
             gas_used,
             block_number,
+        };
+
+        self.cached_burns.lock().await.insert(tx_hash_str.clone(), result);
+
+        Ok(SubmittedTx {
+            external_tx_id: format!("local-burn-{issuer_id}"),
+            fireblocks_tx_id: tx_hash_str,
+        })
+    }
+
+    async fn confirm_burn(
+        &self,
+        fireblocks_tx_id: &str,
+        dust_shares: U256,
+    ) -> Result<MultiBurnResult, VaultError> {
+        // Try cache first (normal path when submit and confirm happen in same process)
+        let cached = self.cached_burns.lock().await.remove(fireblocks_tx_id);
+        if let Some(result) = cached {
+            return Ok(result);
+        }
+
+        // Cache empty (process restarted) — re-fetch receipt from chain using tx hash
+        debug!(target: "vault", tx_hash = %fireblocks_tx_id,
+            "Burn cache empty, recovering from chain"
+        );
+
+        let tx_hash: B256 =
+            fireblocks_tx_id.parse().map_err(|_| VaultError::InvalidReceipt)?;
+
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(VaultError::InvalidReceipt)?;
+
+        let burns: Vec<MultiBurnResultEntry> = receipt
+            .inner
+            .logs()
+            .iter()
+            .filter_map(|log| {
+                log.log_decode::<OffchainAssetReceiptVault::Withdraw>()
+                    .ok()
+                    .map(|decoded| {
+                        let event_data = decoded.data();
+                        MultiBurnResultEntry {
+                            receipt_id: event_data.id,
+                            shares_burned: event_data.shares,
+                        }
+                    })
+            })
+            .collect();
+
+        if burns.is_empty() {
+            return Err(VaultError::EventNotFound { tx_hash });
+        }
+
+        Ok(MultiBurnResult {
+            tx_hash,
+            burns,
+            dust_returned: dust_shares,
+            gas_used: receipt.gas_used,
+            block_number: receipt
+                .block_number
+                .ok_or(VaultError::InvalidReceipt)?,
         })
     }
 }
@@ -222,7 +382,7 @@ mod tests {
     };
     use alloy::network::EthereumWallet;
     use alloy::primitives::{
-        Address, B256, Bloom, Bytes, IntoLogData, U256, address, b256, bytes,
+        Address, B256, Bloom, Bytes, IntoLogData, U256, address, b256,
         fixed_bytes,
     };
     use alloy::providers::ProviderBuilder;
@@ -314,7 +474,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mint_and_transfer_shares_success() {
+    async fn test_submit_and_confirm_mint_success() {
         let assets = U256::from(1000);
         let bot_wallet = test_receiver();
         let user_wallet =
@@ -394,34 +554,15 @@ mod tests {
 
         let asserter = Asserter::new();
 
-        // Mock previewDeposit call (eth_call returns shares as 32-byte hex string)
         asserter.push_success(&"0x00000000000000000000000000000000000000000000000000000000000003e8");
-
-        // Mock eth_getTransactionCount (get nonce)
         asserter.push_success(&0u64);
-
-        // Mock eth_feeHistory
         asserter.push_success(&fee_history);
-
-        // Mock eth_getBlockByNumber (get latest block)
         asserter.push_success(&block);
-
-        // Mock eth_chainId
         asserter.push_success(&1u64);
-
-        // Mock eth_estimateGas
         asserter.push_success(&100_000_u64);
-
-        // Mock eth_maxPriorityFeePerGas or another u64 call
         asserter.push_success(&1_000_000_000_u64);
-
-        // Mock eth_getTransactionCount again (wallet's nonce manager)
         asserter.push_success(&0u64);
-
-        // Mock eth_sendRawTransaction (returns pending tx hash)
         asserter.push_success(&tx_hash);
-
-        // Mock eth_getTransactionReceipt for .get_receipt() polling (may poll multiple times)
         asserter.push_success(&receipt);
         asserter.push_success(&receipt);
 
@@ -434,8 +575,8 @@ mod tests {
             Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
         );
 
-        let result = service
-            .mint_and_transfer_shares(
+        let submitted = service
+            .submit_mint(
                 vault_address,
                 assets,
                 bot_wallet,
@@ -443,6 +584,11 @@ mod tests {
                 receipt_info,
             )
             .await;
+
+        assert!(submitted.is_ok(), "Expected Ok but got: {submitted:?}");
+        let submitted = submitted.unwrap();
+
+        let result = service.confirm_mint(&submitted.fireblocks_tx_id).await;
 
         assert!(result.is_ok(), "Expected Ok but got: {result:?}");
         let mint_result = result.unwrap();
@@ -454,7 +600,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mint_and_transfer_shares_missing_deposit_event() {
+    async fn test_submit_mint_missing_deposit_event() {
         let vault_address = test_vault_address();
         let assets = U256::from(1000);
         let bot_wallet = test_receiver();
@@ -502,37 +648,17 @@ mod tests {
         };
 
         let block: Block = Block::default();
-
         let asserter = Asserter::new();
 
-        // Mock previewDeposit call (eth_call returns shares as 32-byte hex string)
         asserter.push_success(&"0x00000000000000000000000000000000000000000000000000000000000003e8");
-
-        // Mock eth_getTransactionCount (get nonce)
         asserter.push_success(&0u64);
-
-        // Mock eth_feeHistory
         asserter.push_success(&fee_history);
-
-        // Mock eth_getBlockByNumber (get latest block)
         asserter.push_success(&block);
-
-        // Mock eth_chainId
         asserter.push_success(&1u64);
-
-        // Mock eth_estimateGas
         asserter.push_success(&100_000_u64);
-
-        // Mock eth_maxPriorityFeePerGas or another u64 call
         asserter.push_success(&1_000_000_000_u64);
-
-        // Mock eth_getTransactionCount again (wallet's nonce manager)
         asserter.push_success(&0u64);
-
-        // Mock eth_sendRawTransaction (returns pending tx hash)
         asserter.push_success(&tx_hash);
-
-        // Mock eth_getTransactionReceipt for .get_receipt() polling (may poll multiple times)
         asserter.push_success(&receipt);
         asserter.push_success(&receipt);
 
@@ -546,7 +672,7 @@ mod tests {
         );
 
         let result = service
-            .mint_and_transfer_shares(
+            .submit_mint(
                 vault_address,
                 assets,
                 bot_wallet,
@@ -594,84 +720,12 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_mint_and_transfer_shares_produces_exact_calldata() {
-        let vault_address = test_vault_address();
-        let assets = U256::from(1000);
-        let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let user = address!("0x2222222222222222222222222222222222222222");
-
-        let fixed_timestamp =
-            chrono::DateTime::parse_from_rfc3339("2025-01-15T12:00:00Z")
-                .unwrap()
-                .with_timezone(&Utc);
-
-        let receipt_info = ReceiptInformation::new(
-            TokenizationRequestId::new("tok-123"),
-            IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
-            Quantity::new(Decimal::from(100)),
-            fixed_timestamp,
-            None,
-        );
-
-        let signer = PrivateKeySigner::random();
-        let provider = ProviderBuilder::new()
-            .wallet(EthereumWallet::from(signer))
-            .connect_anvil();
-
-        let vault = OffchainAssetReceiptVault::new(vault_address, &provider);
-
-        let receipt_info_bytes =
-            receipt_info.encode(Some(TEST_OA_SCHEMA)).unwrap();
-        let share_ratio = U256::from(10).pow(U256::from(18));
-
-        let deposit_call = vault
-            .deposit(assets, bot, share_ratio, receipt_info_bytes)
-            .calldata()
-            .clone();
-
-        let transfer_call = vault.transfer(user, assets).calldata().clone();
-
-        let multicall_calldata = vault
-            .multicall(vec![deposit_call.clone(), transfer_call.clone()])
-            .calldata()
-            .clone();
-
-        let expected_transfer = bytes!(
-            "0xa9059cbb000000000000000000000000222222222222222222222222222222222222222200000000000000000000000000000000000000000000000000000000000003e8"
-        );
-
-        assert_eq!(
-            transfer_call.as_ref(),
-            expected_transfer.as_ref(),
-            "Transfer calldata mismatch"
-        );
-
-        assert!(
-            !deposit_call.is_empty()
-                && deposit_call[0..4] == [0x14, 0x23, 0xfe, 0xba],
-            "Deposit should start with correct function selector"
-        );
-
-        assert!(
-            !multicall_calldata.is_empty()
-                && multicall_calldata[0..4] == [0xac, 0x96, 0x50, 0xd8],
-            "Multicall should start with correct function selector"
-        );
-
-        assert!(
-            multicall_calldata.len() > deposit_call.len() + transfer_call.len(),
-            "Multicall should contain both calls"
-        );
-    }
-
     fn create_multi_withdraw_receipt(
         vault_address: Address,
         tx_hash: B256,
         owner: Address,
         user: Address,
-        burns: Vec<(U256, U256)>, // (receipt_id, shares)
+        burns: Vec<(U256, U256)>,
     ) -> TransactionReceipt {
         let logs: Vec<alloy::rpc::types::Log> = burns
             .into_iter()
@@ -733,7 +787,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_burn_multiple_receipts_with_two_burns() {
+    async fn test_submit_and_confirm_burn_two_burns() {
         let vault_address = test_vault_address();
         let owner = test_receiver();
         let user = address!("0x3333333333333333333333333333333333333333");
@@ -760,8 +814,11 @@ mod tests {
 
         let service = create_service_with_asserter(asserter);
 
-        let result = service
-            .burn_multiple_receipts(MultiBurnParams {
+        let detected_tx_hash = b256!(
+            "0xabababababababababababababababababababababababababababababababab"
+        );
+        let submitted = service
+            .submit_burn(MultiBurnParams {
                 vault: vault_address,
                 burns: burns
                     .iter()
@@ -776,150 +833,29 @@ mod tests {
                 owner,
                 user,
                 issuer_request_id: test_issuer_redemption_id(),
+                detected_tx_hash,
             })
             .await;
+
+        assert!(submitted.is_ok(), "Expected Ok but got: {submitted:?}");
+        let submitted = submitted.unwrap();
+
+        let result =
+            service.confirm_burn(&submitted.fireblocks_tx_id, U256::ZERO).await;
 
         assert!(result.is_ok(), "Expected Ok but got: {result:?}");
         let multi_result = result.unwrap();
 
         assert_eq!(multi_result.tx_hash, tx_hash);
-        assert_eq!(multi_result.burns.len(), 2, "Should have 2 burn results");
+        assert_eq!(multi_result.burns.len(), 2);
         assert_eq!(multi_result.burns[0].receipt_id, U256::from(1));
         assert_eq!(multi_result.burns[0].shares_burned, U256::from(100));
         assert_eq!(multi_result.burns[1].receipt_id, U256::from(2));
         assert_eq!(multi_result.burns[1].shares_burned, U256::from(50));
-        assert_eq!(multi_result.dust_returned, U256::ZERO);
-        assert_eq!(multi_result.gas_used, 0x8000);
-        assert_eq!(multi_result.block_number, 0x9c4);
     }
 
     #[tokio::test]
-    async fn test_burn_multiple_receipts_with_dust_transfer() {
-        let vault_address = test_vault_address();
-        let owner = test_receiver();
-        let user = address!("0x4444444444444444444444444444444444444444");
-
-        let tx_hash = fixed_bytes!(
-            "0xfeedface feedface feedface feedface feedface feedface feedface feedface"
-        );
-
-        let burns = vec![(U256::from(42), U256::from(1000))];
-        let dust_shares = U256::from(123);
-
-        let receipt = create_multi_withdraw_receipt(
-            vault_address,
-            tx_hash,
-            owner,
-            user,
-            burns.clone(),
-        );
-
-        let asserter = Asserter::new();
-        setup_asserter_for_transaction(&asserter, tx_hash, &receipt);
-
-        let service = create_service_with_asserter(asserter);
-
-        let result = service
-            .burn_multiple_receipts(MultiBurnParams {
-                vault: vault_address,
-                burns: burns
-                    .iter()
-                    .map(|(receipt_id, burn_shares)| MultiBurnEntry {
-                        receipt_id: *receipt_id,
-                        burn_shares: *burn_shares,
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    })
-                    .collect(),
-                dust_shares,
-                owner,
-                user,
-                issuer_request_id: test_issuer_redemption_id(),
-            })
-            .await;
-
-        assert!(result.is_ok(), "Expected Ok but got: {result:?}");
-        let multi_result = result.unwrap();
-
-        assert_eq!(
-            multi_result.dust_returned, dust_shares,
-            "Dust should be returned"
-        );
-        assert_eq!(multi_result.burns.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_burn_multiple_receipts_parses_three_withdraw_events() {
-        let vault_address = test_vault_address();
-        let owner = test_receiver();
-        let user = address!("0x5555555555555555555555555555555555555555");
-
-        let tx_hash = fixed_bytes!(
-            "0xaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd"
-        );
-
-        let burns = vec![
-            (U256::from(10), U256::from(500)),
-            (U256::from(20), U256::from(300)),
-            (U256::from(30), U256::from(200)),
-        ];
-
-        let receipt = create_multi_withdraw_receipt(
-            vault_address,
-            tx_hash,
-            owner,
-            user,
-            burns.clone(),
-        );
-
-        let asserter = Asserter::new();
-        setup_asserter_for_transaction(&asserter, tx_hash, &receipt);
-
-        let service = create_service_with_asserter(asserter);
-
-        let result = service
-            .burn_multiple_receipts(MultiBurnParams {
-                vault: vault_address,
-                burns: burns
-                    .iter()
-                    .map(|(receipt_id, burn_shares)| MultiBurnEntry {
-                        receipt_id: *receipt_id,
-                        burn_shares: *burn_shares,
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    })
-                    .collect(),
-                dust_shares: U256::ZERO,
-                owner,
-                user,
-                issuer_request_id: test_issuer_redemption_id(),
-            })
-            .await;
-
-        assert!(result.is_ok(), "Expected Ok but got: {result:?}");
-        let multi_result = result.unwrap();
-
-        assert_eq!(
-            multi_result.burns.len(),
-            3,
-            "Should parse all 3 Withdraw events"
-        );
-
-        // Verify each burn was parsed correctly
-        for (i, (expected_id, expected_shares)) in burns.iter().enumerate() {
-            assert_eq!(
-                multi_result.burns[i].receipt_id, *expected_id,
-                "Burn {i} receipt_id mismatch"
-            );
-            assert_eq!(
-                multi_result.burns[i].shares_burned, *expected_shares,
-                "Burn {i} shares_burned mismatch"
-            );
-        }
-    }
-
-    #[tokio::test]
-    async fn test_burn_multiple_receipts_returns_error_on_missing_events() {
+    async fn test_submit_burn_returns_error_on_missing_events() {
         let vault_address = test_vault_address();
         let owner = test_receiver();
         let user = address!("0x6666666666666666666666666666666666666666");
@@ -928,7 +864,6 @@ mod tests {
             "0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
         );
 
-        // Empty receipt with no Withdraw events - simulates failed transaction
         let receipt = create_empty_receipt(vault_address, tx_hash);
 
         let asserter = Asserter::new();
@@ -937,34 +872,28 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let result = service
-            .burn_multiple_receipts(MultiBurnParams {
+            .submit_burn(MultiBurnParams {
                 vault: vault_address,
-                burns: vec![
-                    MultiBurnEntry {
-                        receipt_id: U256::from(1),
-                        burn_shares: U256::from(100),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    },
-                    MultiBurnEntry {
-                        receipt_id: U256::from(2),
-                        burn_shares: U256::from(200),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    },
-                ],
+                burns: vec![MultiBurnEntry {
+                    receipt_id: U256::from(1),
+                    burn_shares: U256::from(100),
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
                 dust_shares: U256::ZERO,
                 owner,
                 user,
                 issuer_request_id: test_issuer_redemption_id(),
+                detected_tx_hash: b256!(
+                    "0xabababababababababababababababababababababababababababababababab"
+                ),
             })
             .await;
 
         assert!(result.is_err(), "Expected Err but got Ok: {result:?}");
-        let err = result.unwrap_err();
-        assert!(
-            matches!(err, VaultError::EventNotFound { .. }),
-            "Expected EventNotFound but got: {err:?}"
-        );
+        assert!(matches!(
+            result.unwrap_err(),
+            VaultError::EventNotFound { .. }
+        ));
     }
 }


### PR DESCRIPTION
## Motivation

During the 2026-05-07 incident, mint and burn transactions submitted to Fireblocks were lost when the bot crashed between submitting the transaction and recording the result. The old design treated submission + on-chain confirmation as a single atomic operation (`mint_and_transfer_shares` / `burn_multiple_receipts`), so a crash during the long-running confirmation poll left no record of the Fireblocks transaction ID. Recovery would then resubmit a *new* transaction, risking double-mints or double-burns.

Additionally, `externalTxId` included a timestamp, making it unique per call — so even resubmitting the same logical operation would succeed on Fireblocks instead of being rejected as a duplicate.

## Solution

### 1. Split `VaultService` into submit + confirm

The `VaultService` trait now separates submission from confirmation:
- `submit_mint` / `submit_burn` — encode calldata and submit to the signing backend, returning a `SubmittedTx { external_tx_id, fireblocks_tx_id }`
- `confirm_mint` / `confirm_burn` — poll a previously submitted transaction until completion and parse on-chain events

Both `FireblocksVaultService` and `RealBlockchainService` (local dev) implement this split. The local backend caches results from submit for confirm to return, with fallback to re-fetching from chain if the cache is empty (process restart).

### 2. Deterministic `externalTxId`

Changed from `{timestamp}-{operation}-{issuer_request_id}` to `{operation}-{issuer_request_id}` (mint) and `{operation}-{detected_tx_hash}` (burn). This makes the ID stable across retries so Fireblocks rejects duplicate submissions instead of creating new transactions.

When a duplicate `externalTxId` is detected (HTTP 409/400), `FireblocksVaultService` automatically looks up the existing transaction via `get_transaction_by_external_id` and returns its Fireblocks tx ID for polling.

### 3. New intermediate CQRS events and aggregate states

**Mint aggregate:**
- New `Deposit` command is now pure (no network call) — records intent, transitions `JournalConfirmed → Minting`
- New `SubmitMint` command — submits to backend, emits `FireblocksSubmitted` event, transitions `Minting → FireblocksSubmitted`
- New `ConfirmMint` command — polls backend, emits `TokensMinted` or `MintingFailed`
- New `FireblocksSubmitted` aggregate state stores `external_tx_id` and `fireblocks_tx_id` for crash recovery

**Redemption aggregate:**
- `BurnTokens` command now only submits (emits `BurnFireblocksSubmitted`)
- New `ConfirmBurn` command polls and emits `TokensBurned`
- New `BurnSubmitted` aggregate state with tx metadata
- `BurnRecord` derives `Eq` for use in assertions
- Removed `RetryBurn` command — BurnFailed recovery now uses `ResumeBurn → BurnTokens → ConfirmBurn`
- `RecordBurnFailure` now accepts from both `Burning` and `BurnSubmitted` states, carries optional `fireblocks_tx_id` and `planned_burns` for recovery

### 4. Recovery paths

**Mint recovery (`handle_recover_incomplete`):**
- From `Minting` — submits and persists `FireblocksSubmitted` (next recovery pass confirms)
- From `FireblocksSubmitted` — confirms the existing transaction
- From `MintingFailed` with `FireblocksSubmitted` predecessor — confirms the known tx ID

**Burn recovery (`BurnManager`):**
- From `BurnSubmitted` — confirms existing Fireblocks transaction
- From `BurnFailed` with `fireblocks_tx_id` — calls `confirm_burn` on existing tx; on failure, marks as `Failed` (not `BurnFailed`) to break the retry loop
- From `BurnFailed` without `fireblocks_tx_id` — resumes burn via standard `ResumeBurn → BurnTokens → ConfirmBurn` flow

### 5. View changes

- `BurnFailed` view now carries optional `fireblocks_tx_id` and `planned_burns` (with `#[serde(default)]` for backward compat)
- Both `FireblocksSubmitted` (mint) and `BurnFireblocksSubmitted` (redemption) are internal details — views stay in their parent state (Minting/Burning)

### Files changed

- `src/vault/mod.rs` — `VaultService` trait split, new `SubmittedTx` type, `MultiBurnParams` gains `detected_tx_hash`
- `src/vault/service.rs` — `RealBlockchainService` split with result caching
- `src/fireblocks/vault_service.rs` — `FireblocksVaultService` split, deterministic `externalTxId`, duplicate detection + recovery via `get_transaction_by_external_id`
- `src/vault/mock.rs` — `MockVaultService` updated for split API with pending result caching
- `src/mint/cmd.rs`, `src/mint/event.rs`, `src/mint/mod.rs` — New commands, events, `FireblocksSubmitted` state, updated recovery logic
- `src/mint/view.rs`, `src/receipt_inventory/view.rs` — Handle new events
- `src/mint/api/confirm.rs` — 4-step flow: Deposit → SubmitMint → ConfirmMint → SendCallback
- `src/redemption/cmd.rs`, `src/redemption/event.rs`, `src/redemption/mod.rs` — New `ConfirmBurn`, `BurnFireblocksSubmitted`, `BurnSubmitted` state, removed `RetryBurn`
- `src/redemption/view.rs` — `BurnFailed` carries tx metadata
- `src/redemption/burn_manager.rs` — Two-step burn flow, `BurnSubmitted` recovery, `BurnFailed` with existing tx recovery
- `SPEC.md` — Updated state machines, command/event mappings

### DEPLOYMENT NOTE

The burn `externalTxId` format changed from `burn-{4_byte_request_id}` to `burn-0x{full_detected_tx_hash}`. **Drain all in-flight burn transactions before deploying** to avoid `externalTxId` mismatches on retry.

## Testing

- New unit tests for deterministic `externalTxId` (stable across calls, differs by operation)
- 7 new tests for duplicate `externalTxId` detection (HTTP 409/400 with various bodies, non-response errors)
- Updated `MockVaultService` tests for split submit/confirm API
- New `test_recover_burn_submitted_confirms_existing_transaction` — verifies BurnSubmitted recovery confirms without resubmitting
- Updated mint happy-path test to exercise 6-event flow (Initiated → JournalConfirmed → MintingStarted → FireblocksSubmitted → TokensMinted → MintCompleted)
- Updated redemption tests for `BurnFireblocksSubmitted` event assertions

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
