### PR TITLE
feat: surface Fireblocks subStatus on /admin/stuck and /admin/fireblocks/tx (RAI-621)

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -58,6 +58,11 @@ pub(crate) struct StuckAggregate {
     /// `BurnFailed` (the view carries it for that variant).
     #[serde(skip_serializing_if = "Option::is_none")]
     fireblocks_tx_id: Option<String>,
+    /// Live status of the Fireblocks transaction (subStatus, network tx
+    /// hashes). Best-effort: omitted when `fireblocks_tx_id` is missing,
+    /// the backend is non-Fireblocks, or the lookup itself fails.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fireblocks_status: Option<FireblocksTxStatus>,
 }
 
 #[derive(Debug, Serialize)]
@@ -421,10 +426,15 @@ async fn recover_post_alpaca(
                 );
                 return Err(Status::UnprocessableEntity);
             }
-            Ok(Some(FireblocksTxStatus::Failed { detail: fb_detail })) => {
+            Ok(Some(FireblocksTxStatus::Failed {
+                detail: fb_detail,
+                sub_status: fb_sub_status,
+                network_tx_hashes: _,
+            })) => {
                 info!(target: "admin", aggregate_id = %aggregate_id,
                     fireblocks_tx_id = %fb_tx_id,
                     fireblocks_status = %fb_detail,
+                    fireblocks_sub_status = ?fb_sub_status,
                     "Fireblocks tx failed, proceeding with ResumeBurn"
                 );
                 // Fall through to ResumeBurn below
@@ -667,12 +677,13 @@ pub(crate) async fn close_mint(
     }))
 }
 
-#[tracing::instrument(skip(_auth, pool, mint_event_store))]
+#[tracing::instrument(skip(_auth, pool, mint_event_store, vault_service))]
 #[get("/admin/stuck")]
 pub(crate) async fn list_stuck(
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
     mint_event_store: &rocket::State<MintEventStore>,
+    vault_service: &rocket::State<Arc<dyn VaultService>>,
 ) -> Result<Json<StuckResponse>, Status> {
     let mut stuck = Vec::new();
 
@@ -721,10 +732,43 @@ pub(crate) async fn list_stuck(
             underlying,
             quantity,
             fireblocks_tx_id,
+            fireblocks_status: None,
         });
     }
 
+    enrich_with_fireblocks_status(&mut stuck, vault_service.inner().as_ref())
+        .await;
+
     Ok(Json(StuckResponse { stuck }))
+}
+
+/// Best-effort enrichment: for every stuck entry with a `fireblocks_tx_id`,
+/// query the vault service for the live Fireblocks status (subStatus + network
+/// records) and attach it to the entry. Lookup failures and non-Fireblocks
+/// backends leave `fireblocks_status` as `None`; this is purely additive
+/// information for operators triaging stuck transactions.
+async fn enrich_with_fireblocks_status(
+    stuck: &mut [StuckAggregate],
+    vault_service: &dyn VaultService,
+) {
+    for entry in stuck.iter_mut() {
+        let Some(tx_id) = entry.fireblocks_tx_id.as_deref() else {
+            continue;
+        };
+
+        match vault_service.check_fireblocks_tx(tx_id).await {
+            Ok(Some(status)) => entry.fireblocks_status = Some(status),
+            Ok(None) => {}
+            Err(err) => {
+                warn!(target: "admin",
+                    aggregate_id = %entry.aggregate_id,
+                    fireblocks_tx_id = %tx_id,
+                    error = %err,
+                    "Failed to enrich stuck entry with Fireblocks status"
+                );
+            }
+        }
+    }
 }
 
 fn stuck_redemption_entry(
@@ -782,6 +826,7 @@ fn stuck_redemption_entry(
         underlying,
         quantity,
         fireblocks_tx_id,
+        fireblocks_status: None,
     })
 }
 
@@ -955,8 +1000,10 @@ mod tests {
     };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
-    use crate::vault::VaultService;
     use crate::vault::mock::MockVaultService;
