### PR TITLE
fix: mint recovery sends callback in one command, enrich /admin/stuck

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -12,15 +12,17 @@ use crate::Quantity;
 use crate::alpaca::{AlpacaService, RedeemRequestStatus, TokenizationRequest};
 use crate::auth::InternalAuth;
 use crate::mint::{
-    IssuerMintRequestId, MintCommand, MintView, TokenizationRequestId,
-    find_all_recoverable_mints, find_by_issuer_request_id,
+    IssuerMintRequestId, MintCommand, MintEvent, MintView,
+    TokenizationRequestId, find_all_recoverable_mints,
+    find_by_issuer_request_id,
 };
 use crate::redemption::{
     BurnRecord, IssuerRedemptionRequestId, RedemptionCommand, RedemptionError,
     RedemptionEvent, RedemptionMetadata, RedemptionView, find_stuck,
 };
+use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{FireblocksTxStatus, VaultService};
-use crate::{MintCqrs, RedemptionCqrs, RedemptionEventStore};
+use crate::{MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore};
 
 #[derive(Debug, Clone, Copy, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -46,6 +48,16 @@ pub(crate) struct StuckAggregate {
     state: String,
     detail: String,
     timestamp: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    underlying: Option<UnderlyingSymbol>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quantity: Option<Quantity>,
+    /// Fireblocks transaction ID associated with this aggregate's current
+    /// stuck step. For mints, sourced from the most recent
+    /// `FireblocksSubmitted` event. For redemptions, populated only on
+    /// `BurnFailed` (the view carries it for that variant).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fireblocks_tx_id: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -655,11 +667,12 @@ pub(crate) async fn close_mint(
     }))
 }
 
-#[tracing::instrument(skip(_auth, pool))]
+#[tracing::instrument(skip(_auth, pool, mint_event_store))]
 #[get("/admin/stuck")]
 pub(crate) async fn list_stuck(
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
+    mint_event_store: &rocket::State<MintEventStore>,
 ) -> Result<Json<StuckResponse>, Status> {
     let mut stuck = Vec::new();
 
@@ -669,33 +682,12 @@ pub(crate) async fn list_stuck(
         Status::InternalServerError
     })?;
 
-    for (id, view) in stuck_redemptions {
-        let (tokenization_request_id, state, detail, timestamp) = match &view {
-            RedemptionView::Failed { reason, failed_at, .. } => {
-                (None, "Failed".to_string(), reason.clone(), *failed_at)
-            }
-            RedemptionView::BurnFailed {
-                tokenization_request_id,
-                error,
-                failed_at,
-                ..
-            } => (
-                Some(tokenization_request_id.clone()),
-                "BurnFailed".to_string(),
-                error.clone(),
-                *failed_at,
-            ),
-            _ => continue,
-        };
-
-        stuck.push(StuckAggregate {
-            aggregate_type: AggregateKind::Redemption,
-            aggregate_id: id.to_string(),
-            tokenization_request_id,
-            state,
-            detail,
-            timestamp,
-        });
+    for (issuer_redemption_request_id, view) in stuck_redemptions {
+        if let Some(entry) =
+            stuck_redemption_entry(&issuer_redemption_request_id, &view)
+        {
+            stuck.push(entry);
+        }
     }
 
     // Stuck mints (recoverable states)
@@ -705,63 +697,187 @@ pub(crate) async fn list_stuck(
             Status::InternalServerError
         })?;
 
