### PR TITLE
feat: enrich stuck redemption tx metadata

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -142,10 +142,11 @@ struct TokenizationRequestId(String);
 /// Serializes as a UUID string, e.g. "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
 struct IssuerMintRequestId(Uuid);
 
-/// Redemption operations derive their issuer request ID from the first 4 bytes
-/// of the on-chain tx_hash that triggered the redemption.
-/// Serializes as "red-{hex}", e.g. "red-574378e0"
-struct IssuerRedemptionRequestId(FixedBytes<4>);
+/// Redemption operations derive their issuer request ID from the full on-chain
+/// tx_hash that triggered the redemption.
+/// Serializes as a 32-byte hash, e.g. "0x1234...abcd".
+/// Legacy "red-{first4bytes}" IDs remain readable for historical events.
+struct IssuerRedemptionRequestId(TxHash);
 
 struct ClientId(String);
 struct AlpacaAccountNumber(String);
@@ -1310,7 +1311,7 @@ Where `{account_id}` is our designated tokenization account ID at Alpaca.
 
 ```json
 {
-  "issuer_request_id": "red-574378e0",
+  "issuer_request_id": "0x574378e0d4f3a8b9c2e1f0a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5",
   "underlying_symbol": "AAPL",
   "token_symbol": "AAPL0x",
   "client_id": "5505-1234-ABC-4G45",
@@ -1321,12 +1322,16 @@ Where `{account_id}` is our designated tokenization account ID at Alpaca.
 }
 ```
 
