### PR TITLE
fix: burn recovered redemptions immediately

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -336,8 +336,9 @@ on-chain transfer through calling Alpaca to burning tokens.
   call step. Only valid from `Failed` state. Used for post-Alpaca failures where
   Alpaca has already completed the journal. The API layer polls Alpaca to verify
   journal completion before issuing this command — refuses if Pending or
-  Rejected. Emits `BurnResumed` event. Burn executes on next service restart via
-  `recover_burning_redemptions`.
+  Rejected. Emits `BurnResumed` event. The admin recovery path immediately
+  invokes burn recovery in-process so the on-chain burn does not wait for a
+  service restart.
 
 **Events:**
 
@@ -1928,7 +1929,8 @@ Auto-detects the right recovery path from the event history:
 - **Post-Alpaca failures** (`AlpacaCalled` event exists): Polls Alpaca to verify
   journal completion, then dispatches `ResumeBurn` to transition to `Burning`.
   Refuses if Alpaca journal is `Pending` or `Rejected` (to avoid burning without
-  backing). `BurnManager` executes the burn on next restart.
+  backing). `BurnManager` executes the burn immediately in the same recovery
+  request.
 
 **Mint:** `POST /admin/reprocess/mint/<aggregate_id>`
 
@@ -1956,7 +1958,8 @@ polling timeout scenario where burns landed on-chain but weren't recorded.
 - `409`: Aggregate already completed or closed (cannot recover)
 - `422`: Aggregate in a state that cannot be recovered, or Alpaca journal not
   completed (for post-Alpaca redemption recovery)
-- `502`: Failed to poll Alpaca for journal status (post-Alpaca recovery only)
+- `502`: Failed to poll Alpaca for journal status, or failed to execute the burn
+  recovery (post-Alpaca recovery only)
 
 ### Close Redemption
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,4 +1,5 @@
 use alloy::primitives::B256;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::{AggregateError, EventStore};
 use rocket::http::Status;
@@ -17,13 +18,38 @@ use crate::mint::{
     TokenizationRequestId, find_all_recoverable_mints,
     find_by_issuer_request_id, recovery::spawn_scheduled_mint_recovery,
 };