+    use crate::vault::{FireblocksTxStatus, VaultService};
+
+    use super::{AggregateKind, StuckAggregate};
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
@@ -1604,5 +1651,159 @@ mod tests {
         let body = response.into_string().await.unwrap();
         assert!(body.contains("Burning"));
         assert!(logs_contain_at!(Level::INFO, &["recovered", "Burning"]));
+    }
+
+    /// Stub VaultService that returns a pre-canned `FireblocksTxStatus` for a
+    /// specific tx id and `None` for everything else. Lets us drive
+    /// `enrich_with_fireblocks_status` without spinning up Fireblocks.
+    struct StubFireblocksVault {
+        tx_id: String,
+        response: FireblocksTxStatus,
+    }
+
+    #[async_trait]
+    impl VaultService for StubFireblocksVault {
+        async fn submit_mint(
+            &self,
+            _vault: alloy::primitives::Address,
+            _assets: alloy::primitives::U256,
+            _bot: alloy::primitives::Address,
+            _user: alloy::primitives::Address,
+            _receipt_info: crate::vault::ReceiptInformation,
+        ) -> Result<crate::vault::SubmittedTx, crate::vault::VaultError>
+        {
+            unimplemented!("not used in enrichment tests")
+        }
+
+        async fn confirm_mint(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<crate::vault::MintResult, crate::vault::VaultError>
+        {
+            unimplemented!("not used in enrichment tests")
+        }
+
+        async fn get_share_balance(
+            &self,
+            _vault: alloy::primitives::Address,
+            _owner: alloy::primitives::Address,
+        ) -> Result<alloy::primitives::U256, crate::vault::VaultError> {
+            unimplemented!("not used in enrichment tests")
+        }
+
+        async fn check_fireblocks_tx(
+            &self,
+            fireblocks_tx_id: &str,
+        ) -> Result<Option<FireblocksTxStatus>, crate::vault::VaultError>
+        {
+            if fireblocks_tx_id == self.tx_id {
+                Ok(Some(self.response.clone()))
+            } else {
+                Ok(None)
+            }
+        }
+
+        async fn submit_burn(
+            &self,
+            _params: crate::vault::MultiBurnParams,
+        ) -> Result<crate::vault::SubmittedTx, crate::vault::VaultError>
+        {
+            unimplemented!("not used in enrichment tests")
+        }
+
+        async fn confirm_burn(
+            &self,
+            _fireblocks_tx_id: &str,
+            _dust_shares: alloy::primitives::U256,
+        ) -> Result<crate::vault::MultiBurnResult, crate::vault::VaultError>
+        {
+            unimplemented!("not used in enrichment tests")
+        }
+    }
+
+    fn stuck_entry(id: &str, fireblocks_tx_id: Option<&str>) -> StuckAggregate {
+        StuckAggregate {
+            aggregate_type: AggregateKind::Mint,
+            aggregate_id: id.to_string(),
+            tokenization_request_id: None,
+            state: "MintingFailed".to_string(),
+            detail: "Fireblocks transaction X reached terminal status: Failed"
+                .to_string(),
+            timestamp: Utc::now(),
+            underlying: None,
+            quantity: None,
+            fireblocks_tx_id: fireblocks_tx_id.map(str::to_owned),
+            fireblocks_status: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn enrich_populates_status_for_matching_tx_id() {
+        let tx_id = "a29e5027-1e44-4a66-b78b-b579e55757db";
+        let stub = StubFireblocksVault {
+            tx_id: tx_id.to_string(),
+            response: FireblocksTxStatus::Failed {
+                detail: "Failed".to_string(),
+                sub_status: Some("INSUFFICIENT_FUNDS".to_string()),
+                network_tx_hashes: vec![
+                    "0xabc0000000000000000000000000000000000000000000000000000000000001"
+                        .to_string(),
+                ],
+            },
+        };
+
+        let mut entries = vec![stuck_entry("mint-1", Some(tx_id))];
+        super::enrich_with_fireblocks_status(&mut entries, &stub).await;
+
+        match entries[0].fireblocks_status.as_ref().expect(
+            "matching tx id should produce a populated fireblocks_status",
+        ) {
+            FireblocksTxStatus::Failed {
+                detail,
+                sub_status,
+                network_tx_hashes,
+            } => {
+                assert_eq!(detail, "Failed");
+                assert_eq!(sub_status.as_deref(), Some("INSUFFICIENT_FUNDS"),);
+                assert_eq!(network_tx_hashes.len(), 1);
+            }
+            other => panic!("unexpected status: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn enrich_leaves_entries_without_tx_id_untouched() {
+        let stub = StubFireblocksVault {
+            tx_id: "any".to_string(),
+            response: FireblocksTxStatus::Pending,
+        };
+
+        let mut entries = vec![
+            stuck_entry("redemption-no-tx", None),
+            stuck_entry("redemption-unknown-tx", Some("unrelated-tx")),
+        ];
+
+        super::enrich_with_fireblocks_status(&mut entries, &stub).await;
+
+        // Entry without a tx id is skipped entirely.
+        assert!(entries[0].fireblocks_status.is_none());
+        // Entry with a tx id the stub doesn't recognise gets `Ok(None)` back
+        // from the vault service, which maps to a left-as-None status.
+        assert!(entries[1].fireblocks_status.is_none());
+    }
+
+    #[test]
+    fn failed_status_serializes_with_sub_status_and_network_hashes() {
+        let status = FireblocksTxStatus::Failed {
+            detail: "Failed".to_string(),
+            sub_status: Some("BLOCKED_BY_POLICY".to_string()),
+            network_tx_hashes: vec!["0xdeadbeef".to_string()],
+        };
+
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["status"], "failed");
+        assert_eq!(json["detail"], "Failed");
+        assert_eq!(json["sub_status"], "BLOCKED_BY_POLICY");
+        assert_eq!(json["network_tx_hashes"][0], "0xdeadbeef");
     }
 }

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -528,6 +528,17 @@ impl VaultOperation {
     }
 }
 
+/// Serializes a `TransactionSubStatus` to its Fireblocks-wire string
+/// (e.g. `INSUFFICIENT_FUNDS`, `BLOCKED_BY_POLICY`). Relies on the SDK's serde
+/// rename rules so the output matches what Fireblocks' API surfaces.
+fn serialize_sub_status(
+    sub_status: models::TransactionSubStatus,
+) -> Option<String> {
+    serde_json::to_value(sub_status)
+        .ok()
+        .and_then(|value| value.as_str().map(str::to_owned))
+}
+
 /// Returns true if the transaction status indicates the transaction is still
 /// in progress and may eventually confirm on-chain. Used to distinguish
 /// "polling timed out but tx might still land" from "tx definitively failed."
@@ -809,6 +820,15 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             .await
             .map_err(FireblocksVaultError::from)?;
 
+        let sub_status = tx.sub_status.and_then(serialize_sub_status);
+        let network_tx_hashes = tx
+            .network_records
+            .as_ref()
+            .map(|records| {
+                records.iter().filter_map(|r| r.tx_hash.clone()).collect()
+            })
+            .unwrap_or_default();
+
         let status = match tx.status {
             TransactionStatus::Completed => {
                 let tx_hash_str = tx.tx_hash.ok_or_else(|| {
@@ -827,15 +847,19 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
                         detail: format!(
                             "EVM reverted (Fireblocks Completed, tx {tx_hash})"
                         ),
+                        sub_status,
+                        network_tx_hashes,
                     }));
                 }
 
                 FireblocksTxStatus::Completed { tx_hash, block_number }
             }
             status if is_still_pending(status) => FireblocksTxStatus::Pending,
-            status => {
-                FireblocksTxStatus::Failed { detail: format!("{status:?}") }
-            }
+            status => FireblocksTxStatus::Failed {
+                detail: format!("{status:?}"),
+                sub_status,
+                network_tx_hashes,
+            },
         };
 
         Ok(Some(status))