-    for (id, view) in recoverable_mints {
-        let (tokenization_request_id, state, detail, timestamp) = match &view {
-            MintView::JournalConfirmed {
-                tokenization_request_id,
-                journal_confirmed_at,
-                ..
-            } => (
-                Some(tokenization_request_id.clone()),
-                "JournalConfirmed".to_string(),
-                "Waiting for deposit".to_string(),
-                *journal_confirmed_at,
-            ),
-            MintView::Minting {
-                tokenization_request_id,
-                minting_started_at,
-                ..
-            } => (
-                Some(tokenization_request_id.clone()),
-                "Minting".to_string(),
-                "Deposit in progress".to_string(),
-                *minting_started_at,
-            ),
-            MintView::MintingFailed {
-                tokenization_request_id,
-                error,
-                failed_at,
-                ..
-            } => (
-                Some(tokenization_request_id.clone()),
-                "MintingFailed".to_string(),
-                error.clone(),
-                *failed_at,
-            ),
-            MintView::CallbackPending {
-                tokenization_request_id,
-                minted_at,
-                ..
-            } => (
-                Some(tokenization_request_id.clone()),
-                "CallbackPending".to_string(),
-                "Waiting for callback".to_string(),
-                *minted_at,
-            ),
-            _ => continue,
+    for (issuer_mint_request_id, view) in recoverable_mints {
+        let Some((tokenization_request_id, state, detail, timestamp)) =
+            mint_view_summary(&view)
+        else {
+            continue;
         };
+
+        let (underlying, quantity) = mint_view_asset(&view);
+        let fireblocks_tx_id = latest_fireblocks_tx_id(
+            mint_event_store.inner(),
+            &issuer_mint_request_id.to_string(),
+        )
+        .await;
 
         stuck.push(StuckAggregate {
             aggregate_type: AggregateKind::Mint,
-            aggregate_id: id.to_string(),
+            aggregate_id: issuer_mint_request_id.to_string(),
             tokenization_request_id,
             state,
             detail,
             timestamp,
+            underlying,
+            quantity,
+            fireblocks_tx_id,
         });
     }
 
     Ok(Json(StuckResponse { stuck }))
+}
+
+fn stuck_redemption_entry(
+    issuer_redemption_request_id: &IssuerRedemptionRequestId,
+    view: &RedemptionView,
+) -> Option<StuckAggregate> {
+    let (
+        tokenization_request_id,
+        state,
+        detail,
+        timestamp,
+        underlying,
+        quantity,
+        fireblocks_tx_id,
+    ) = match view {
+        RedemptionView::Failed { reason, failed_at, .. } => (
+            None,
+            "Failed".to_string(),
+            reason.clone(),
+            *failed_at,
+            None,
+            None,
+            None,
+        ),
+        RedemptionView::BurnFailed {
+            tokenization_request_id,
+            underlying,
+            quantity,
+            error,
+            failed_at,
+            fireblocks_tx_id,
+            ..
+        } => (
+            Some(tokenization_request_id.clone()),
+            "BurnFailed".to_string(),
+            error.clone(),
+            *failed_at,
+            Some(underlying.clone()),
+            Some(quantity.clone()),
+            fireblocks_tx_id.clone(),
+        ),
+        // find_stuck only returns Failed/BurnFailed; surface any other
+        // variant as a real mismatch rather than fabricating placeholder
+        // data that could mislead operators.
+        _ => return None,
+    };
+
+    Some(StuckAggregate {
+        aggregate_type: AggregateKind::Redemption,
+        aggregate_id: issuer_redemption_request_id.to_string(),
+        tokenization_request_id,
+        state,
+        detail,
+        timestamp,
+        underlying,
+        quantity,
+        fireblocks_tx_id,
+    })
+}
+
+fn mint_view_summary(
+    view: &MintView,
+) -> Option<(Option<TokenizationRequestId>, String, String, DateTime<Utc>)> {
+    match view {
+        MintView::JournalConfirmed {
+            tokenization_request_id,
+            journal_confirmed_at,
+            ..
+        } => Some((
+            Some(tokenization_request_id.clone()),
+            "JournalConfirmed".to_string(),
+            "Waiting for deposit".to_string(),
+            *journal_confirmed_at,
+        )),
+        MintView::Minting {
+            tokenization_request_id,
+            minting_started_at,
+            ..
+        } => Some((
+            Some(tokenization_request_id.clone()),
+            "Minting".to_string(),
+            "Deposit in progress".to_string(),
+            *minting_started_at,
+        )),
+        MintView::MintingFailed {
+            tokenization_request_id,
+            error,
+            failed_at,
+            ..
+        } => Some((
+            Some(tokenization_request_id.clone()),
+            "MintingFailed".to_string(),
+            error.clone(),
+            *failed_at,
+        )),
+        MintView::CallbackPending {
+            tokenization_request_id,
+            minted_at,
+            ..
+        } => Some((
+            Some(tokenization_request_id.clone()),
+            "CallbackPending".to_string(),
+            "Waiting for callback".to_string(),
+            *minted_at,
+        )),
+        _ => None,
+    }
+}
+
+fn mint_view_asset(
+    view: &MintView,
+) -> (Option<UnderlyingSymbol>, Option<Quantity>) {
+    match view {
+        MintView::JournalConfirmed { underlying, quantity, .. }
+        | MintView::Minting { underlying, quantity, .. }
+        | MintView::MintingFailed { underlying, quantity, .. }
+        | MintView::CallbackPending { underlying, quantity, .. } => {
+            (Some(underlying.clone()), Some(quantity.clone()))
+        }
+        _ => (None, None),
+    }
+}
+
+/// Returns the `fireblocks_tx_id` from the most recent `FireblocksSubmitted`
+/// event in this mint's history, if one exists. Used to surface the in-flight
+/// Fireblocks transaction in the stuck-aggregate response so operators don't
+/// have to grep logs.
+///
+/// Returns `None` if loading events fails — the caller logs that as a warning
+/// and the stuck listing still includes the aggregate without this hint.
+async fn latest_fireblocks_tx_id(
+    event_store: &crate::SqliteEventStore<crate::mint::Mint>,
+    aggregate_id: &str,
+) -> Option<String> {
+    let events = match event_store.load_events(aggregate_id).await {
+        Ok(events) => events,
+        Err(err) => {
+            warn!(
+                target: "admin",
+                aggregate_id = aggregate_id,
+                error = %err,
+                "Failed to load mint events for fireblocks_tx_id lookup"
+            );
+            return None;
+        }
+    };
+
+    events.into_iter().rev().find_map(|event| match event.payload {
+        MintEvent::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+            Some(fireblocks_tx_id)
+        }
+        _ => None,
+    })
 }
 
 /// Response for the Fireblocks transaction status lookup endpoint.

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -655,10 +655,17 @@ impl Mint {
                 self.handle_deposit(issuer_request_id)
             }
             Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