+use crate::redemption::Redemption;
+use crate::redemption::burn_manager::{
+    BurnManager, BurnManagerError, RecoveryOutcome,
+};
 use crate::redemption::{
     BurnRecord, IssuerRedemptionRequestId, RedemptionCommand, RedemptionError,
     RedemptionEvent, RedemptionMetadata, RedemptionView, find_stuck,
 };
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{FireblocksTxStatus, VaultService};
-use crate::{MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore};
+use crate::{
+    MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore,
+    SqliteEventStore,
+};
+
+#[async_trait]
+pub(crate) trait RedemptionBurnRecovery: Send + Sync {
+    async fn execute_recovered_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<RecoveryOutcome, BurnManagerError>;
+}
+
+#[async_trait]
+impl RedemptionBurnRecovery for BurnManager<SqliteEventStore<Redemption>> {
+    async fn execute_recovered_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<RecoveryOutcome, BurnManagerError> {
+        self.recover_burning_redemption(issuer_request_id).await
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -197,14 +223,15 @@ async fn load_reprocess_context(
 /// Auto-detects the right recovery path from the event history:
 /// - **Pre-Alpaca failures**: Resets to `Detected` so `RedeemCallManager` re-calls Alpaca.
 /// - **Post-Alpaca failures**: Polls Alpaca to verify the journal completed, then
-///   resumes to `Burning` so `BurnManager` can execute the on-chain burn.
+///   resumes to `Burning` and invokes burn recovery immediately.
 ///   Refuses if Alpaca's journal hasn't completed (to avoid burning without backing).
 #[tracing::instrument(skip(
     _auth,
     cqrs,
     event_store,
     alpaca_service,
-    vault_service
+    vault_service,
+    burn_recovery
 ))]
 #[post("/admin/recover/redemption/<issuer_request_id>")]
 pub(crate) async fn recover_redemption(
@@ -213,6 +240,7 @@ pub(crate) async fn recover_redemption(
     event_store: &rocket::State<RedemptionEventStore>,
     alpaca_service: &rocket::State<Arc<dyn AlpacaService>>,
     vault_service: &rocket::State<Arc<dyn VaultService>>,
+    burn_recovery: &rocket::State<Arc<dyn RedemptionBurnRecovery>>,
     issuer_request_id: IssuerRedemptionRequestId,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let aggregate_id = issuer_request_id.to_string();
@@ -236,6 +264,7 @@ pub(crate) async fn recover_redemption(
         cqrs,
         alpaca_service,
         vault_service.inner(),
+        burn_recovery.inner(),
         PostAlpacaRecoveryInput {
             aggregate_id,
             issuer_request_id,
@@ -296,6 +325,7 @@ async fn recover_post_alpaca(
     cqrs: &RedemptionCqrs,
     alpaca_service: &Arc<dyn AlpacaService>,
     vault_service: &Arc<dyn VaultService>,
+    burn_recovery: &Arc<dyn RedemptionBurnRecovery>,
     input: PostAlpacaRecoveryInput,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let PostAlpacaRecoveryInput {
@@ -493,14 +523,62 @@ async fn recover_post_alpaca(
         "Redemption recovered from Failed to Burning"
     );
 
+    let outcome = burn_recovery
+        .execute_recovered_burn(&issuer_request_id)
+        .await
+        .map_err(|err| {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                error = %err,
+                "Failed to execute recovered redemption burn"
+            );
+            Status::BadGateway
+        })?;
+
+    let message = report_recovery_outcome(outcome, &aggregate_id);
+
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Redemption,
         aggregate_id: aggregate_id.clone(),
         previous_state: "Failed".to_string(),
-        message:
-            "Recovered to Burning — burn will execute on next service restart"
-                .to_string(),
+        message: message.to_string(),
     }))
+}
+
+/// Logs each recovery outcome at a severity matching what actually happened and
+/// returns the operator-facing message. Only `SkippedManualIntervention` leaves
+/// the redemption unresolved, so it alone warns; the other outcomes describe
+/// their distinct resolutions without ever claiming a burn that didn't run.
+fn report_recovery_outcome(
+    outcome: RecoveryOutcome,
+    aggregate_id: &str,
+) -> &'static str {
+    match outcome {
+        RecoveryOutcome::Executed => {
+            info!(target: "admin", aggregate_id = %aggregate_id, outcome = ?outcome,
+                "Recovered redemption and executed burn immediately"
+            );
+            "Recovered from Failed and executed burn immediately"
+        }
+        RecoveryOutcome::ExistingBurnRecorded => {
+            info!(target: "admin", aggregate_id = %aggregate_id, outcome = ?outcome,
+                "Recovered redemption by recording a previously submitted on-chain burn"
+            );
+            "Recovered from Failed and recorded a previously submitted on-chain burn"
+        }
+        RecoveryOutcome::SkippedManualIntervention => {
+            warn!(target: "admin", aggregate_id = %aggregate_id, outcome = ?outcome,
+                "Recovered redemption to Burning but burn was skipped; manual intervention required"
+            );
+            "Recovered to Burning but burn skipped: on-chain balance \
+             insufficient, manual intervention required"
+        }
+        RecoveryOutcome::AlreadyAdvanced => {
+            info!(target: "admin", aggregate_id = %aggregate_id, outcome = ?outcome,
+                "Redemption had already advanced past Burning; no burn executed"
+            );
+            "Redemption had already advanced past Burning; no burn executed"
+        }
+    }
 }
 
 const fn map_redemption_error(err: &AggregateError<RedemptionError>) -> Status {
@@ -1133,6 +1211,7 @@ mod tests {
     };
     use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tracing::Level;
     use tracing_test::traced_test;
 
@@ -1170,6 +1249,57 @@ mod tests {
     /// `poll_request_status`. Other methods are unused in these tests.
     struct PollMockAlpaca {
         response: PollResponse,
+    }
+
+    /// Configurable result for `MockBurnRecovery`. `Fails` exercises the
+    /// endpoint's error path; the concrete `BurnManagerError` is irrelevant
+    /// since every error maps to `502`.
+    #[derive(Clone, Copy)]
+    enum MockBurnResult {
+        Succeeds(super::RecoveryOutcome),
+        Fails,
+    }
+
+    struct MockBurnRecovery {
+        calls: AtomicUsize,
+        result: MockBurnResult,
+    }
+
+    impl Default for MockBurnRecovery {
+        fn default() -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                result: MockBurnResult::Succeeds(
+                    super::RecoveryOutcome::Executed,
+                ),
+            }
+        }
+    }
+
+    impl MockBurnRecovery {
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl super::RedemptionBurnRecovery for MockBurnRecovery {
+        async fn execute_recovered_burn(
+            &self,
+            _issuer_request_id: &IssuerRedemptionRequestId,
+        ) -> Result<super::RecoveryOutcome, super::BurnManagerError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            match self.result {
+                MockBurnResult::Succeeds(outcome) => Ok(outcome),
+                MockBurnResult::Fails => {
+                    Err(super::BurnManagerError::SharesOverflow)
+                }
+            }
+        }
+    }
+
+    fn mock_burn_recovery() -> Arc<dyn super::RedemptionBurnRecovery> {
+        Arc::new(MockBurnRecovery::default())
     }
 
     fn redeem_response(
@@ -1446,11 +1576,15 @@ mod tests {
                 &alpaca_data,
             )),
         });
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
 
         let result = recover_post_alpaca(
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &burn_recovery_state,
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1463,8 +1597,11 @@ mod tests {
 
         let response = result.expect("Expected Ok response");
         assert_eq!(response.previous_state, "Failed");
-        assert!(response.message.contains("Burning"));
+        assert!(response.message.contains("Recovered from Failed"));
+        assert!(response.message.contains("executed burn"));
+        assert_eq!(burn_recovery.calls(), 1);
         assert!(logs_contain_at!(Level::INFO, &["recovered", "Burning"]));
+        assert!(logs_contain_at!(Level::INFO, &["burn", "executed"]));
     }
 
     #[traced_test]
@@ -1484,6 +1621,7 @@ mod tests {
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &mock_burn_recovery(),
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1515,6 +1653,7 @@ mod tests {
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &mock_burn_recovery(),
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1545,6 +1684,7 @@ mod tests {
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &mock_burn_recovery(),
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1572,6 +1712,7 @@ mod tests {
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &mock_burn_recovery(),
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1614,6 +1755,7 @@ mod tests {
             &cqrs,
             &alpaca,
             &mock_vault_service(),
+            &mock_burn_recovery(),
             PostAlpacaRecoveryInput {
                 aggregate_id: metadata.issuer_request_id.to_string(),
                 issuer_request_id: metadata.issuer_request_id.clone(),
@@ -1683,6 +1825,7 @@ mod tests {
             .manage(event_store.clone())
             .manage(alpaca)
             .manage(mock_vault_service())
+            .manage(mock_burn_recovery())
             .mount("/", rocket::routes![super::recover_redemption]);
 
         (rocket, cqrs, event_store)
@@ -1811,6 +1954,66 @@ mod tests {
         assert!(logs_contain_at!(Level::INFO, &["recovered", "Detected"]));
     }
 
+    fn post_alpaca_rocket(
+        cqrs: Arc<SqliteCqrs<Redemption>>,
+        event_store: TestEventStore,
+        alpaca: Arc<dyn AlpacaService>,
+        burn_recovery: Arc<dyn super::RedemptionBurnRecovery>,
+    ) -> rocket::Rocket<rocket::Build> {
+        use crate::alpaca::service::AlpacaConfig;
+        use crate::auth::{FailedAuthRateLimiter, test_auth_config};
+        use crate::config::{Config, LogLevel};
+        use crate::fireblocks::SignerConfig;
+        use alloy::primitives::B256;
+        use url::Url;
+
+        let config = Config {
+            database_url: "sqlite::memory:".to_string(),
+            database_max_connections: 5,
+            rpc_url: Url::parse("wss://localhost:8545").unwrap(),
+            chain_id: crate::test_utils::ANVIL_CHAIN_ID,
+            signer: SignerConfig::Local(B256::ZERO),
+            backfill_start_block: 0,
+            auth: test_auth_config().unwrap(),
+            log_level: LogLevel::Debug,
+            hyperdx: None,
+            alpaca: AlpacaConfig::test_default(),
+            subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
+        };
+
+        rocket::build()
+            .manage(config)
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(cqrs)
+            .manage(event_store)
+            .manage(alpaca)
+            .manage(mock_vault_service())
+            .manage(burn_recovery)
+            .mount("/", rocket::routes![super::recover_redemption])
+    }
+
+    async fn dispatch_recover_redemption(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+
+        let response = client
+            .post(format!("/admin/recover/redemption/{issuer_request_id}"))
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        let status = response.status();
+        let body = response.into_string().await.unwrap();
+        (status, body)
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn test_endpoint_post_alpaca_recovery_resumes_to_burning() {
@@ -1829,61 +2032,103 @@ mod tests {
                 &alpaca_data,
             )),
         });
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
 
-        let rocket = {
-            use crate::alpaca::service::AlpacaConfig;
-            use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-            use crate::config::{Config, LogLevel};
-            use crate::fireblocks::SignerConfig;
-            use alloy::primitives::B256;
-            use url::Url;
+        let rocket =
+            post_alpaca_rocket(cqrs, event_store, alpaca, burn_recovery_state);
 
-            let config = Config {
-                database_url: "sqlite::memory:".to_string(),
-                database_max_connections: 5,
-                rpc_url: Url::parse("wss://localhost:8545").unwrap(),
-                chain_id: crate::test_utils::ANVIL_CHAIN_ID,
-                signer: SignerConfig::Local(B256::ZERO),
-                backfill_start_block: 0,
-                auth: test_auth_config().unwrap(),
-                log_level: LogLevel::Debug,
-                hyperdx: None,
-                alpaca: AlpacaConfig::test_default(),
-                subgraph_url: Url::parse("http://localhost:0/subgraph")
-                    .unwrap(),
-            };
+        let (status, body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
 
-            rocket::build()
-                .manage(config)
-                .manage(FailedAuthRateLimiter::new().unwrap())
-                .manage(cqrs)
-                .manage(event_store)
-                .manage(alpaca)
-                .manage(mock_vault_service())
-                .mount("/", rocket::routes![super::recover_redemption])
-        };
-
-        let client =
-            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
-
-        let response = client
-            .post(format!(
-                "/admin/recover/redemption/{}",
-                metadata.issuer_request_id
-            ))
-            .header(rocket::http::Header::new(
-                "X-API-KEY",
-                "test-key-12345678901234567890123456",
-            ))
-            .remote("127.0.0.1:8000".parse().unwrap())
-            .dispatch()
-            .await;
-
-        assert_eq!(response.status(), Status::Ok);
-
-        let body = response.into_string().await.unwrap();
-        assert!(body.contains("Burning"));
+        assert_eq!(status, Status::Ok);
+        assert!(body.contains("Recovered from Failed"));
+        assert!(body.contains("executed burn"));
+        assert_eq!(burn_recovery.calls(), 1);
         assert!(logs_contain_at!(Level::INFO, &["recovered", "Burning"]));
+        assert!(logs_contain_at!(Level::INFO, &["burn", "executed"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_post_alpaca_recovery_reports_skipped_burn() {
+        let pool = setup_pool().await;
+        let (cqrs, event_store) = setup_cqrs(&pool);
+        let (metadata, alpaca_data) = setup_post_alpaca_failure(&cqrs).await;
+
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        // The burn was skipped (e.g. insufficient on-chain balance), so the
+        // endpoint must NOT claim the burn executed.
+        let burn_recovery = Arc::new(MockBurnRecovery {
+            result: MockBurnResult::Succeeds(
+                super::RecoveryOutcome::SkippedManualIntervention,
+            ),
+            ..Default::default()
+        });
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket =
+            post_alpaca_rocket(cqrs, event_store, alpaca, burn_recovery_state);
+
+        let (status, body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(body.contains("manual intervention required"));
+        assert!(!body.contains("executed burn"));
+        assert_eq!(burn_recovery.calls(), 1);
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &["burn was skipped", "manual intervention required"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_post_alpaca_recovery_burn_failure_returns_502() {
+        let pool = setup_pool().await;
+        let (cqrs, event_store) = setup_cqrs(&pool);
+        let (metadata, alpaca_data) = setup_post_alpaca_failure(&cqrs).await;
+
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        // The burn execution itself fails, which must surface as a 502 so the
+        // operator knows the recovery did not complete.
+        let burn_recovery = Arc::new(MockBurnRecovery {
+            result: MockBurnResult::Fails,
+            ..Default::default()
+        });
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket =
+            post_alpaca_rocket(cqrs, event_store, alpaca, burn_recovery_state);
+
+        let (status, _body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::BadGateway);
+        assert_eq!(burn_recovery.calls(), 1);
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &["Failed to execute recovered redemption burn"]
+        ));
     }
 
     /// Stub VaultService that returns a pre-canned `FireblocksTxStatus` for a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,8 @@ pub async fn initialize_rocket(
         redemption_cqrs,
         redemption_event_store,
         alpaca_service,
+        burn_recovery: managers.burn.clone()
+            as Arc<dyn admin::RedemptionBurnRecovery>,
         vault_service: vault_service_for_rocket,
     }))
 }
@@ -402,6 +404,7 @@ struct RocketState {
     redemption_cqrs: RedemptionCqrs,
     redemption_event_store: RedemptionEventStore,
     alpaca_service: Arc<dyn AlpacaService>,
+    burn_recovery: Arc<dyn admin::RedemptionBurnRecovery>,
     vault_service: Arc<dyn vault::VaultService>,
 }
 
@@ -426,6 +429,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .manage(state.redemption_cqrs)
         .manage(state.redemption_event_store)
         .manage(state.alpaca_service)
+        .manage(state.burn_recovery)
         .manage(state.vault_service)
         .manage(state.pool)
         .mount(

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -20,6 +20,26 @@ use crate::tokenized_asset::view::{
 };
 use crate::vault::{MultiBurnEntry, VaultError, VaultService};
 
+/// Outcome of recovering a single redemption stuck in a burning state.
+///
+/// Recovery can legitimately finish without executing a burn — the redemption
+/// may have already advanced, or the bot's on-chain balance may be too low to
+/// burn safely. Callers must distinguish these no-ops from an actual burn so
+/// they don't report success while the redemption is still unresolved.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecoveryOutcome {
+    /// A fresh burn was submitted on-chain for a `Burning` redemption.
+    Executed,
+    /// A previously submitted Fireblocks burn was confirmed and recorded.
+    ExistingBurnRecorded,
+    /// Burn skipped: the bot's on-chain balance is insufficient, so the burn
+    /// likely already landed but was never recorded. Needs manual review.
+    SkippedManualIntervention,
+    /// The redemption already advanced past `Burning`/`BurnSubmitted`; there
+    /// was nothing to burn.
+    AlreadyAdvanced,
+}
+
 /// Orchestrates the on-chain burning process in response to `AlpacaJournalCompleted` events.
 ///
 /// The manager reacts to `AlpacaJournalCompleted` events by querying for a suitable receipt,
@@ -139,6 +159,13 @@ where
                 );
             }
         }
+    }
+
+    pub(crate) async fn recover_burning_redemption(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<RecoveryOutcome, BurnManagerError> {
+        self.recover_single_burning(issuer_request_id).await
     }
 
     async fn recover_single_burn_failed(
@@ -363,7 +390,7 @@ where
     async fn recover_single_burning(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
-    ) -> Result<(), BurnManagerError> {
+    ) -> Result<RecoveryOutcome, BurnManagerError> {
         let context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
@@ -401,7 +428,7 @@ where
                         info!(target: "redemption", issuer_request_id = %issuer_request_id,
                             "Burn confirmed successfully during recovery"
                         );
-                        Ok(())
+                        Ok(RecoveryOutcome::ExistingBurnRecorded)
                     }
                     Err(AggregateError::UserError(RedemptionError::Vault(
                         err,
@@ -477,21 +504,24 @@ where
                          Burn likely already succeeded but was not recorded. \
                          Skipping to avoid recording false failure."
                     );
-                    return Ok(());
+                    return Ok(RecoveryOutcome::SkippedManualIntervention);
                 }
 
                 debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "Recovering Burning redemption - resuming burn"
                 );
 
-                self.handle_burning_started(issuer_request_id, aggregate).await
+                self.handle_burning_started(issuer_request_id, aggregate)
+                    .await?;
+
+                Ok(RecoveryOutcome::Executed)
             }
 
             _ => {
                 debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "Redemption no longer in Burning or BurnSubmitted state, skipping"
                 );
-                Ok(())
+                Ok(RecoveryOutcome::AlreadyAdvanced)
             }
         }
     }

--- a/tests/redemption.rs
+++ b/tests/redemption.rs
@@ -458,7 +458,10 @@ async fn test_redemption_recovery_after_restart()
     let link_body = harness::setup_account(&client, user_wallet).await;
     let shares_minted =
         perform_mint_flow(&client, &evm, user_wallet, &link_body).await?;
-    mint_callback_mock.assert();
+    // The bot sends the mint callback asynchronously after the on-chain mint,
+    // so `wait_for_shares` (inside `perform_mint_flow`) can return before the
+    // callback lands. Poll for the hit instead of asserting synchronously.
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     // Setup user provider for transfer
     let user_wallet_instance = EthereumWallet::from(user_signer.clone());


### PR DESCRIPTION
## Motivation

Post-Alpaca redemption recovery currently records `ResumeBurn` and leaves the aggregate in `Burning`, but the actual burn recovery sweep only runs during startup. That means an operator can manually recover a redemption and still need to restart the issuance bot before the on-chain burn is submitted or confirmed.

Closes [RAI-630](https://linear.app/makeitrain/issue/RAI-630/issuance-redemption-recovery-should-burn-without-restart).

## Solution

- Update `SPEC.md` so post-Alpaca admin recovery is specified to execute the burn in-process.
- Add a single-redemption `BurnManager::recover_burning_redemption` entry point that reuses the existing `Burning` / `BurnSubmitted` recovery logic.
- Manage a `RedemptionBurnRecovery` service in Rocket state and call it after `recover_post_alpaca` successfully records `ResumeBurn`.
- Update the admin recovery response/logging so it no longer says a restart is required.
- Extend unit and endpoint tests to assert that post-Alpaca recovery invokes burn execution immediately.

Stacked on #161.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Tested with:

- `nix develop -c cargo test -q admin::tests:: --lib`
- `nix develop -c cargo test -q --lib`
- `nix develop -c cargo test -q --workspace`
- `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `nix develop -c cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Redemption burn recovery now executes immediately during admin recovery operations instead of waiting for the next service restart
  * Added 502 Bad Gateway error responses for recovery execution failures

* **Documentation**
  * Updated specification to document immediate in-process burn recovery behavior for post-redemption failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->