### PR TITLE
fix: stabilize deploy-blocking tests

### DIFF
--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -66,7 +66,7 @@ where
     T: alloy::providers::Provider,
 {
     let start = tokio::time::Instant::now();
-    let timeout = tokio::time::Duration::from_secs(5);
+    let timeout = tokio::time::Duration::from_secs(15);
     let poll_interval = tokio::time::Duration::from_millis(100);
 
     loop {

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -22,6 +22,61 @@ use st0x_issuance::{
     SignerConfig, initialize_rocket,
 };
 
+async fn wait_for_receipt_depleted(
+    db_url: &str,
+    vault: Address,
+    receipt_id: U256,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+    let start = tokio::time::Instant::now();
+    let timeout = Duration::from_secs(10);
+    let poll_interval = Duration::from_millis(100);
+    let expected_receipt_id = format!("{receipt_id:#x}");
+
+    loop {
+        let events: Vec<(String,)> = sqlx::query_as(
+            "
+            SELECT payload
+            FROM events
+            WHERE aggregate_type = 'ReceiptInventory'
+              AND aggregate_id = ?
+              AND event_type = 'ReceiptInventoryEvent::Depleted'
+            ",
+        )
+        .bind(vault.to_string())
+        .fetch_all(&pool)
+        .await?;
+
+        let depleted = events.iter().any(|(payload,)| {
+            receipt_id_from_event_payload(payload).as_deref()
+                == Some(expected_receipt_id.as_str())
+        });
+
+        if depleted {
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "Timeout waiting for receipt {expected_receipt_id} to be depleted"
+            )
+            .into());
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+fn receipt_id_from_event_payload(payload: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(payload).ok()?;
+
+    value["receipt_id"]
+        .as_str()
+        .or_else(|| value["Depleted"]["receipt_id"].as_str())
+        .map(ToString::to_string)
+}
+
 /// Tests that backfill checkpoint is independent from monitor discoveries.
 ///
 /// The critical scenario:
@@ -526,8 +581,7 @@ async fn test_external_burn_detected_by_withdraw_monitor()
         "Receipt A should be fully burned on-chain"
     );
 
-    // Give the monitor time to detect the Withdraw event and reconcile
-    tokio::time::sleep(Duration::from_secs(2)).await;
+    wait_for_receipt_depleted(&db_url, evm.vault_address, receipt_a_id).await?;
 
     // Step 4: Mint receipt B via API (50 shares to user)
     let link_body = harness::setup_account(&client, user_wallet).await;

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -9,12 +9,65 @@ use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
+use std::time::Duration;
+use tokio::sync::{Mutex, MutexGuard};
 use uuid::{Uuid, uuid};
 
 use harness::alpaca_mocks::{setup_mint_mocks, setup_redemption_mocks};
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+
+static RECOVERY_TEST_LOCK: Mutex<()> = Mutex::const_new(());
+
+async fn recovery_test_guard() -> MutexGuard<'static, ()> {
+    RECOVERY_TEST_LOCK.lock().await
+}
+
+async fn wait_for_event_count(
+    db_url: &str,
+    aggregate_type: &str,
+    aggregate_id: &str,
+    event_type: &str,
+    min_count: i64,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+    let start = tokio::time::Instant::now();
+    let timeout = Duration::from_secs(10);
+    let poll_interval = Duration::from_millis(100);
+
+    loop {
+        let count = sqlx::query_scalar::<_, i64>(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = ?
+              AND aggregate_id = ?
+              AND event_type = ?
+            ",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(event_type)
+        .fetch_one(&pool)
+        .await?;
+
+        if count >= min_count {
+            return Ok(count);
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "Timeout waiting for {event_type} on {aggregate_type}/{aggregate_id}; \
+                 found {count}, expected at least {min_count}"
+            )
+            .into());
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
 
 async fn insert_event(
     pool: &sqlx::Pool<sqlx::Sqlite>,
@@ -127,6 +180,8 @@ async fn insert_minting_state_events(
 #[tokio::test]
 async fn test_mint_recovery_after_view_deletion()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -177,6 +232,15 @@ async fn test_mint_recovery_after_view_deletion()
         &user_provider,
     );
     harness::wait_for_shares(&vault, user_wallet).await?;
+
+    wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintCompleted",
+        1,
+    )
+    .await?;
 
     // "Crash" - drop the service
     drop(client1);
@@ -233,8 +297,14 @@ async fn test_mint_recovery_after_view_deletion()
     // duplicate mint, but that's a separate issue (Task 7-9 handles this).
     // For now, we just want to verify recovery FINDS the stuck mint.
 
-    // Give recovery time to run
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+    wait_for_event_count(
+        &db_url,
+        "Mint",
+        &aggregate_id,
+        "MintEvent::MintingStarted",
+        1,
+    )
+    .await?;
 
     // Check if the mint progressed past JournalConfirmed
     let query_pool2 =
@@ -280,6 +350,8 @@ async fn test_mint_recovery_after_view_deletion()
 #[tokio::test]
 async fn test_mint_recovery_from_minting_state_when_receipt_exists()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -421,6 +493,8 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
 #[tokio::test]
 async fn test_mint_recovery_from_minting_state_when_no_receipt()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -518,6 +592,8 @@ async fn test_mint_recovery_from_minting_state_when_no_receipt()
 #[tokio::test]
 async fn test_mint_recovery_prevents_double_mint()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -667,6 +743,8 @@ async fn test_mint_recovery_prevents_double_mint()
 #[tokio::test]
 async fn test_receipt_monitor_triggers_recovery_for_failed_mint()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -791,6 +869,8 @@ async fn test_receipt_monitor_triggers_recovery_for_failed_mint()
 #[tokio::test]
 async fn test_mint_recovery_from_minting_failed_state()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -909,6 +989,8 @@ async fn test_mint_recovery_from_minting_failed_state()
 #[tokio::test]
 async fn test_startup_clears_and_rebuilds_views()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -1028,6 +1110,8 @@ async fn test_startup_clears_and_rebuilds_views()
 #[tokio::test]
 async fn test_detected_redemption_auto_failed_when_no_account()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -1171,6 +1255,8 @@ async fn test_detected_redemption_auto_failed_when_no_account()
 #[tokio::test]
 async fn test_burn_failed_redemption_auto_failed_when_no_balance()
 -> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
     let evm = LocalEvm::new().await?;
     let mock_alpaca = MockServer::start();
 
@@ -1286,22 +1372,13 @@ async fn test_burn_failed_redemption_auto_failed_when_no_balance()
     let _client2 =
         rocket::local::asynchronous::Client::tracked(rocket2).await?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-    // Assert: The stuck redemption should have a RedemptionFailed event
-    let verify_pool =
-        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
-
-    let failed_count = sqlx::query_scalar!(
-        r#"
-        SELECT COUNT(*) as "count: i64"
-        FROM events
-        WHERE aggregate_type = 'Redemption'
-          AND aggregate_id = 'red-baadf00d'
-          AND event_type = 'RedemptionEvent::RedemptionFailed'
-        "#
+    let failed_count = wait_for_event_count(
+        &db_url,
+        "Redemption",
+        stuck_id,
+        "RedemptionEvent::RedemptionFailed",
+        1,
     )
-    .fetch_one(&verify_pool)
     .await?;
 
     assert_eq!(


### PR DESCRIPTION
## Motivation

Deploy was blocked by flaky integration tests that depend on asynchronous Rocket background tasks and periodic receipt/redemption polling. The failing deploy run hit `test_external_burn_detected_by_withdraw_monitor`, which slept for 2 seconds even though receipt reconciliation polls every 5 seconds.

A full workspace run also exposed `tests/recovery.rs` races: tests in that binary start Rocket instances, temp SQLite databases, local EVM nodes, and mock HTTP servers concurrently, while background tasks can outlive an individual test's main future.

The first PR CI attempt then exposed the same timing class on the redemption side: `wait_for_burn` timed out after 5 seconds, exactly matching the redemption poller's 5-second interval.

## Solution

- Replace the fixed 2-second wait in `test_external_burn_detected_by_withdraw_monitor` with a polling helper that waits for the specific `ReceiptInventoryEvent::Depleted` event for receipt A.
- Extend the shared `wait_for_burn` test helper timeout to 15 seconds so poller-driven burn assertions cover more than one redemption poll cycle.
- Add a generic event-count wait helper in `tests/recovery.rs` and use it instead of sleeps for mint/recovery completion assertions.
- Serialize the `tests/recovery.rs` integration tests with a file-local async mutex so each test's Rocket/background-task infrastructure has isolated DB/mock lifetimes.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Test plan

- [x] `nix develop -c cargo test -q --test receipt_inventory test_external_burn_detected_by_withdraw_monitor -- --nocapture`
- [x] `nix develop -c cargo test -q --test receipt_inventory`
- [x] `nix develop -c cargo test -q --test recovery`
- [x] `nix develop -c cargo test -q --workspace`
- [x] `rm -f /tmp/build_db.sqlite && nix develop -c bash -c 'export DATABASE_URL=sqlite:///tmp/build_db.sqlite && sqlx database create && sqlx migrate run && cargo test -q'`
- [x] `nix develop -c cargo fmt --all -- --check`
- [x] `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- [x] `PATH="$HOME/.cargo/bin:$PATH" nix develop -c cargo nextest run --workspace --retries 2 --flaky-result fail --no-fail-fast --status-level retry --final-status-level flaky --failure-output final`
- [x] `PATH="$HOME/.cargo/bin:$PATH" nix develop -c cargo nextest run test_external_burn_detected_by_withdraw_monitor --stress-count 5 --retries 2 --flaky-result fail --no-fail-fast --status-level retry --final-status-level flaky --failure-output final`
- [x] `PATH="$HOME/.cargo/bin:$PATH" nix develop -c cargo nextest run --test recovery --stress-count 3 --retries 2 --flaky-result fail --no-fail-fast --status-level retry --final-status-level flaky --failure-output final`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased timeout for vault balance verification tests to improve reliability
  * Added enhanced test synchronization utilities to ensure consistent test execution and event monitoring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/160?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
Linear: RAI-633