-                self.handle_confirm_mint(
+                let deposit_events = self
+                    .handle_confirm_mint(
+                        services,
+                        issuer_request_id.clone(),
+                        fireblocks_tx_id.clone(),
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
                     issuer_request_id,
-                    fireblocks_tx_id.clone(),
+                    deposit_events,
                 )
                 .await
             }
@@ -672,20 +679,34 @@ impl Mint {
                     _ => None,
                 };
 
-                self.handle_recover_incomplete(
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        None,
+                        known_tx_id,
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
                     issuer_request_id,
-                    None,
-                    known_tx_id,
+                    deposit_events,
                 )
                 .await
             }
             Self::Minting { .. } => {
-                self.handle_recover_incomplete(
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        None,
+                        None,
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
                     issuer_request_id,
-                    None,
-                    None,
+                    deposit_events,
                 )
                 .await
             }
@@ -707,10 +728,6 @@ impl Mint {
     /// (when the deposit creates a new on-chain receipt). Handling
     /// `CallbackPending` here would race with the normal flow's
     /// `SendCallback` command, causing duplicate Alpaca callbacks.
-    ///
-    /// Instead, when the deposit recovery succeeds and the mint moves to
-    /// `CallbackPending`, this handler immediately sends the callback in
-    /// the same command execution, atomically advancing to `Completed`.
     async fn handle_recover_from_receipt(
         &self,
         services: &MintServices,
@@ -739,40 +756,76 @@ impl Mint {
                         known_tx_id,
                     )
                     .await?;
-
-                // If the deposit failed, return early with just the failure
-                // event — no callback should be sent.
-                let deposit_succeeded = deposit_events.iter().any(|event| {
-                    matches!(
-                        event,
-                        MintEvent::TokensMinted { .. }
-                            | MintEvent::ExistingMintRecovered { .. }
-                    )
-                });
-
-                if !deposit_succeeded {
-                    return Ok(deposit_events);
-                }
-
-                // Construct intermediate state to send callback from.
-                let mut intermediate = self.clone();
-                for event in &deposit_events {
-                    intermediate.apply(event.clone());
-                }
-
-                let callback_events = intermediate
-                    .handle_send_callback(services, issuer_request_id)
-                    .await?;
-
-                let all_events =
-                    deposit_events.into_iter().chain(callback_events).collect();
-
-                Ok(all_events)
+                self.advance_through_callback(
+                    services,
+                    issuer_request_id,
+                    deposit_events,
+                )
+                .await
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
             }),
         }