@@ -864,6 +888,31 @@ mod tests {
 
     use super::*;
     use crate::fireblocks::config::parse_chain_asset_ids;
+
+    #[test]
+    fn serialize_sub_status_returns_fireblocks_wire_string() {
+        // Pick a few variants the SDK's serde rename rules should turn into
+        // the canonical Fireblocks API strings.
+        assert_eq!(
+            serialize_sub_status(
+                models::TransactionSubStatus::InsufficientFunds
+            )
+            .as_deref(),
+            Some("INSUFFICIENT_FUNDS"),
+        );
+        assert_eq!(
+            serialize_sub_status(models::TransactionSubStatus::BlockedByPolicy)
+                .as_deref(),
+            Some("BLOCKED_BY_POLICY"),
+        );
+        assert_eq!(
+            serialize_sub_status(
+                models::TransactionSubStatus::RejectedByBlockchain
+            )
+            .as_deref(),
+            Some("REJECTED_BY_BLOCKCHAIN"),
+        );
+    }
 
     static TEST_RSA_PEM: LazyLock<Vec<u8>> = LazyLock::new(|| {
         let mut rng = rand::thread_rng();

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -118,7 +118,18 @@ pub(crate) enum FireblocksTxStatus {
     /// Transaction is still pending (submitted, confirming, etc.).
     Pending,
     /// Transaction reached a terminal failure status.
-    Failed { detail: String },
+    Failed {
+        /// Top-level Fireblocks `TransactionStatus` variant (debug-formatted).
+        detail: String,
+        /// Fireblocks `subStatus` (e.g. `INSUFFICIENT_FUNDS`,
+        /// `BLOCKED_BY_POLICY`, `REJECTED_BY_BLOCKCHAIN`). This is what tells
+        /// you *why* a transaction failed; `detail` alone just says it did.
+        sub_status: Option<String>,
+        /// Per-network transaction hashes Fireblocks recorded. Useful when a
+        /// blockchain-level failure (revert, dropped tx) needs to be inspected
+        /// against an explorer.
+        network_tx_hashes: Vec<String>,
+    },
 }
 
 /// Result of a successful on-chain minting operation.


### PR DESCRIPTION
## Motivation

Resolves [RAI-621](https://linear.app/makeitrain/issue/RAI-621/surface-fireblocks-substatus-on-adminstuck-and-adminfireblockstx).

When a Fireblocks transaction fails terminally, the `/admin/stuck` and `/admin/fireblocks/tx/<id>` endpoints currently only return `"status": "failed"` plus a `detail` that is just the `TransactionStatus` enum variant name (e.g. `"Failed"`, `"Cancelled"`, `"Rejected"`). The Fireblocks `subStatus` field — the value that actually explains *why* (e.g. `INSUFFICIENT_FUNDS`, `BLOCKED_BY_POLICY`, `REJECTED_BY_BLOCKCHAIN`, `SMART_CONTRACT_EXECUTION_FAILED`) — was being discarded inside `check_fireblocks_tx` via `format!("{status:?}")`. The `network_records[].tx_hash` was also dropped.

Operationally this means: when items appear in `/admin/stuck`, operators have to open the Fireblocks UI per `fireblocks_tx_id` to find the failure reason. On 2026-05-19 prod had 8 stuck Fireblocks transactions (2 `MintingFailed`, 6 `BurnFailed`), each returning the same uninformative `"reached terminal status: Failed"` — making triage prohibitively manual.

[RAI-599](https://linear.app/makeitrain/issue/RAI-599) (#154) enriched each `/admin/stuck` entry with the asset (`underlying`) and `quantity`. This PR completes the triage shape by attaching the live Fireblocks status — together they let an operator decide whether to recover, close, or escalate without opening Linear or the Fireblocks UI.

## Solution

### `src/vault/mod.rs`

Extend `FireblocksTxStatus::Failed` from a single-field `{ detail }` to:

```rust
Failed {
    detail: String,                 // existing — TransactionStatus variant name
    sub_status: Option<String>,     // new — Fireblocks subStatus, the actual reason
    network_tx_hashes: Vec<String>, // new — per-network tx hashes for explorer lookup
}
```

### `src/fireblocks/vault_service.rs`

- New helper `serialize_sub_status` maps the SDK's `models::TransactionSubStatus` to its Fireblocks-wire string (`InsufficientFunds` → `INSUFFICIENT_FUNDS`, etc.) via `serde_json::to_value` so the API consumer sees the same identifier Fireblocks itself surfaces.
- `check_fireblocks_tx` reads `tx.sub_status` and `tx.network_records` once at the top of the function and threads both through every failure branch (EVM-revert-after-Completed and non-Completed terminal statuses).
- Adds a unit test verifying `INSUFFICIENT_FUNDS`, `BLOCKED_BY_POLICY`, `REJECTED_BY_BLOCKCHAIN` serialize to the right strings.

### `src/admin.rs`

- `StuckAggregate` gains a new optional `fireblocks_status: Option<FireblocksTxStatus>` field (serde-skipped when `None`).
- New best-effort helper `enrich_with_fireblocks_status` walks the assembled stuck list once, calling `vault_service.check_fireblocks_tx(tx_id)` for each entry that already has a `fireblocks_tx_id`. Missing tx id / non-Fireblocks backend / lookup error all leave `fireblocks_status` as `None` (the helper logs a `WARN` on lookup errors with the entry's `aggregate_id` and `fireblocks_tx_id` for triage but does not propagate the failure).
- `list_stuck` now takes `vault_service: &State<Arc<dyn VaultService>>` (added to the `#[tracing::instrument(skip(...))]` list as well) and calls the helper after assembling the list.
- The `recover_post_alpaca` match arm that pattern-matched `FireblocksTxStatus::Failed { detail }` now destructures `sub_status` (and ignores `network_tx_hashes` with `_`), logging the substatus alongside `fireblocks_status` so the existing recovery path also gets the richer signal.
- Three new unit tests:
  - `enrich_populates_status_for_matching_tx_id`: a stub vault service returns a populated `Failed` and the entry's `fireblocks_status` ends up with the correct `sub_status` and `network_tx_hashes`.
  - `enrich_leaves_entries_without_tx_id_untouched`: covers both the no-tx-id and unknown-tx-id paths.
  - `failed_status_serializes_with_sub_status_and_network_hashes`: pins the wire format (`{"status": "failed", "detail": …, "sub_status": "BLOCKED_BY_POLICY", "network_tx_hashes": ["0xdeadbeef"]}`).

After this, the response for each stuck item carries enough info to diagnose without leaving the terminal:

```json
{
  "aggregate_id": "...",
  "state": "MintingFailed",
  "underlying": "AAPL",
  "quantity": "3.034424121",
  "fireblocks_tx_id": "a29e5027-...",
  "fireblocks_status": {
    "status": "failed",
    "detail": "Failed",
    "sub_status": "INSUFFICIENT_FUNDS",
    "network_tx_hashes": []
  }
}
```

The `/admin/fireblocks/tx/<id>` endpoint shape is unchanged at the wrapper level — the same fields are now just visible inside the `Failed` variant.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Test plan

- [x] `cargo test --lib` — 577 passed, 0 failed
- [x] `cargo clippy --lib --tests --all-features -- -D warnings` — clean (with `-D clippy::pedantic`)
- [x] `cargo fmt` — clean
- [x] 4 new unit tests cover the new field serialization, the enrichment helper (matching tx, missing tx, unknown tx), and the SDK substatus → wire-string mapping

## Anything else

- **Stacked on:** #157 ([rai-364-alpaca-redeem-callback-path](https://github.com/ST0x-Technology/st0x.issuance/pull/157)).
- **Builds on:** #154 ([RAI-599](https://linear.app/makeitrain/issue/RAI-599)) which added `underlying` / `quantity` to each stuck entry. This PR adds `fireblocks_status` alongside them.
- **Backward compatible:** `FireblocksTxStatus` is a non-public type; existing JSON consumers of `/admin/stuck` and `/admin/fireblocks/tx/<id>` will see two additional fields inside the `Failed` variant (`sub_status`, `network_tx_hashes`) and a new top-level `fireblocks_status` field on each stuck entry. The pre-existing `detail` field is preserved.
- **Failure-reason coverage:** the substatus string passes through the SDK's typed enum. The same upstream-SDK staleness that already affects `TransactionStatus` (cf. the `QUEUED_FOR_BROADCAST` decode errors observed in prod) applies to `TransactionSubStatus` — a Fireblocks-introduced substatus the SDK doesn't know about will make the whole `get_transaction` call fail at deserialize time, leaving `fireblocks_status: None` for that entry. SDK upgrade is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin stuck operations endpoint now displays live Fireblocks transaction status details to support operator triage and diagnostics
  * Transaction failures now include detailed sub-status information and associated on-chain transaction hashes for improved error visibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/158?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->