### PR TITLE
fix: use Alpaca callback redeem endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,8 @@ endpoints.
 
 - `POST /v1/accounts/{account_id}/tokenization/callback/mint` - Confirm mint
   completed
-- `POST /v1/accounts/{account_id}/tokenization/redeem` - Initiate redemption
+- `POST /v1/accounts/{account_id}/tokenization/callback/redeem` - Initiate
+  redemption
 - `GET /v1/accounts/{account_id}/tokenization/requests` - Poll request status
 
 ## Mint Flow

--- a/SPEC.md
+++ b/SPEC.md
@@ -1189,7 +1189,7 @@ sequenceDiagram
     Blockchain->>Us: Transfer event detected
     Note right of Us: DetectRedemption command<br/>Event: RedemptionDetected<br/>Status: detected
 
-    Us->>Alpaca: POST /tokenization/redeem<br/>{issuer_request_id, qty, tx_hash}
+    Us->>Alpaca: POST /tokenization/callback/redeem<br/>{issuer_request_id, qty, tx_hash}
     Alpaca->>Us: {tokenization_request_id, status: "pending"}
     Note right of Us: RecordAlpacaCall command<br/>Event: AlpacaCalled<br/>Status: alpaca_called
 
@@ -1280,7 +1280,7 @@ struct TransferEvent {
 
 When we detect a redemption, we notify Alpaca.
 
-**Endpoint:** `POST /v1/accounts/{account_id}/tokenization/redeem`
+**Endpoint:** `POST /v1/accounts/{account_id}/tokenization/callback/redeem`
 
 Where `{account_id}` is our designated tokenization account ID at Alpaca.
 
@@ -1546,7 +1546,7 @@ We call these Alpaca endpoints:
 
 1. **`POST /v1/accounts/{account_id}/tokenization/callback/mint`** - Confirm
    mint completed
-2. **`POST /v1/accounts/{account_id}/tokenization/redeem`** - Initiate
+2. **`POST /v1/accounts/{account_id}/tokenization/callback/redeem`** - Initiate
    redemption
 3. **`GET /v1/accounts/{account_id}/tokenization/requests`** - List/poll
    requests

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -198,7 +198,7 @@ impl AlpacaService for RealAlpacaService {
         request: RedeemRequest,
     ) -> Result<RedeemResponse, AlpacaError> {
         let url = format!(
-            "{}/v1/accounts/{}/tokenization/redeem",
+            "{}/v1/accounts/{}/tokenization/callback/redeem",
             self.base_url.trim_end_matches('/'),
             self.account_id
         );
@@ -592,7 +592,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem")
+                .path("/v1/accounts/test-account/tokenization/callback/redeem")
                 .header("authorization", "Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ=")
                 .header("APCA-API-KEY-ID", "test-key")
                 .header("APCA-API-SECRET-KEY", "test-secret");
@@ -646,7 +646,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(200).json_body(serde_json::json!({
                 "tokenization_request_id": "tok-456",
                 "issuer_request_id": "red-abcdefab",
@@ -689,7 +689,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(401).body("Unauthorized");
         });
 
@@ -716,7 +716,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(403).body("Forbidden");
         });
 
@@ -743,7 +743,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(400).body("Invalid request");
         });
 