+    }
+
+    /// If `deposit_events` contain a successful deposit (`TokensMinted` or
+    /// `ExistingMintRecovered`), advance through `CallbackPending` by
+    /// sending the Alpaca callback in the same command execution and
+    /// return the combined event list. Otherwise return `deposit_events`
+    /// unchanged.
+    ///
+    /// Keeps recovery atomic: a single `Recover` command takes the
+    /// aggregate from a stuck pre-callback state straight to `Completed`,
+    /// so the aggregate never lingers in `CallbackPending` between
+    /// commands and so any recovery entry-point (admin reprocess, the
+    /// boot-time loop, or receipt-discovery handler) picks up the same
+    /// advancing behavior.
+    async fn advance_through_callback(
+        &self,
+        services: &MintServices,
+        issuer_request_id: IssuerMintRequestId,
+        deposit_events: Vec<MintEvent>,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let deposit_succeeded = deposit_events.iter().any(|event| {
+            matches!(
+                event,
+                MintEvent::TokensMinted { .. }
+                    | MintEvent::ExistingMintRecovered { .. }
+            )
+        });
+
+        if !deposit_succeeded {
+            return Ok(deposit_events);
+        }
+
+        let mut intermediate = self.clone();
+        for event in &deposit_events {
+            intermediate.apply(event.clone());
+        }
+
+        // If callback delivery fails after a successful on-chain deposit,
+        // preserve the deposit events so the aggregate advances to
+        // CallbackPending. The next recovery picks up from there instead
+        // of re-running the deposit path.
+        let callback_events = match intermediate
+            .handle_send_callback(services, issuer_request_id.clone())
+            .await
+        {
+            Ok(events) => events,
+            Err(err) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Callback failed after successful deposit; \
+                     keeping mint in CallbackPending"
+                );
+                return Ok(deposit_events);
+            }
+        };
+
+        Ok(deposit_events.into_iter().chain(callback_events).collect())
     }
 
     async fn handle_recover_incomplete(

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -141,7 +141,7 @@ mod tests {
         )
     }
 
-    fn minting_failed_events(
+    fn minting_events(
         issuer_request_id: &IssuerMintRequestId,
     ) -> Vec<MintEvent> {
         let now = Utc::now();
@@ -166,12 +166,38 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 started_at: now,
             },
-            MintEvent::MintingFailed {
-                issuer_request_id: issuer_request_id.clone(),
-                error: "timeout".to_string(),
-                failed_at: now,
-            },
         ]
+    }
+
+    fn fireblocks_submitted_events(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let now = Utc::now();
+        let mut events = minting_events(issuer_request_id);
+
+        events.push(MintEvent::FireblocksSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            fireblocks_tx_id: "fb-tx-123".to_string(),
+            submitted_at: now,
+        });
+
+        events
+    }
+
+    fn minting_failed_events(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let now = Utc::now();
+        let mut events = minting_events(issuer_request_id);
+
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "timeout".to_string(),
+            failed_at: now,
+        });
+
+        events
     }
 
     fn callback_pending_events(
@@ -276,9 +302,12 @@ mod tests {
             log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
             1,
         );
+        // A single Recover command advances MintingFailed → CallbackPending
+        // → Completed atomically via advance_through_callback, so the
+        // drive_recovery loop only needs one successful step.
         assert_eq!(
             log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            2,
+            1,
         );
     }
 
@@ -309,6 +338,126 @@ mod tests {
         );
         assert_eq!(
             log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
+            1,
+        );
+    }
+
+    /// A single `Recover` command on a mint stuck in `Minting` must reach
+    /// `Completed` in one execution when an on-chain receipt is already
+    /// present — the deposit event and the callback must be committed
+    /// together so the aggregate never lingers in `CallbackPending`.
+    #[traced_test]
+    #[tokio::test]
+    async fn single_recover_command_from_minting_reaches_completed() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = minting_events(&issuer_request_id);
+        let fixture = setup_with_receipt_and_events(events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(context.aggregate(), Mint::Completed { .. }),
+            "Expected Completed state after one Recover, got: {}",
+            context.aggregate().state_name()
+        );
+        let test = "single_recover_command_from_minting_reaches_completed";
+        assert_eq!(
+            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
+            1,
+        );
+    }
+
+    /// Same invariant for the `MintingFailed` starting state.
+    #[traced_test]
+    #[tokio::test]
+    async fn single_recover_command_from_minting_failed_reaches_completed() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = minting_failed_events(&issuer_request_id);
+        let fixture = setup_with_receipt_and_events(events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(context.aggregate(), Mint::Completed { .. }),
+            "Expected Completed state after one Recover, got: {}",
+            context.aggregate().state_name()
+        );
+        let test =
+            "single_recover_command_from_minting_failed_reaches_completed";
+        assert_eq!(
+            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
+            1,
+        );
+    }
+
+    /// Same invariant for the `FireblocksSubmitted` starting state — the
+    /// mock vault's `confirm_mint` succeeds, so `TokensMinted` and
+    /// `MintCompleted` must be emitted in one command.
+    #[traced_test]
+    #[tokio::test]
+    async fn single_recover_command_from_fireblocks_submitted_reaches_completed()
+     {
+        let issuer_request_id = test_issuer_request_id();
+        let events = fireblocks_submitted_events(&issuer_request_id);
+        // No pre-existing receipt — the mock confirm path produces TokensMinted.
+        let fixture = MintTestFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+
+        assert!(
+            matches!(context.aggregate(), Mint::Completed { .. }),
+            "Expected Completed state after one Recover, got: {}",
+            context.aggregate().state_name()
+        );
+        let test = "single_recover_command_from_fireblocks_submitted_reaches_completed";
+        assert_eq!(
+            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
             1,
         );
     }


