### PR TITLE
fix: reserve submitted redemption burn receipts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ target/
 *.db-wal
 *.log
 claude-local-ctx/
+.claude/

--- a/SPEC.md
+++ b/SPEC.md
@@ -347,7 +347,12 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `AlpacaCallFailed` - Alpaca API call failed (terminal)
 - `AlpacaJournalCompleted` - Alpaca confirmed journal transfer
 - `BurnFireblocksSubmitted` - Burn transaction submitted to signing backend
-  (carries `external_tx_id`, `fireblocks_tx_id`, and `planned_burns`)
+  (carries `external_tx_id`, `fireblocks_tx_id`, and `planned_burns`). The burn
+  manager reserves the `planned_burns` in the receipt inventory **before** this
+  submission, so a concurrent redemption that already committed the same receipt
+  balance fails to reserve and never submits an unbacked burn. On confirmation
+  the reservation is settled (mirror balance reduced); on a definitive
+  terminal/reverted failure it is released.
 - `TokensBurned` - On-chain burn succeeded, redemption complete (terminal
   success). Payload contains `burns: Vec<BurnRecord>` where each `BurnRecord`
   has `receipt_id` and `shares_burned`, supporting multi-receipt burns when a
@@ -532,10 +537,23 @@ bot_wallet) and reconcile outbound transfers (from == bot_wallet). Mint/burn
 transfers (from/to == address(0)) are filtered out since those are already
 covered by the vault's Deposit/Withdraw events.
 
+Each receipt tracks two quantities: a `balance` that mirrors the on-chain
+ERC-1155 balance the bot believes it holds, and a `reserved` map of shares
+committed to submitted-but-unconfirmed burns, keyed by the redemption that
+submitted them. **Available inventory for burn planning is
+`balance - sum(reserved)`**. Keeping the on-chain mirror and reservations
+separate is what lets reconciliation compare against the true on-chain balance
+without ever clobbering a pending reservation.
+
 Receipts leave the inventory (or have their balance corrected) through
 reconciliation — querying `balanceOf(bot_wallet, receipt_id)` on-chain and
-emitting `BalanceReconciled` when the on-chain balance differs from the
-aggregate balance in either direction. Reconciliation is triggered by:
+emitting `BalanceReconciled` when the on-chain balance falls outside the
+`[available, balance]` band. While a submitted burn is pending, on-chain
+legitimately sits anywhere in that band (it has not landed yet at `balance`;
+once it lands it drops toward `available`), so reconciliation treats those
+values as "no external change" and leaves the reservation intact. Settlement,
+not reconciliation, consumes a reservation once its burn confirms.
+Reconciliation is triggered by:
 
 - **Startup**: After receipt backfill, reconciles all receipts with positive
   aggregate balance before redemption recovery and live monitoring begin
@@ -553,16 +571,65 @@ aggregate balance in either direction. Reconciliation is triggered by:
 Commands:
 
 - `DiscoverReceipt` - Register a newly discovered receipt
-- `ReconcileBalance { receipt_id, on_chain_balance }` - Correct aggregate
-  balance to match on-chain state (both increases and decreases). No-op if
-  balances match or receipt unknown
+- `ReconcileBalance { receipt_id, on_chain_balance }` - Correct the mirror
+  balance to match on-chain state. No-op if the on-chain balance is within the
+  `[available, balance]` band (no external change while a reservation is
+  pending) or the receipt is unknown
+- `ReserveBurn { redemption_issuer_request_id, burns }` - **Atomic
+  clear-and-reserve** issued **before** submitting a burn to the signing
+  backend. It drops any prior reservation the redemption held (e.g. from a
+  retried attempt that planned different receipts) and installs the new one in a
+  single serialized transaction, validated against availability excluding the
+  redemption's own prior reservation. Because clear and reserve are one step,
+  the prior reservation is never returned to global availability (no concurrent
+  redemption can grab it) and no stale reservation can survive to be
+  over-consumed at settle. The vault inventory is a single serialized aggregate,
+  so a concurrent _different_ redemption that already committed the same balance
+  fails to reserve and never submits an unbacked burn. Burn planning
+  (`for_burn`) likewise excludes the planning redemption's own reservation, so a
+  retry re-plans its full burn
+- `ReleaseBurn { redemption_issuer_request_id }` - Clear the redemption's
+  reservation (wherever held), restoring availability without changing the
+  mirror balance (the burn consumed nothing on-chain). No-op when the redemption
+  holds no reservation. Issued **only** on a definitive terminal/reverted
+  failure; pending or ambiguous Fireblocks statuses are not released because the
+  burn may still land
+- `SettleBurn { redemption_issuer_request_id }` - Consume the redemption's
+  reservation after its burn confirmed on-chain: clear the reservation and
+  reduce the mirror balance by the reserved amount. Idempotent; emits `Depleted`
+  for any receipt the settlement empties
+
+Release and settle are keyed only by redemption; `apply` uses the stored
+`reserved` amounts, so neither carries a `burns` payload.
 
 Events:
 
 - `Discovered` - Receipt discovered with initial balance
 - `BalanceReconciled { receipt_id, previous_balance, on_chain_balance }` -