@@ -777,7 +777,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/my-special-account/tokenization/redeem");
+                .path("/v1/accounts/my-special-account/tokenization/callback/redeem");
             then.status(200).json_body(serde_json::json!({
                 "tokenization_request_id": "tok-789",
                 "issuer_request_id": "red-abcdefab",
@@ -819,7 +819,7 @@ mod tests {
         // Legacy auth requires both Basic auth AND the APCA headers
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem")
+                .path("/v1/accounts/test-account/tokenization/callback/redeem")
                 .header("authorization", "Basic bXlrZXk6bXlzZWNyZXQ=")
                 .header("APCA-API-KEY-ID", "mykey")
                 .header("APCA-API-SECRET-KEY", "mysecret");
@@ -863,7 +863,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem")
+                .path("/v1/accounts/test-account/tokenization/callback/redeem")
                 .header("content-type", "application/json")
                 .json_body(serde_json::json!({
                     "issuer_request_id": "red-abcdefab",
@@ -1340,7 +1340,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(401).body("Unauthorized");
         });
 
@@ -1368,7 +1368,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(400).body("Bad Request");
         });
 
@@ -1399,7 +1399,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(500).body("Internal Server Error");
         });
 
@@ -1645,7 +1645,7 @@ mod tests {
 
         let mock = server.mock(|when, then| {
             when.method(POST)
-                .path("/v1/accounts/test-account/tokenization/redeem");
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(200).body("invalid json");
         });
 

--- a/tests/harness/alpaca_mocks.rs
+++ b/tests/harness/alpaca_mocks.rs
@@ -39,7 +39,7 @@ pub fn setup_redemption_mocks(
 
     let redeem_mock = mock_alpaca.mock(|when, then| {
         when.method(POST)
-            .path("/v1/accounts/test-account/tokenization/redeem")
+            .path("/v1/accounts/test-account/tokenization/callback/redeem")
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);

--- a/tests/redemption.rs
+++ b/tests/redemption.rs
@@ -106,7 +106,7 @@ fn setup_redemption_mocks_with_shared_state(
 
     let redeem_mock = mock_alpaca.mock(|when, then| {
         when.method(POST)
-            .path("/v1/accounts/test-account/tokenization/redeem")
+            .path("/v1/accounts/test-account/tokenization/callback/redeem")
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);

--- a/tests/redemption_dust.rs
+++ b/tests/redemption_dust.rs
@@ -162,7 +162,7 @@ fn setup_redemption_mocks_with_qty_capture(
 
     let redeem_mock = mock_alpaca.mock(|when, then| {
         when.method(POST)
-            .path("/v1/accounts/test-account/tokenization/redeem")
+            .path("/v1/accounts/test-account/tokenization/callback/redeem")
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);


### PR DESCRIPTION
## Motivation

Alpaca's redemption API has moved from the legacy redeem path to the callback redeem path. The issuance bot was still posting redemption notifications to `/v1/accounts/{account_id}/tokenization/redeem`, which would call the wrong Alpaca endpoint for new redemption flows.

Closes [RAI-364](https://linear.app/makeitrain/issue/RAI-364/migrate-alpaca-redeem-endpoint-to-callbackredeem-path).

## Solution

Update the Alpaca redemption call path to use `/v1/accounts/{account_id}/tokenization/callback/redeem`.

Changed files:

- `src/alpaca/service.rs`: updates `RealAlpacaService::call_redeem_endpoint` to construct the callback redeem URL, and updates the Alpaca service unit tests to expect the new path.
- `tests/harness/alpaca_mocks.rs`: updates shared redemption integration mocks to match the new callback redeem endpoint.
- `tests/redemption.rs`: updates restart/shared-state redemption mocks to match the new endpoint.
- `tests/redemption_dust.rs`: updates quantity-capture redemption mocks to match the new endpoint.
- `SPEC.md`: updates the redemption flow sequence and Alpaca endpoint list.
- `README.md`: updates the documented Alpaca redemption endpoint.

No request/response payload shape changes are included in this PR.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Test plan

- [x] `nix develop -c cargo fmt --all -- --check`
- [x] `nix develop -c cargo test -q alpaca::service::tests::test_call_redeem_endpoint_success`
- [x] `nix develop -c cargo test -q alpaca::service::tests::test_call_redeem_endpoint_constructs_correct_url`
- [x] `nix develop -c cargo test -q --test redemption`
- [x] `nix develop -c cargo test -q --test redemption_dust`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Alpaca integration endpoint for token redemption callbacks to align with current API specifications. The service now routes all redemption requests through the properly configured endpoint path, ensuring seamless processing. Related documentation, test mocks, and test cases have been updated to reflect and validate this configuration change across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->