### PR TITLE
fix: retry terminal failed Fireblocks mints

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -198,15 +198,22 @@ initial request through journal confirmation to on-chain minting and callback.
   `TokensMinted` or `MintingFailed`
 - `SendCallback { issuer_request_id }` - Send the callback to Alpaca confirming
   mint completion
-- `Recover { issuer_request_id }` - Recover a mint stuck in an incomplete state.
-  Invoked at startup by the mint recovery process for any mint in
-  `JournalConfirmed`, `Minting`, `MintingFailed`, or `CallbackPending` state.
-  Queries the receipt inventory for a receipt matching the `issuer_request_id`.
-  If a matching receipt is found, the mint already succeeded on-chain, so
-  recovery records the existing mint (`ExistingMintRecovered`) and proceeds to
-  callback. If no receipt is found, recovery retries the on-chain deposit
-  (`MintRetryStarted`). This prevents double-minting after crashes while
-  ensuring stuck mints eventually complete
+- `Recover { issuer_request_id, mode }` - Recover a mint stuck in an incomplete
+  state. Startup recovery drives any mint in `JournalConfirmed`, `Minting`,
+  `MintingFailed`, or `CallbackPending` state; at runtime, live retry scheduling
+  is triggered specifically when a mint lands in `MintingFailed` during the
+  journal-confirmation flow. Both paths hand a mint that is waiting on a retry
+  window or a pending Fireblocks transaction to a background scheduled-recovery
+  task, so retries fire on schedule without waiting for a restart. Queries the
+  receipt inventory for a receipt matching the `issuer_request_id`. If a
+  matching receipt is found, the mint already succeeded on-chain, so recovery
+  records the existing mint (`ExistingMintRecovered`) and proceeds to callback.
+  If no receipt is found and the previous Fireblocks transaction is terminally
+  failed, automatic recovery submits up to four retry transactions after 1m,
+  10m, 30m, and 1h delays. Manual admin reprocess uses the same recovery path
+  but bypasses the automatic retry cap so an operator can retry after fixing the
+  underlying cause. This prevents double-minting after crashes while ensuring
+  terminal Fireblocks failures can be retried with new `externalTxId`s
 - `RecoverFromReceipt { issuer_request_id, tx_hash }` - Recover a mint that
   failed during the minting step when an ITN receipt is discovered on-chain.
   Triggered by the receipt monitor when it finds a Deposit event with a matching
@@ -258,7 +265,22 @@ either `TokensMinted` (success) or `MintingFailed` (failure).
 `Recover` checks the receipt inventory for a receipt matching the
 `issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
 in `Minting` state, submits and emits `FireblocksSubmitted`. If in
-`FireblocksSubmitted` state, confirms the existing transaction.
+`FireblocksSubmitted` (or `MintingFailed` with a known prior transaction), it
+first checks the Fireblocks transaction status without blocking: a `Pending`
+status pauses recovery (so the scheduled loop backs off rather than blocking in
+a long confirmation poll), `Completed` proceeds to confirmation, and `Failed`
+submits the next retry. Retry transactions use
+`mint-{issuer_request_id}-retry-{n}` where automatic retries use n = 1..4 and
+the delay schedule is 1m, 10m, 30m, then 1h.
+
+The retry-delay/exhaustion schedule is driven by a `MintingFailed` attempt
+counter that advances on every failure — including a submission that fails
+before Fireblocks accepts it (no `FireblocksSubmitted` predecessor). In that
+case the `external_tx_id` is reused unchanged (Fireblocks deduplicates) so
+resubmission stays idempotent, while the schedule still escalates and eventually
+exhausts. A running service keeps driving deferred and pending retries via a
+background scheduled-recovery task (also spawned at startup and after a manual
+reprocess), rather than waiting for the next restart.
 
 `RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
 receipt for a mint in `MintingFailed` state (where the predecessor was
@@ -1137,7 +1159,7 @@ stateDiagram-v2
     Minting --> MintingFailed: SubmitMint (MintingFailed)
     FireblocksSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
     FireblocksSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
-    MintingFailed --> FireblocksSubmitted: Recover (MintRetryStarted + FireblocksSubmitted)
+    MintingFailed --> FireblocksSubmitted: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + FireblocksSubmitted)
     MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
     MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
     CallbackPending --> Completed: SendCallback
@@ -1905,8 +1927,10 @@ Auto-detects the right recovery path from the event history:
 
 **Mint:** `POST /admin/reprocess/mint/<aggregate_id>`
 