+The `issuer_request_id` is the full redemption tx hash
+(`IssuerRedemptionRequestId::Full`). Redemptions recorded before this format
+still render legacy `red-{first4bytes}` IDs for their historical events.
+
 **Alpaca's Response:**
 
 ```json
 {
   "tokenization_request_id": "12345-678-90AB",
-  "issuer_request_id": "red-574378e0",
+  "issuer_request_id": "0x574378e0d4f3a8b9c2e1f0a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5",
   "created_at": "2025-09-12T17:28:48.642437-04:00",
   "type": "redeem",
   "status": "pending",
@@ -1940,7 +1945,8 @@ polling timeout scenario where burns landed on-chain but weren't recorded.
 
 **Examples:**
 
-- `POST /admin/recover/redemption/red-61e089c6`
+- `POST /admin/recover/redemption/0x61e089c6a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8`
+  (legacy `red-61e089c6` IDs are also accepted for historical redemptions)
 - `POST /admin/reprocess/mint/358508d1-54eb-4e3a-b1c5-c08fb0424f82`
 
 **Status Codes:**

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,3 +1,4 @@
+use alloy::primitives::B256;
 use chrono::{DateTime, Utc};
 use cqrs_es::{AggregateError, EventStore};
 use rocket::http::Status;
@@ -24,7 +25,7 @@ use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{FireblocksTxStatus, VaultService};
 use crate::{MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore};
 
-#[derive(Debug, Clone, Copy, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum AggregateKind {
     Mint,
@@ -52,6 +53,12 @@ pub(crate) struct StuckAggregate {
     underlying: Option<UnderlyingSymbol>,
     #[serde(skip_serializing_if = "Option::is_none")]
     quantity: Option<Quantity>,
+    /// Primary on-chain transaction hash for this aggregate, when known.
+    /// For redemptions this is the detected transfer tx hash. For mints this
+    /// is the successful mint tx hash, or a Fireblocks network hash when the
+    /// signing backend exposes one.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tx_hash: Option<B256>,
     /// Fireblocks transaction ID associated with this aggregate's current
     /// stuck step. For mints, sourced from the most recent
     /// `FireblocksSubmitted` event. For redemptions, populated only on
@@ -691,12 +698,19 @@ pub(crate) async fn close_mint(
     }))
 }
 
-#[tracing::instrument(skip(_auth, pool, mint_event_store, vault_service))]
+#[tracing::instrument(skip(
+    _auth,
+    pool,
+    mint_event_store,
+    redemption_event_store,
+    vault_service
+))]
 #[get("/admin/stuck")]
 pub(crate) async fn list_stuck(
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
     mint_event_store: &rocket::State<MintEventStore>,
+    redemption_event_store: &rocket::State<RedemptionEventStore>,
     vault_service: &rocket::State<Arc<dyn VaultService>>,
 ) -> Result<Json<StuckResponse>, Status> {
     let mut stuck = Vec::new();
@@ -708,9 +722,17 @@ pub(crate) async fn list_stuck(
     })?;
 
     for (issuer_redemption_request_id, view) in stuck_redemptions {
-        if let Some(entry) =
-            stuck_redemption_entry(&issuer_redemption_request_id, &view)
-        {
+        let history = redemption_history_summary(
+            redemption_event_store.inner(),
+            &issuer_redemption_request_id.to_string(),
+        )
+        .await;
+
+        if let Some(entry) = stuck_redemption_entry(
+            &issuer_redemption_request_id,
+            &view,
+            history,
+        ) {
             stuck.push(entry);
         }
     }
@@ -730,7 +752,7 @@ pub(crate) async fn list_stuck(
         };
 
         let (underlying, quantity) = mint_view_asset(&view);
-        let fireblocks_tx_id = latest_fireblocks_tx_id(
+        let mint_history = mint_history_summary(
             mint_event_store.inner(),
             &issuer_mint_request_id.to_string(),
         )
@@ -745,7 +767,8 @@ pub(crate) async fn list_stuck(
             timestamp,
             underlying,
             quantity,
-            fireblocks_tx_id,
+            tx_hash: mint_history.tx_hash,
+            fireblocks_tx_id: mint_history.fireblocks_tx_id,
             fireblocks_status: None,
         });
     }
@@ -771,7 +794,12 @@ async fn enrich_with_fireblocks_status(
         };
 
         match vault_service.check_fireblocks_tx(tx_id).await {
-            Ok(Some(status)) => entry.fireblocks_status = Some(status),
+            Ok(Some(status)) => {
+                if entry.tx_hash.is_none() {
+                    entry.tx_hash = tx_hash_from_fireblocks_status(&status);
+                }
+                entry.fireblocks_status = Some(status);
+            }
             Ok(None) => {}
             Err(err) => {
                 warn!(target: "admin",
@@ -788,6 +816,7 @@ async fn enrich_with_fireblocks_status(
 fn stuck_redemption_entry(
     issuer_redemption_request_id: &IssuerRedemptionRequestId,
     view: &RedemptionView,
+    history: RedemptionHistorySummary,
 ) -> Option<StuckAggregate> {
     let (
         tokenization_request_id,
@@ -796,21 +825,24 @@ fn stuck_redemption_entry(
         timestamp,
         underlying,
         quantity,
+        tx_hash,
         fireblocks_tx_id,
     ) = match view {
         RedemptionView::Failed { reason, failed_at, .. } => (
-            None,
+            history.tokenization_request_id,
             "Failed".to_string(),
             reason.clone(),
             *failed_at,
-            None,
-            None,
-            None,
+            history.underlying,
+            history.quantity,
+            history.tx_hash,
+            history.fireblocks_tx_id,
         ),
         RedemptionView::BurnFailed {
             tokenization_request_id,
             underlying,
             quantity,
+            tx_hash,
             error,
             failed_at,
             fireblocks_tx_id,
@@ -822,7 +854,8 @@ fn stuck_redemption_entry(
             *failed_at,
             Some(underlying.clone()),
             Some(quantity.clone()),
-            fireblocks_tx_id.clone(),
+            Some(*tx_hash),
+            fireblocks_tx_id.clone().or(history.fireblocks_tx_id),
         ),
         // find_stuck only returns Failed/BurnFailed; surface any other
         // variant as a real mismatch rather than fabricating placeholder
@@ -839,9 +872,83 @@ fn stuck_redemption_entry(
         timestamp,
         underlying,
         quantity,
+        tx_hash,
         fireblocks_tx_id,
         fireblocks_status: None,
     })
+}
+
+#[derive(Debug, Default)]
+struct RedemptionHistorySummary {
+    tokenization_request_id: Option<TokenizationRequestId>,
+    underlying: Option<UnderlyingSymbol>,
+    quantity: Option<Quantity>,
+    tx_hash: Option<B256>,
+    fireblocks_tx_id: Option<String>,
+}
+
+async fn redemption_history_summary(
+    event_store: &crate::SqliteEventStore<crate::redemption::Redemption>,
+    aggregate_id: &str,
+) -> RedemptionHistorySummary {
+    let events = match event_store.load_events(aggregate_id).await {
+        Ok(events) => events,
+        Err(err) => {
+            warn!(
+                target: "admin",
+                aggregate_id = aggregate_id,
+                error = %err,
+                "Failed to load redemption events for stuck metadata lookup"
+            );
+            return RedemptionHistorySummary::default();
+        }
+    };
+
+    let mut summary = RedemptionHistorySummary::default();
+    for event in events {
+        match event.payload {
+            RedemptionEvent::Detected {
+                underlying, quantity, tx_hash, ..
+            }
+            | RedemptionEvent::Reprocessed {
+                underlying,
+                quantity,
+                tx_hash,
+                ..
+            }
+            | RedemptionEvent::BurnResumed {
+                underlying,
+                quantity,
+                tx_hash,
+                ..
+            } => {
+                summary.underlying = Some(underlying);
+                summary.quantity = Some(quantity);
+                summary.tx_hash = Some(tx_hash);
+            }
+            RedemptionEvent::AlpacaCalled {
+                tokenization_request_id, ..
+            } => {
+                summary.tokenization_request_id = Some(tokenization_request_id);
+            }
+            RedemptionEvent::BurnFireblocksSubmitted {
+                fireblocks_tx_id,
+                ..
+            }
+            | RedemptionEvent::ExistingBurnRecovered {
+                fireblocks_tx_id, ..
+            }
+            | RedemptionEvent::BurningFailed {
+                fireblocks_tx_id: Some(fireblocks_tx_id),
+                ..
+            } => {
+                summary.fireblocks_tx_id = Some(fireblocks_tx_id);
+            }
+            _ => {}
+        }
+    }
+
+    summary
 }
 
 fn mint_view_summary(
@@ -907,17 +1014,17 @@ fn mint_view_asset(
     }
 }
 
-/// Returns the `fireblocks_tx_id` from the most recent `FireblocksSubmitted`
-/// event in this mint's history, if one exists. Used to surface the in-flight
-/// Fireblocks transaction in the stuck-aggregate response so operators don't
-/// have to grep logs.
-///
-/// Returns `None` if loading events fails — the caller logs that as a warning
-/// and the stuck listing still includes the aggregate without this hint.
-async fn latest_fireblocks_tx_id(
+#[derive(Debug, Default)]
+struct MintHistorySummary {
+    tx_hash: Option<B256>,
+    fireblocks_tx_id: Option<String>,
+}
+
+/// Returns the latest useful transaction hints from this mint's history.
+async fn mint_history_summary(
     event_store: &crate::SqliteEventStore<crate::mint::Mint>,
     aggregate_id: &str,
-) -> Option<String> {
+) -> MintHistorySummary {
     let events = match event_store.load_events(aggregate_id).await {
         Ok(events) => events,
         Err(err) => {
@@ -927,16 +1034,46 @@ async fn latest_fireblocks_tx_id(
                 error = %err,
                 "Failed to load mint events for fireblocks_tx_id lookup"
             );
-            return None;
+            return MintHistorySummary::default();
         }
     };
 
-    events.into_iter().rev().find_map(|event| match event.payload {
-        MintEvent::FireblocksSubmitted { fireblocks_tx_id, .. } => {
-            Some(fireblocks_tx_id)
+    let mut summary = MintHistorySummary::default();
+    for event in events {
+        match event.payload {
+            MintEvent::TokensMinted { tx_hash, .. }
+            | MintEvent::ExistingMintRecovered { tx_hash, .. }
+            | MintEvent::MintRetryStarted { tx_hash: Some(tx_hash), .. } => {
+                summary.tx_hash = Some(tx_hash);
+            }
+            MintEvent::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                summary.fireblocks_tx_id = Some(fireblocks_tx_id);
+            }
+            _ => {}
         }
-        _ => None,
-    })
+    }
+
+    summary
+}
+
+fn tx_hash_from_fireblocks_status(status: &FireblocksTxStatus) -> Option<B256> {
+    match status {
+        FireblocksTxStatus::Completed { tx_hash, .. } => Some(*tx_hash),
+        FireblocksTxStatus::Failed { network_tx_hashes, .. } => {
+            network_tx_hashes.iter().find_map(|tx_hash| match tx_hash.parse() {
+                Ok(parsed) => Some(parsed),
+                Err(err) => {
+                    warn!(target: "admin",
+                        network_tx_hash = %tx_hash,
+                        error = %err,
+                        "Skipping malformed Fireblocks network_tx_hash"
+                    );
+                    None
+                }
+            })
+        }
+        FireblocksTxStatus::Pending => None,
+    }
 }
 
 /// Response for the Fireblocks transaction status lookup endpoint.
@@ -1116,6 +1253,88 @@ mod tests {
             dust_quantity: Quantity::new(Decimal::ZERO),
             called_at: Utc::now(),
         }
+    }
+
+    #[test]
+    fn failed_redemption_stuck_entry_uses_history_metadata() {
+        let metadata = test_metadata();
+        let tokenization_request_id = TokenizationRequestId::new("tok-red-1");
+        let fireblocks_tx_id = "fb-redemption-1".to_string();
+        let failed_at = Utc::now();
+        let view = RedemptionView::Failed {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            reason: "Fireblocks burn confirmation failed".to_string(),
+            failed_at,
+        };
+        let history = super::RedemptionHistorySummary {
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            underlying: Some(metadata.underlying.clone()),
+            quantity: Some(metadata.quantity.clone()),
+            tx_hash: Some(metadata.detected_tx_hash),
+            fireblocks_tx_id: Some(fireblocks_tx_id.clone()),
+        };
+
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            &view,
+            history,
+        )
+        .expect("failed redemption should produce stuck entry");
+
+        assert_eq!(entry.aggregate_type, AggregateKind::Redemption);
+        assert_eq!(entry.aggregate_id, metadata.issuer_request_id.to_string());
+        assert_eq!(
+            entry.tokenization_request_id,
+            Some(tokenization_request_id)
+        );
+        assert_eq!(entry.underlying, Some(metadata.underlying));
+        assert_eq!(entry.quantity, Some(metadata.quantity));
+        assert_eq!(entry.tx_hash, Some(metadata.detected_tx_hash));
+        assert_eq!(entry.fireblocks_tx_id, Some(fireblocks_tx_id));
+        assert_eq!(entry.timestamp, failed_at);
+    }
+
+    #[test]
+    fn burn_failed_stuck_entry_prefers_view_metadata() {
+        let metadata = test_metadata();
+        let tokenization_request_id = TokenizationRequestId::new("tok-red-2");
+        let fireblocks_tx_id = "fb-burn-failed".to_string();
+        let failed_at = Utc::now();
+        let view = RedemptionView::BurnFailed {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            underlying: metadata.underlying.clone(),
+            token: metadata.token.clone(),
+            wallet: metadata.wallet,
+            quantity: metadata.quantity.clone(),
+            alpaca_quantity: metadata.quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at: metadata.detected_at,
+            called_at: Utc::now(),
+            alpaca_journal_completed_at: Utc::now(),
+            error: "burn failed".to_string(),
+            failed_at,
+            fireblocks_tx_id: Some(fireblocks_tx_id.clone()),
+            planned_burns: vec![],
+        };
+
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            &view,
+            super::RedemptionHistorySummary::default(),
+        )
+        .expect("burn failed redemption should produce stuck entry");
+
+        assert_eq!(
+            entry.tokenization_request_id,
+            Some(tokenization_request_id)
+        );
+        assert_eq!(entry.tx_hash, Some(metadata.detected_tx_hash));
+        assert_eq!(entry.fireblocks_tx_id, Some(fireblocks_tx_id));
+        assert_eq!(entry.underlying, Some(metadata.underlying));
+        assert_eq!(entry.quantity, Some(metadata.quantity));
     }
 
     type TestEventStore =
@@ -1747,6 +1966,7 @@ mod tests {
             timestamp: Utc::now(),
             underlying: None,
             quantity: None,
+            tx_hash: None,
             fireblocks_tx_id: fireblocks_tx_id.map(str::to_owned),
             fireblocks_status: None,
         }
@@ -1784,6 +2004,31 @@ mod tests {
             }
             other => panic!("unexpected status: {other:?}"),
         }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn enrich_warns_on_malformed_network_tx_hash() {
+        let tx_id = "a29e5027-1e44-4a66-b78b-b579e55757db";
+        let stub = StubFireblocksVault {
+            tx_id: tx_id.to_string(),
+            response: FireblocksTxStatus::Failed {
+                detail: "Failed".to_string(),
+                sub_status: Some("REJECTED_BY_BLOCKCHAIN".to_string()),
+                network_tx_hashes: vec!["not-a-hash".to_string()],
+            },
+        };
+
+        let mut entries = vec![stuck_entry("mint-1", Some(tx_id))];
+        super::enrich_with_fireblocks_status(&mut entries, &stub).await;
+
+        // The unparseable hash must not be silently dropped: tx_hash stays
+        // None and the bad value is surfaced in a warning.
+        assert!(entries[0].tx_hash.is_none());
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &["malformed Fireblocks network_tx_hash", "not-a-hash"]
+        ));
     }
 
     #[tokio::test]

--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -289,7 +289,12 @@ mod tests {
 
         let serialized = serde_json::to_value(&request).unwrap();
 
-        assert_eq!(serialized["issuer_request_id"], json!("red-12345678"));
+        assert_eq!(
+            serialized["issuer_request_id"],
+            json!(
+                "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+            )
+        );
         assert_eq!(serialized["underlying_symbol"], json!("AAPL"));
         assert_eq!(serialized["token_symbol"], json!("tAAPL"));
         assert_eq!(

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -598,7 +598,7 @@ mod tests {
                 .header("APCA-API-SECRET-KEY", "test-secret");
             then.status(200).json_body(serde_json::json!({
                 "tokenization_request_id": "tok-456",
-                "issuer_request_id": "red-abcdefab",
+                "issuer_request_id": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
                 "created_at": "2025-09-12T17:28:48.642437-04:00",
                 "type": "redeem",
                 "status": "pending",
@@ -649,7 +649,7 @@ mod tests {
                 .path("/v1/accounts/test-account/tokenization/callback/redeem");
             then.status(200).json_body(serde_json::json!({
                 "tokenization_request_id": "tok-456",
-                "issuer_request_id": "red-abcdefab",
+                "issuer_request_id": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
                 "created_at": "2025-09-12T17:28:48.642437-04:00",
                 "type": "redeem",
                 "status": "rejected",
@@ -866,7 +866,7 @@ mod tests {
                 .path("/v1/accounts/test-account/tokenization/callback/redeem")
                 .header("content-type", "application/json")
                 .json_body(serde_json::json!({
-                    "issuer_request_id": "red-abcdefab",
+                    "issuer_request_id": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
                     "underlying_symbol": "AAPL",
                     "token_symbol": "tAAPL",
                     "client_id": "00000000-0000-0000-0000-000000000456",
@@ -877,7 +877,7 @@ mod tests {
                 }));
             then.status(200).json_body(serde_json::json!({
                 "tokenization_request_id": "tok-002",
-                "issuer_request_id": "red-abcdefab",
+                "issuer_request_id": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
                 "created_at": "2025-09-12T17:28:48.642437-04:00",
                 "type": "redeem",
                 "status": "pending",
@@ -1625,10 +1625,10 @@ mod tests {
                 issuer_request_id, status, ..
             } => {
                 assert_eq!(
-                    *issuer_request_id,
-                    IssuerRedemptionRequestId::new(b256!(
-                        "0x842331fb00000000000000000000000000000000000000000000000000000000"
-                    )),
+                    issuer_request_id,
+                    &"red-842331fb"
+                        .parse::<IssuerRedemptionRequestId>()
+                        .unwrap(),
                 );
                 assert!(matches!(status, RedeemRequestStatus::Completed));
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ fn setup_aggregate_cqrs(
         ));
     let redemption_query = GenericQuery::new(redemption_view_repo);
 
-    // ReceiptBurnsView tracks burns keyed by redemption aggregate_id (red-xxx).
+    // ReceiptBurnsView tracks burns keyed by redemption aggregate_id.
     // Use GenericQuery since aggregate_id = view_id is correct for this view.
     // Available balance is computed at query time by joining with receipt_inventory_view.
     let receipt_burns_repo =

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -18,7 +18,7 @@ use crate::vault::ReceiptInformation;
 
 /// Tracks burn operations for a redemption.
 ///
-/// This is a cqrs-es view keyed by redemption aggregate_id (red-xxx).
+/// This is a cqrs-es view keyed by redemption aggregate_id.
 /// Each successful burn creates one record. Use GenericQuery to update.
 ///
 /// To compute available receipt balance, join with receipt_inventory_view

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -25,15 +25,19 @@ use crate::mint::TokenizationRequestId;
 
 /// Issuer request ID for redemption operations.
 ///
-/// Derived from the triggering transaction hash — the first 4 bytes are
-/// extracted and serialized as `"red-{hex}"` (e.g., `"red-574378e0"`).
+/// New IDs are the full triggering transaction hash. Legacy IDs used the first
+/// 4 bytes formatted as `"red-{hex}"`; keep parsing/serializing them so
+/// historical aggregates remain operable.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct IssuerRedemptionRequestId(FixedBytes<4>);
+pub(crate) enum IssuerRedemptionRequestId {
+    Full(TxHash),
+    Legacy(FixedBytes<4>),
+}
 
 impl IssuerRedemptionRequestId {
     #[must_use]
-    pub(crate) fn new(tx_hash: TxHash) -> Self {
-        Self(FixedBytes::<4>::from_slice(&tx_hash[..4]))
+    pub(crate) const fn new(tx_hash: TxHash) -> Self {
+        Self::Full(tx_hash)
     }
 
     #[cfg(test)]
@@ -44,7 +48,10 @@ impl IssuerRedemptionRequestId {
 
 impl std::fmt::Display for IssuerRedemptionRequestId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "red-{}", hex::encode(self.0))
+        match self {
+            Self::Full(tx_hash) => write!(f, "{tx_hash:#x}"),
+            Self::Legacy(id) => write!(f, "red-{}", hex::encode(id)),
+        }
     }
 }
 
@@ -52,12 +59,16 @@ impl std::str::FromStr for IssuerRedemptionRequestId {
     type Err = IssuerRedemptionRequestIdParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let hex_str = s
-            .strip_prefix("red-")
-            .ok_or(IssuerRedemptionRequestIdParseError::Format)?;
+        if let Some(hex_str) = s.strip_prefix("red-") {
+            let bytes = hex::decode(hex_str)?;
+            return Ok(Self::Legacy(FixedBytes::<4>::try_from(
+                bytes.as_slice(),
+            )?));
+        }
 
-        let bytes = hex::decode(hex_str)?;
-        Ok(Self(FixedBytes::<4>::try_from(bytes.as_slice())?))
+        s.parse::<B256>()
+            .map(Self::Full)
+            .map_err(|_| IssuerRedemptionRequestIdParseError::Format)
     }
 }
 
@@ -67,7 +78,7 @@ pub(crate) enum IssuerRedemptionRequestIdParseError {
     Hex(#[from] hex::FromHexError),
     #[error(transparent)]
     Slice(#[from] std::array::TryFromSliceError),
-    #[error("expected 'red-' prefix")]
+    #[error("expected full 0x transaction hash or legacy 'red-' prefix")]
     Format,
 }
 
@@ -1839,35 +1850,41 @@ mod tests {
     }
 
     #[test]
-    fn test_new_extracts_first_4_bytes_of_tx_hash() {
+    fn test_new_uses_full_tx_hash() {
         let tx_hash = b256!(
-            "574378e000000000000000000000000000000000000000000000000000000000"
+            "0x574378e000000000000000000000000000000000000000000000000000000000"
         );
 
         let id = IssuerRedemptionRequestId::new(tx_hash);
 
-        assert_eq!(id.to_string(), "red-574378e0");
+        assert_eq!(
+            id.to_string(),
+            "0x574378e000000000000000000000000000000000000000000000000000000000"
+        );
     }
 
     #[test]
-    fn test_display_format_is_red_dash_hex() {
+    fn test_display_format_is_full_tx_hash() {
         let tx_hash = b256!(
-            "deadbeef00000000000000000000000000000000000000000000000000000000"
+            "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
         );
 
         let id = IssuerRedemptionRequestId::new(tx_hash);
 
         let display = id.to_string();
         assert!(
-            display.starts_with("red-"),
-            "expected 'red-' prefix, got: {display}"
+            display.starts_with("0x"),
+            "expected '0x' prefix, got: {display}"
         );
         assert_eq!(
             display.len(),
-            12,
-            "expected 12 chars (red- + 8 hex), got: {display}"
+            66,
+            "expected 66 chars (0x + 64 hex), got: {display}"
         );
-        assert_eq!(display, "red-deadbeef");
+        assert_eq!(
+            display,
+            "0xdeadbeef00000000000000000000000000000000000000000000000000000000"
+        );
     }
 
     #[test]
@@ -1898,24 +1915,39 @@ mod tests {
     }
 
     #[test]
-    fn test_serialize_produces_red_hex_string() {
+    fn test_serialize_produces_full_tx_hash_string() {
         let tx_hash = b256!(
-            "574378e000000000000000000000000000000000000000000000000000000000"
+            "0x574378e000000000000000000000000000000000000000000000000000000000"
         );
 
         let id = IssuerRedemptionRequestId::new(tx_hash);
         let json = serde_json::to_string(&id).unwrap();
 
-        assert_eq!(json, "\"red-574378e0\"");
+        assert_eq!(
+            json,
+            "\"0x574378e000000000000000000000000000000000000000000000000000000000\""
+        );
     }
 
     #[test]
-    fn test_deserialize_red_hex_string() {
+    fn test_deserialize_legacy_red_hex_string() {
         let json = "\"red-574378e0\"";
 
         let id: IssuerRedemptionRequestId = serde_json::from_str(json).unwrap();
 
         assert_eq!(id.to_string(), "red-574378e0");
+    }
+
+    #[test]
+    fn test_deserialize_full_tx_hash_string() {
+        let json = "\"0x574378e000000000000000000000000000000000000000000000000000000000\"";
+
+        let id: IssuerRedemptionRequestId = serde_json::from_str(json).unwrap();
+
+        assert_eq!(
+            id.to_string(),
+            "0x574378e000000000000000000000000000000000000000000000000000000000"
+        );
     }
 
     #[test]
@@ -1933,7 +1965,7 @@ mod tests {
     }
 
     #[test]
-    fn test_from_str_rejects_missing_prefix() {
+    fn test_from_str_rejects_hash_without_0x_prefix() {
         let result = "574378e0".parse::<IssuerRedemptionRequestId>();
         assert!(matches!(
             result.unwrap_err(),
@@ -2409,10 +2441,10 @@ mod tests {
         }
 
         #[test]
-        fn test_display_always_starts_with_red_prefix(id in arb_issuer_redemption_request_id()) {
+        fn test_display_always_uses_full_hash_for_new_ids(id in arb_issuer_redemption_request_id()) {
             let display = id.to_string();
-            prop_assert!(display.starts_with("red-"));
-            prop_assert_eq!(display.len(), 12);
+            prop_assert!(display.starts_with("0x"));
+            prop_assert_eq!(display.len(), 66);
         }
     }
 }


### PR DESCRIPTION
## Motivation

The stuck admin endpoint reported redemptions with short generated `red-...` aggregate IDs and sparse metadata, while mint failures exposed richer transaction context. That made failed redemption investigation harder and left newly detected redemptions with weaker collision resistance.

Tracks [RAI-631](https://linear.app/makeitrain/issue/RAI-631/expose-full-tx-hash-metadata-for-stuck-redemptions).

## Solution

- Change new `IssuerRedemptionRequestId` values to serialize as the full detected on-chain transaction hash.
- Keep legacy `red-...` redemption IDs parseable and serializable so existing aggregates and callbacks continue to work.
- Enrich `/admin/stuck` redemption entries from event history with tokenization request ID, underlying, quantity, detected transfer tx hash, and Fireblocks tx ID when available.
- Add a `tx_hash` field to stuck entries and populate it for both mint and redemption failures when known, including Fireblocks status lookups that expose a network tx hash.
- Update `SPEC.md` to document full-hash redemption IDs and legacy compatibility.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Tested with:

- `nix develop -c cargo check --workspace`
- `nix develop -c cargo test -q --lib`
- `nix develop -c cargo test -q --workspace`
- `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `nix develop -c cargo fmt --all -- --check`
- `PATH="$HOME/.cargo/bin:$PATH" nix develop -c cargo nextest run --workspace --retries 2 --flaky-result fail --no-fail-fast --status-level retry --final-status-level flaky --failure-output final`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Redemption request IDs now use full transaction hash format (`0x...`) instead of shortened identifiers.
  * Admin recovery endpoint updated to accept and return full transaction hash format for redemption IDs.

* **Documentation**
  * Updated specification and API documentation to reflect new redemption identifier format.
  * Added backward compatibility notes for historical redemptions using legacy identifier format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/161?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->