-  Balance changed (detected during reconciliation, either increase or decrease)
-- `Depleted` - Receipt fully consumed (balance reached zero)
+  Mirror balance corrected to on-chain state (external change outside the
+  reservation band). A receipt drained to zero on-chain while it still holds a
+  reservation is preserved (mirror set to zero) rather than removed, so the
+  reservation can still resolve
+- `Depleted` - Receipt fully consumed (mirror balance reached zero) with no
+  outstanding reservation
+- `BurnReserved { redemption_issuer_request_id, burns }` - Submitted burn
+  allocation removed from available inventory (recorded in `reserved`, leaving
+  the mirror balance unchanged) so concurrent redemptions cannot reuse it
+- `BurnReleased { redemption_issuer_request_id }` - Reservation cleared after a
+  definitive terminal/reverted failure, restoring availability
+- `BurnSettled { redemption_issuer_request_id }` - Reservation consumed after
+  on-chain confirmation; mirror balance reduced by the reserved amount
+
+**Startup reservation recovery** (`recover_stuck_reservations`) runs after
+redemption recovery. For each vault it enumerates the redemptions holding a
+reservation and resolves each against the redemption's terminal state: a
+`Completed` redemption is **settled** (the burn confirmed but settlement was
+missed, e.g. a crash in the confirm→settle window). All other states are left
+untouched — a definitive failure already released its reservation in the
+live/recovery paths, so a reservation surviving on a `Failed`/`Closed`
+redemption is from an _ambiguous_ failure whose burn may still have landed;
+releasing it would over-credit inventory and risk a duplicate burn, so it is
+left for on-chain settlement or manual intervention.
 
 The per-vault receipt backfill cursor (previously `BackfillCheckpoint` events on
 this aggregate) is not domain state — it is a single mutable counter with no

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -392,6 +392,14 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
     ) -> Result<MultiBurnResult, VaultError> {
         let receipt = self.fetch_receipt(tx_hash).await?;
 
+        // A Fireblocks transaction can report `Completed` while the EVM
+        // transaction itself reverted (e.g. ERC1155InsufficientBalance). A
+        // reverted burn consumes no receipts, so it is a definitive failure
+        // distinct from an anomalous missing-Withdraw parse error.
+        if !receipt.status() {
+            return Err(VaultError::Reverted { tx_hash });
+        }
+
         let burns: Vec<MultiBurnResultEntry> = receipt
             .inner
             .logs()
@@ -542,7 +550,7 @@ fn serialize_sub_status(
 /// Returns true if the transaction status indicates the transaction is still
 /// in progress and may eventually confirm on-chain. Used to distinguish
 /// "polling timed out but tx might still land" from "tx definitively failed."
-const fn is_still_pending(status: TransactionStatus) -> bool {
+pub(crate) const fn is_still_pending(status: TransactionStatus) -> bool {
     use TransactionStatus::*;
 
     match status {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,8 +335,17 @@ pub async fn initialize_rocket(
     // idempotency, not on completing before the server is up. If the
     // synchronous pass hangs it is cancelled and any remaining stuck aggregates
     // are left for manual admin intervention.
-    run_recovery_with_timeout(&pool, &mint.cqrs, &mint.event_store, &managers)
-        .await;
+    let vaults: Vec<Address> =
+        vault_configs.iter().map(|config| config.vault).collect();
+
+    run_recovery_with_timeout(
+        &pool,
+        &mint.cqrs,
+        &mint.event_store,
+        &managers,
+        &vaults,
+    )
+    .await;
 
     spawn_periodic_receipt_backfills(
         pool.clone(),
@@ -349,9 +358,6 @@ pub async fn initialize_rocket(
     );
 
     {
-        let vaults: Vec<Address> =
-            vault_configs.iter().map(|config| config.vault).collect();
-
         info!(
             target: "redemption",
             vault_count = vaults.len(),
@@ -674,6 +680,7 @@ async fn run_redemption_recovery(
         PersistedEventStore<SqliteEventRepository, Redemption>,
     >,
     burn: &BurnManager<PersistedEventStore<SqliteEventRepository, Redemption>>,
+    vaults: &[Address],
 ) {
     info!(target: "redemption", "Running redemption recovery");
 
@@ -681,6 +688,12 @@ async fn run_redemption_recovery(
     journal.recover_alpaca_called_redemptions().await;
     burn.recover_burning_redemptions().await;
     burn.recover_burn_failed_redemptions().await;
+    // Runs last, after the recovery passes above have re-confirmed in-flight
+    // burns. It only SETTLES reservations whose redemption confirmed
+    // (Completed) but whose settlement was missed; ambiguous/in-flight
+    // reservations are left untouched, since releasing a burn that may have
+    // landed would risk a duplicate burn.
+    burn.recover_stuck_reservations(vaults).await;
 }
 
 /// Maximum time to wait for recovery before starting the HTTP server.
@@ -702,6 +715,7 @@ async fn run_recovery_with_timeout(
     mint_cqrs: &MintCqrs,
     mint_event_store: &MintEventStore,
     managers: &RedemptionManagers,
+    vaults: &[Address],
 ) {
     let recovery = async {
         run_mint_recovery(pool, mint_cqrs, mint_event_store).await;
@@ -709,6 +723,7 @@ async fn run_recovery_with_timeout(
             &managers.redeem_call,
             &managers.journal,
             &managers.burn,
+            vaults,
         )
         .await;
     };

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -178,7 +178,7 @@ pub(crate) fn plan_burn(
                 return None;
             }
 
-            let burn_from_this = remaining.min(receipt.available_balance);
+            let burn_from_this = (*remaining).min(receipt.available_balance);
 
             match remaining.checked_sub(burn_from_this) {
                 Some(new_remaining) => {
@@ -740,6 +740,79 @@ mod tests {
             matches!(err, BurnTrackingError::InsufficientBalance { required, available }
                 if required == burn_amount && available == Shares::new(uint!(50_000000000000000000_U256))),
             "Expected InsufficientBalance error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_plan_spans_two_receipts_when_first_is_short_by_one_gwei() {
+        let receipts = vec![
+            ReceiptWithBalance {
+                receipt_id: ReceiptId::from(uint!(131_U256)),
+                available_balance: Shares::new(uint!(
+                    10079999999000000000_U256
+                )),
+                tx_hash: TxHash::ZERO,
+                block_number: 0,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+            ReceiptWithBalance {
+                receipt_id: ReceiptId::from(uint!(124_U256)),
+                available_balance: Shares::new(uint!(1000000000_U256)),
+                tx_hash: TxHash::ZERO,
+                block_number: 0,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        ];
+
+        let burn_amount = Shares::new(uint!(10080000000000000000_U256));
+        let dust_amount = Shares::new(U256::ZERO);
+
+        let plan = plan_burn(receipts, burn_amount, dust_amount)
+            .expect("Plan should use both receipts to cover the remainder");
+
+        assert_eq!(plan.allocations.len(), 2);
+        assert_eq!(
+            plan.allocations[0].receipt.receipt_id,
+            ReceiptId::from(uint!(131_U256))
+        );
+        assert_eq!(
+            plan.allocations[0].burn_amount,
+            Shares::new(uint!(10079999999000000000_U256))
+        );
+        assert_eq!(
+            plan.allocations[1].receipt.receipt_id,
+            ReceiptId::from(uint!(124_U256))
+        );
+        assert_eq!(
+            plan.allocations[1].burn_amount,
+            Shares::new(uint!(1000000000_U256))
+        );
+    }
+
+    #[test]
+    fn test_plan_fails_when_single_receipt_short_by_one_gwei() {
+        let receipts = vec![ReceiptWithBalance {
+            receipt_id: ReceiptId::from(uint!(131_U256)),
+            available_balance: Shares::new(uint!(10079999999000000000_U256)),
+            tx_hash: TxHash::ZERO,
+            block_number: 0,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        }];
+
+        let burn_amount = Shares::new(uint!(10080000000000000000_U256));
+        let dust_amount = Shares::new(U256::ZERO);
+
+        let err = plan_burn(receipts, burn_amount, dust_amount)
+            .expect_err("Plan should fail before Fireblocks submission");
+
+        assert!(
+            matches!(err, BurnTrackingError::InsufficientBalance { required, available }
+                if required == burn_amount
+                    && available == Shares::new(uint!(10079999999000000000_U256))),
+            "Expected one-gwei-short InsufficientBalance error, got {err:?}"
         );
     }
 

--- a/src/receipt_inventory/cmd.rs
+++ b/src/receipt_inventory/cmd.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::event::ReceiptSource;
 use super::{ReceiptId, Shares};
+use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -19,5 +20,15 @@ pub(crate) enum ReceiptInventoryCommand {
     ReconcileBalance {
         receipt_id: ReceiptId,
         on_chain_balance: Shares,
+    },
+    ReserveBurn {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+        burns: Vec<BurnRecord>,
+    },
+    ReleaseBurn {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    },
+    SettleBurn {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
     },
 }

--- a/src/receipt_inventory/event.rs
+++ b/src/receipt_inventory/event.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{ReceiptId, Shares};
 use crate::mint::IssuerMintRequestId;
+use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 
 /// Identifies how a receipt was created.
@@ -40,6 +41,23 @@ pub(crate) enum ReceiptInventoryEvent {
     Depleted {
         receipt_id: ReceiptId,
     },
+    BurnReserved {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+        burns: Vec<BurnRecord>,
+    },
+    /// A reservation was released without consuming on-chain shares (the burn
+    /// failed definitively or was never submitted). Keyed only by redemption:
+    /// `apply` clears the redemption's reservation wherever it is held.
+    BurnReleased {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    },
+    /// A submitted burn confirmed on-chain. The redemption's reservation is
+    /// consumed: it is removed and the receipt's mirror balance is reduced by
+    /// the reserved amount, reflecting the shares that left the vault. Keyed
+    /// only by redemption; `apply` uses the stored reserved amounts.
+    BurnSettled {
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    },
 }
 
 impl DomainEvent for ReceiptInventoryEvent {
@@ -53,6 +71,15 @@ impl DomainEvent for ReceiptInventoryEvent {
             }
             Self::Depleted { .. } => {
                 "ReceiptInventoryEvent::Depleted".to_string()
+            }
+            Self::BurnReserved { .. } => {
+                "ReceiptInventoryEvent::BurnReserved".to_string()
+            }
+            Self::BurnReleased { .. } => {
+                "ReceiptInventoryEvent::BurnReleased".to_string()
+            }
+            Self::BurnSettled { .. } => {
+                "ReceiptInventoryEvent::BurnSettled".to_string()
             }
         }
     }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -10,6 +10,7 @@ use async_trait::async_trait;
 use cqrs_es::{
     Aggregate, AggregateContext, AggregateError, CqrsFramework, EventStore,
 };
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -17,6 +18,7 @@ use thiserror::Error;
 use tracing::warn;
 
 use crate::mint::IssuerMintRequestId;
+use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 use crate::vault::rain_meta;
 pub(crate) use backfill::ItnReceiptHandler;
@@ -81,10 +83,14 @@ impl std::fmt::Display for ReceiptId {
 ///
 /// Shares represent ownership in the vault and are minted/burned
 /// proportionally to deposited/withdrawn assets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize,
+)]
 pub(crate) struct Shares(U256);
 
 impl Shares {
+    pub(crate) const ZERO: Self = Self(U256::ZERO);
+
     pub(crate) const fn new(amount: U256) -> Self {
         Self(amount)
     }
@@ -138,15 +144,79 @@ impl std::ops::Add for Shares {
 }
 
 /// Metadata about a receipt stored in the inventory.
+///
+/// `balance` mirrors the on-chain ERC-1155 balance the bot believes it holds.
+/// `reserved` tracks shares committed to submitted-but-unconfirmed burns,
+/// keyed by the redemption that submitted them. Available inventory for burn
+/// planning is `balance - sum(reserved)`. Keeping the two separate is what lets
+/// reconciliation compare against the true on-chain mirror without clobbering a
+/// pending reservation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 struct ReceiptMetadata {
     balance: Shares,
+    #[serde(default)]
+    reserved: HashMap<IssuerRedemptionRequestId, Shares>,
     tx_hash: TxHash,
     block_number: u64,
     #[serde(default)]
     receipt_info: Option<ReceiptInformation>,
     #[serde(default)]
     receipt_info_bytes: Option<Bytes>,
+}
+
+impl ReceiptMetadata {
+    /// Total shares reserved across all redemptions for this receipt.
+    fn reserved_total(&self) -> Shares {
+        Self::sum_reserved(self.reserved.values().copied())
+    }
+
+    /// Shares reserved by every redemption except `redemption`.
+    ///
+    /// Used when validating a reservation so a redemption re-reserving the same
+    /// receipt (idempotent re-delivery) does not count its own prior amount.
+    fn reserved_excluding(
+        &self,
+        redemption: &IssuerRedemptionRequestId,
+    ) -> Shares {
+        Self::sum_reserved(
+            self.reserved
+                .iter()
+                .filter(|(id, _)| *id != redemption)
+                .map(|(_, shares)| *shares),
+        )
+    }
+
+    /// Shares available for new burn planning: mirror balance minus all
+    /// outstanding reservations. Saturates to zero if reservations somehow
+    /// exceed the mirror (e.g. after an external on-chain drain).
+    fn available(&self) -> Shares {
+        self.balance.checked_sub(self.reserved_total()).unwrap_or(Shares::ZERO)
+    }
+
+    /// Shares available to `redemption` for planning: mirror balance minus
+    /// every *other* redemption's reservation. Excludes `redemption`'s own
+    /// prior reservation so a retry can re-plan its full burn against the
+    /// inventory it is entitled to; the atomic clear-and-reserve then replaces
+    /// that prior reservation.
+    fn available_excluding(
+        &self,
+        redemption: &IssuerRedemptionRequestId,
+    ) -> Shares {
+        self.balance
+            .checked_sub(self.reserved_excluding(redemption))
+            .unwrap_or(Shares::ZERO)
+    }
+
+    /// Sums reserved amounts. Each reservation was validated at `ReserveBurn`
+    /// time to be `<=` this receipt's mirror balance (a real U256 share
+    /// amount), so the sum cannot overflow U256 in practice; `saturating_add`
+    /// is a non-panicking guard for that impossible case, not a silent cap over
+    /// a real value.
+    fn sum_reserved(reserved: impl Iterator<Item = Shares>) -> Shares {
+        reserved.fold(Shares::ZERO, |acc, shares| {
+            Shares::new(acc.inner().saturating_add(shares.inner()))
+        })
+    }
 }
 
 /// Parameters for registering a newly minted receipt.
@@ -181,13 +251,43 @@ pub(crate) trait ReceiptService: Send + Sync {
     /// Returns a burn plan: which receipts to burn and how much from each.
     ///
     /// The plan satisfies the required burn amount by selecting from available
-    /// receipts in descending order of balance.
+    /// receipts in descending order of balance. Availability excludes
+    /// `redemption_issuer_request_id`'s own prior reservation, so a retry plans
+    /// against its full entitlement; the subsequent `reserve_burn` atomically
+    /// replaces that reservation.
     async fn for_burn(
         &self,
         vault: Address,
+        redemption_issuer_request_id: &IssuerRedemptionRequestId,
         shares_to_burn: Shares,
         dust: Shares,
     ) -> Result<BurnPlan, BurnTrackingError>;
+
+    async fn reserve_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+        burns: Vec<BurnRecord>,
+    ) -> Result<(), ReceiptRegistrationError>;
+
+    async fn release_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    ) -> Result<(), ReceiptRegistrationError>;
+
+    async fn settle_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    ) -> Result<(), ReceiptRegistrationError>;
+
+    /// Returns the redemptions that currently hold a reservation on the vault,
+    /// for startup reservation recovery.
+    async fn reserved_redemptions(
+        &self,
+        vault: Address,
+    ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>;
 
     /// Finds a receipt by its issuer_request_id (for ITN mints only).
     ///
@@ -260,13 +360,77 @@ where
     async fn for_burn(
         &self,
         vault: Address,
+        redemption_issuer_request_id: &IssuerRedemptionRequestId,
         shares_to_burn: Shares,
         dust: Shares,
     ) -> Result<BurnPlan, BurnTrackingError> {
         let context = self.store.load_aggregate(&vault.to_string()).await?;
 
-        let receipts = context.aggregate().receipts_with_balance();
+        let receipts = context
+            .aggregate()
+            .receipts_with_balance_excluding(redemption_issuer_request_id);
         plan_burn(receipts, shares_to_burn, dust)
+    }
+
+    async fn reserve_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+        burns: Vec<BurnRecord>,
+    ) -> Result<(), ReceiptRegistrationError> {
+        self.cqrs
+            .execute(
+                &vault.to_string(),
+                ReceiptInventoryCommand::ReserveBurn {
+                    redemption_issuer_request_id,
+                    burns,
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn release_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    ) -> Result<(), ReceiptRegistrationError> {
+        self.cqrs
+            .execute(
+                &vault.to_string(),
+                ReceiptInventoryCommand::ReleaseBurn {
+                    redemption_issuer_request_id,
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn settle_burn(
+        &self,
+        vault: Address,
+        redemption_issuer_request_id: IssuerRedemptionRequestId,
+    ) -> Result<(), ReceiptRegistrationError> {
+        self.cqrs
+            .execute(
+                &vault.to_string(),
+                ReceiptInventoryCommand::SettleBurn {
+                    redemption_issuer_request_id,
+                },
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn reserved_redemptions(
+        &self,
+        vault: Address,
+    ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError> {
+        let context = self.store.load_aggregate(&vault.to_string()).await?;
+        Ok(context.aggregate().reserved_redemptions())
     }
 
     async fn find_by_issuer_request_id(
@@ -321,15 +485,45 @@ impl ReceiptInventory {
     pub(crate) fn receipts_with_balance(&self) -> Vec<ReceiptWithBalance> {
         self.receipts
             .iter()
-            .map(|(receipt_id, metadata)| ReceiptWithBalance {
-                receipt_id: *receipt_id,
-                available_balance: metadata.balance,
-                tx_hash: metadata.tx_hash,
-                block_number: metadata.block_number,
-                receipt_info: metadata.receipt_info.clone(),
-                receipt_info_bytes: metadata.receipt_info_bytes.clone(),
+            .map(|(receipt_id, metadata)| {
+                Self::receipt_row(*receipt_id, metadata, metadata.available())
             })
             .collect()
+    }
+
+    /// Receipts with the availability `redemption` may plan against, treating
+    /// its own prior reservation as not held (see
+    /// `ReceiptMetadata::available_excluding`). Used by `for_burn` so a retry
+    /// re-plans its full burn rather than being blocked by its own reservation.
+    pub(crate) fn receipts_with_balance_excluding(
+        &self,
+        redemption: &IssuerRedemptionRequestId,
+    ) -> Vec<ReceiptWithBalance> {
+        self.receipts
+            .iter()
+            .map(|(receipt_id, metadata)| {
+                Self::receipt_row(
+                    *receipt_id,
+                    metadata,
+                    metadata.available_excluding(redemption),
+                )
+            })
+            .collect()
+    }
+
+    fn receipt_row(
+        receipt_id: ReceiptId,
+        metadata: &ReceiptMetadata,
+        available_balance: Shares,
+    ) -> ReceiptWithBalance {
+        ReceiptWithBalance {
+            receipt_id,
+            available_balance,
+            tx_hash: metadata.tx_hash,
+            block_number: metadata.block_number,
+            receipt_info: metadata.receipt_info.clone(),
+            receipt_info_bytes: metadata.receipt_info_bytes.clone(),
+        }
     }
 
     /// Finds a receipt by its issuer_request_id (for ITN mints only).
@@ -339,6 +533,70 @@ impl ReceiptInventory {
         issuer_request_id: &IssuerMintRequestId,
     ) -> Option<ReceiptId> {
         self.itn_receipts.get(issuer_request_id).copied()
+    }
+
+    /// Whether the given redemption holds a reservation on any receipt.
+    fn holds_reservation(
+        &self,
+        redemption: &IssuerRedemptionRequestId,
+    ) -> bool {
+        self.receipts
+            .values()
+            .any(|metadata| metadata.reserved.contains_key(redemption))
+    }
+
+    /// Distinct redemptions that currently hold a reservation on any receipt.
+    ///
+    /// Used by startup reservation recovery to find reservations that were
+    /// never settled or released (e.g. a crash between burn confirmation and
+    /// settlement) and resolve them against the redemption's terminal state.
+    pub(crate) fn reserved_redemptions(
+        &self,
+    ) -> Vec<IssuerRedemptionRequestId> {
+        self.receipts
+            .values()
+            .flat_map(|metadata| metadata.reserved.keys().cloned())
+            .unique()
+            .collect()
+    }
+
+    /// `Depleted` events for receipts that clearing `redemption`'s reservation
+    /// would leave at zero balance with no other reservation outstanding.
+    ///
+    /// `consume_balance` true models settlement (the mirror drops by the
+    /// reserved amount); false models release (the mirror is unchanged). This
+    /// also covers a receipt already at zero balance — preserved by the
+    /// zero-drain reconcile guard — so it is depleted once its last reservation
+    /// resolves rather than lingering empty forever.
+    fn depletions_after_clearing(
+        &self,
+        redemption: &IssuerRedemptionRequestId,
+        consume_balance: bool,
+    ) -> Vec<ReceiptInventoryEvent> {
+        self.receipts
+            .iter()
+            .filter_map(|(receipt_id, metadata)| {
+                let reserved = metadata.reserved.get(redemption)?;
+
+                // Another redemption still holds this receipt; leave it.
+                if metadata.reserved.len() > 1 {
+                    return None;
+                }
+
+                let post_balance = if consume_balance {
+                    metadata
+                        .balance
+                        .checked_sub(*reserved)
+                        .unwrap_or(Shares::ZERO)
+                } else {
+                    metadata.balance
+                };
+
+                post_balance.is_zero().then_some(
+                    ReceiptInventoryEvent::Depleted { receipt_id: *receipt_id },
+                )
+            })
+            .collect()
     }
 }
 
@@ -390,7 +648,21 @@ pub(crate) fn determine_source(
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum ReceiptInventoryError {}
+pub(crate) enum ReceiptInventoryError {
+    #[error("Unknown receipt {receipt_id}")]
+    UnknownReceipt { receipt_id: ReceiptId },
+    #[error(transparent)]
+    SharesOverflow(#[from] SharesOverflow),
+    #[error(
+        "Receipt {receipt_id} has insufficient balance: \
+         available={available}, required={required}"
+    )]
+    InsufficientReceiptBalance {
+        receipt_id: ReceiptId,
+        available: Shares,
+        required: Shares,
+    },
+}
 
 #[async_trait]
 impl Aggregate for ReceiptInventory {
@@ -441,22 +713,120 @@ impl Aggregate for ReceiptInventory {
                     return Ok(vec![]);
                 };
 
-                let aggregate_balance = metadata.balance;
-                if on_chain_balance == aggregate_balance {
-                    return Ok(vec![]);
+                let mirror = metadata.balance;
+                let available = metadata.available();
+
+                // While a submitted burn is pending, on-chain legitimately
+                // sits between `available` (all reservations settled) and
+                // `mirror` (none landed yet). Treat anything in that band as
+                // "no external change" so reconciliation never clobbers a
+                // reservation — settlement, not reconciliation, consumes it.
+                if (available..=mirror).contains(&on_chain_balance) {
+                    return Ok(if mirror.is_zero() {
+                        depletion_events(receipt_id, metadata)
+                    } else {
+                        vec![]
+                    });
                 }
 
                 let reconciled = ReceiptInventoryEvent::BalanceReconciled {
                     receipt_id,
-                    previous_balance: aggregate_balance,
+                    previous_balance: mirror,
                     on_chain_balance,
                 };
 
-                let depleted = on_chain_balance
-                    .is_zero()
-                    .then_some(ReceiptInventoryEvent::Depleted { receipt_id });
+                let depletion = if on_chain_balance.is_zero() {
+                    depletion_events(receipt_id, metadata)
+                } else {
+                    vec![]
+                };
 
-                Ok(std::iter::once(reconciled).chain(depleted).collect())
+                Ok(std::iter::once(reconciled).chain(depletion).collect())
+            }
+
+            ReceiptInventoryCommand::ReserveBurn {
+                redemption_issuer_request_id,
+                burns,
+            } => {
+                let required_by_receipt = required_burns_by_receipt(&burns)?;
+
+                for (receipt_id, required) in required_by_receipt {
+                    let Some(metadata) = self.receipts.get(&receipt_id) else {
+                        return Err(ReceiptInventoryError::UnknownReceipt {
+                            receipt_id,
+                        });
+                    };
+
+                    // Validate against availability excluding this redemption's
+                    // own prior reservation, matching how `for_burn` plans, so a
+                    // retry (or re-delivered ReserveBurn) does not count itself
+                    // and over-reject. The atomic clear-and-reserve apply then
+                    // replaces that prior reservation.
+                    let available = metadata
+                        .available_excluding(&redemption_issuer_request_id);
+
+                    if available < required {
+                        return Err(
+                            ReceiptInventoryError::InsufficientReceiptBalance {
+                                receipt_id,
+                                available,
+                                required,
+                            },
+                        );
+                    }
+                }
+
+                Ok(vec![ReceiptInventoryEvent::BurnReserved {
+                    redemption_issuer_request_id,
+                    burns,
+                }])
+            }
+
+            // Release restores a reservation without touching the mirror
+            // balance (the burn never consumed any shares on-chain). It is a
+            // no-op when the redemption holds no reservation, which makes it
+            // safe to call defensively before re-planning a retry. Emits
+            // Depleted for a zero-balance receipt whose last reservation this
+            // release clears.
+            ReceiptInventoryCommand::ReleaseBurn {
+                redemption_issuer_request_id,
+            } => {
+                if !self.holds_reservation(&redemption_issuer_request_id) {
+                    return Ok(vec![]);
+                }
+
+                let depletions = self.depletions_after_clearing(
+                    &redemption_issuer_request_id,
+                    false,
+                );
+
+                Ok(std::iter::once(ReceiptInventoryEvent::BurnReleased {
+                    redemption_issuer_request_id,
+                })
+                .chain(depletions)
+                .collect())
+            }
+
+            // Settle consumes a reservation after its burn confirmed on-chain:
+            // the mirror balance drops by the reserved amount. Emits Depleted
+            // for any receipt the settlement empties.
+            ReceiptInventoryCommand::SettleBurn {
+                redemption_issuer_request_id,
+            } => {
+                if !self.holds_reservation(&redemption_issuer_request_id) {
+                    return Ok(vec![]);
+                }
+
+                let depletions = self.depletions_after_clearing(
+                    &redemption_issuer_request_id,
+                    true,
+                );
+
+                Ok(std::iter::once(ReceiptInventoryEvent::BurnSettled {
+                    redemption_issuer_request_id,
+                })
+                .chain(depletions)
+                .collect())
             }
         }
     }
@@ -476,6 +846,7 @@ impl Aggregate for ReceiptInventory {
                     receipt_id,
                     ReceiptMetadata {
                         balance,
+                        reserved: HashMap::new(),
                         tx_hash,
                         block_number,
                         receipt_info: receipt_info.map(|boxed| *boxed),
@@ -492,7 +863,17 @@ impl Aggregate for ReceiptInventory {
                 on_chain_balance,
                 ..
             } => {
-                if on_chain_balance.is_zero() {
+                // Remove the receipt only when on-chain hit zero AND no
+                // reservation survives. A reserved receipt drained to zero is
+                // preserved (mirror set to zero) so a pending settle/release
+                // can still resolve the reservation rather than have it
+                // silently discarded with the receipt.
+                let has_reservation = self
+                    .receipts
+                    .get(&receipt_id)
+                    .is_some_and(|metadata| !metadata.reserved.is_empty());
+
+                if on_chain_balance.is_zero() && !has_reservation {
                     self.receipts.remove(&receipt_id);
                     self.itn_receipts.retain(|_, indexed_receipt_id| {
                         *indexed_receipt_id != receipt_id
@@ -510,8 +891,131 @@ impl Aggregate for ReceiptInventory {
                     *indexed_receipt_id != receipt_id
                 });
             }
+
+            // Atomic clear-and-reserve: a reservation is the redemption's whole
+            // current allocation, so first drop any prior reservation it held
+            // (e.g. from a retried attempt that planned different receipts),
+            // then install the new one. This makes a retry's reserve replace the
+            // redemption's reservation set in a single transaction — no stale
+            // entry can survive to be over-consumed at settle, and the balance
+            // is never returned to global availability between clear and
+            // reserve.
+            ReceiptInventoryEvent::BurnReserved {
+                redemption_issuer_request_id,
+                burns,
+            } => {
+                let reserved_by_receipt = match required_burns_by_receipt(
+                    &burns,
+                ) {
+                    Ok(reserved_by_receipt) => reserved_by_receipt,
+                    Err(err) => {
+                        warn!(target: "receipt",
+                            redemption_issuer_request_id = %redemption_issuer_request_id,
+                            error = %err,
+                            "BurnReserved burns failed to aggregate; reservation not applied"
+                        );
+                        return;
+                    }
+                };
+
+                for metadata in self.receipts.values_mut() {
+                    metadata.reserved.remove(&redemption_issuer_request_id);
+                }
+
+                for (receipt_id, reserved) in reserved_by_receipt {
+                    let Some(metadata) = self.receipts.get_mut(&receipt_id)
+                    else {
+                        warn!(target: "receipt", receipt_id = %receipt_id,
+                            redemption_issuer_request_id = %redemption_issuer_request_id,
+                            "BurnReserved for unknown receipt; reservation skipped"
+                        );
+                        continue;
+                    };
+
+                    metadata
+                        .reserved
+                        .insert(redemption_issuer_request_id.clone(), reserved);
+                }
+            }
+
+            // Release clears the redemption's reservation everywhere it is
+            // held, restoring availability without touching the mirror balance.
+            ReceiptInventoryEvent::BurnReleased {
+                redemption_issuer_request_id,
+            } => {
+                for metadata in self.receipts.values_mut() {
+                    metadata.reserved.remove(&redemption_issuer_request_id);
+                }
+            }
+
+            // Settle consumes the reservation: drop it and reduce the mirror
+            // balance by the reserved amount, since those shares left on-chain.
+            // Idempotent — a receipt with no matching reservation is skipped.
+            ReceiptInventoryEvent::BurnSettled {
+                redemption_issuer_request_id,
+            } => {
+                for (receipt_id, metadata) in &mut self.receipts {
+                    let Some(reserved) =
+                        metadata.reserved.remove(&redemption_issuer_request_id)
+                    else {
+                        continue;
+                    };
+
+                    let Some(new_balance) =
+                        metadata.balance.checked_sub(reserved)
+                    else {
+                        warn!(target: "receipt", receipt_id = %receipt_id,
+                            redemption_issuer_request_id = %redemption_issuer_request_id,
+                            balance = %metadata.balance,
+                            reserved = %reserved,
+                            "BurnSettled reservation exceeds mirror balance; clamping balance to zero"
+                        );
+                        metadata.balance = Shares::ZERO;
+                        continue;
+                    };
+
+                    metadata.balance = new_balance;
+                }
+            }
         }
     }
+}
+
+/// Decides whether a receipt that has reached zero balance should be depleted.
+///
+/// A receipt that still holds a reservation is preserved (with a WARN) instead
+/// of depleted: removing it would silently discard the reservation and turn a
+/// later settle/release into a no-op. A pending settle/release or the startup
+/// reservation recovery resolves it instead.
+fn depletion_events(
+    receipt_id: ReceiptId,
+    metadata: &ReceiptMetadata,
+) -> Vec<ReceiptInventoryEvent> {
+    if metadata.reserved.is_empty() {
+        return vec![ReceiptInventoryEvent::Depleted { receipt_id }];
+    }
+
+    warn!(target: "receipt", receipt_id = %receipt_id,
+        "Receipt reached zero balance while still holding reservations; \
+         preserving it so the reservation can resolve"
+    );
+    vec![]
+}
+
+fn required_burns_by_receipt(
+    burns: &[BurnRecord],
+) -> Result<HashMap<ReceiptId, Shares>, ReceiptInventoryError> {
+    burns.iter().try_fold(HashMap::new(), |mut required, burn| {
+        let receipt_id = ReceiptId::from(burn.receipt_id);
+        let shares = Shares::from(burn.shares_burned);
+        let current = required
+            .remove(&receipt_id)
+            .map_or(Ok(shares), |existing| existing + shares)?;
+
+        required.insert(receipt_id, current);
+
+        Ok(required)
+    })
 }
 
 #[cfg(test)]
@@ -519,8 +1023,11 @@ mod tests {
     use alloy::primitives::{Bytes, TxHash, address, b256};
     use cqrs_es::{CqrsFramework, EventStore, mem_store::MemStore};
     use std::sync::Arc;
+    use tracing::Level;
+    use tracing_test::traced_test;
 
     use super::*;
+    use crate::test_utils::logs_contain_at;
 
     const TEST_OA_SCHEMA: &str =
         "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
@@ -533,9 +1040,17 @@ mod tests {
         Shares::new(U256::from(n))
     }
 
+    /// A redemption distinct from any used to reserve in these tests, so
+    /// `for_burn` planning counts (does not exclude) the reservations under
+    /// test — i.e. the "another redemption is planning" viewpoint.
+    fn planning_redemption() -> IssuerRedemptionRequestId {
+        "red-00000000".parse().unwrap()
+    }
+
     fn make_metadata(balance: u64) -> ReceiptMetadata {
         ReceiptMetadata {
             balance: make_shares(balance),
+            reserved: HashMap::new(),
             tx_hash: TxHash::ZERO,
             block_number: 0,
             receipt_info: None,
@@ -1055,6 +1570,7 @@ mod tests {
         let plan = service
             .for_burn(
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                &planning_redemption(),
                 make_shares(150),
                 make_shares(0),
             )
@@ -1073,6 +1589,7 @@ mod tests {
         let plan = service
             .for_burn(
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                &planning_redemption(),
                 make_shares(100),
                 make_shares(10),
             )
@@ -1092,6 +1609,7 @@ mod tests {
         let result = service
             .for_burn(
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                &planning_redemption(),
                 make_shares(100),
                 make_shares(0),
             )
@@ -1111,6 +1629,7 @@ mod tests {
         let result = service
             .for_burn(
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                &planning_redemption(),
                 make_shares(100),
                 make_shares(0),
             )
@@ -1130,6 +1649,7 @@ mod tests {
         let result = service
             .for_burn(
                 address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+                &planning_redemption(),
                 make_shares(50),
                 make_shares(0),
             )
@@ -1149,6 +1669,7 @@ mod tests {
         let plan = service
             .for_burn(
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                &planning_redemption(),
                 make_shares(100),
                 make_shares(0),
             )
@@ -1157,6 +1678,722 @@ mod tests {
 
         assert_eq!(plan.total_burn, make_shares(100));
         assert_eq!(plan.allocations.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_reserve_burn_removes_receipt_from_future_plans() {
+        let service =
+            setup_receipt_service_with_receipts(vec![(1, 100), (2, 50)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        service
+            .reserve_burn(
+                vault,
+                "red-00000001".parse().unwrap(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(1),
+                    shares_burned: U256::from(100),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(50),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(plan.allocations.len(), 1);
+        assert_eq!(plan.allocations[0].receipt.receipt_id, make_receipt_id(2));
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(50));
+    }
+
+    #[tokio::test]
+    async fn test_reserve_burn_reduces_partial_receipt_balance() {
+        let service =
+            setup_receipt_service_with_receipts(vec![(1, 100), (2, 50)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        service
+            .reserve_burn(
+                vault,
+                "red-00000001".parse().unwrap(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(1),
+                    shares_burned: U256::from(60),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(90),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(plan.allocations.len(), 2);
+        assert_eq!(plan.allocations[0].receipt.receipt_id, make_receipt_id(2));
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(50));
+        assert_eq!(plan.allocations[1].receipt.receipt_id, make_receipt_id(1));
+        assert_eq!(plan.allocations[1].burn_amount, make_shares(40));
+    }
+
+    #[tokio::test]
+    async fn test_reserve_burn_rejects_duplicate_rows_exceeding_balance() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        let err = service
+            .reserve_burn(
+                vault,
+                "red-00000001".parse().unwrap(),
+                vec![
+                    BurnRecord {
+                        receipt_id: U256::from(1),
+                        shares_burned: U256::from(60),
+                    },
+                    BurnRecord {
+                        receipt_id: U256::from(1),
+                        shares_burned: U256::from(60),
+                    },
+                ],
+            )
+            .await
+            .expect_err("Duplicate receipt rows must be checked cumulatively");
+
+        assert!(matches!(
+            err,
+            ReceiptRegistrationError::Aggregate(AggregateError::UserError(
+                ReceiptInventoryError::InsufficientReceiptBalance {
+                    available,
+                    required,
+                    ..
+                }
+            )) if available == make_shares(100) && required == make_shares(120)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_release_burn_restores_reserved_balance() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(
+                vault,
+                redemption_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(1),
+                    shares_burned: U256::from(100),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let err = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(1),
+                make_shares(0),
+            )
+            .await
+            .expect_err("Fully reserved receipt should not be available");
+
+        assert!(matches!(err, BurnTrackingError::InsufficientBalance { .. }));
+
+        service.release_burn(vault, redemption_id).await.unwrap();
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(100),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(plan.allocations.len(), 1);
+        assert_eq!(plan.allocations[0].receipt.receipt_id, make_receipt_id(1));
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(100));
+    }
+
+    fn burn(receipt_id: u64, shares: u64) -> BurnRecord {
+        BurnRecord {
+            receipt_id: U256::from(receipt_id),
+            shares_burned: U256::from(shares),
+        }
+    }
+
+    /// Critical regression guard for the same-receipt burn race: while a
+    /// submitted burn is pending (its shares have NOT left on-chain),
+    /// reconciliation against the unchanged on-chain balance must NOT restore
+    /// the reservation to available inventory.
+    #[tokio::test]
+    async fn test_reconcile_preserves_pending_reservation() {
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(42),
+            balance: make_shares(100),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+            redemption_issuer_request_id: "red-00000001".parse().unwrap(),
+            burns: vec![burn(42, 100)],
+        });
+
+        assert_eq!(
+            aggregate.receipts_with_balance()[0].available_balance,
+            make_shares(0),
+            "fully reserved receipt must be unavailable"
+        );
+
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(100),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            events.is_empty(),
+            "reconcile against unchanged on-chain balance must not wipe a \
+             pending reservation, got {events:?}"
+        );
+
+        for event in events {
+            aggregate.apply(event);
+        }
+
+        assert_eq!(
+            aggregate.receipts_with_balance()[0].available_balance,
+            make_shares(0),
+            "reservation must remain in effect after reconcile"
+        );
+    }
+
+    /// A burn landing on-chain (on-chain drops to the available level, below
+    /// the mirror) is still inside the no-op band — settlement, not reconcile,
+    /// consumes the reservation.
+    #[tokio::test]
+    async fn test_reconcile_no_op_for_landed_unsettled_burn() {
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(42),
+            balance: make_shares(100),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+            redemption_issuer_request_id: "red-00000001".parse().unwrap(),
+            burns: vec![burn(42, 60)],
+        });
+
+        // available = 40, mirror = 100; the burn of 60 lands -> on-chain 40.
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(40),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            events.is_empty(),
+            "on-chain within [available, mirror] is not an external change, got {events:?}"
+        );
+    }
+
+    /// An on-chain balance below the available level is a genuine external
+    /// change (e.g. a transfer out) and must reconcile while leaving the
+    /// pending reservation intact.
+    #[tokio::test]
+    async fn test_reconcile_external_drain_below_available_reconciles() {
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(42),
+            balance: make_shares(100),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+            redemption_issuer_request_id: "red-00000001".parse().unwrap(),
+            burns: vec![burn(42, 30)],
+        });
+
+        // available = 70; on-chain 50 < 70 -> external drain.
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(50),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            ReceiptInventoryEvent::BalanceReconciled { on_chain_balance, .. }
+                if *on_chain_balance == make_shares(50)
+        ));
+    }
+
+    /// In the anomalous case of a receipt at zero mirror balance that still
+    /// holds a reservation, an on-chain==0 reconcile must NOT deplete it: doing
+    /// so would silently drop the reservation and turn a later settle/release
+    /// into a no-op.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_reconcile_preserves_reservation_at_zero_mirror() {
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(42),
+            balance: make_shares(0),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate
+            .receipts
+            .get_mut(&make_receipt_id(42))
+            .unwrap()
+            .reserved
+            .insert("red-00000001".parse().unwrap(), make_shares(50));
+
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            events.is_empty(),
+            "must not deplete a receipt that still holds a reservation"
+        );
+        assert!(
+            aggregate.receipts.contains_key(&make_receipt_id(42)),
+            "receipt must be preserved so its reservation can still resolve"
+        );
+        assert!(logs_contain_at!(Level::WARN, &["still holding reservations"]));
+    }
+
+    /// An external drain that pushes on-chain below `available` to zero while a
+    /// reservation is outstanding must record the mirror change but NOT deplete
+    /// the receipt — depleting would silently discard the reservation.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_reconcile_zero_drain_preserves_reservation() {
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(42),
+            balance: make_shares(100),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate
+            .receipts
+            .get_mut(&make_receipt_id(42))
+            .unwrap()
+            .reserved
+            .insert("red-00000001".parse().unwrap(), make_shares(70));
+
+        // available = 30; an external drain to 0 is below it (out of band).
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            events.len(),
+            1,
+            "must reconcile the mirror but not deplete, got {events:?}"
+        );
+        assert!(matches!(
+            &events[0],
+            ReceiptInventoryEvent::BalanceReconciled { on_chain_balance, .. }
+                if on_chain_balance.is_zero()
+        ));
+
+        for event in events {
+            aggregate.apply(event);
+        }
+
+        assert!(
+            aggregate.receipts.contains_key(&make_receipt_id(42)),
+            "receipt with an outstanding reservation must be preserved"
+        );
+        assert!(
+            !aggregate
+                .receipts
+                .get(&make_receipt_id(42))
+                .unwrap()
+                .reserved
+                .is_empty(),
+            "the reservation must survive the zero-drain reconcile"
+        );
+        assert!(logs_contain_at!(Level::WARN, &["still holding reservations"]));
+    }
+
+    #[tokio::test]
+    async fn test_settle_burn_consumes_reservation_and_reduces_mirror() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 60)])
+            .await
+            .unwrap();
+
+        service.settle_burn(vault, redemption_id).await.unwrap();
+
+        // The mirror balance itself must drop 100 -> 40 and the reservation
+        // must be cleared. Checking internals distinguishes a real settlement
+        // from merely leaving the reservation in place (which would leave the
+        // same 40 available but a stale 100 mirror).
+        let context =
+            service.store.load_aggregate(&vault.to_string()).await.unwrap();
+        let metadata = context
+            .aggregate()
+            .receipts
+            .get(&make_receipt_id(1))
+            .expect("receipt should remain after partial settlement");
+        assert_eq!(metadata.balance, make_shares(40));
+        assert!(
+            metadata.reserved.is_empty(),
+            "settlement must consume the reservation"
+        );
+
+        let err = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(41),
+                make_shares(0),
+            )
+            .await
+            .expect_err("settled shares must not be available");
+        assert!(matches!(err, BurnTrackingError::InsufficientBalance { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_settle_burn_depletes_fully_consumed_receipt() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .await
+            .unwrap();
+        service.settle_burn(vault, redemption_id).await.unwrap();
+
+        let context =
+            service.store.load_aggregate(&vault.to_string()).await.unwrap();
+        assert!(
+            context.aggregate().receipts_with_balance().is_empty(),
+            "a fully settled receipt must be depleted and removed"
+        );
+    }
+
+    /// A receipt drained to zero on-chain while reserved is preserved by the
+    /// reconcile guard; once its last reservation resolves (here via release),
+    /// it must be depleted and removed rather than linger empty forever.
+    #[tokio::test]
+    async fn test_release_depletes_zero_drained_receipt() {
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+        let mut aggregate = ReceiptInventory::default();
+        aggregate.apply(ReceiptInventoryEvent::Discovered {
+            receipt_id: make_receipt_id(1),
+            balance: make_shares(0),
+            block_number: 1,
+            tx_hash: TxHash::ZERO,
+            source: ReceiptSource::External,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        });
+        aggregate
+            .receipts
+            .get_mut(&make_receipt_id(1))
+            .unwrap()
+            .reserved
+            .insert(redemption_id.clone(), make_shares(100));
+
+        let events = aggregate
+            .handle(
+                ReceiptInventoryCommand::ReleaseBurn {
+                    redemption_issuer_request_id: redemption_id,
+                },
+                &(),
+            )
+            .await
+            .unwrap();
+
+        assert!(
+            events.iter().any(|event| matches!(
+                event,
+                ReceiptInventoryEvent::Depleted { receipt_id }
+                    if *receipt_id == make_receipt_id(1)
+            )),
+            "releasing the last reservation on a zero-balance receipt must deplete it, got {events:?}"
+        );
+
+        for event in events {
+            aggregate.apply(event);
+        }
+
+        assert!(
+            !aggregate.receipts.contains_key(&make_receipt_id(1)),
+            "the zero-drained receipt must be removed after depletion"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_release_burn_is_idempotent() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .await
+            .unwrap();
+        service.release_burn(vault, redemption_id.clone()).await.unwrap();
+        // Second release must NOT over-credit the balance.
+        service.release_burn(vault, redemption_id).await.unwrap();
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(100),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(100));
+
+        let err = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(101),
+                make_shares(0),
+            )
+            .await
+            .expect_err("double release must not inflate balance above 100");
+        assert!(matches!(err, BurnTrackingError::InsufficientBalance { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_release_burn_without_reservation_is_noop() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        service
+            .release_burn(vault, "red-00000001".parse().unwrap())
+            .await
+            .expect("releasing with no reservation must be a no-op");
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(100),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(100));
+    }
+
+    #[tokio::test]
+    async fn test_second_redemption_cannot_reserve_committed_balance() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        service
+            .reserve_burn(
+                vault,
+                "red-00000001".parse().unwrap(),
+                vec![burn(1, 60)],
+            )
+            .await
+            .unwrap();
+
+        let err = service
+            .reserve_burn(
+                vault,
+                "red-00000002".parse().unwrap(),
+                vec![burn(1, 60)],
+            )
+            .await
+            .expect_err("second redemption must not reserve committed balance");
+        assert!(matches!(
+            err,
+            ReceiptRegistrationError::Aggregate(AggregateError::UserError(
+                ReceiptInventoryError::InsufficientReceiptBalance { .. }
+            ))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_reserve_burn_is_idempotent_for_same_redemption() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 60)])
+            .await
+            .unwrap();
+        // Re-delivery of the same reservation must not double-count itself.
+        service
+            .reserve_burn(vault, redemption_id, vec![burn(1, 60)])
+            .await
+            .expect("re-reserving the same redemption must succeed");
+
+        let plan = service
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(40),
+                make_shares(0),
+            )
+            .await
+            .unwrap();
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(40));
+    }
+
+    /// A retry that plans a DIFFERENT receipt must atomically replace the
+    /// redemption's prior reservation, not accumulate it — otherwise settle
+    /// (keyed only by redemption) would over-consume the stale receipt.
+    #[tokio::test]
+    async fn test_reserve_replaces_prior_reservation_atomically() {
+        let service =
+            setup_receipt_service_with_receipts(vec![(1, 100), (2, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        // First attempt reserves receipt 1; the retry reserves receipt 2.
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .await
+            .unwrap();
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(2, 100)])
+            .await
+            .unwrap();
+
+        service.settle_burn(vault, redemption_id).await.unwrap();
+
+        let context =
+            service.store.load_aggregate(&vault.to_string()).await.unwrap();
+        let aggregate = context.aggregate();
+
+        // Receipt 1's stale reservation was cleared by the retry, so settle
+        // left it untouched; only receipt 2 was consumed (and depleted).
+        let receipt_1 = aggregate
+            .receipts
+            .get(&make_receipt_id(1))
+            .expect("receipt 1 must remain untouched");
+        assert_eq!(receipt_1.balance, make_shares(100));
+        assert!(receipt_1.reserved.is_empty());
+        assert!(
+            !aggregate.receipts.contains_key(&make_receipt_id(2)),
+            "receipt 2 was settled to zero and depleted"
+        );
+    }
+
+    /// `for_burn` excludes the planning redemption's own reservation (so a retry
+    /// can re-plan its full burn) while still counting other redemptions'.
+    #[tokio::test]
+    async fn test_for_burn_excludes_own_reservation_on_retry() {
+        let service = setup_receipt_service_with_receipts(vec![(1, 100)]).await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let redemption_id: IssuerRedemptionRequestId =
+            "red-00000001".parse().unwrap();
+
+        service
+            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .await
+            .unwrap();
+
+        // Another redemption sees receipt 1 fully reserved.
+        let other = service
+            .for_burn(
+                vault,
+                &"red-00000002".parse().unwrap(),
+                make_shares(100),
+                make_shares(0),
+            )
+            .await;
+        assert!(matches!(
+            other,
+            Err(BurnTrackingError::InsufficientBalance { .. })
+        ));
+
+        // The same redemption re-planning excludes its own reservation.
+        let plan = service
+            .for_burn(vault, &redemption_id, make_shares(100), make_shares(0))
+            .await
+            .unwrap();
+        assert_eq!(plan.allocations[0].burn_amount, make_shares(100));
     }
 
     use chrono::{TimeZone, Utc};
@@ -1517,7 +2754,12 @@ mod tests {
             .expect("Registration should succeed");
 
         let plan = service
-            .for_burn(vault, make_shares(50), make_shares(0))
+            .for_burn(
+                vault,
+                &planning_redemption(),
+                make_shares(50),
+                make_shares(0),
+            )
             .await
             .expect("Burn planning should succeed with registered receipt");
 

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -10,9 +10,11 @@ use super::view::{
 use super::{
     IssuerRedemptionRequestId, Redemption, RedemptionCommand, RedemptionError,
 };
+use crate::fireblocks::{FireblocksVaultError, vault_service};
 use crate::mint::QuantityConversionError;
 use crate::receipt_inventory::{
-    BurnPlan, BurnTrackingError, ReceiptService, Shares,
+    BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
+    Shares,
 };
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::tokenized_asset::view::{
@@ -168,6 +170,105 @@ where
         self.recover_single_burning(issuer_request_id).await
     }
 
+    /// Resolves receipt reservations left dangling by a missed settlement —
+    /// e.g. a crash between burn confirmation and settlement, which
+    /// reconciliation cannot heal because a landed-but-unsettled burn sits
+    /// inside the reconcile no-op band.
+    ///
+    /// Only a `Completed` redemption's reservation is settled (mirror reduced).
+    /// Every other state is left in place: a definitive failure already released
+    /// its reservation in the live/recovery paths, so a reservation surviving on
+    /// a `Failed`/`Closed` redemption is from an *ambiguous* failure whose burn
+    /// may still have landed — releasing it would over-credit inventory and risk
+    /// a duplicate burn. In-flight redemptions are owned by the normal flow or
+    /// burn recovery. Runs at startup after redemption recovery so in-flight
+    /// `BurnSubmitted` reservations have already been confirmed-and-settled (or
+    /// left for the ambiguous case) by then.
+    pub(crate) async fn recover_stuck_reservations(&self, vaults: &[Address]) {
+        let mut stuck: Vec<(Address, IssuerRedemptionRequestId)> = Vec::new();
+
+        for vault in vaults {
+            match self.receipt_service.reserved_redemptions(*vault).await {
+                Ok(redemptions) => {
+                    stuck
+                        .extend(redemptions.into_iter().map(|id| (*vault, id)));
+                }
+                Err(error) => {
+                    warn!(target: "redemption", %vault, %error,
+                        "Failed to list reserved redemptions during reservation recovery"
+                    );
+                }
+            }
+        }
+
+        if stuck.is_empty() {
+            debug!(target: "redemption", "No reservations to recover");
+            return;
+        }
+
+        info!(target: "redemption", count = stuck.len(),
+            "Recovering reservations against redemption terminal state"
+        );
+
+        for (vault, issuer_request_id) in stuck {
+            if let Err(err) =
+                self.resolve_stuck_reservation(vault, &issuer_request_id).await
+            {
+                warn!(target: "redemption", vault = %vault,
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Failed to resolve stuck reservation"
+                );
+            }
+        }
+    }
+
+    async fn resolve_stuck_reservation(
+        &self,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<(), BurnManagerError> {
+        use Redemption::{Completed, Uninitialized};
+
+        let context =
+            self.store.load_aggregate(&issuer_request_id.to_string()).await?;
+
+        match context.aggregate() {
+            // The burn confirmed on-chain but settlement was missed (e.g. a
+            // crash in the confirm->settle window). Settle to reduce the mirror.
+            Completed { .. } => {
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Settling reservation for completed redemption"
+                );
+                self.settle_reserved_burn(vault, issuer_request_id).await;
+            }
+            // A reservation for a redemption with no events is anomalous (e.g.
+            // pruned history). Leave it for manual review rather than releasing
+            // blindly against an unknown on-chain outcome.
+            Uninitialized => {
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Reservation held for an unknown redemption; left for manual review"
+                );
+            }
+            // All other states are LEFT in place. A definitive failure already
+            // released its reservation in the live/recovery paths (gated on
+            // `should_release_reserved_burn`), so a reservation surviving on a
+            // `Failed`/`Closed` redemption here is from an *ambiguous* failure
+            // whose burn may still have landed. Releasing it would over-credit
+            // inventory and risk a duplicate burn; leaving it keeps
+            // availability conservatively correct until on-chain settlement or
+            // manual intervention resolves it. In-flight states are owned by
+            // the live flow / burn recovery.
+            _ => {
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Leaving reservation for ambiguous or in-flight redemption"
+                );
+            }
+        }
+
+        Ok(())
+    }
+
     async fn recover_single_burn_failed(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
@@ -196,6 +297,12 @@ where
             return Ok(());
         };
 
+        let vault = find_vault_by_underlying(&self.view_pool, underlying)
+            .await?
+            .ok_or_else(|| BurnManagerError::AssetNotFound {
+                underlying: underlying.clone(),
+            })?;
+
         // If a Fireblocks tx was already submitted before failure, try to
         // confirm it instead of resubmitting. This prevents double-burns
         // when the failure was a transient confirmation error.
@@ -203,17 +310,12 @@ where
             return self
                 .recover_burn_failed_with_existing_tx(
                     issuer_request_id,
+                    vault,
                     fb_tx_id,
                     dust_quantity,
                 )
                 .await;
         }
-
-        let vault = find_vault_by_underlying(&self.view_pool, underlying)
-            .await?
-            .ok_or_else(|| BurnManagerError::AssetNotFound {
-                underlying: underlying.clone(),
-            })?;
 
         let burn_shares = alpaca_quantity.to_u256_with_18_decimals()?;
         let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
@@ -250,6 +352,11 @@ where
 
             self.cqrs.execute(&issuer_request_id.to_string(), command).await?;
 
+            // The burn likely already landed (on-chain balance is too low to
+            // burn again), so any reservation from a prior attempt is LEFT in
+            // place: releasing would over-credit inventory against a stale-high
+            // mirror and risk a duplicate burn. It is resolved by on-chain
+            // settlement or manual intervention.
             return Ok(());
         }
 
@@ -307,6 +414,7 @@ where
     async fn recover_burn_failed_with_existing_tx(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
+        vault: Address,
         fireblocks_tx_id: &str,
         dust_quantity: &crate::Quantity,
     ) -> Result<(), BurnManagerError> {
@@ -355,6 +463,8 @@ where
                     )
                     .await?;
 
+                self.settle_reserved_burn(vault, issuer_request_id).await;
+
                 Ok(())
             }
             Err(err) => {
@@ -364,6 +474,10 @@ where
                     "Failed to confirm previously submitted burn — \
                      marking as failed to prevent infinite retry loop"
                 );
+
+                if should_release_reserved_burn(&err) {
+                    self.release_reserved_burn(vault, issuer_request_id).await;
+                }
 
                 // Re-mark as failed WITHOUT preserving the fireblocks_tx_id.
                 // This moves the view from BurnFailed to Failed, so the next
@@ -399,12 +513,24 @@ where
         match aggregate {
             // Already submitted to Fireblocks but never confirmed — resume polling
             Redemption::BurnSubmitted {
+                metadata,
                 fireblocks_tx_id,
                 dust_quantity,
                 planned_burns,
                 ..
             } => {
                 let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
+
+                let vault = find_vault_by_underlying(
+                    &self.view_pool,
+                    &metadata.underlying,
+                )
+                .await?
+                .ok_or_else(|| {
+                    BurnManagerError::AssetNotFound {
+                        underlying: metadata.underlying.clone(),
+                    }
+                })?;
 
                 info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     fireblocks_tx_id = %fireblocks_tx_id,
@@ -428,6 +554,10 @@ where
                         info!(target: "redemption", issuer_request_id = %issuer_request_id,
                             "Burn confirmed successfully during recovery"
                         );
+
+                        self.settle_reserved_burn(vault, issuer_request_id)
+                            .await;
+
                         Ok(RecoveryOutcome::ExistingBurnRecorded)
                     }
                     Err(AggregateError::UserError(RedemptionError::Vault(
@@ -437,6 +567,14 @@ where
                             error = %err,
                             "Burn confirmation failed during recovery"
                         );
+
+                        if should_release_reserved_burn(&err) {
+                            self.release_reserved_burn(
+                                vault,
+                                issuer_request_id,
+                            )
+                            .await;
+                        }
 
                         self.cqrs
                             .execute(
@@ -504,6 +642,14 @@ where
                          Burn likely already succeeded but was not recorded. \
                          Skipping to avoid recording false failure."
                     );
+
+                    // The redemption stays Burning for manual review. Any
+                    // reservation from the crashed attempt is LEFT in place:
+                    // the burn likely already landed, so releasing would
+                    // over-credit inventory and risk a duplicate burn against
+                    // the stale-high mirror. Leaving it keeps availability
+                    // conservatively correct until manual intervention resolves
+                    // the redemption.
                     return Ok(RecoveryOutcome::SkippedManualIntervention);
                 }
 
@@ -617,6 +763,11 @@ where
             "Starting on-chain burning process with dust handling"
         );
 
+        // A retry plans against availability that EXCLUDES this redemption's own
+        // prior reservation (see `for_burn`), and `reserve_burn` atomically
+        // replaces that reservation — so no separate release-before-plan is
+        // needed, and the prior reservation is never returned to global
+        // availability where a concurrent redemption could grab it.
         let plan = self
             .plan_burn(
                 issuer_request_id,
@@ -641,7 +792,12 @@ where
     ) -> Result<BurnPlan, BurnManagerError> {
         let plan = self
             .receipt_service
-            .for_burn(vault, Shares::new(burn_shares), Shares::new(dust_shares))
+            .for_burn(
+                vault,
+                issuer_request_id,
+                Shares::new(burn_shares),
+                Shares::new(dust_shares),
+            )
             .await;
 
         match plan {
@@ -736,6 +892,39 @@ where
 
         let dust_shares = plan.dust.inner();
 
+        // Reserve the planned receipts BEFORE submitting to the signing
+        // backend. The vault inventory is a single serialized aggregate, so a
+        // concurrent redemption that already committed the same balance makes
+        // this reservation fail — and we must not submit an unbacked burn that
+        // would later revert on-chain with ERC1155InsufficientBalance.
+        if let Err(err) = self
+            .reserve_with_conflict_retry(
+                vault,
+                issuer_request_id,
+                planned_burns.clone(),
+            )
+            .await
+        {
+            error!(target: "redemption", issuer_request_id = %issuer_request_id,
+                error = %err,
+                "Failed to reserve receipts before burn submission; aborting to avoid double-spend"
+            );
+
+            self.cqrs
+                .execute(
+                    &issuer_request_id.to_string(),
+                    RedemptionCommand::RecordBurnFailure {
+                        issuer_request_id: issuer_request_id.clone(),
+                        error: err.to_string(),
+                        fireblocks_tx_id: None,
+                        planned_burns,
+                    },
+                )
+                .await?;
+
+            return Err(err.into());
+        }
+
         // Step 1: Submit the burn transaction (emits BurnFireblocksSubmitted)
         let submit_result = self
             .cqrs
@@ -766,6 +955,21 @@ where
                     "Burn submission failed"
                 );
 
+                // Release only on a DEFINITIVE failure that proves no shares
+                // were consumed — a terminal Fireblocks status or an EVM revert
+                // (the local backend submits synchronously, so a revert can
+                // surface here). Otherwise RETAIN: a submit error does not prove
+                // no transaction was created (a duplicate `externalTxId` whose
+                // lookup failed, a missing transaction id, or an SDK/RPC error
+                // after the request was sent all leave a possibly-in-flight
+                // burn), and releasing could let a concurrent redemption reuse
+                // the balance and double-submit. Recovery (via the preserved
+                // `fireblocks_tx_id`) or manual intervention resolves retained
+                // reservations.
+                if should_release_reserved_burn(&err) {
+                    self.release_reserved_burn(vault, issuer_request_id).await;
+                }
+
                 self.cqrs
                     .execute(
                         &issuer_request_id.to_string(),
@@ -780,6 +984,10 @@ where
 
                 return Err(BurnManagerError::Vault(err));
             }
+            // Submission outcome is unknown (non-vault error): keep the
+            // reservation so a concurrent redemption cannot reuse the balance.
+            // A retry's atomic clear-and-reserve (ReserveBurn) replaces this
+            // redemption's reservation in one step.
             Err(err) => return Err(err.into()),
         }
 
@@ -817,6 +1025,10 @@ where
                     "Burn confirmed successfully"
                 );
 
+                // The burn landed on-chain: consume the reservation so the
+                // mirror balance drops to match.
+                self.settle_reserved_burn(vault, issuer_request_id).await;
+
                 Ok(())
             }
             Err(AggregateError::UserError(RedemptionError::Vault(err))) => {
@@ -824,6 +1036,10 @@ where
                     error = %err,
                     "Burn confirmation failed"
                 );
+
+                if should_release_reserved_burn(&err) {
+                    self.release_reserved_burn(vault, issuer_request_id).await;
+                }
 
                 self.cqrs
                     .execute(
@@ -840,6 +1056,93 @@ where
                 Err(BurnManagerError::Vault(err))
             }
             Err(err) => Err(err.into()),
+        }
+    }
+
+    /// Reserves planned burns, retrying a bounded number of times on an
+    /// optimistic-concurrency conflict.
+    ///
+    /// Concurrent redemptions for the same vault contend on the single
+    /// `ReceiptInventory` aggregate; a lost commit race is transient and should
+    /// be retried (each `execute` reloads), not treated as a terminal burn
+    /// failure the way a genuine `InsufficientReceiptBalance` is.
+    async fn reserve_with_conflict_retry(
+        &self,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        planned_burns: Vec<super::BurnRecord>,
+    ) -> Result<(), ReceiptRegistrationError> {
+        const MAX_ATTEMPTS: usize = 3;
+
+        let mut attempt = 1;
+        loop {
+            match self
+                .receipt_service
+                .reserve_burn(
+                    vault,
+                    issuer_request_id.clone(),
+                    planned_burns.clone(),
+                )
+                .await
+            {
+                Ok(()) => return Ok(()),
+                Err(ReceiptRegistrationError::Aggregate(
+                    AggregateError::AggregateConflict,
+                )) if attempt < MAX_ATTEMPTS => {
+                    warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        attempt,
+                        "Reserve hit an optimistic-concurrency conflict; retrying"
+                    );
+                    attempt += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    /// Releases a redemption's burn reservation, restoring available inventory.
+    ///
+    /// Best-effort: a failure is logged but not propagated. A stuck reservation
+    /// is the failure mode the startup reservation recovery scan
+    /// (`recover_stuck_reservations`) exists to clean up.
+    async fn release_reserved_burn(
+        &self,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) {
+        if let Err(err) = self
+            .receipt_service
+            .release_burn(vault, issuer_request_id.clone())
+            .await
+        {
+            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                error = %err,
+                "Failed to release burn receipt reservation"
+            );
+        }
+    }
+
+    /// Settles a redemption's burn reservation after on-chain confirmation,
+    /// reducing the mirror balance by the reserved amount.
+    ///
+    /// Best-effort: a failure is logged but not propagated. A reservation left
+    /// unsettled here is recovered by the startup reservation recovery scan
+    /// (`recover_stuck_reservations`); reconciliation cannot heal it because a
+    /// landed-but-unsettled burn sits inside the reconcile no-op band.
+    async fn settle_reserved_burn(
+        &self,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) {
+        if let Err(err) = self
+            .receipt_service
+            .settle_burn(vault, issuer_request_id.clone())
+            .await
+        {
+            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                error = %err,
+                "Failed to settle burn receipt reservation"
+            );
         }
     }
 }
@@ -872,6 +1175,20 @@ fn extract_fireblocks_tx_id(error: &VaultError) -> Option<String> {
     }
 }
 
+/// Whether a failed burn confirmation definitively consumed no receipts, so its
+/// inventory reservation must be released. Ambiguous pending Fireblocks statuses
+/// keep the reservation (the transaction may still land on-chain).
+const fn should_release_reserved_burn(error: &VaultError) -> bool {
+    match error {
+        VaultError::Fireblocks(FireblocksVaultError::TransactionFailed {
+            status,
+            ..
+        }) => !vault_service::is_still_pending(*status),
+        VaultError::Reverted { .. } => true,
+        _ => false,
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum BurnManagerError {
     #[error("Vault error: {0}")]
@@ -896,6 +1213,8 @@ pub(crate) enum BurnManagerError {
     AssetNotFound { underlying: UnderlyingSymbol },
     #[error("Arithmetic overflow when computing total shares needed")]
     SharesOverflow,
+    #[error("Receipt reservation error: {0}")]
+    ReceiptRegistration(#[from] ReceiptRegistrationError),
 }
 
 #[cfg(test)]
@@ -906,6 +1225,7 @@ mod tests {
         AggregateContext, EventStore,
         persist::{GenericQuery, PersistedEventStore},
     };
+    use fireblocks_sdk::models::TransactionStatus;
     use rust_decimal::Decimal;
     use sqlite_es::{
         SqliteCqrs, SqliteEventRepository, SqliteViewRepository, sqlite_cqrs,
@@ -914,7 +1234,11 @@ mod tests {
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    use super::{BurnManager, BurnManagerError, Redemption, RedemptionCommand};
+    use super::{
+        BurnManager, BurnManagerError, Redemption, RedemptionCommand,
+        should_release_reserved_burn,
+    };
+    use crate::fireblocks::FireblocksVaultError;
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Network, Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
@@ -928,12 +1252,77 @@ mod tests {
     use crate::tokenized_asset::{
         TokenSymbol, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
     };
-    use crate::vault::ReceiptInformation;
-    use crate::vault::VaultService;
     use crate::vault::mock::MockVaultService;
+    use crate::vault::{ReceiptInformation, VaultError, VaultService};
 
     const TEST_WALLET: Address =
         address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    fn transaction_failed(status: TransactionStatus) -> VaultError {
+        VaultError::Fireblocks(FireblocksVaultError::TransactionFailed {
+            tx_id: "tx-123".to_string(),
+            status,
+        })
+    }
+
+    #[test]
+    fn should_release_on_terminal_fireblocks_failure() {
+        for status in [
+            TransactionStatus::Failed,
+            TransactionStatus::Rejected,
+            TransactionStatus::Cancelled,
+            TransactionStatus::Blocked,
+        ] {
+            assert!(
+                should_release_reserved_burn(&transaction_failed(status)),
+                "terminal status {status:?} should release the reservation"
+            );
+        }
+    }
+
+    #[test]
+    fn should_retain_reservation_on_pending_fireblocks_status() {
+        for status in [
+            TransactionStatus::Broadcasting,
+            TransactionStatus::Confirming,
+            TransactionStatus::PendingEnrichment,
+            TransactionStatus::Submitted,
+        ] {
+            assert!(
+                !should_release_reserved_burn(&transaction_failed(status)),
+                "pending status {status:?} must keep the reservation"
+            );
+        }
+    }
+
+    #[test]
+    fn should_release_on_evm_revert() {
+        let reverted = VaultError::Reverted {
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+        };
+
+        assert!(
+            should_release_reserved_burn(&reverted),
+            "a reverted burn consumed no receipts and must release"
+        );
+    }
+
+    #[test]
+    fn should_retain_reservation_on_non_definitive_errors() {
+        let ambiguous = VaultError::EventNotFound {
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+        };
+
+        assert!(
+            !should_release_reserved_burn(&ambiguous),
+            "ambiguous parse errors must not release the reservation"
+        );
+        assert!(!should_release_reserved_burn(&VaultError::InvalidReceipt));
+    }
 
     type TestCqrs = SqliteCqrs<Redemption>;
     type TestStore = PersistedEventStore<SqliteEventRepository, Redemption>;
@@ -1186,6 +1575,17 @@ mod tests {
             matches!(updated_aggregate, Redemption::Completed { .. }),
             "Expected Completed state, got {updated_aggregate:?}"
         );
+
+        // A successful burn must settle (consume) its reservation; if the
+        // settle wiring were removed the reservation would linger here.
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "successful burn must leave no dangling reservation"
+        );
     }
 
     #[tokio::test]
@@ -1424,6 +1824,196 @@ mod tests {
         assert!(
             reason.contains("Invalid receipt"),
             "Expected error message to contain 'Invalid receipt', got: {reason}"
+        );
+
+        // The confirmation failed with an ambiguous (non-terminal) error, so
+        // the reservation is intentionally RETAINED — the transaction may still
+        // land on-chain, and releasing now could let a concurrent redemption
+        // reuse shares that are about to be consumed.
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "ambiguous burn failure must retain the reservation"
+        );
+    }
+
+    /// A burn SUBMISSION failure does not prove no transaction was created
+    /// (e.g. a duplicate externalTxId whose lookup failed), so the reservation
+    /// must be RETAINED — releasing could let a concurrent redemption reuse the
+    /// balance and double-submit.
+    #[tokio::test]
+    async fn test_burn_submission_failure_retains_reservation() {
+        let vault_mock = Arc::new(MockVaultService::new_submit_failure());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .discover_receipt(
+                vault,
+                uint!(7_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let aggregate = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(result, Err(BurnManagerError::Vault(_))),
+            "Expected submission failure, got {result:?}"
+        );
+
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "an ambiguous submission failure must retain the reservation"
+        );
+    }
+
+    /// A submission that fails with a DEFINITIVE on-chain revert
+    /// (`VaultError::Reverted`, as the synchronous local backend produces)
+    /// consumed no receipts, so the reservation must be RELEASED — unlike an
+    /// ambiguous submit failure, which is retained.
+    #[tokio::test]
+    async fn test_submit_revert_releases_reservation() {
+        let vault_mock = Arc::new(MockVaultService::new_submit_revert());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .discover_receipt(
+                vault,
+                uint!(7_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let aggregate = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(result, Err(BurnManagerError::Vault(_))),
+            "Expected a revert submission failure, got {result:?}"
+        );
+
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a definitive on-chain revert at submit must release the reservation"
+        );
+    }
+
+    /// A confirmation that fails with a DEFINITIVE on-chain revert
+    /// (`VaultError::Reverted`) consumed no receipts, so the reservation must be
+    /// RELEASED (exercises the `should_release_reserved_burn`-gated release in
+    /// the confirm-failure path).
+    #[tokio::test]
+    async fn test_confirm_revert_releases_reservation() {
+        let vault_mock = Arc::new(MockVaultService::new_confirm_revert());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .discover_receipt(
+                vault,
+                uint!(7_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let aggregate = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(result, Err(BurnManagerError::Vault(_))),
+            "Expected a revert confirmation failure, got {result:?}"
+        );
+
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "a definitive on-chain revert must release the reservation"
         );
     }
 
@@ -2336,5 +2926,231 @@ mod tests {
             matches!(recovered, Redemption::Completed { .. }),
             "Expected Completed state after recovery, got {recovered:?}"
         );
+    }
+
+    /// Reserves `shares` on `receipt_id` for `redemption`, simulating a
+    /// reservation a missed settle/release left dangling.
+    async fn seed_stuck_reservation(
+        harness: &TestHarness,
+        vault: Address,
+        redemption: &IssuerRedemptionRequestId,
+        receipt_id: U256,
+        shares: U256,
+    ) {
+        harness
+            .receipt_inventory_cqrs
+            .execute(
+                &vault.to_string(),
+                ReceiptInventoryCommand::ReserveBurn {
+                    redemption_issuer_request_id: redemption.clone(),
+                    burns: vec![crate::redemption::BurnRecord {
+                        receipt_id,
+                        shares_burned: shares,
+                    }],
+                },
+            )
+            .await
+            .expect("seeding a reservation should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_recover_stuck_reservations_settles_completed() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            harness.pool.clone(),
+            harness.cqrs.clone(),
+            harness.store.clone(),
+            harness.receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        // Receipt 1 funds the real burn; receipt 2 will hold the stuck
+        // reservation we simulate after completion.
+        harness
+            .discover_receipt(
+                vault,
+                uint!(1_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(2_U256),
+                uint!(50_000000000000000000_U256),
+            )
+            .await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let aggregate = create_test_redemption_in_burning_state(
+            &harness.cqrs,
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await
+            .unwrap();
+
+        seed_stuck_reservation(
+            &harness,
+            vault,
+            &issuer_request_id,
+            uint!(2_U256),
+            uint!(50_000000000000000000_U256),
+        )
+        .await;
+        assert!(
+            harness
+                .receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id)
+        );
+
+        manager.recover_stuck_reservations(&[vault]).await;
+
+        assert!(
+            harness
+                .receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "GC must settle the reservation of a completed redemption"
+        );
+    }
+
+    /// A reservation surviving on a `Failed` redemption is from an *ambiguous*
+    /// failure (definitive failures release in the live/recovery paths), so the
+    /// burn may still have landed. The GC must LEAVE it rather than release it —
+    /// releasing would over-credit inventory and risk a duplicate burn.
+    #[tokio::test]
+    async fn test_recover_stuck_reservations_leaves_failed() {
+        let vault_mock = Arc::new(MockVaultService::new_failure());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            harness.pool.clone(),
+            harness.cqrs.clone(),
+            harness.store.clone(),
+            harness.receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(1_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        // Drive the redemption to Failed (the failing mock fails the burn).
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let aggregate = create_test_redemption_in_burning_state(
+            &harness.cqrs,
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        let _ = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+        assert!(matches!(
+            load_aggregate(&harness.store, &issuer_request_id).await,
+            Redemption::Failed { .. }
+        ));
+
+        seed_stuck_reservation(
+            &harness,
+            vault,
+            &issuer_request_id,
+            uint!(1_U256),
+            uint!(40_000000000000000000_U256),
+        )
+        .await;
+
+        manager.recover_stuck_reservations(&[vault]).await;
+
+        assert!(
+            harness
+                .receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "GC must leave an ambiguous failed redemption's reservation in place"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_stuck_reservations_warns_and_leaves_unknown() {
+        let harness = TestHarness::new().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service = Arc::new(MockVaultService::new_success())
+            as Arc<dyn crate::vault::VaultService>;
+        let manager = BurnManager::new(
+            blockchain_service,
+            harness.pool.clone(),
+            harness.cqrs.clone(),
+            harness.store.clone(),
+            harness.receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(1_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        // No redemption aggregate exists for this id (Uninitialized): the GC
+        // must leave the reservation in place and surface a WARN rather than
+        // releasing it blindly.
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        seed_stuck_reservation(
+            &harness,
+            vault,
+            &issuer_request_id,
+            uint!(1_U256),
+            uint!(60_000000000000000000_U256),
+        )
+        .await;
+
+        manager.recover_stuck_reservations(&[vault]).await;
+
+        assert!(
+            harness
+                .receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "GC must leave an unknown redemption's reservation in place"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["unknown redemption"]
+        ));
     }
 }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -29,6 +29,15 @@ enum MockBehavior {
     Failure,
     #[cfg(test)]
     SubmitFailure,
+    /// Submit succeeds; confirm fails with a definitive on-chain revert
+    /// (`VaultError::Reverted`) — exercises the terminal-failure release path.
+    #[cfg(test)]
+    ConfirmRevert,
+    /// `submit_burn` fails with a definitive on-chain revert
+    /// (`VaultError::Reverted`), as the synchronous local backend does when a
+    /// burn mines but reverts — exercises the submit-failure release path.
+    #[cfg(test)]
+    SubmitRevert,
 }
 
 /// Mock blockchain service for testing.
@@ -93,6 +102,36 @@ impl MockVaultService {
     pub(crate) fn new_submit_failure() -> Self {
         Self {
             behavior: MockBehavior::SubmitFailure,
+            mint_delay_ms: 0,
+            call_count: Arc::new(AtomicUsize::new(0)),
+            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
+            last_call: Arc::new(Mutex::new(None)),
+            share_balance: Arc::new(Mutex::new(U256::MAX)),
+            last_multi_burn_params: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_confirm_revert() -> Self {
+        Self {
+            behavior: MockBehavior::ConfirmRevert,
+            mint_delay_ms: 0,
+            call_count: Arc::new(AtomicUsize::new(0)),
+            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
+            last_call: Arc::new(Mutex::new(None)),
+            share_balance: Arc::new(Mutex::new(U256::MAX)),
+            last_multi_burn_params: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_submit_revert() -> Self {
+        Self {
+            behavior: MockBehavior::SubmitRevert,
             mint_delay_ms: 0,
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
@@ -261,6 +300,10 @@ impl VaultService for MockVaultService {
                     });
                 Ok(result)
             }
+            #[cfg(test)]
+            MockBehavior::ConfirmRevert | MockBehavior::SubmitRevert => {
+                Err(VaultError::InvalidReceipt)
+            }
         }
     }
 
@@ -286,6 +329,11 @@ impl VaultService for MockVaultService {
         #[cfg(test)]
         if matches!(self.behavior, MockBehavior::SubmitFailure) {
             return Err(VaultError::InvalidReceipt);
+        }
+
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitRevert) {
+            return Err(VaultError::Reverted { tx_hash: MOCK_BURN_TX_HASH });
         }
 
         self.multi_burn_call_count.fetch_add(1, Ordering::Relaxed);
@@ -349,6 +397,28 @@ impl VaultService for MockVaultService {
             MockBehavior::Failure => Err(VaultError::InvalidReceipt),
             #[cfg(test)]
             MockBehavior::SubmitFailure => {
+                let result = self
+                    .pending_burn_result
+                    .lock()
+                    .expect("pending_burn_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(|| MultiBurnResult {
+                        tx_hash: MOCK_BURN_TX_HASH,
+                        burns: vec![],
+                        dust_returned: dust_shares,
+                        gas_used: 50000,
+                        block_number: 5000,
+                    });
+                Ok(result)
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmRevert => {
+                Err(VaultError::Reverted { tx_hash: MOCK_BURN_TX_HASH })
+            }
+            // SubmitRevert fails at submit; if confirm is somehow reached,
+            // return the cached result like the other submit-* behaviors.
+            #[cfg(test)]
+            MockBehavior::SubmitRevert => {
                 let result = self
                     .pending_burn_result
                     .lock()

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -309,6 +309,12 @@ pub(crate) enum VaultError {
     /// Expected event (e.g., Deposit) not found in transaction logs
     #[error("Event not found in transaction: {tx_hash:?}")]
     EventNotFound { tx_hash: B256 },
+    /// Transaction was mined but reverted on-chain (status == 0).
+    ///
+    /// A reverted burn consumes no receipts, so any inventory reservation
+    /// held for it must be released.
+    #[error("Transaction reverted on-chain: {tx_hash:?}")]
+    Reverted { tx_hash: B256 },
     /// Contract call error
     #[error(transparent)]
     Contract(#[from] alloy::contract::Error),

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -270,6 +270,17 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let receipt =
             vault_contract.multicall(calls).send().await?.get_receipt().await?;
 
+        // The local backend executes the burn synchronously, so a mined-but-
+        // reverted transaction is a definitive no-consumption outcome here (the
+        // Fireblocks backend, which submits asynchronously, catches reverts at
+        // confirm time instead). Surface it as a definitive failure so the
+        // reservation is released rather than retained as ambiguous.
+        if !receipt.status() {
+            return Err(VaultError::Reverted {
+                tx_hash: receipt.transaction_hash,
+            });
+        }
+
         // Parse all Withdraw events from the receipt
         let burns: Vec<super::MultiBurnResultEntry> = receipt
             .inner
@@ -341,6 +352,12 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             .get_transaction_receipt(tx_hash)
             .await?
             .ok_or(VaultError::InvalidReceipt)?;
+
+        // A mined-but-reverted burn consumes no receipts, so it is a definitive
+        // failure distinct from an anomalous missing-Withdraw parse error.
+        if !receipt.status() {
+            return Err(VaultError::Reverted { tx_hash });
+        }
 
         let burns: Vec<MultiBurnResultEntry> = receipt
             .inner


### PR DESCRIPTION
## Motivation

A production redemption retry exposed a race in receipt burn planning: one redemption can submit a Fireblocks burn for a receipt, then remain pending (or fail ambiguously) during confirmation, while a second redemption plans against the same receipt balance before the first burn is reflected in receipt inventory. That produces a later on-chain `ERC1155InsufficientBalance` revert even though the second redemption appeared to have enough inventory at planning time.

The fix is to treat a submitted burn as *committed* inventory the moment it is submitted — and to resolve that commitment correctly across the full lifecycle: consume it when the burn confirms, release it only when the burn definitively did not consume any shares, and never release it while the outcome is ambiguous (the transaction may still land).

Closes [RAI-649](https://linear.app/makeitrain/issue/RAI-649/same-receipt-burn-race-concurrent-redemptions-reuse-submitted-burn).

Related follow-up: [RAI-646](https://linear.app/makeitrain/issue/RAI-646/separate-ambiguous-fireblocks-burn-confirmation-from-definitive-burn).

## Solution

**Two-quantity inventory model.** Each `ReceiptMetadata` now tracks a `balance` (the on-chain ERC-1155 balance the bot believes it holds) plus a `reserved` map of shares committed to submitted-but-unconfirmed burns, keyed by redemption. Available inventory for planning is `balance − sum(reserved)`. Keeping the mirror and the reservations separate is what lets reconciliation compare against the true on-chain balance without clobbering a pending reservation. `Shares` gains `ZERO` and `Ord`.

**Reservation lifecycle** (new `ReceiptInventoryCommand`/`Event` variants):

- `ReserveBurn` / `BurnReserved` — **atomic clear-and-reserve**, issued *before* submitting the burn to the signing backend. It drops any prior reservation the redemption held (e.g. a retry that planned different receipts) and installs the new one in one serialized transaction, validated against availability that excludes the redemption's own prior reservation. The prior reservation is never returned to global availability between clear and reserve, so a concurrent *different* redemption that already committed the same balance fails to reserve and never submits an unbacked burn.
- `SettleBurn` / `BurnSettled` — consume the reservation after the burn confirms on-chain: clear it and reduce the mirror balance by the reserved amount. Idempotent; emits `Depleted` for any receipt it empties.
- `ReleaseBurn` / `BurnReleased` — clear the redemption's reservation, restoring availability without touching the mirror (the burn consumed nothing). No-op when no reservation is held.

**Planning excludes the planner's own reservation.** `for_burn` now takes the redemption id and plans against `available_excluding(redemption)`, so a retry re-plans its full burn rather than being blocked by its own prior reservation; the subsequent atomic `ReserveBurn` then replaces it.

**`BurnManager` wiring** (`src/redemption/burn_manager.rs`):

- Reserve planned burns *before* submission via `reserve_with_conflict_retry` (bounded retry on optimistic-concurrency conflict, since concurrent redemptions contend on the single per-vault inventory aggregate). On reserve failure, record the burn failure and abort rather than submit an unbacked burn.
- Settle on confirmation (live path and `BurnSubmitted`/`BurnFailed` recovery paths).
- Release only on a **definitive** failure, gated by the new `should_release_reserved_burn` helper: a terminal Fireblocks status or an EVM revert. Ambiguous/pending statuses, missing-tx-id, and other non-vault errors **retain** the reservation so a concurrent redemption can't reuse the balance and double-submit.

**Definitive on-chain revert detection** (new `VaultError::Reverted`). Both backends now treat a mined-but-reverted burn (`receipt.status() == false`) as a definitive no-consumption failure, distinct from an anomalous missing-`Withdraw` parse error: the local backend catches it synchronously at submit (`src/vault/service.rs`), the Fireblocks backend at confirm time (`src/fireblocks/vault_service.rs`). `is_still_pending` is re-exported from the fireblocks module so the burn manager can distinguish ambiguous-pending from definitive failure.

**Reconciliation respects pending reservations.** `ReconcileBalance` now treats any on-chain balance within the `[available, balance]` band as "no external change" — while a submitted burn is pending, on-chain legitimately sits there (not yet landed at `balance`, dropping toward `available` once it lands). A reserved receipt drained to zero on-chain is preserved (mirror set to zero) rather than removed, so its reservation can still resolve; depletion is deferred until the last reservation clears. Settlement, not reconciliation, consumes a reservation.

**Startup reservation recovery** (`recover_stuck_reservations`, run after redemption recovery). For each vault it resolves dangling reservations against the redemption's terminal state: a `Completed` redemption is **settled** (confirmed but settlement was missed, e.g. a crash in the confirm→settle window); `Failed`/`Closed`/unknown are **left in place**, because a surviving reservation there is from an *ambiguous* failure whose burn may still have landed — releasing would over-credit inventory and risk a duplicate burn.

**Tests.** Extensive aggregate coverage for reserve/settle/release (idempotency, atomic replace-on-retry, second-redemption rejection, reconcile band / zero-drain / pending-reservation preservation), `BurnManager` coverage for retain-vs-release across submit/confirm reverts and Fireblocks statuses, and `recover_stuck_reservations` (settles completed, leaves failed/unknown). New mock behaviors `new_submit_revert`/`new_confirm_revert`. Burn-planner one-gwei boundary tests added.

**Docs.** `SPEC.md` updated with the reservation model, the reconcile band, and the startup recovery semantics.

Stacked on #162.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Tested with:

- `direnv exec . cargo test -q receipt_inventory`
- `direnv exec . cargo test -q burn_manager`
- `direnv exec . cargo test -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added burn reservation and release lifecycle management to prevent concurrent redemptions from reusing committed balances
  * Introduced startup recovery mechanism for stuck reservations based on terminal redemption states
  * Enhanced on-chain transaction monitoring with explicit revert detection

* **Bug Fixes**
  * Improved reconciliation behavior to preserve pending burn reservations
  * Better error handling for insufficient per-receipt balances

* **Tests**
  * Extended test coverage for burn reservation edge cases, settlement behavior, and revert scenarios

* **Documentation**
  * Updated specification for burn-reservation timing and inventory aggregate lifecycle

* **Chores**
  * Updated .gitignore to exclude internal directories

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