-Dispatches the existing `Recover` command which already handles
-`JournalConfirmed`, `Minting`, `MintingFailed`, and `CallbackPending` states.
+Dispatches the manual `Recover` command which handles `JournalConfirmed`,
+`Minting`, `MintingFailed`, and `CallbackPending` states. Manual reprocess can
+submit the next deterministic Fireblocks retry even after automatic retries have
+exhausted.
 
 **Post-Alpaca with existing on-chain burn:** If a `BurningFailed` event carries
 a Fireblocks tx ID (enrichment added in PR #143), the endpoint queries

--- a/docs/fireblocks.md
+++ b/docs/fireblocks.md
@@ -10,14 +10,22 @@ is rejected with HTTP 400.
 Source:
 [Fireblocks API Idempotency](https://developers.fireblocks.com/reference/api-idempotency)
 
-Our `externalTxId` format: `mint-{issuer_request_id}` or
-`burn-{issuer_request_id}`.
+Our normal `externalTxId` format: `mint-{issuer_request_id}` or
+`burn-{issuer_request_id}`. Mint retries after a terminal Fireblocks failure use
+fresh deterministic IDs: `mint-{issuer_request_id}-retry-1`,
+`mint-{issuer_request_id}-retry-2`, etc.
 
 **Implication for recovery:** If a mint/burn transaction was submitted to
 Fireblocks but we lost track of it (e.g., process restart before polling
 completion), retrying with the same `externalTxId` will fail with HTTP 400. The
 recovery path must look up the existing Fireblocks transaction by `externalTxId`
 rather than creating a new one.
+
+**Terminal mint failures:** Once Fireblocks reports a submitted mint transaction
+as terminally failed, the bot may submit a fresh mint transaction with the next
+retry `externalTxId`. Automatic retry attempts are capped at four and delayed by
+1m, 10m, 30m, and 1h. Manual admin reprocess bypasses that cap for operator-run
+retries after the underlying issue has been fixed.
 
 ## SDK Error Handling
 

--- a/docs/ops-recovery-guide.md
+++ b/docs/ops-recovery-guide.md
@@ -96,8 +96,14 @@ curl -s -X POST -H "X-API-KEY: $ISSUER_API_KEY" \
   http://localhost:8000/admin/reprocess/mint/<aggregate_id> | python3 -m json.tool
 ```
 
-This retries the on-chain deposit + Alpaca callback inline (no restart needed).
-A 409 Conflict response means it already completed — no action needed.
+This retries recovery inline (no restart needed). If the previous Fireblocks
+mint transaction terminally failed, manual reprocess submits the next
+deterministic retry transaction even after automatic retries are exhausted, and
+hands the mint to a background task that drives that submitted transaction
+through confirmation. A single reprocess is usually enough. The exception is a
+retry submitted past the automatic cap (e.g. `retry-5`): if that transaction
+also fails, the background task is exhausted and gives up, so you must reprocess
+again. A 409 Conflict response means it already completed — no action needed.
 
 ### Recovering redemptions
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -14,7 +14,7 @@ use crate::auth::InternalAuth;
 use crate::mint::{
     IssuerMintRequestId, MintCommand, MintEvent, MintView,
     TokenizationRequestId, find_all_recoverable_mints,
-    find_by_issuer_request_id,
+    find_by_issuer_request_id, recovery::spawn_scheduled_mint_recovery,
 };
 use crate::redemption::{
     BurnRecord, IssuerRedemptionRequestId, RedemptionCommand, RedemptionError,
@@ -556,11 +556,12 @@ pub(crate) async fn close_redemption(
     }))
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool))]
+#[tracing::instrument(skip(_auth, cqrs, event_store, pool))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
     _auth: InternalAuth,
     cqrs: &rocket::State<MintCqrs>,
+    event_store: &rocket::State<MintEventStore>,
     pool: &rocket::State<Pool<Sqlite>>,
     aggregate_id: &str,
 ) -> Result<Json<ReprocessResponse>, Status> {
@@ -600,7 +601,10 @@ pub(crate) async fn reprocess_mint(
 
     cqrs.execute(
         aggregate_id,
-        MintCommand::Recover { issuer_request_id: issuer_request_id.clone() },
+        MintCommand::Recover {
+            issuer_request_id: issuer_request_id.clone(),
+            mode: crate::mint::MintRecoveryMode::Manual,
+        },
     )
     .await
     .map_err(|err| {
@@ -617,6 +621,16 @@ pub(crate) async fn reprocess_mint(
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
         "Mint reprocessed successfully"
+    );
+
+    // A single manual Recover advances the mint by one step (e.g. submits the
+    // next retry, leaving it in FireblocksSubmitted). Hand it to a background
+    // scheduled-recovery task so it is driven to completion instead of
+    // stalling until the next restart or another manual reprocess.
+    spawn_scheduled_mint_recovery(
+        cqrs.inner().clone(),
+        event_store.inner().clone(),
+        issuer_request_id,
     );
 
     Ok(Json(ReprocessResponse {
@@ -1670,6 +1684,7 @@ mod tests {
             _bot: alloy::primitives::Address,
             _user: alloy::primitives::Address,
             _receipt_info: crate::vault::ReceiptInformation,
+            _external_tx_id: Option<String>,
         ) -> Result<crate::vault::SubmittedTx, crate::vault::VaultError>
         {
             unimplemented!("not used in enrichment tests")

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -616,6 +616,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
+        external_tx_id: Option<String>,
     ) -> Result<SubmittedTx, VaultError> {
         let oa_schema = self.oa_schema_cache.get(vault).await;
         let receipt_info_bytes = receipt_info.encode(oa_schema.as_deref())?;
@@ -651,8 +652,9 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             receipt_info.issuer_request_id,
         );
 
-        let external_tx_id = VaultOperation::Mint
-            .external_tx_id(&receipt_info.issuer_request_id);
+        let external_tx_id = external_tx_id.unwrap_or_else(|| {
+            VaultOperation::Mint.external_tx_id(&receipt_info.issuer_request_id)
+        });
 
         let fireblocks_tx_id = self
             .submit_contract_call(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,10 @@ use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
-    recovery::{MintRecoveryHandler, recover_mint},
+    recovery::{
+        DriveOutcome, MintRecoveryHandler, recover_mint,
+        spawn_scheduled_mint_recovery,
+    },
     replay_mint_view,
 };
 use crate::receipt_inventory::backfill::{NoOpItnHandler, ReceiptBackfiller};
@@ -324,11 +327,16 @@ pub async fn initialize_rocket(
         );
     }
 
-    // Recovery runs with a timeout before the HTTP server starts. If it
-    // completes within the timeout, there is no race with incoming requests.
-    // If it hangs (e.g., Fireblocks call), it is cancelled and stuck
-    // aggregates are left for manual admin intervention.
-    run_recovery_with_timeout(&pool, &mint.cqrs, &managers).await;
+    // The synchronous recovery pass runs with a timeout before the HTTP server
+    // starts. Mints that need deferred or pending follow-up are handed to
+    // detached background scheduled-recovery tasks that intentionally outlive
+    // this timeout and run concurrently with request handling; their safety
+    // rests on cqrs-es optimistic concurrency and Fireblocks externalTxId
+    // idempotency, not on completing before the server is up. If the
+    // synchronous pass hangs it is cancelled and any remaining stuck aggregates
+    // are left for manual admin intervention.
+    run_recovery_with_timeout(&pool, &mint.cqrs, &mint.event_store, &managers)
+        .await;
 
     spawn_periodic_receipt_backfills(
         pool.clone(),
@@ -606,7 +614,11 @@ fn setup_redemption_managers(
     Ok(RedemptionManagers { redeem_call, journal, burn })
 }
 
-async fn run_mint_recovery(pool: &Pool<Sqlite>, mint_cqrs: &MintCqrs) {
+async fn run_mint_recovery(
+    pool: &Pool<Sqlite>,
+    mint_cqrs: &MintCqrs,
+    mint_event_store: &MintEventStore,
+) {
     info!(target: "mint", "Running mint recovery");
 
     let recoverable_mints = match find_all_recoverable_mints(pool).await {
@@ -626,7 +638,25 @@ async fn run_mint_recovery(pool: &Pool<Sqlite>, mint_cqrs: &MintCqrs) {
     debug!(target: "mint", count, "Recovering mints");
 
     for (issuer_request_id, _view) in recoverable_mints {
-        recover_mint(mint_cqrs, issuer_request_id).await;
+        // Drive one synchronous pass so mints that can finish immediately
+        // (e.g. an on-chain receipt already exists) complete before the HTTP
+        // server starts. If the pass does not reach a terminal/exhausted state
+        // — waiting on a retry window, a pending Fireblocks tx, or a transient
+        // failure — hand the mint to a background scheduled-recovery task so it
+        // keeps progressing while the service runs instead of waiting for the
+        // next restart.
+        match recover_mint(mint_cqrs, issuer_request_id.clone()).await {
+            DriveOutcome::RetryNotDue
+            | DriveOutcome::Pending
+            | DriveOutcome::Failed => {
+                spawn_scheduled_mint_recovery(
+                    mint_cqrs.clone(),
+                    mint_event_store.clone(),
+                    issuer_request_id,
+                );
+            }
+            DriveOutcome::Done | DriveOutcome::Exhausted => {}
+        }
     }
 
     debug!(target: "mint", count, "Mint recovery complete");
@@ -666,10 +696,11 @@ const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 async fn run_recovery_with_timeout(
     pool: &Pool<Sqlite>,
     mint_cqrs: &MintCqrs,
+    mint_event_store: &MintEventStore,
     managers: &RedemptionManagers,
 ) {
     let recovery = async {
-        run_mint_recovery(pool, mint_cqrs).await;
+        run_mint_recovery(pool, mint_cqrs, mint_event_store).await;
         run_redemption_recovery(
             &managers.redeem_call,
             &managers.journal,

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -6,6 +6,7 @@ use tracing::{error, info, warn};
 use crate::auth::IssuerAuth;
 use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, TokenizationRequestId,
+    recovery::spawn_scheduled_mint_recovery,
 };
 use crate::{MintCqrs, MintEventStore};
 
@@ -204,13 +205,14 @@ async fn process_journal_completion(
         let state = context.aggregate().state_name();
         match context.aggregate() {
             Mint::MintingFailed { .. } => {
-                // Submission failed (e.g., transient Fireblocks error).
-                // Recovery runs at startup via run_recovery_with_timeout.
-                // In the current design, no periodic recovery loop exists,
-                // so this mint will remain stuck until the next service restart.
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     %state,
-                    "Mint submission failed — recovery will retry on next restart"
+                    "Mint submission failed — scheduling automatic recovery"
+                );
+                spawn_scheduled_mint_recovery(
+                    cqrs,
+                    event_store,
+                    issuer_request_id,
                 );
             }
             Mint::CallbackPending { .. } | Mint::Completed { .. } => {
@@ -229,7 +231,42 @@ async fn process_journal_completion(
         return;
     }
 
-    // Step 4: Send callback to Alpaca
+    let context = match event_store.load_aggregate(&aggregate_id).await {
+        Ok(ctx) => ctx,
+        Err(err) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = ?err,
+                "Failed to load aggregate after ConfirmMint"
+            );
+            return;
+        }
+    };
+
+    match context.aggregate() {
+        Mint::MintingFailed { .. } => {
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint confirmation failed — scheduling automatic recovery"
+            );
+            spawn_scheduled_mint_recovery(cqrs, event_store, issuer_request_id);
+            return;
+        }
+        Mint::CallbackPending { .. } => {}
+        Mint::Completed { .. } => {
+            info!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint already completed by recovery"
+            );
+            return;
+        }
+        state => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                state = %state.state_name(),
+                "Unexpected aggregate state after ConfirmMint"
+            );
+            return;
+        }
+    }
+
+    // Step 4: Send callback to Alpaca.
     if let Err(err) = cqrs
         .execute(
             &issuer_request_id.to_string(),

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -6,6 +6,12 @@ use super::{
     TokenizationRequestId, UnderlyingSymbol,
 };
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub(crate) enum MintRecoveryMode {
+    Automatic,
+    Manual,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum MintCommand {
     Initiate {
@@ -71,6 +77,7 @@ pub(crate) enum MintCommand {
     /// - Retries sending the callback
     Recover {
         issuer_request_id: IssuerMintRequestId,
+        mode: MintRecoveryMode,
     },
 
     /// Admin-closes a mint that cannot be automatically recovered.

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -6,7 +6,7 @@ mod view;
 
 use alloy::primitives::{Address, B256, TxHash, U256};
 use async_trait::async_trait;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use cqrs_es::Aggregate;
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
@@ -23,12 +23,14 @@ use crate::receipt_inventory::{
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
-use crate::vault::{ReceiptInformation, VaultService};
+use crate::vault::{
+    FireblocksTxStatus, ReceiptInformation, VaultError, VaultService,
+};
 
 pub use api::MintResponse;
 
 pub(crate) use api::{confirm_journal, initiate_mint};
-pub(crate) use cmd::MintCommand;
+pub(crate) use cmd::{MintCommand, MintRecoveryMode};
 pub(crate) use event::MintEvent;
 pub(crate) use view::{
     MintView, find_all_recoverable_mints, find_by_issuer_request_id,
@@ -189,6 +191,24 @@ pub(crate) enum Mint {
         journal_confirmed_at: DateTime<Utc>,
         error: String,
         failed_at: DateTime<Utc>,
+        /// 1-indexed attempt number of the *next* retry, driving the automatic
+        /// delay schedule and exhaustion cap. Unlike the `external_tx_id`-
+        /// derived attempt (see `next_retry_attempt`), this advances on every
+        /// failure — including submission failures that never reached Fireblocks
+        /// (no `FireblocksSubmitted` predecessor) — so the schedule still
+        /// escalates and eventually exhausts. The `external_tx_id` is derived
+        /// separately and is reused unchanged across such failures to stay
+        /// idempotent.
+        ///
+        /// Note: when a submission finally lands after pre-acceptance failures,
+        /// the next failure re-seeds this from the new `FireblocksSubmitted`
+        /// predecessor's retry number, which can lower it (the delay schedule
+        /// then runs longer than the nominal 1m/10m/30m/1h). This only affects
+        /// schedule *duration*; the number of distinct on-chain mint
+        /// transactions stays hard-capped at four because `external_tx_id`
+        /// (and thus a new `FireblocksSubmitted`) advances only on a successful
+        /// submission. So there is no double-mint and no cap breach.
+        attempts: u32,
         /// The state the mint was in before it failed. Used to determine
         /// whether receipt-triggered recovery is safe (only when failed
         /// from `Minting`, meaning a tx was actually submitted).
@@ -230,9 +250,27 @@ struct MintSubmissionInput<'a> {
     wallet: Address,
     journal_confirmed_at: DateTime<Utc>,
     receipt_note: Option<&'a str>,
+    external_tx_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct KnownMintTx {
+    external_tx_id: String,
+    fireblocks_tx_id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AutomaticRetryDecision {
+    Ready,
+    Wait(std::time::Duration),
+    Exhausted,
+    NotRecoverable,
 }
 
 impl Mint {
+    pub(crate) const MAX_AUTOMATIC_MINT_RETRY_ATTEMPT: u32 = 4;
+    const RETRY_EXTERNAL_TX_MARKER: &'static str = "-retry-";
+
     const fn state_name(&self) -> &'static str {
         match self {
             Self::Uninitialized => "Uninitialized",
@@ -257,6 +295,109 @@ impl Mint {
             }
             _ => self,
         }
+    }
+
+    fn latest_known_mint_tx(&self) -> Option<KnownMintTx> {
+        match self.non_failed_predecessor() {
+            Self::FireblocksSubmitted {
+                external_tx_id,
+                fireblocks_tx_id,
+                ..
+            } => Some(KnownMintTx {
+                external_tx_id: external_tx_id.clone(),
+                fireblocks_tx_id: fireblocks_tx_id.clone(),
+            }),
+            _ => None,
+        }
+    }
+
+    /// The Fireblocks transaction id currently in flight for this mint (the
+    /// latest `FireblocksSubmitted`, whether the aggregate is in that state or
+    /// `MintingFailed` with it as the non-failed predecessor). `None` when no
+    /// transaction has reached Fireblocks. Used by the scheduled-recovery loop
+    /// to give each distinct transaction its own pending-poll budget.
+    pub(crate) fn pending_fireblocks_tx_id(&self) -> Option<String> {
+        self.latest_known_mint_tx().map(|known| known.fireblocks_tx_id)
+    }
+
+    fn base_mint_external_tx_id(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> String {
+        format!("mint-{issuer_request_id}")
+    }
+
+    fn retry_mint_external_tx_id(
+        issuer_request_id: &IssuerMintRequestId,
+        attempt: u32,
+    ) -> String {
+        format!(
+            "{}{}{}",
+            Self::base_mint_external_tx_id(issuer_request_id),
+            Self::RETRY_EXTERNAL_TX_MARKER,
+            attempt,
+        )
+    }
+
+    fn retry_attempt_from_external_tx_id(external_tx_id: &str) -> Option<u32> {
+        external_tx_id
+            .rsplit_once(Self::RETRY_EXTERNAL_TX_MARKER)
+            .and_then(|(_, attempt)| attempt.parse().ok())
+    }
+
+    /// Attempt number for the *next* retry's `external_tx_id`, derived from the
+    /// latest persisted `FireblocksSubmitted` predecessor. Stays unchanged when
+    /// a submission fails before Fireblocks accepts it (no new
+    /// `FireblocksSubmitted`), so the deterministic id is reused and Fireblocks
+    /// dedupes — keeping retries idempotent. The delay/exhaustion schedule uses
+    /// the separate `MintingFailed::attempts` counter instead.
+    fn next_retry_attempt(&self) -> u32 {
+        self.latest_known_mint_tx()
+            .and_then(|known| {
+                Self::retry_attempt_from_external_tx_id(&known.external_tx_id)
+            })
+            .unwrap_or(0)
+            + 1
+    }
+
+    const fn automatic_retry_delay(attempt: u32) -> Option<ChronoDuration> {
+        match attempt {
+            1 => Some(ChronoDuration::minutes(1)),
+            2 => Some(ChronoDuration::minutes(10)),
+            3 => Some(ChronoDuration::minutes(30)),
+            4 => Some(ChronoDuration::hours(1)),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn automatic_retry_decision(
+        &self,
+        now: DateTime<Utc>,
+    ) -> AutomaticRetryDecision {
+        let Self::MintingFailed { failed_at, attempts, .. } = self else {
+            return match self {
+                Self::JournalConfirmed { .. }
+                | Self::Minting { .. }
+                | Self::FireblocksSubmitted { .. }
+                | Self::CallbackPending { .. } => AutomaticRetryDecision::Ready,
+                _ => AutomaticRetryDecision::NotRecoverable,
+            };
+        };
+
+        if *attempts > Self::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT {
+            return AutomaticRetryDecision::Exhausted;
+        }
+
+        let Some(delay) = Self::automatic_retry_delay(*attempts) else {
+            return AutomaticRetryDecision::Exhausted;
+        };
+        let retry_at = *failed_at + delay;
+        if now >= retry_at {
+            return AutomaticRetryDecision::Ready;
+        }
+
+        (retry_at - now)
+            .to_std()
+            .map_or(AutomaticRetryDecision::Ready, AutomaticRetryDecision::Wait)
     }
 
     pub(crate) const fn tokenization_request_id(
@@ -390,6 +531,7 @@ impl Mint {
                 wallet: *wallet,
                 journal_confirmed_at: *journal_confirmed_at,
                 receipt_note: None,
+                external_tx_id: None,
             },
         )
         .await?;
@@ -411,6 +553,7 @@ impl Mint {
             wallet,
             journal_confirmed_at,
             receipt_note,
+            external_tx_id,
         } = input;
         let vault = find_vault_by_underlying(&services.pool, underlying)
             .await?
@@ -433,7 +576,14 @@ impl Mint {
 
         match services
             .vault
-            .submit_mint(vault, assets, services.bot, wallet, receipt_info)
+            .submit_mint(
+                vault,
+                assets,
+                services.bot,
+                wallet,
+                receipt_info,
+                external_tx_id,
+            )
             .await
         {
             Ok(submitted) => {
@@ -647,6 +797,7 @@ impl Mint {
         &self,
         services: &MintServices,
         issuer_request_id: IssuerMintRequestId,
+        mode: MintRecoveryMode,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::JournalConfirmed { .. } => {
@@ -655,6 +806,22 @@ impl Mint {
                 self.handle_deposit(issuer_request_id)
             }
             Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                // Non-blocking pre-check: a pending tx must pause recovery (so
+                // the scheduled loop backs off) instead of blocking in
+                // confirm_mint's long poll, which the bounded startup recovery
+                // would cancel before any follow-up is scheduled.
+                if matches!(
+                    services
+                        .vault
+                        .check_fireblocks_tx(fireblocks_tx_id)
+                        .await?,
+                    Some(FireblocksTxStatus::Pending)
+                ) {
+                    return Err(MintError::FireblocksTxStillPending {
+                        fireblocks_tx_id: fireblocks_tx_id.clone(),
+                    });
+                }
+
                 let deposit_events = self
                     .handle_confirm_mint(
                         services,
@@ -670,21 +837,18 @@ impl Mint {
                 .await
             }
             Self::MintingFailed { .. } => {
-                // Extract the fireblocks_tx_id from the predecessor if
-                // the tx was already submitted (avoids resubmission).
-                let known_tx_id = match self.non_failed_predecessor() {
-                    Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
-                        Some(fireblocks_tx_id.clone())
-                    }
-                    _ => None,
-                };
+                // Preserve the previous Fireblocks tx so recovery can
+                // distinguish pending/completed transactions from terminal
+                // failures that are safe to resubmit.
+                let known_tx = self.latest_known_mint_tx();
 
                 let deposit_events = self
                     .handle_recover_incomplete(
                         services,
                         issuer_request_id.clone(),
                         None,
-                        known_tx_id,
+                        known_tx,
+                        mode,
                     )
                     .await?;
                 self.advance_through_callback(
@@ -701,6 +865,7 @@ impl Mint {
                         issuer_request_id.clone(),
                         None,
                         None,
+                        mode,
                     )
                     .await?;
                 self.advance_through_callback(
@@ -741,19 +906,15 @@ impl Mint {
                     Self::Minting { .. } | Self::FireblocksSubmitted { .. }
                 ) =>
             {
-                let known_tx_id = match self.non_failed_predecessor() {
-                    Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
-                        Some(fireblocks_tx_id.clone())
-                    }
-                    _ => None,
-                };
+                let known_tx = self.latest_known_mint_tx();
 
                 let deposit_events = self
                     .handle_recover_incomplete(
                         services,
                         issuer_request_id.clone(),
                         Some(tx_hash),
-                        known_tx_id,
+                        known_tx,
+                        MintRecoveryMode::Manual,
                     )
                     .await?;
                 self.advance_through_callback(
@@ -833,7 +994,8 @@ impl Mint {
         services: &MintServices,
         issuer_request_id: IssuerMintRequestId,
         receipt_tx_hash: Option<TxHash>,
-        known_fireblocks_tx_id: Option<String>,
+        known_mint_tx: Option<KnownMintTx>,
+        mode: MintRecoveryMode,
     ) -> Result<Vec<MintEvent>, MintError> {
         let (Self::Minting {
             issuer_request_id: expected_id,
@@ -887,25 +1049,68 @@ impl Mint {
         );
 
         let now = Utc::now();
-        let retry_event =
-            matches!(self, Self::MintingFailed { .. }).then(|| {
-                MintEvent::MintRetryStarted {
-                    issuer_request_id: issuer_request_id.clone(),
-                    tx_hash: receipt_tx_hash,
-                    started_at: now,
-                }
-            });
 
-        if let Some(tx_id) = known_fireblocks_tx_id {
+        if let Some(known_tx) = known_mint_tx {
             // Known tx_id from a prior submission: go straight to confirm.
             info!(
                 target: "mint",
                 issuer_request_id = %issuer_request_id,
-                fireblocks_tx_id = %tx_id,
+                fireblocks_tx_id = %known_tx.fireblocks_tx_id,
                 "Resuming confirmation of previously submitted mint"
             );
 
-            return match services.vault.confirm_mint(&tx_id).await {
+            if let Some(status) = services
+                .vault
+                .check_fireblocks_tx(&known_tx.fireblocks_tx_id)
+                .await?
+            {
+                match status {
+                    FireblocksTxStatus::Completed { .. } => {}
+                    FireblocksTxStatus::Pending => {
+                        return Err(MintError::FireblocksTxStillPending {
+                            fireblocks_tx_id: known_tx.fireblocks_tx_id,
+                        });
+                    }
+                    FireblocksTxStatus::Failed {
+                        detail, sub_status, ..
+                    } => {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            fireblocks_tx_id = %known_tx.fireblocks_tx_id,
+                            external_tx_id = %known_tx.external_tx_id,
+                            sub_status = sub_status.as_deref().unwrap_or(""),
+                            detail = %detail,
+                            "Previous Fireblocks mint transaction failed; \
+                             submitting retry"
+                        );
+
+                        return self
+                            .submit_recovery_mint(
+                                services,
+                                MintSubmissionInput {
+                                    issuer_request_id,
+                                    tokenization_request_id,
+                                    quantity,
+                                    underlying,
+                                    wallet: *wallet,
+                                    journal_confirmed_at: *journal_confirmed_at,
+                                    receipt_note: Some("Recovery mint"),
+                                    external_tx_id: None,
+                                },
+                                receipt_tx_hash,
+                                mode,
+                            )
+                            .await;
+                    }
+                }
+            }
+
+            return match services
+                .vault
+                .confirm_mint(&known_tx.fireblocks_tx_id)
+                .await
+            {
                 Ok(result) => {
                     info!(
                         target: "mint",
@@ -938,6 +1143,15 @@ impl Mint {
                              (monitor/backfill will discover it)"
                         );
                     }
+
+                    let retry_event =
+                        matches!(self, Self::MintingFailed { .. }).then(|| {
+                            MintEvent::MintRetryStarted {
+                                issuer_request_id: issuer_request_id.clone(),
+                                tx_hash: receipt_tx_hash,
+                                started_at: now,
+                            }
+                        });
 
                     let minted = MintEvent::TokensMinted {
                         issuer_request_id,
@@ -980,7 +1194,7 @@ impl Mint {
         // No prior tx_id: submit and persist FireblocksSubmitted.
         // Don't confirm here — let the next recovery pass handle
         // ConfirmMint from the FireblocksSubmitted state.
-        let submission_event = Self::execute_mint_submission(
+        self.submit_recovery_mint(
             services,
             MintSubmissionInput {
                 issuer_request_id,
@@ -990,9 +1204,75 @@ impl Mint {
                 wallet: *wallet,
                 journal_confirmed_at: *journal_confirmed_at,
                 receipt_note: Some("Recovery mint"),
+                external_tx_id: None,
             },
+            receipt_tx_hash,
+            mode,
         )
-        .await?;
+        .await
+    }
+
+    async fn submit_recovery_mint(
+        &self,
+        services: &MintServices,
+        mut input: MintSubmissionInput<'_>,
+        receipt_tx_hash: Option<TxHash>,
+        mode: MintRecoveryMode,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let retrying_failed_mint = matches!(self, Self::MintingFailed { .. });
+        // The delay/cap gate uses the failure-count-based schedule
+        // (`automatic_retry_decision`); the external_tx_id uses the
+        // FireblocksSubmitted-derived attempt so it is reused unchanged across
+        // submission failures (Fireblocks dedupes — keeps retries idempotent).
+        if retrying_failed_mint && matches!(mode, MintRecoveryMode::Automatic) {
+            let now = Utc::now();
+            match self.automatic_retry_decision(now) {
+                AutomaticRetryDecision::Exhausted => {
+                    return Err(MintError::AutomaticRetriesExhausted {
+                        attempts: Self::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT,
+                    });
+                }
+                AutomaticRetryDecision::Wait(wait) => {
+                    let retry_at = now
+                        + ChronoDuration::from_std(wait)
+                            .map_err(|_| MintError::RetryDelayOutOfRange)?;
+                    return Err(MintError::RetryNotDue { retry_at });
+                }
+                AutomaticRetryDecision::Ready
+                | AutomaticRetryDecision::NotRecoverable => {}
+            }
+        }
+
+        let now = Utc::now();
+        let external_attempt = self.next_retry_attempt();
+        let issuer_request_id = input.issuer_request_id.clone();
+        let external_tx_id = retrying_failed_mint.then(|| {
+            Self::retry_mint_external_tx_id(
+                &issuer_request_id,
+                external_attempt,
+            )
+        });
+        input.external_tx_id = external_tx_id;
+
+        let submission_event =
+            Self::execute_mint_submission(services, input).await?;
+
+        // Only record MintRetryStarted alongside a *successful* submission.
+        // execute_mint_submission returns Ok(MintingFailed) when the backend
+        // rejects the submission; emitting MintRetryStarted in that case would
+        // move the aggregate MintingFailed -> Minting, discarding the
+        // FireblocksSubmitted predecessor (its fireblocks_tx_id and the retry
+        // counter derived from external_tx_id). Re-emitting only the failure
+        // keeps the predecessor chain intact for the next retry.
+        let retry_event = matches!(
+            (retrying_failed_mint, &submission_event),
+            (true, MintEvent::FireblocksSubmitted { .. })
+        )
+        .then(|| MintEvent::MintRetryStarted {
+            issuer_request_id,
+            tx_hash: receipt_tx_hash,
+            started_at: now,
+        });
 
         Ok(retry_event
             .into_iter()
@@ -1232,6 +1512,36 @@ impl Mint {
         error: String,
         failed_at: DateTime<Utc>,
     ) {
+        // Re-failure while already in MintingFailed (e.g. a recovery confirm
+        // or resubmission attempt failed again): refresh error/failed_at and
+        // advance the attempt counter so the delay schedule escalates and
+        // eventually exhausts, but keep the original failed_from chain (and the
+        // external_tx_id derived from it) so resubmission stays idempotent.
+        if let Self::MintingFailed {
+            error: existing_error,
+            failed_at: existing_failed_at,
+            attempts,
+            ..
+        } = self
+        {
+            *existing_error = error;
+            *existing_failed_at = failed_at;
+            *attempts += 1;
+            return;
+        }
+
+        // First failure from a live state: seed the attempt counter from the
+        // FireblocksSubmitted predecessor's retry number when present, else 1
+        // (a submission that failed before Fireblocks accepted it).
+        let attempts = match self {
+            Self::FireblocksSubmitted { external_tx_id, .. } => {
+                Self::retry_attempt_from_external_tx_id(external_tx_id)
+                    .unwrap_or(0)
+                    + 1
+            }
+            _ => 1,
+        };
+
         let failed_from = Box::new(self.clone());
 
         let (Self::Minting {
@@ -1277,6 +1587,7 @@ impl Mint {
             journal_confirmed_at,
             error,
             failed_at,
+            attempts,
             failed_from,
         };
     }
@@ -1524,8 +1835,8 @@ impl Aggregate for Mint {
             MintCommand::SendCallback { issuer_request_id } => {
                 self.handle_send_callback(services, issuer_request_id).await
             }
-            MintCommand::Recover { issuer_request_id } => {
-                self.handle_recover(services, issuer_request_id).await
+            MintCommand::Recover { issuer_request_id, mode } => {
+                self.handle_recover(services, issuer_request_id, mode).await
             }
             MintCommand::RecoverFromReceipt { issuer_request_id, tx_hash } => {
                 self.handle_recover_from_receipt(
@@ -1677,6 +1988,14 @@ pub(crate) enum MintError {
     NotInMintingOrMintingFailedState { current_state: String },
     #[error("Mint not in recoverable state. Current state: {current_state}")]
     NotRecoverable { current_state: String },
+    #[error("Automatic mint retry is not due until {retry_at}")]
+    RetryNotDue { retry_at: DateTime<Utc> },
+    #[error("Automatic mint retries exhausted after {attempts} attempts")]
+    AutomaticRetriesExhausted { attempts: u32 },
+    #[error("Fireblocks mint transaction is still pending: {fireblocks_tx_id}")]
+    FireblocksTxStillPending { fireblocks_tx_id: String },
+    #[error("Retry delay out of range")]
+    RetryDelayOutOfRange,
     #[error(
         "Fireblocks tx ID mismatch. Expected: {expected}, provided: {provided}"
     )]
@@ -1695,12 +2014,15 @@ pub(crate) enum MintError {
     ReceiptInventoryView(#[from] ReceiptInventoryViewError),
     #[error(transparent)]
     ReceiptLookup(#[from] ReceiptLookupError),
+    #[error("Vault: {0}")]
+    Vault(#[from] VaultError),
 }
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, B256, address, b256, uint};
-    use chrono::Utc;
+    use alloy::primitives::{Address, B256, U256, address, b256, uint};
+    use async_trait::async_trait;
+    use chrono::{DateTime, Duration as ChronoDuration, Utc};
     use cqrs_es::View;
     use cqrs_es::{
         Aggregate, AggregateContext, CqrsFramework, EventStore,
@@ -1712,25 +2034,173 @@ pub(crate) mod tests {
     use sqlx::sqlite::SqlitePoolOptions;
     use std::collections::HashMap;
     use std::sync::Arc;
+    use tracing::Level;
+    use tracing_test::traced_test;
     use uuid::Uuid;
 
     use super::{
-        ClientId, IssuerMintRequestId, Mint, MintCommand, MintError, MintEvent,
-        MintServices, MintView, Network, Quantity, TokenSymbol,
-        TokenizationRequestId, UnderlyingSymbol,
+        AutomaticRetryDecision, ClientId, IssuerMintRequestId, Mint,
+        MintCommand, MintError, MintEvent, MintRecoveryMode, MintServices,
+        MintView, Network, Quantity, TokenSymbol, TokenizationRequestId,
+        UnderlyingSymbol,
     };
     use crate::alpaca::mock::MockAlpacaService;
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+    use crate::test_utils::log_count_at;
     use crate::tokenized_asset::{
         TokenizedAsset, TokenizedAssetCommand, TokenizedAssetView,
     };
     use crate::vault::mock::MockVaultService;
+    use crate::vault::{
+        FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
+        ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    };
 
     pub(super) const VAULT: Address =
         address!("0xcccccccccccccccccccccccccccccccccccccccc");
 
     pub(super) const BOT: Address =
         address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    struct TerminalFailedMintVault {
+        submitted_external_tx_id: Arc<std::sync::Mutex<Option<String>>>,
+    }
+
+    impl TerminalFailedMintVault {
+        fn new() -> Self {
+            Self {
+                submitted_external_tx_id: Arc::new(std::sync::Mutex::new(None)),
+            }
+        }
+
+        fn submitted_external_tx_id(&self) -> Option<String> {
+            self.submitted_external_tx_id.lock().unwrap().clone()
+        }
+    }
+
+    #[async_trait]
+    impl VaultService for TerminalFailedMintVault {
+        async fn submit_mint(
+            &self,
+            _vault: Address,
+            _assets: U256,
+            _bot: Address,
+            _user: Address,
+            _receipt_info: ReceiptInformation,
+            external_tx_id: Option<String>,
+        ) -> Result<SubmittedTx, VaultError> {
+            let external_tx_id =
+                external_tx_id.unwrap_or_else(|| "mint-base".to_string());
+            *self.submitted_external_tx_id.lock().unwrap() =
+                Some(external_tx_id.clone());
+
+            Ok(SubmittedTx {
+                external_tx_id,
+                fireblocks_tx_id: "fb-retry".to_string(),
+            })
+        }
+
+        async fn confirm_mint(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<MintResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn get_share_balance(
+            &self,
+            _vault: Address,
+            _owner: Address,
+        ) -> Result<U256, VaultError> {
+            Ok(U256::ZERO)
+        }
+
+        async fn check_fireblocks_tx(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<Option<FireblocksTxStatus>, VaultError> {
+            Ok(Some(FireblocksTxStatus::Failed {
+                detail: "Failed".to_string(),
+                sub_status: Some("INSUFFICIENT_FUNDS_FOR_FEE".to_string()),
+                network_tx_hashes: vec![],
+            }))
+        }
+
+        async fn submit_burn(
+            &self,
+            _params: MultiBurnParams,
+        ) -> Result<SubmittedTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn confirm_burn(
+            &self,
+            _fireblocks_tx_id: &str,
+            _expected_dust_shares: U256,
+        ) -> Result<MultiBurnResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+    }
+
+    /// Vault whose prior Fireblocks tx is terminally failed and whose retry
+    /// submission also fails. Exercises the failed-resubmission path.
+    struct RetrySubmitFailsVault;
+
+    #[async_trait]
+    impl VaultService for RetrySubmitFailsVault {
+        async fn submit_mint(
+            &self,
+            _vault: Address,
+            _assets: U256,
+            _bot: Address,
+            _user: Address,
+            _receipt_info: ReceiptInformation,
+            _external_tx_id: Option<String>,
+        ) -> Result<SubmittedTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn confirm_mint(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<MintResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn get_share_balance(
+            &self,
+            _vault: Address,
+            _owner: Address,
+        ) -> Result<U256, VaultError> {
+            Ok(U256::ZERO)
+        }
+
+        async fn check_fireblocks_tx(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<Option<FireblocksTxStatus>, VaultError> {
+            Ok(Some(FireblocksTxStatus::Failed {
+                detail: "Failed".to_string(),
+                sub_status: Some("INSUFFICIENT_FUNDS_FOR_FEE".to_string()),
+                network_tx_hashes: vec![],
+            }))
+        }
+
+        async fn submit_burn(
+            &self,
+            _params: MultiBurnParams,
+        ) -> Result<SubmittedTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn confirm_burn(
+            &self,
+            _fireblocks_tx_id: &str,
+            _expected_dust_shares: U256,
+        ) -> Result<MultiBurnResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+    }
 
     pub(super) struct MintTestFixture {
         pub(super) mint_cqrs: Arc<CqrsFramework<Mint, MemStore<Mint>>>,
@@ -1741,6 +2211,13 @@ pub(crate) mod tests {
 
     impl MintTestFixture {
         pub(super) async fn new() -> Self {
+            Self::new_with_vault(Arc::new(MockVaultService::new_success()))
+                .await
+        }
+
+        pub(super) async fn new_with_vault(
+            vault: Arc<dyn VaultService>,
+        ) -> Self {
             let pool = SqlitePoolOptions::new()
                 .max_connections(1)
                 .connect(":memory:")
@@ -1782,7 +2259,7 @@ pub(crate) mod tests {
             ));
 
             let services = MintServices {
-                vault: Arc::new(MockVaultService::new_success()),
+                vault,
                 alpaca: Arc::new(MockAlpacaService::new_success()),
                 receipts: Arc::new(CqrsReceiptService::new(
                     receipt_store,
@@ -1815,6 +2292,45 @@ pub(crate) mod tests {
                 .await
                 .unwrap();
         }
+    }
+
+    fn minting_events_for_retry(
+        issuer_request_id: &IssuerMintRequestId,
+        external_tx_id: String,
+        failed_at: DateTime<Utc>,
+    ) -> Vec<MintEvent> {
+        vec![
+            MintEvent::Initiated {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("tok-123"),
+                quantity: Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::new("base"),
+                client_id: ClientId::new(),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                initiated_at: failed_at,
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: failed_at,
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: failed_at,
+            },
+            MintEvent::FireblocksSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id,
+                fireblocks_tx_id: "fb-failed".to_string(),
+                submitted_at: failed_at,
+            },
+            MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "terminal Fireblocks failure".to_string(),
+                failed_at,
+            },
+        ]
     }
 
     prop_compose! {
@@ -2901,6 +3417,389 @@ pub(crate) mod tests {
         assert_eq!(format!("{id}"), "alp-456");
     }
 
+    #[traced_test]
+    #[tokio::test]
+    async fn automatic_recovery_retries_terminal_failed_fireblocks_mint_after_delay()
+     {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let failed_at = Utc::now() - ChronoDuration::minutes(2);
+        let events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}"),
+            failed_at,
+        );
+        let vault = Arc::new(TerminalFailedMintVault::new());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            vault.submitted_external_tx_id(),
+            Some(format!("mint-{issuer_request_id}-retry-1"))
+        );
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+
+        let Mint::FireblocksSubmitted { external_tx_id, .. } =
+            context.aggregate()
+        else {
+            panic!("Expected FireblocksSubmitted after retry");
+        };
+        assert_eq!(
+            external_tx_id,
+            &format!("mint-{issuer_request_id}-retry-1")
+        );
+
+        // A successful retry must record MintRetryStarted as the permanent
+        // audit-trail fact that recovery resubmitted the mint.
+        let stored = fixture
+            .mint_store
+            .load_events(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        let retry_started = stored
+            .iter()
+            .filter(|event| {
+                matches!(event.payload, MintEvent::MintRetryStarted { .. })
+            })
+            .count();
+        assert_eq!(
+            retry_started, 1,
+            "Expected exactly one MintRetryStarted event after a retry"
+        );
+
+        // The retry-submission warning is the primary operational signal that
+        // recovery resubmitted after a terminal Fireblocks failure.
+        let test = "automatic_recovery_retries_terminal_failed_fireblocks_mint_after_delay";
+        assert_eq!(
+            log_count_at!(Level::WARN, &[test, "submitting retry"]),
+            1,
+            "Expected the retry-submission warning to be emitted once"
+        );
+    }
+
+    #[tokio::test]
+    async fn automatic_recovery_waits_until_retry_delay_elapses() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}"),
+            Utc::now(),
+        );
+        let vault = Arc::new(TerminalFailedMintVault::new());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        let result = fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(cqrs_es::AggregateError::UserError(
+                    MintError::RetryNotDue { .. }
+                ))
+            ),
+            "Expected RetryNotDue, got {result:?}"
+        );
+        assert_eq!(vault.submitted_external_tx_id(), None);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn manual_reprocess_can_bypass_automatic_retry_cap() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let failed_at = Utc::now() - ChronoDuration::hours(2);
+        let events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}-retry-4"),
+            failed_at,
+        );
+        let vault = Arc::new(TerminalFailedMintVault::new());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        let automatic_result = fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await;
+        assert!(
+            matches!(
+                automatic_result,
+                Err(cqrs_es::AggregateError::UserError(
+                    MintError::AutomaticRetriesExhausted { attempts: 4 }
+                ))
+            ),
+            "Expected AutomaticRetriesExhausted, got {automatic_result:?}"
+        );
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Manual,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            vault.submitted_external_tx_id(),
+            Some(format!("mint-{issuer_request_id}-retry-5"))
+        );
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        let Mint::FireblocksSubmitted { external_tx_id, .. } =
+            context.aggregate()
+        else {
+            panic!(
+                "Expected FireblocksSubmitted after manual retry, got: {}",
+                context.aggregate().state_name()
+            );
+        };
+        assert_eq!(
+            external_tx_id,
+            &format!("mint-{issuer_request_id}-retry-5")
+        );
+
+        // The manual bypass submits the next retry transaction; the automatic
+        // attempt before it was rejected by the cap and never submitted.
+        let test = "manual_reprocess_can_bypass_automatic_retry_cap";
+        let expected_external = format!("mint-{issuer_request_id}-retry-5");
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    test,
+                    "Mint transaction submitted to signing backend",
+                    expected_external.as_str(),
+                ]
+            ),
+            1,
+            "Expected the manual retry-5 submission to be logged once"
+        );
+    }
+
+    /// A retry whose *submission* fails (vs. confirmation) must not advance the
+    /// aggregate past MintingFailed: emitting MintRetryStarted there would drop
+    /// the FireblocksSubmitted predecessor and reset the retry counter to 1,
+    /// reusing a spent external_tx_id and bypassing the automatic cap.
+    #[tokio::test]
+    async fn failed_retry_submission_preserves_predecessor_and_counter() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        // Predecessor was retry attempt 1; failed 2h ago so attempt 2 is due.
+        let original_failed_at = Utc::now() - ChronoDuration::hours(2);
+        let events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}-retry-1"),
+            original_failed_at,
+        );
+        let fixture =
+            MintTestFixture::new_with_vault(Arc::new(RetrySubmitFailsVault))
+                .await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        let aggregate = context.aggregate();
+
+        let Mint::MintingFailed { failed_at, failed_from, .. } = aggregate
+        else {
+            panic!(
+                "Expected MintingFailed after failed resubmission, got: {}",
+                aggregate.state_name()
+            );
+        };
+        assert!(
+            matches!(failed_from.as_ref(), Mint::FireblocksSubmitted { .. }),
+            "Predecessor chain must be preserved on submission failure"
+        );
+        assert_eq!(
+            aggregate.next_retry_attempt(),
+            2,
+            "Retry counter must not reset after a failed retry submission"
+        );
+        assert!(
+            *failed_at > original_failed_at,
+            "failed_at must advance so the backoff anchor moves forward"
+        );
+
+        let stored = fixture
+            .mint_store
+            .load_events(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        let retry_started = stored
+            .iter()
+            .filter(|event| {
+                matches!(event.payload, MintEvent::MintRetryStarted { .. })
+            })
+            .count();
+        assert_eq!(
+            retry_started, 0,
+            "A failed submission must not emit MintRetryStarted"
+        );
+    }
+
+    /// Manual recovery bypasses the not-yet-elapsed retry window, not just the
+    /// attempt cap: an operator who has fixed the underlying issue can submit
+    /// the next retry immediately instead of waiting for the automatic delay.
+    #[tokio::test]
+    async fn manual_reprocess_bypasses_retry_delay() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        // Failed just now: automatic recovery would return RetryNotDue.
+        let events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}"),
+            Utc::now(),
+        );
+        let vault = Arc::new(TerminalFailedMintVault::new());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        fixture
+            .mint_cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Manual,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            vault.submitted_external_tx_id(),
+            Some(format!("mint-{issuer_request_id}-retry-1")),
+            "Manual recovery must submit immediately despite the unelapsed \
+             retry window"
+        );
+    }
+
+    /// Submission failures that never reach Fireblocks (no FireblocksSubmitted
+    /// predecessor) must still escalate the retry schedule and eventually
+    /// exhaust, while the external_tx_id stays at retry-1 so resubmission is
+    /// idempotent (Fireblocks dedupes a spent id rather than double-minting).
+    #[test]
+    fn pre_acceptance_failures_escalate_attempts_but_reuse_external_id() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let now = Utc::now();
+        let mut mint = Mint::default();
+        mint.apply(MintEvent::Initiated {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: TokenizationRequestId::new("tok-123"),
+            quantity: Quantity::new(Decimal::from(100)),
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::new("base"),
+            client_id: ClientId::new(),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            initiated_at: now,
+        });
+        mint.apply(MintEvent::JournalConfirmed {
+            issuer_request_id: issuer_request_id.clone(),
+            confirmed_at: now,
+        });
+        mint.apply(MintEvent::MintingStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            started_at: now,
+        });
+
+        // failed_at far in the past so every retry window has elapsed; the
+        // decision then turns only on the escalating attempt counter.
+        let failed_at = now - ChronoDuration::hours(3);
+
+        // First submission failure from Minting: attempts = 1, retryable.
+        mint.apply(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "submission rejected".to_string(),
+            failed_at,
+        });
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Ready
+        );
+
+        // Three more pre-acceptance failures push attempts to 4 (still the last
+        // retryable attempt), then a fifth exhausts the automatic schedule —
+        // proving the counter escalates without a FireblocksSubmitted record.
+        for _ in 0..3 {
+            mint.apply(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+            });
+        }
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Ready
+        );
+
+        mint.apply(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "submission rejected".to_string(),
+            failed_at,
+        });
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Exhausted
+        );
+
+        // The external_tx_id attempt never advanced — retries reuse retry-1.
+        assert_eq!(mint.next_retry_attempt(), 1);
+    }
+
     #[test]
     fn test_recover_from_receipt_rejects_journal_confirmed() {
         let issuer_request_id = IssuerMintRequestId::random();
@@ -3019,6 +3918,7 @@ pub(crate) mod tests {
             journal_confirmed_at: now,
             error: "some error".to_string(),
             failed_at: now,
+            attempts: 1,
             failed_from: Box::new(journal_confirmed),
         };
 

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1,12 +1,18 @@
 use alloy::primitives::TxHash;
 use async_trait::async_trait;
-use cqrs_es::{AggregateError, CqrsFramework, EventStore};
+use chrono::Utc;
+use cqrs_es::{AggregateContext, AggregateError, CqrsFramework, EventStore};
 use sqlite_es::SqliteCqrs;
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
-use super::{IssuerMintRequestId, Mint, MintCommand, MintError};
+use super::{
+    AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
+    MintRecoveryMode,
+};
 use crate::receipt_inventory::ItnReceiptHandler;
+use crate::{MintCqrs, MintEventStore};
 
 /// Production handler that triggers mint recovery when an ITN receipt is
 /// discovered by the receipt monitor.
@@ -41,17 +47,196 @@ impl ItnReceiptHandler for MintRecoveryHandler {
     }
 }
 
+/// Why a [`drive_recovery`] pass stopped. Lets the scheduled recovery loop
+/// decide whether to wait, back off, or give up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum DriveOutcome {
+    /// Reached a terminal or non-recoverable state — no further work.
+    Done,
+    /// Paused until the next automatic retry window elapses.
+    RetryNotDue,
+    /// The previously submitted Fireblocks transaction is still pending.
+    Pending,
+    /// Automatic retry budget is exhausted.
+    Exhausted,
+    /// A command failed unexpectedly, or recovery did not converge.
+    Failed,
+}
+
 /// Drives a mint through recovery to completion using `MintCommand::Recover`.
 pub(crate) async fn recover_mint<ES>(
     mint_cqrs: &CqrsFramework<Mint, ES>,
     issuer_request_id: IssuerMintRequestId,
-) where
+) -> DriveOutcome
+where
     ES: EventStore<Mint>,
 {
     drive_recovery(mint_cqrs, issuer_request_id, |id| MintCommand::Recover {
         issuer_request_id: id,
+        mode: MintRecoveryMode::Automatic,
     })
-    .await;
+    .await
+}
+
+/// Fixed backoff applied when a scheduled recovery pass cannot make progress —
+/// the previously submitted Fireblocks tx is still pending, or a transient
+/// error (e.g. RPC blip) occurred. Keeps the loop from spinning while waiting.
+const SCHEDULED_RECOVERY_BACKOFF: Duration = Duration::from_secs(60);
+
+/// Budget for retry-window wakeups (`Wait` / `RetryNotDue`). The automatic
+/// schedule already terminates healthy retries via `Exhausted` after the
+/// attempt cap; this bounds the degenerate case where a mint keeps re-failing
+/// at the same attempt (e.g. submission errors before Fireblocks acceptance),
+/// so the task gives up and the next restart re-picks it instead of looping.
+const MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS: usize =
+    (Mint::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT as usize) * 2 + 4;
+
+/// Budget for consecutive transient-failure backoffs (e.g. RPC blips) before
+/// giving up. Small: a persistent error should surface for investigation, not
+/// be hammered indefinitely. The next restart re-picks the mint.
+const MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS: usize = 8;
+
+/// Budget for polling a still-pending Fireblocks tx. A pending tx is a healthy
+/// state (queued, awaiting policy approval, broadcasting, confirming) that we do
+/// not control, so this is sized generously — ~6h at [`SCHEDULED_RECOVERY_BACKOFF`]
+/// — separate from the transient-failure budget, so a slow finalization is not
+/// abandoned prematurely.
+const MAX_SCHEDULED_RECOVERY_PENDING_POLLS: usize = 360;
+
+pub(crate) fn spawn_scheduled_mint_recovery(
+    mint_cqrs: MintCqrs,
+    event_store: MintEventStore,
+    issuer_request_id: IssuerMintRequestId,
+) {
+    tokio::spawn(async move {
+        recover_mint_until_automatic_budget_exhausted(
+            mint_cqrs.as_ref(),
+            event_store.as_ref(),
+            issuer_request_id,
+            SCHEDULED_RECOVERY_BACKOFF,
+            MAX_SCHEDULED_RECOVERY_PENDING_POLLS,
+        )
+        .await;
+    });
+}
+
+async fn recover_mint_until_automatic_budget_exhausted<ES>(
+    mint_cqrs: &CqrsFramework<Mint, ES>,
+    event_store: &ES,
+    issuer_request_id: IssuerMintRequestId,
+    backoff: Duration,
+    max_pending_polls: usize,
+) where
+    ES: EventStore<Mint>,
+{
+    let aggregate_id = issuer_request_id.to_string();
+    let mut retry_wakeups = 0;
+    let mut failure_backoffs = 0;
+    let mut pending_polls = 0;
+    let mut polled_tx_id: Option<String> = None;
+
+    loop {
+        let context = match event_store.load_aggregate(&aggregate_id).await {
+            Ok(context) => context,
+            Err(err) => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Failed to load mint for scheduled recovery"
+                );
+                return;
+            }
+        };
+
+        // Give each distinct Fireblocks transaction its own pending-poll
+        // budget: when recovery advances to a new submitted tx, reset the
+        // counter so a healthy retry is not abandoned because a prior tx
+        // already spent the budget.
+        let current_tx_id = context.aggregate().pending_fireblocks_tx_id();
+        if current_tx_id != polled_tx_id {
+            pending_polls = 0;
+            polled_tx_id = current_tx_id;
+        }
+
+        match context.aggregate().automatic_retry_decision(Utc::now()) {
+            AutomaticRetryDecision::Ready => {
+                match recover_mint(mint_cqrs, issuer_request_id.clone()).await {
+                    DriveOutcome::Done | DriveOutcome::Exhausted => return,
+                    // A still-pending Fireblocks tx is healthy; poll it on a
+                    // generous budget separate from transient failures.
+                    DriveOutcome::Pending => {
+                        pending_polls += 1;
+                        if pending_polls > max_pending_polls {
+                            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                                max_pending_polls,
+                                "Scheduled mint recovery stopped after maximum pending polls"
+                            );
+                            return;
+                        }
+
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            backoff_ms = backoff.as_millis(),
+                            "Scheduled recovery waiting for pending Fireblocks transaction"
+                        );
+                        tokio::time::sleep(backoff).await;
+                    }
+                    // A transient error: back off and retry a bounded number of
+                    // times so a persistent error surfaces rather than looping.
+                    DriveOutcome::Failed => {
+                        failure_backoffs += 1;
+                        if failure_backoffs
+                            > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS
+                        {
+                            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                                max_failure_backoffs = MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS,
+                                "Scheduled mint recovery stopped after maximum failure backoffs"
+                            );
+                            return;
+                        }
+
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            backoff_ms = backoff.as_millis(),
+                            "Scheduled recovery backing off after a transient failure"
+                        );
+                        tokio::time::sleep(backoff).await;
+                    }
+                    // The retry window passed between the decision and the
+                    // submit-time re-check; sleep so a clock race does not spin
+                    // the wakeup budget, then re-evaluate (next decision Waits).
+                    DriveOutcome::RetryNotDue => {
+                        retry_wakeups += 1;
+                        if retry_wakeups > MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS
+                        {
+                            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                                max_retry_wakeups = MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS,
+                                "Scheduled mint recovery stopped after maximum retry wakeups"
+                            );
+                            return;
+                        }
+
+                        tokio::time::sleep(backoff).await;
+                    }
+                }
+            }
+            AutomaticRetryDecision::Wait(wait) => {
+                retry_wakeups += 1;
+                if retry_wakeups > MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS {
+                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                        max_retry_wakeups = MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS,
+                        "Scheduled mint recovery stopped after maximum retry wakeups"
+                    );
+                    return;
+                }
+
+                debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                    wait_ms = wait.as_millis(),
+                    "Waiting for next automatic mint retry window"
+                );
+                tokio::time::sleep(wait).await;
+            }
+            AutomaticRetryDecision::Exhausted
+            | AutomaticRetryDecision::NotRecoverable => return,
+        }
+    }
 }
 
 const MAX_RECOVERY_ATTEMPTS: usize = 10;
@@ -70,7 +255,8 @@ async fn drive_recovery<ES>(
     mint_cqrs: &CqrsFramework<Mint, ES>,
     issuer_request_id: IssuerMintRequestId,
     make_command: impl Fn(IssuerMintRequestId) -> MintCommand,
-) where
+) -> DriveOutcome
+where
     ES: EventStore<Mint>,
 {
     let aggregate_id = issuer_request_id.to_string();
@@ -94,14 +280,41 @@ async fn drive_recovery<ES>(
                     current_state,
                     "Mint recovery complete"
                 );
-                return;
+                return DriveOutcome::Done;
+            }
+            Err(AggregateError::UserError(MintError::RetryNotDue {
+                retry_at,
+            })) => {
+                info!(target: "mint", issuer_request_id = %issuer_request_id,
+                    %retry_at,
+                    "Mint recovery paused until retry window"
+                );
+                return DriveOutcome::RetryNotDue;
+            }
+            Err(AggregateError::UserError(
+                MintError::AutomaticRetriesExhausted { attempts },
+            )) => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    attempts,
+                    "Automatic mint retries exhausted"
+                );
+                return DriveOutcome::Exhausted;
+            }
+            Err(AggregateError::UserError(
+                MintError::FireblocksTxStillPending { fireblocks_tx_id },
+            )) => {
+                info!(target: "mint", issuer_request_id = %issuer_request_id,
+                    fireblocks_tx_id,
+                    "Mint recovery paused while Fireblocks transaction is pending"
+                );
+                return DriveOutcome::Pending;
             }
             Err(err) => {
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     error = %err,
                     "Mint recovery failed"
                 );
-                return;
+                return DriveOutcome::Failed;
             }
         }
     }
@@ -111,11 +324,13 @@ async fn drive_recovery<ES>(
         max_attempts = MAX_RECOVERY_ATTEMPTS,
         "Mint recovery exceeded maximum attempts without reaching terminal state"
     );
+
+    DriveOutcome::Failed
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, b256, uint};
+    use alloy::primitives::{Address, U256, address, b256, uint};
     use chrono::Utc;
     use cqrs_es::AggregateContext;
     use rust_decimal::Decimal;
@@ -132,7 +347,80 @@ mod tests {
         ReceiptId, ReceiptInventoryCommand, ReceiptSource, Shares,
     };
     use crate::test_utils::log_count_at;
-    use crate::vault::ReceiptInformation;
+    use crate::vault::{
+        FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
+        ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    };
+
+    /// Vault whose Fireblocks transaction never finalizes — every status check
+    /// returns `Pending`. Used to exercise the scheduled-recovery backoff.
+    struct PendingMintVault;
+
+    #[async_trait]
+    impl VaultService for PendingMintVault {
+        async fn submit_mint(
+            &self,
+            _vault: Address,
+            _assets: U256,
+            _bot: Address,
+            _user: Address,
+            _receipt_info: ReceiptInformation,
+            _external_tx_id: Option<String>,
+        ) -> Result<SubmittedTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn confirm_mint(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<MintResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn get_share_balance(
+            &self,
+            _vault: Address,
+            _owner: Address,
+        ) -> Result<U256, VaultError> {
+            Ok(U256::ZERO)
+        }
+
+        async fn check_fireblocks_tx(
+            &self,
+            _fireblocks_tx_id: &str,
+        ) -> Result<Option<FireblocksTxStatus>, VaultError> {
+            Ok(Some(FireblocksTxStatus::Pending))
+        }
+
+        async fn submit_burn(
+            &self,
+            _params: MultiBurnParams,
+        ) -> Result<SubmittedTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn confirm_burn(
+            &self,
+            _fireblocks_tx_id: &str,
+            _expected_dust_shares: U256,
+        ) -> Result<MultiBurnResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+    }
+
+    fn fireblocks_failed_events(
+        issuer_request_id: &IssuerMintRequestId,
+        failed_at: chrono::DateTime<Utc>,
+    ) -> Vec<MintEvent> {
+        let mut events = fireblocks_submitted_events(issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "terminal Fireblocks failure".to_string(),
+            failed_at,
+        });
+
+        events
+    }
 
     fn test_issuer_request_id() -> IssuerMintRequestId {
         IssuerMintRequestId::new(
@@ -359,6 +647,7 @@ mod tests {
                 &issuer_request_id.to_string(),
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
                 },
             )
             .await
@@ -396,6 +685,7 @@ mod tests {
                 &issuer_request_id.to_string(),
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
                 },
             )
             .await
@@ -439,6 +729,7 @@ mod tests {
                 &issuer_request_id.to_string(),
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
                 },
             )
             .await
@@ -487,6 +778,106 @@ mod tests {
         assert_eq!(
             log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
             1,
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_mint_returns_pending_while_fireblocks_tx_pending() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = fireblocks_failed_events(&issuer_request_id, failed_at);
+        let fixture =
+            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        let outcome =
+            recover_mint(fixture.mint_cqrs.as_ref(), issuer_request_id).await;
+
+        assert_eq!(outcome, DriveOutcome::Pending);
+    }
+
+    /// A pending Fireblocks transaction must make the scheduled loop back off
+    /// between wakeups rather than spinning through its budget instantly. The
+    /// loop sleeps the backoff on every pending wakeup, so total elapsed time
+    /// must be at least one backoff per wakeup — a spinning loop would finish
+    /// in microseconds.
+    #[traced_test]
+    #[tokio::test]
+    async fn scheduled_recovery_backs_off_while_fireblocks_tx_pending() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = fireblocks_failed_events(&issuer_request_id, failed_at);
+        let fixture =
+            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        let backoff = Duration::from_millis(5);
+        let max_pending_polls = 8;
+        let start = tokio::time::Instant::now();
+        recover_mint_until_automatic_budget_exhausted(
+            fixture.mint_cqrs.as_ref(),
+            fixture.mint_store.as_ref(),
+            issuer_request_id.clone(),
+            backoff,
+            max_pending_polls,
+        )
+        .await;
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed
+                >= backoff * (u32::try_from(max_pending_polls).unwrap() - 1),
+            "Scheduled recovery must sleep the backoff on each pending \
+             poll, elapsed={elapsed:?}"
+        );
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        assert!(
+            matches!(context.aggregate(), Mint::MintingFailed { .. }),
+            "Mint stays MintingFailed while the tx remains pending, got: {}",
+            context.aggregate().state_name()
+        );
+
+        let test = "scheduled_recovery_backs_off_while_fireblocks_tx_pending";
+        assert!(
+            log_count_at!(
+                Level::WARN,
+                &[test, "stopped after maximum pending polls"]
+            ) >= 1,
+            "Loop must stop with a warning once the pending-poll budget is spent"
+        );
+    }
+
+    /// A mint already in `FireblocksSubmitted` whose tx is still pending must
+    /// pause recovery (DriveOutcome::Pending) via the non-blocking pre-check
+    /// rather than blocking in confirm_mint or flipping to MintingFailed.
+    #[tokio::test]
+    async fn fireblocks_submitted_pending_tx_pauses_recovery() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = fireblocks_submitted_events(&issuer_request_id);
+        let fixture =
+            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
+        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+
+        let outcome =
+            recover_mint(fixture.mint_cqrs.as_ref(), issuer_request_id.clone())
+                .await;
+
+        assert_eq!(outcome, DriveOutcome::Pending);
+
+        let context = fixture
+            .mint_store
+            .load_aggregate(&issuer_request_id.to_string())
+            .await
+            .unwrap();
+        assert!(
+            matches!(context.aggregate(), Mint::FireblocksSubmitted { .. }),
+            "A pending tx must leave the mint in FireblocksSubmitted, got: {}",
+            context.aggregate().state_name()
         );
     }
 }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -163,6 +163,7 @@ impl VaultService for MockVaultService {
         bot: Address,
         _user: Address,
         receipt_info: ReceiptInformation,
+        external_tx_id: Option<String>,
     ) -> Result<SubmittedTx, VaultError> {
         #[cfg(test)]
         if matches!(self.behavior, MockBehavior::SubmitFailure) {
@@ -211,7 +212,8 @@ impl VaultService for MockVaultService {
         });
 
         Ok(SubmittedTx {
-            external_tx_id: "mock-mint".to_string(),
+            external_tx_id: external_tx_id
+                .unwrap_or_else(|| "mock-mint".to_string()),
             fireblocks_tx_id: "mock-fb-mint".to_string(),
         })
     }
@@ -411,7 +413,14 @@ mod tests {
         let receipt_info = test_receipt_info();
 
         let submitted = mock
-            .submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
+            .submit_mint(
+                vault,
+                assets,
+                bot_wallet,
+                user_wallet,
+                receipt_info,
+                None,
+            )
             .await
             .unwrap();
 
@@ -438,7 +447,14 @@ mod tests {
 
         // Submit always succeeds
         let submitted = mock
-            .submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
+            .submit_mint(
+                vault,
+                assets,
+                bot_wallet,
+                user_wallet,
+                receipt_info,
+                None,
+            )
             .await
             .unwrap();
 
@@ -464,6 +480,7 @@ mod tests {
             bot_wallet,
             user_wallet,
             test_receipt_info(),
+            None,
         )
         .await
         .unwrap();
@@ -488,6 +505,7 @@ mod tests {
             bot_wallet,
             user_wallet,
             receipt_info.clone(),
+            None,
         )
         .await
         .unwrap();
@@ -517,9 +535,16 @@ mod tests {
         let receipt_info = test_receipt_info();
 
         let start = tokio::time::Instant::now();
-        mock.submit_mint(vault, assets, bot_wallet, user_wallet, receipt_info)
-            .await
-            .unwrap();
+        mock.submit_mint(
+            vault,
+            assets,
+            bot_wallet,
+            user_wallet,
+            receipt_info,
+            None,
+        )
+        .await
+        .unwrap();
         let elapsed = start.elapsed();
 
         assert!(elapsed.as_millis() >= u128::from(delay_ms));
@@ -541,6 +566,7 @@ mod tests {
             bot_wallet,
             user_wallet,
             receipt_info.clone(),
+            None,
         )
         .await
         .unwrap();
@@ -627,6 +653,7 @@ mod tests {
                 test_receiver(),
                 address!("0x1111111111111111111111111111111111111111"),
                 test_receipt_info(),
+                None,
             )
             .await;
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -36,6 +36,7 @@ pub(crate) trait VaultService: Send + Sync {
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
+        external_tx_id: Option<String>,
     ) -> Result<SubmittedTx, VaultError>;
 
     /// Confirms a previously submitted mint transaction.

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -70,6 +70,7 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         bot: Address,
         user: Address,
         receipt_info: ReceiptInformation,
+        external_tx_id: Option<String>,
     ) -> Result<SubmittedTx, VaultError> {
         let oa_schema = self.oa_schema_cache.get(vault).await;
         let receipt_info_bytes = receipt_info.encode(oa_schema.as_deref())?;
@@ -135,10 +136,9 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         self.cached_mints.lock().await.insert(tx_hash_str.clone(), result);
 
         Ok(SubmittedTx {
-            external_tx_id: format!(
-                "local-mint-{}",
-                receipt_info.issuer_request_id
-            ),
+            external_tx_id: external_tx_id.unwrap_or_else(|| {
+                format!("local-mint-{}", receipt_info.issuer_request_id)
+            }),
             fireblocks_tx_id: tx_hash_str,
         })
     }
@@ -582,6 +582,7 @@ mod tests {
                 bot_wallet,
                 user_wallet,
                 receipt_info,
+                None,
             )
             .await;
 
@@ -678,6 +679,7 @@ mod tests {
                 bot_wallet,
                 user_wallet,
                 receipt_info,
+                None,
             )
             .await;
 

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -840,12 +840,14 @@ async fn test_mint_recovery_from_minting_failed_state()
     )
     .await?;
 
-    // Event 4: MintingFailed
+    // Event 4: MintingFailed. failed_at is set well in the past so the first
+    // automatic retry window (1m) has already elapsed and recovery retries
+    // immediately rather than waiting.
     let failed_payload = json!({
         "MintingFailed": {
             "issuer_request_id": issuer_request_id,
             "error": "Simulated blockchain error",
-            "failed_at": chrono::Utc::now().to_rfc3339()
+            "failed_at": (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339()
         }
     });
     insert_event(


### PR DESCRIPTION
## Motivation

Resolves [RAI-626](https://linear.app/makeitrain/issue/RAI-626/retry-terminal-failed-fireblocks-mints).

Terminally failed Fireblocks mint transactions were getting stuck permanently. Recovery preserved the original `fireblocks_tx_id` and kept re-confirming that same failed transaction, so even after the underlying issue was fixed (for example, funding the issuer wallet for gas), `/admin/reprocess/mint/<id>` and startup recovery could not submit a fresh transaction.

The bot also only retried mint recovery at startup. If a mint submission or confirmation failed while the service was already running, the aggregate stayed in `MintingFailed` until the next restart or manual intervention.

## Solution

### Mint recovery behavior

- Adds `MintRecoveryMode::{Automatic, Manual}` and threads it through `MintCommand::Recover`.
- Automatic recovery now treats terminal Fireblocks mint failures as retryable with a bounded schedule:
  - retry 1 after `1m`
  - retry 2 after `10m`
  - retry 3 after `30m`
  - retry 4 after `1h`
- Manual admin reprocess bypasses the automatic retry cap, so an operator can submit the next retry after fixing the underlying issue.

### Deterministic retry submissions

- Extends `VaultService::submit_mint` with an optional caller-provided `external_tx_id`.
- Fireblocks mint retries use fresh deterministic external IDs:
  - `mint-{issuer_request_id}-retry-1`
  - `mint-{issuer_request_id}-retry-2`
  - etc.
- The current retry attempt is derived from the latest persisted `FireblocksSubmitted.external_tx_id`, so restarts do not reset retry state and no new event schema is needed.

### Terminal transaction handling

- `MintingFailed` recovery now preserves the previous Fireblocks transaction metadata and checks `VaultService::check_fireblocks_tx` before deciding what to do:
  - `Completed` continues through confirmation.
  - `Pending` pauses recovery.
  - `Failed` submits the next deterministic retry transaction.
- Existing receipt discovery still wins first, so recovery records an already-minted receipt instead of resubmitting.

### Runtime retry scheduling

- Adds `spawn_scheduled_mint_recovery` in `src/mint/recovery.rs`.
- `process_journal_completion` now schedules automatic recovery when live mint submission or confirmation lands in `MintingFailed`, instead of waiting for process restart.
- Startup recovery continues to use the same automatic policy.

### Docs and operations

- Updates `SPEC.md` with the new recovery mode, retry state machine behavior, and delay schedule.
- Updates `docs/fireblocks.md` with retry `externalTxId` formats and the terminal failure retry policy.
- Updates `docs/ops-recovery-guide.md` to clarify that manual mint reprocess can submit another retry after automatic retries are exhausted.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Test plan

- [x] `nix develop --command cargo test -q --lib` — 580 passed, 0 failed, 1 ignored
- [x] `nix develop --command cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated mint recovery specifications and retry behavior documentation, including external transaction ID formats and timing/capping details for automatic retries.
  * Clarified admin recovery endpoint behavior and manual reprocess capabilities.

* **New Features**
  * Added automatic mint recovery with scheduled retry attempts and configurable delay schedules.
  * Manual admin reprocess now supports bypassing automatic retry caps.
  * Improved distinction between automatic and manual recovery modes for mint operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/159?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->