### PR TITLE
fix: remove deleted sqlite-es crate from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,12 +17,10 @@ COPY flake.nix flake.lock ./
 RUN nix develop --command echo "Nix dev env ready"
 
 COPY Cargo.toml Cargo.lock ./
-COPY crates/sqlite-es/Cargo.toml ./crates/sqlite-es/
 
-RUN mkdir -p src crates/sqlite-es/src && \
+RUN mkdir -p src && \
     echo 'fn main() {}' > src/main.rs && \
-    touch src/lib.rs && \
-    touch crates/sqlite-es/src/lib.rs
+    touch src/lib.rs
 
 RUN nix develop --command cargo chef prepare --recipe-path recipe.json
 


### PR DESCRIPTION
## Motivation

The Docker build (`build-and-push` CI job) fails because the Dockerfile still
copies `crates/sqlite-es/Cargo.toml`, which was removed in #151 ("rm sqlite-es
crate in favor of event-sorcery repo").

## Solution

Remove the `COPY crates/sqlite-es/Cargo.toml` line and the corresponding
`mkdir`/`touch` stubs for `crates/sqlite-es/src/lib.rs` from the cargo-chef
dependency caching stage.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Closes RAI-578