### PR DESCRIPTION
## Motivation

Two operational fixes from the 2026-05-18 incident on mint `5f30e910-1856-4261-881d-5fe8c2cc121f` (tokenization request `3c4fefbb-7b8c-4fd6-8d73-18bb7e7408d9`):

- `POST /admin/reprocess/mint` confirmed the on-chain deposit but left the aggregate in `CallbackPending` without sending the Alpaca callback. Operators had to call reprocess a second time. (RAI-599)
- `GET /admin/stuck` did not surface which asset/amount each stuck entry was for, or the in-flight Fireblocks tx id. Triaging required cross-referencing container logs. (RAI-600)

## Solution

**RAI-599** — `Mint::handle_recover_from_receipt` already advanced atomically through `CallbackPending` in a single command. `Mint::handle_recover` (the path behind `/admin/reprocess/mint`) did not.

This PR extracts the "if deposit succeeded, send the callback in the same command" logic into a shared `Mint::advance_through_callback` helper, called from both `handle_recover` (the `Minting`, `MintingFailed`, and `FireblocksSubmitted` arms) and `handle_recover_from_receipt`. Any future recovery entry-point inherits the atomic behavior by routing its deposit events through the helper.

**RAI-600** — `StuckAggregate` gains three optional fields:

- `underlying`: extracted from the mint or redemption view variants (present in all stuck mint states and in `RedemptionView::BurnFailed`).
- `quantity`: same.
- `fireblocks_tx_id`: for mints, sourced by scanning the aggregate's events for the most recent `MintEvent::FireblocksSubmitted`; for redemptions, taken from `RedemptionView::BurnFailed.fireblocks_tx_id`.

All three use `#[serde(skip_serializing_if = "Option::is_none")]` so existing consumers are unaffected. The `list_stuck` handler is refactored into a few small helpers (`stuck_redemption_entry`, `mint_view_summary`, `mint_view_asset`, `latest_fireblocks_tx_id`) to keep the per-entry assembly readable.

## Concrete impact

For the 2026-05-18 incident specifically:

- The 18:57 reprocess call would have finished the mint inline (deposit + callback) instead of needing the second 19:07 call.
- The `/admin/stuck` listing would have surfaced `underlying: AAPL`, the quantity, and Fireblocks tx `35de2cc7-e669-4674-bc16-ad5c509843ee` directly — no log grep required.

Closes RAI-599
Closes RAI-600

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Test plan

- [x] Three new tests in `src/mint/recovery.rs` — `single_recover_command_from_minting_reaches_completed`, `single_recover_command_from_minting_failed_reaches_completed`, `single_recover_command_from_fireblocks_submitted_reaches_completed` — assert that one `Recover` command advances each starting state to `Completed`.
- [x] Updated `minting_failed_with_receipt_recovers_to_completed` to expect one "Recovery step succeeded" log instead of two (the `drive_recovery` loop now needs one pass, not two).
- [x] `cargo test --workspace` passes (573 lib tests + integration).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] Smoke-test on staging: hit a stuck mint with `/admin/reprocess/mint` and verify a single call reaches `Completed`, and that `/admin/stuck` includes the new fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin stuck aggregates endpoint now displays enriched mint details: underlying asset symbol, quantity, and Fireblocks transaction ID for improved tracking visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
