### PR TITLE
fix: retry terminal failed redemption burns

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -331,14 +331,18 @@ on-chain transfer through calling Alpaca to burning tokens.
   and timestamp for audit trail. The existing recovery logic then picks it up
   naturally from `Detected` state.
 - `ResumeBurn { issuer_request_id, metadata, tokenization_request_id,
-  alpaca_quantity, dust_quantity, called_at }` -
+  alpaca_quantity, dust_quantity, called_at, alpaca_journal_completed_at,
+  external_tx_id }` -
   Resume a failed redemption directly to `Burning` state, bypassing the Alpaca
   call step. Only valid from `Failed` state. Used for post-Alpaca failures where
   Alpaca has already completed the journal. The API layer polls Alpaca to verify
   journal completion before issuing this command — refuses if Pending or
-  Rejected. Emits `BurnResumed` event. The admin recovery path immediately
-  invokes burn recovery in-process so the on-chain burn does not wait for a
-  service restart.
+  Rejected. If the failed redemption already has a terminal failed Fireblocks
+  burn, `external_tx_id` is set to the next deterministic retry id:
+  `burn-{detected_tx_hash}-retry-{n}`. If a retry submission fails before
+  Fireblocks accepts it, recovery reuses the same retry id. Emits `BurnResumed`
+  event. The admin recovery path immediately invokes burn recovery in-process so
+  the on-chain burn does not wait for a service restart.
 
 **Events:**
 
@@ -367,8 +371,9 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `BurnResumed` - Redemption resumed directly to `Burning` state from `Failed`.
   Carries the original `RedemptionMetadata`, `tokenization_request_id`,
   `alpaca_quantity`, `dust_quantity`, `called_at` (from the original
-  `AlpacaCalled` event), and `resumed_at` timestamp. Used for post-Alpaca
-  recovery where the journal already completed.
+  `AlpacaCalled` event), `alpaca_journal_completed_at`, optional retry
+  `external_tx_id`, and `resumed_at` timestamp. Used for post-Alpaca recovery
+  where the journal already completed.
 
 **Command -> Event Mappings:**
 

--- a/docs/fireblocks.md
+++ b/docs/fireblocks.md
@@ -10,10 +10,12 @@ is rejected with HTTP 400.
 Source:
 [Fireblocks API Idempotency](https://developers.fireblocks.com/reference/api-idempotency)
 
-Our normal `externalTxId` format: `mint-{issuer_request_id}` or
-`burn-{issuer_request_id}`. Mint retries after a terminal Fireblocks failure use
-fresh deterministic IDs: `mint-{issuer_request_id}-retry-1`,
-`mint-{issuer_request_id}-retry-2`, etc.
+Our normal `externalTxId` format: `mint-{issuer_request_id}` for mints and
+`burn-{detected_tx_hash}` for redemption burns. Mint retries after a terminal
+Fireblocks failure use fresh deterministic IDs:
+`mint-{issuer_request_id}-retry-1`, `mint-{issuer_request_id}-retry-2`, etc.
+Burn retries use the same pattern on the detected transfer hash:
+`burn-{detected_tx_hash}-retry-1`, `burn-{detected_tx_hash}-retry-2`, etc.
 
 **Implication for recovery:** If a mint/burn transaction was submitted to
 Fireblocks but we lost track of it (e.g., process restart before polling
@@ -26,6 +28,12 @@ as terminally failed, the bot may submit a fresh mint transaction with the next
 retry `externalTxId`. Automatic retry attempts are capped at four and delayed by
 1m, 10m, 30m, and 1h. Manual admin reprocess bypasses that cap for operator-run
 retries after the underlying issue has been fixed.
+
+**Terminal burn failures:** Once Fireblocks reports a submitted burn transaction
+as terminally failed, redemption recovery may submit a replacement burn with the
+next retry `externalTxId`. If a retry submission fails before Fireblocks accepts
+it, the same retry `externalTxId` is reused on the next recovery attempt so the
+replacement submission remains idempotent.
 
 ## SDK Error Handling
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -23,8 +23,9 @@ use crate::redemption::burn_manager::{
     BurnManager, BurnManagerError, RecoveryOutcome,
 };
 use crate::redemption::{
-    BurnRecord, IssuerRedemptionRequestId, RedemptionCommand, RedemptionError,
-    RedemptionEvent, RedemptionMetadata, RedemptionView, find_stuck,
+    BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, RedemptionCommand,
+    RedemptionError, RedemptionEvent, RedemptionMetadata, RedemptionView,
+    find_stuck, next_burn_retry_external_tx_id_from_history,
 };
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{FireblocksTxStatus, VaultService};
@@ -125,6 +126,9 @@ struct ReprocessContext {
     alpaca_called: Option<AlpacaCalledData>,
     /// Data from the most recent BurningFailed event, if one exists.
     burning_failed: Option<BurningFailedData>,
+    /// Replacement Fireblocks externalTxId for a retry burn, when event
+    /// history shows a prior accepted burn or an unaccepted retry attempt.
+    burn_retry_external_tx_id: Option<BurnExternalTxId>,
 }
 
 /// Loads all events for a redemption and extracts:
@@ -215,7 +219,25 @@ async fn load_reprocess_context(
         return Err(Status::InternalServerError);
     };
 
-    Ok(ReprocessContext { metadata, alpaca_called, burning_failed })
+    let burn_retry_external_tx_id =
+        next_burn_retry_external_tx_id_from_history(
+            &metadata.detected_tx_hash,
+            events.iter().map(|event| &event.payload),
+        )
+        .map_err(|error| {
+            error!(target: "admin", aggregate_id = aggregate_id,
+                %error,
+                "Failed to compute next burn retry external tx id"
+            );
+            Status::InternalServerError
+        })?;
+
+    Ok(ReprocessContext {
+        metadata,
+        alpaca_called,
+        burning_failed,
+        burn_retry_external_tx_id,
+    })
 }
 
 /// Unified recovery endpoint for stuck redemptions.
@@ -271,6 +293,7 @@ pub(crate) async fn recover_redemption(
             metadata: context.metadata,
             alpaca_data,
             burning_failed: context.burning_failed,
+            burn_retry_external_tx_id: context.burn_retry_external_tx_id,
         },
     )
     .await
@@ -319,6 +342,7 @@ struct PostAlpacaRecoveryInput {
     metadata: RedemptionMetadata,
     alpaca_data: AlpacaCalledData,
     burning_failed: Option<BurningFailedData>,
+    burn_retry_external_tx_id: Option<BurnExternalTxId>,
 }
 
 async fn recover_post_alpaca(
@@ -334,6 +358,7 @@ async fn recover_post_alpaca(
         metadata,
         alpaca_data,
         burning_failed,
+        burn_retry_external_tx_id,
     } = input;
     // Verify journal status with Alpaca before resuming to Burning.
     // Burning without a completed journal would destroy on-chain tokens
@@ -402,93 +427,24 @@ async fn recover_post_alpaca(
         }
     }
 
-    // If we have a Fireblocks tx ID from a previous BurningFailed event,
-    // check whether the burn actually succeeded on-chain.
-    if let Some(ref bf_data) = burning_failed
-        && let Some(ref fb_tx_id) = bf_data.fireblocks_tx_id
+    // If a Fireblocks tx ID was recorded on a previous BurningFailed event,
+    // inspect it before deciding whether to record the existing burn or resume.
+    let burn_retry_external_tx_id = match inspect_prior_fireblocks_burn(
+        cqrs,
+        vault_service,
+        &aggregate_id,
+        &issuer_request_id,
+        &metadata.detected_tx_hash,
+        burning_failed.as_ref(),
+        burn_retry_external_tx_id,
+    )
+    .await?
     {
-        match vault_service.check_fireblocks_tx(fb_tx_id).await {
-            Ok(Some(FireblocksTxStatus::Completed {
-                tx_hash,
-                block_number,
-            })) => {
-                if bf_data.planned_burns.is_empty() {
-                    warn!(target: "admin", aggregate_id = %aggregate_id,
-                        fireblocks_tx_id = %fb_tx_id,
-                        tx_hash = ?tx_hash,
-                        "Pre-enrichment BurningFailed event has no planned_burns — \
-                         burn records will be empty. Manual receipt inventory \
-                         reconciliation may be needed after recovery."
-                    );
-                }
-
-                info!(target: "admin", aggregate_id = %aggregate_id,
-                    fireblocks_tx_id = %fb_tx_id,
-                    tx_hash = ?tx_hash,
-                    "Fireblocks tx already completed on-chain, recording existing burn"
-                );
-
-                cqrs.execute(
-                    &aggregate_id,
-                    RedemptionCommand::RecordExistingBurn {
-                        issuer_request_id: issuer_request_id.clone(),
-                        fireblocks_tx_id: fb_tx_id.clone(),
-                        tx_hash,
-                        planned_burns: bf_data.planned_burns.clone(),
-                        block_number,
-                    },
-                )
-                .await
-                .map_err(|err| {
-                    error!(target: "admin", aggregate_id = %aggregate_id,
-                        error = %err,
-                        "Failed to record existing burn"
-                    );
-                    map_redemption_error(&err)
-                })?;
-
-                return Ok(Json(ReprocessResponse {
-                    aggregate_type: AggregateKind::Redemption,
-                    aggregate_id: aggregate_id.clone(),
-                    previous_state: "Failed".to_string(),
-                    message:
-                        "Existing on-chain burn recorded via Fireblocks tx lookup"
-                            .to_string(),
-                }));
-            }
-            Ok(Some(FireblocksTxStatus::Pending)) => {
-                info!(target: "admin", aggregate_id = %aggregate_id,
-                    fireblocks_tx_id = %fb_tx_id,
-                    "Fireblocks tx still pending, cannot recover yet"
-                );
-                return Err(Status::UnprocessableEntity);
-            }
-            Ok(Some(FireblocksTxStatus::Failed {
-                detail: fb_detail,
-                sub_status: fb_sub_status,
-                network_tx_hashes: _,
-            })) => {
-                info!(target: "admin", aggregate_id = %aggregate_id,
-                    fireblocks_tx_id = %fb_tx_id,
-                    fireblocks_status = %fb_detail,
-                    fireblocks_sub_status = ?fb_sub_status,
-                    "Fireblocks tx failed, proceeding with ResumeBurn"
-                );
-                // Fall through to ResumeBurn below
-            }
-            Ok(None) => {
-                // Non-Fireblocks backend, fall through to ResumeBurn
-            }
-            Err(err) => {
-                error!(target: "admin", aggregate_id = %aggregate_id,
-                    fireblocks_tx_id = %fb_tx_id,
-                    error = %err,
-                    "Failed to check Fireblocks tx status"
-                );
-                return Err(Status::BadGateway);
-            }
+        PriorBurnDisposition::AlreadyRecorded(response) => {
+            return Ok(Json(response));
         }
-    }
+        PriorBurnDisposition::ResumeWith(external_tx_id) => external_tx_id,
+    };
 
     let Some(alpaca_journal_completed_at) = alpaca_updated_at else {
         error!(target: "admin", aggregate_id = %aggregate_id,
@@ -508,6 +464,7 @@ async fn recover_post_alpaca(
             dust_quantity: alpaca_data.dust_quantity,
             called_at: alpaca_data.called_at,
             alpaca_journal_completed_at,
+            external_tx_id: burn_retry_external_tx_id,
         },
     )
     .await
@@ -542,6 +499,132 @@ async fn recover_post_alpaca(
         previous_state: "Failed".to_string(),
         message: message.to_string(),
     }))
+}
+
+/// Outcome of inspecting a prior Fireblocks burn on a failed redemption.
+enum PriorBurnDisposition {
+    /// The prior burn already completed on-chain and was recorded; the caller
+    /// should return this response directly.
+    AlreadyRecorded(ReprocessResponse),
+    /// No conclusive prior burn — resume with this (possibly fallback) retry
+    /// `externalTxId`.
+    ResumeWith(Option<BurnExternalTxId>),
+}
+
+/// Inspects the Fireblocks tx (if any) from a previous `BurningFailed` event to
+/// decide whether the on-chain burn already succeeded (record it), is still
+/// pending (cannot recover yet), or terminally failed (resume with a fresh
+/// replacement `externalTxId`).
+async fn inspect_prior_fireblocks_burn(
+    cqrs: &RedemptionCqrs,
+    vault_service: &Arc<dyn VaultService>,
+    aggregate_id: &str,
+    issuer_request_id: &IssuerRedemptionRequestId,
+    detected_tx_hash: &B256,
+    burning_failed: Option<&BurningFailedData>,
+    burn_retry_external_tx_id: Option<BurnExternalTxId>,
+) -> Result<PriorBurnDisposition, Status> {
+    let Some(bf_data) = burning_failed else {
+        return Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id));
+    };
+    let Some(fb_tx_id) = bf_data.fireblocks_tx_id.as_ref() else {
+        return Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id));
+    };
+
+    match vault_service.check_fireblocks_tx(fb_tx_id).await {
+        Ok(Some(FireblocksTxStatus::Completed { tx_hash, block_number })) => {
+            if bf_data.planned_burns.is_empty() {
+                warn!(target: "admin", aggregate_id = %aggregate_id,
+                    fireblocks_tx_id = %fb_tx_id,
+                    tx_hash = ?tx_hash,
+                    "Pre-enrichment BurningFailed event has no planned_burns — \
+                     burn records will be empty. Manual receipt inventory \
+                     reconciliation may be needed after recovery."
+                );
+            }
+
+            info!(target: "admin", aggregate_id = %aggregate_id,
+                fireblocks_tx_id = %fb_tx_id,
+                tx_hash = ?tx_hash,
+                "Fireblocks tx already completed on-chain, recording existing burn"
+            );
+
+            cqrs.execute(
+                aggregate_id,
+                RedemptionCommand::RecordExistingBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    fireblocks_tx_id: fb_tx_id.clone(),
+                    tx_hash,
+                    planned_burns: bf_data.planned_burns.clone(),
+                    block_number,
+                },
+            )
+            .await
+            .map_err(|err| {
+                error!(target: "admin", aggregate_id = %aggregate_id,
+                    error = %err,
+                    "Failed to record existing burn"
+                );
+                map_redemption_error(&err)
+            })?;
+
+            Ok(PriorBurnDisposition::AlreadyRecorded(ReprocessResponse {
+                aggregate_type: AggregateKind::Redemption,
+                aggregate_id: aggregate_id.to_string(),
+                previous_state: "Failed".to_string(),
+                message:
+                    "Existing on-chain burn recorded via Fireblocks tx lookup"
+                        .to_string(),
+            }))
+        }
+        Ok(Some(FireblocksTxStatus::Pending)) => {
+            info!(target: "admin", aggregate_id = %aggregate_id,
+                fireblocks_tx_id = %fb_tx_id,
+                "Fireblocks tx still pending, cannot recover yet"
+            );
+            Err(Status::UnprocessableEntity)
+        }
+        Ok(Some(FireblocksTxStatus::Failed {
+            detail: fb_detail,
+            sub_status: fb_sub_status,
+            network_tx_hashes: _,
+        })) => {
+            // The terminally failed Fireblocks tx permanently reserves its
+            // externalTxId, so the replacement burn must never reuse the base
+            // id. When event history has no recorded retry id (e.g.
+            // pre-enrichment BurningFailed events without a
+            // BurnFireblocksSubmitted event), fall back to retry-1 — mirror of
+            // the startup recovery path in BurnManager.
+            let retry_external_tx_id =
+                burn_retry_external_tx_id.or_else(|| {
+                    Some(Redemption::retry_burn_external_tx_id_typed(
+                        detected_tx_hash,
+                        1,
+                    ))
+                });
+
+            info!(target: "admin", aggregate_id = %aggregate_id,
+                fireblocks_tx_id = %fb_tx_id,
+                fireblocks_status = %fb_detail,
+                fireblocks_sub_status = ?fb_sub_status,
+                retry_external_tx_id = ?retry_external_tx_id,
+                "Fireblocks tx failed, proceeding with ResumeBurn"
+            );
+
+            Ok(PriorBurnDisposition::ResumeWith(retry_external_tx_id))
+        }
+        Ok(None) => {
+            Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id))
+        }
+        Err(err) => {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                fireblocks_tx_id = %fb_tx_id,
+                error = %err,
+                "Failed to check Fireblocks tx status"
+            );
+            Err(Status::BadGateway)
+        }
+    }
 }
 
 /// Logs each recovery outcome at a severity matching what actually happened and
@@ -1200,10 +1283,11 @@ pub(crate) async fn check_fireblocks_tx(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, b256};
+    use alloy::primitives::{Address, U256, address, b256};
     use async_trait::async_trait;
     use chrono::Utc;
     use cqrs_es::persist::{GenericQuery, PersistedEventStore};
+    use cqrs_es::{AggregateContext, EventStore};
     use rocket::http::Status;
     use rust_decimal::Decimal;
     use sqlite_es::{
@@ -1216,14 +1300,15 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        AlpacaCalledData, PostAlpacaRecoveryInput, load_reprocess_context,
-        recover_post_alpaca,
+        AlpacaCalledData, BurningFailedData, PostAlpacaRecoveryInput,
+        load_reprocess_context, recover_post_alpaca,
     };
     use crate::alpaca::{
         AlpacaError, AlpacaService, MintCallbackRequest, RedeemRequest,
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
+    use crate::redemption::BurnExternalTxId;
     use crate::redemption::{
         IssuerRedemptionRequestId, Redemption, RedemptionCommand,
         RedemptionMetadata, RedemptionView,
@@ -1231,7 +1316,7 @@ mod tests {
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{FireblocksTxStatus, VaultService};
+    use crate::vault::{FireblocksTxStatus, MultiBurnEntry, VaultService};
 
     use super::{AggregateKind, StuckAggregate};
 
@@ -1564,6 +1649,113 @@ mod tests {
         (cqrs, event_store, metadata, alpaca_data)
     }
 
+    #[tokio::test]
+    async fn test_load_reprocess_context_derives_retry_id_from_history() {
+        let pool = setup_pool().await;
+        let (cqrs, event_store) = setup_cqrs(&pool);
+
+        let metadata = test_metadata();
+        let alpaca_data = test_alpaca_data();
+        let aggregate_id = metadata.issuer_request_id.to_string();
+
+        // Drive the redemption through a real burn submission that then fails,
+        // so event history carries a BurnFireblocksSubmitted event the
+        // derivation must scan — rather than injecting the retry id directly.
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::Detect {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                underlying: metadata.underlying.clone(),
+                token: metadata.token.clone(),
+                wallet: metadata.wallet,
+                quantity: metadata.quantity.clone(),
+                tx_hash: metadata.detected_tx_hash,
+                block_number: metadata.block_number,
+            },
+        )
+        .await
+        .expect("Detect failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::RecordAlpacaCall {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                tokenization_request_id: alpaca_data
+                    .tokenization_request_id
+                    .clone(),
+                alpaca_quantity: alpaca_data.alpaca_quantity.clone(),
+                dust_quantity: alpaca_data.dust_quantity.clone(),
+            },
+        )
+        .await
+        .expect("RecordAlpacaCall failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::ConfirmAlpacaComplete {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+            },
+        )
+        .await
+        .expect("ConfirmAlpacaComplete failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::BurnTokens {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                vault: address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+                burns: vec![MultiBurnEntry {
+                    receipt_id: U256::from(99),
+                    burn_shares: U256::from(100),
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
+                dust_shares: U256::ZERO,
+                owner: Address::ZERO,
+                external_tx_id: Some(BurnExternalTxId::base(
+                    &metadata.detected_tx_hash,
+                )),
+            },
+        )
+        .await
+        .expect("BurnTokens failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                error: "burn terminally failed".to_string(),
+                fireblocks_tx_id: Some("mock-fb-burn".to_string()),
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("RecordBurnFailure failed");
+
+        let context = load_reprocess_context(&event_store, &aggregate_id)
+            .await
+            .expect("load_reprocess_context failed");
+
+        // The base BurnFireblocksSubmitted in history must advance the derived
+        // id to retry-1, proving the derivation is wired into
+        // load_reprocess_context rather than the retry id being injected.
+        assert_eq!(
+            context.burn_retry_external_tx_id,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &metadata.detected_tx_hash,
+                1
+            ))
+        );
+
+        let burning_failed = context
+            .burning_failed
+            .expect("expected BurningFailed data in context");
+        assert_eq!(
+            burning_failed.fireblocks_tx_id,
+            Some("mock-fb-burn".to_string())
+        );
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn test_recover_post_alpaca_completed_succeeds() {
@@ -1591,6 +1783,7 @@ mod tests {
                 metadata: metadata.clone(),
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;
@@ -1602,6 +1795,128 @@ mod tests {
         assert_eq!(burn_recovery.calls(), 1);
         assert!(logs_contain_at!(Level::INFO, &["recovered", "Burning"]));
         assert!(logs_contain_at!(Level::INFO, &["burn", "executed"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_post_alpaca_persists_retry_external_tx_id() {
+        let (cqrs, event_store, metadata, alpaca_data) =
+            setup_failed_redemption().await;
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let retry_external_tx_id =
+            BurnExternalTxId::from_string("burn-0xabc-retry-1".to_string());
+
+        let result = recover_post_alpaca(
+            &cqrs,
+            &alpaca,
+            &mock_vault_service(),
+            &mock_burn_recovery(),
+            PostAlpacaRecoveryInput {
+                aggregate_id: metadata.issuer_request_id.to_string(),
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                metadata: metadata.clone(),
+                alpaca_data,
+                burning_failed: None,
+                burn_retry_external_tx_id: Some(retry_external_tx_id.clone()),
+            },
+        )
+        .await;
+
+        result.expect("Expected Ok response");
+
+        let context = event_store
+            .load_aggregate(&metadata.issuer_request_id.to_string())
+            .await
+            .expect("Expected aggregate to load");
+
+        let Redemption::Burning { external_tx_id, .. } = context.aggregate()
+        else {
+            panic!("Expected Burning state, got {:?}", context.aggregate());
+        };
+
+        assert_eq!(external_tx_id, &Some(retry_external_tx_id));
+
+        assert!(logs_contain_at!(Level::INFO, &["recovered", "Burning"]));
+        assert!(logs_contain_at!(Level::INFO, &["burn", "executed"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_post_alpaca_uses_retry_id_fallback_on_terminal_failure()
+     {
+        let (cqrs, event_store, metadata, alpaca_data) =
+            setup_failed_redemption().await;
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let vault: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success().with_fireblocks_tx_status(
+                FireblocksTxStatus::Failed {
+                    detail: "FAILED".to_string(),
+                    sub_status: Some("REJECTED_BY_BLOCKCHAIN".to_string()),
+                    network_tx_hashes: vec![],
+                },
+            ),
+        );
+
+        let result = recover_post_alpaca(
+            &cqrs,
+            &alpaca,
+            &vault,
+            &mock_burn_recovery(),
+            PostAlpacaRecoveryInput {
+                aggregate_id: metadata.issuer_request_id.to_string(),
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                metadata: metadata.clone(),
+                alpaca_data,
+                // Pre-enrichment failure: a Fireblocks tx exists but history
+                // carries no recorded retry id.
+                burning_failed: Some(BurningFailedData {
+                    fireblocks_tx_id: Some("fb-terminal-1".to_string()),
+                    planned_burns: vec![],
+                }),
+                burn_retry_external_tx_id: None,
+            },
+        )
+        .await;
+
+        result.expect("Expected Ok response");
+
+        let context = event_store
+            .load_aggregate(&metadata.issuer_request_id.to_string())
+            .await
+            .expect("Expected aggregate to load");
+
+        let Redemption::Burning { external_tx_id, .. } = context.aggregate()
+        else {
+            panic!("Expected Burning state, got {:?}", context.aggregate());
+        };
+
+        // The terminally failed Fireblocks tx permanently blocks the base
+        // externalTxId, so recovery must fall back to retry-1 rather than
+        // reuse it.
+        assert_eq!(
+            external_tx_id,
+            &Some(Redemption::retry_burn_external_tx_id_typed(
+                &metadata.detected_tx_hash,
+                1
+            ))
+        );
+
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Fireblocks tx failed", "ResumeBurn"]
+        ));
     }
 
     #[traced_test]
@@ -1628,6 +1943,7 @@ mod tests {
                 metadata,
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;
@@ -1660,6 +1976,7 @@ mod tests {
                 metadata,
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;
@@ -1691,6 +2008,7 @@ mod tests {
                 metadata,
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;
@@ -1719,6 +2037,7 @@ mod tests {
                 metadata,
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;
@@ -1762,6 +2081,7 @@ mod tests {
                 metadata,
                 alpaca_data,
                 burning_failed: None,
+                burn_retry_external_tx_id: None,
             },
         )
         .await;

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -21,6 +21,7 @@ use super::config::{
     FireblocksVaultAccountId,
 };
 use crate::bindings::OffchainAssetReceiptVault;
+use crate::redemption::BurnExternalTxId;
 use crate::vault::rain_meta::OaSchemaCache;
 use crate::vault::{
     MintResult, MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
@@ -584,12 +585,20 @@ fn is_duplicate_external_tx_id_error(
     {
         // HTTP 409 Conflict is the canonical duplicate response.
         // HTTP 400 with "externalTxId" in the body is also observed.
-        // For both, verify the body mentions the externalTxId keyword
-        // to avoid false positives from unrelated 409/400 errors.
+        // Require BOTH an externalTxId mention AND explicit duplicate
+        // semantics: an unrelated 409/400 that merely references the field
+        // (e.g. a validation error) must not be misrouted into the
+        // externalTxId recovery lookup, which would mask the real error.
         if status.as_u16() == 409 || status.as_u16() == 400 {
             let lower = content.to_lowercase();
-            return lower.contains("externaltxid")
-                || lower.contains("external_tx_id");
+            let mentions_external_id = lower.contains("externaltxid")
+                || lower.contains("external_tx_id")
+                || lower.contains("external tx id");
+            let indicates_duplicate = lower.contains("already exists")
+                || lower.contains("duplicate")
+                || lower.contains(r#""code":1438"#);
+
+            return mentions_external_id && indicates_duplicate;
         }
     }
 
@@ -793,19 +802,25 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         // DEPLOYMENT NOTE: This format changed from `burn-red-{4_bytes}` to
         // `burn-0x{full_tx_hash}`. Drain all in-flight burn transactions
         // before deploying this change to avoid externalTxId mismatches.
-        let external_tx_id =
-            VaultOperation::Burn.external_tx_id(&params.detected_tx_hash);
+        let external_tx_id = params.external_tx_id.unwrap_or_else(|| {
+            BurnExternalTxId::from_string(
+                VaultOperation::Burn.external_tx_id(&params.detected_tx_hash),
+            )
+        });
 
         let fireblocks_tx_id = self
             .submit_contract_call(
                 params.vault,
                 &multicall_calldata,
                 &note,
-                &external_tx_id,
+                &external_tx_id.to_string(),
             )
             .await?;
 
-        Ok(SubmittedTx { external_tx_id, fireblocks_tx_id })
+        Ok(SubmittedTx {
+            external_tx_id: external_tx_id.into_string(),
+            fireblocks_tx_id,
+        })
     }
 
     async fn confirm_burn(
@@ -1402,11 +1417,37 @@ mod tests {
     }
 
     #[test]
+    fn duplicate_detection_http_400_with_external_tx_id_words() {
+        let err = make_response_error(
+            400,
+            r#"{"message":"The external tx id that was provided in the request, already exists","code":1438}"#,
+        );
+        assert!(
+            is_duplicate_external_tx_id_error(&err),
+            "HTTP 400 with 'external tx id' words should be detected as duplicate"
+        );
+    }
+
+    #[test]
     fn duplicate_detection_http_400_without_keyword() {
         let err = make_response_error(400, r#"{"message": "Invalid amount"}"#);
         assert!(
             !is_duplicate_external_tx_id_error(&err),
             "HTTP 400 without keyword should not be detected as duplicate"
+        );
+    }
+
+    #[test]
+    fn duplicate_detection_http_400_external_tx_id_without_duplicate_semantics()
+    {
+        let err = make_response_error(
+            400,
+            r#"{"message": "externalTxId exceeds the maximum allowed length"}"#,
+        );
+        assert!(
+            !is_duplicate_external_tx_id_error(&err),
+            "HTTP 400 that mentions externalTxId but does not indicate a \
+             duplicate must not be misrouted into the recovery lookup"
         );
     }
 

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, U256};
+use alloy::primitives::{Address, B256, U256};
 use cqrs_es::{AggregateContext, AggregateError, CqrsFramework, EventStore};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
@@ -8,7 +8,8 @@ use super::view::{
     RedemptionView, RedemptionViewError, find_burn_failed, find_burning,
 };
 use super::{
-    IssuerRedemptionRequestId, Redemption, RedemptionCommand, RedemptionError,
+    BurnExternalTxId, IssuerRedemptionRequestId, Redemption, RedemptionCommand,
+    RedemptionError, next_burn_retry_external_tx_id_from_history,
 };
 use crate::fireblocks::{FireblocksVaultError, vault_service};
 use crate::mint::QuantityConversionError;
@@ -20,7 +21,9 @@ use crate::tokenized_asset::UnderlyingSymbol;
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
-use crate::vault::{MultiBurnEntry, VaultError, VaultService};
+use crate::vault::{
+    FireblocksTxStatus, MultiBurnEntry, VaultError, VaultService,
+};
 
 /// Outcome of recovering a single redemption stuck in a burning state.
 ///
@@ -303,19 +306,57 @@ where
                 underlying: underlying.clone(),
             })?;
 
-        // If a Fireblocks tx was already submitted before failure, try to
-        // confirm it instead of resubmitting. This prevents double-burns
-        // when the failure was a transient confirmation error.
-        if let Some(fb_tx_id) = fireblocks_tx_id {
-            return self
-                .recover_burn_failed_with_existing_tx(
-                    issuer_request_id,
-                    vault,
-                    fb_tx_id,
-                    dust_quantity,
-                )
-                .await;
-        }
+        // If a Fireblocks tx was already submitted before failure, inspect it
+        // before deciding whether to confirm, wait, or submit a replacement.
+        let retry_external_tx_id = if let Some(fb_tx_id) = fireblocks_tx_id {
+            match self.vault_service.check_fireblocks_tx(fb_tx_id).await? {
+                // Completed: the tx landed on-chain. None: non-Fireblocks
+                // backend with no status to inspect. Both confirm/record the
+                // existing tx rather than resubmit.
+                Some(FireblocksTxStatus::Completed { .. }) | None => {
+                    return self
+                        .recover_burn_failed_with_existing_tx(
+                            issuer_request_id,
+                            vault,
+                            fb_tx_id,
+                            dust_quantity,
+                        )
+                        .await;
+                }
+                Some(FireblocksTxStatus::Pending) => {
+                    info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        fireblocks_tx_id = %fb_tx_id,
+                        "BurnFailed recovery found pending Fireblocks transaction; leaving for a later recovery pass"
+                    );
+                    return Ok(());
+                }
+                Some(FireblocksTxStatus::Failed { .. }) => {
+                    let retry_external_tx_id = Some(
+                        self.next_burn_retry_external_tx_id(
+                            issuer_request_id,
+                            tx_hash,
+                        )
+                        .await?
+                        .unwrap_or_else(|| {
+                            Redemption::retry_burn_external_tx_id_typed(
+                                tx_hash, 1,
+                            )
+                        }),
+                    );
+
+                    info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        fireblocks_tx_id = %fb_tx_id,
+                        retry_external_tx_id = ?retry_external_tx_id,
+                        "BurnFailed recovery found terminal failed Fireblocks transaction; submitting replacement burn"
+                    );
+
+                    retry_external_tx_id
+                }
+            }
+        } else {
+            self.next_burn_retry_external_tx_id(issuer_request_id, tx_hash)
+                .await?
+        };
 
         let burn_shares = alpaca_quantity.to_u256_with_18_decimals()?;
         let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
@@ -363,7 +404,7 @@ where
         debug!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_shares = %burn_shares,
             dust_shares = %dust_shares,
-            "Retrying burn for BurnFailed redemption (no prior submission)"
+            "Retrying burn for BurnFailed redemption"
         );
 
         // Step 1: Resume the burn (Failed → Burning) so the standard
@@ -390,6 +431,7 @@ where
                     dust_quantity: dust_quantity.clone(),
                     called_at: *called_at,
                     alpaca_journal_completed_at: *alpaca_journal_completed_at,
+                    external_tx_id: retry_external_tx_id,
                 },
             )
             .await?;
@@ -602,6 +644,7 @@ where
                 metadata,
                 alpaca_quantity,
                 dust_quantity,
+                external_tx_id,
                 ..
             } => {
                 let vault = find_vault_by_underlying(
@@ -654,6 +697,7 @@ where
                 }
 
                 debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    external_tx_id = ?external_tx_id,
                     "Recovering Burning redemption - resuming burn"
                 );
 
@@ -709,6 +753,7 @@ where
             metadata,
             alpaca_quantity,
             dust_quantity,
+            external_tx_id,
             ..
         } = aggregate
         else {
@@ -778,8 +823,27 @@ where
             )
             .await?;
 
-        self.execute_burn_and_record_result(issuer_request_id, vault, plan)
-            .await
+        self.execute_burn_and_record_result(
+            issuer_request_id,
+            vault,
+            plan,
+            external_tx_id.clone(),
+        )
+        .await
+    }
+
+    async fn next_burn_retry_external_tx_id(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        detected_tx_hash: &B256,
+    ) -> Result<Option<BurnExternalTxId>, BurnManagerError> {
+        let events =
+            self.store.load_events(&issuer_request_id.to_string()).await?;
+
+        Ok(next_burn_retry_external_tx_id_from_history(
+            detected_tx_hash,
+            events.iter().map(|event| &event.payload),
+        )?)
     }
 
     async fn plan_burn(
@@ -868,6 +932,7 @@ where
         issuer_request_id: &IssuerRedemptionRequestId,
         vault: Address,
         plan: BurnPlan,
+        external_tx_id: Option<BurnExternalTxId>,
     ) -> Result<(), BurnManagerError> {
         let burns: Vec<MultiBurnEntry> = plan
             .allocations
@@ -936,6 +1001,7 @@ where
                     burns,
                     dust_shares,
                     owner: self.bot_wallet,
+                    external_tx_id,
                 },
             )
             .await;
@@ -1197,6 +1263,8 @@ pub(crate) enum BurnManagerError {
     Sqlx(#[from] sqlx::Error),
     #[error("CQRS error: {0}")]
     Cqrs(#[from] AggregateError<RedemptionError>),
+    #[error("Redemption error: {0}")]
+    Redemption(#[from] RedemptionError),
     #[error("Invalid aggregate state: {current_state}")]
     InvalidAggregateState { current_state: String },
     #[error("Quantity conversion error: {0}")]
@@ -1234,6 +1302,8 @@ mod tests {
     use std::sync::Arc;
     use tracing_test::traced_test;
 
+    use crate::redemption::BurnExternalTxId;
+
     use super::{
         BurnManager, BurnManagerError, Redemption, RedemptionCommand,
         should_release_reserved_burn,
@@ -1253,7 +1323,10 @@ mod tests {
         TokenSymbol, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{ReceiptInformation, VaultError, VaultService};
+    use crate::vault::{
+        FireblocksTxStatus, MultiBurnEntry, ReceiptInformation, VaultError,
+        VaultService,
+    };
 
     const TEST_WALLET: Address =
         address!("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
@@ -1586,6 +1659,111 @@ mod tests {
                 .is_empty(),
             "successful burn must leave no dangling reservation"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_handle_burning_started_passes_retry_external_tx_id() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let retry_external_tx_id =
+            BurnExternalTxId::from_string("burn-0xabc-retry-1".to_string());
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(42_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        // Thread the retry externalTxId through a real persisted BurnResumed
+        // event (Failed → Burning) so we verify the full apply path, not an
+        // in-memory mutation.
+        let burning = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let Redemption::Burning {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            ..
+        } = burning
+        else {
+            panic!("Expected Burning state, got {burning:?}");
+        };
+
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "burn failed".to_string(),
+                fireblocks_tx_id: None,
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("RecordBurnFailure failed");
+
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::ResumeBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                external_tx_id: Some(retry_external_tx_id.clone()),
+            },
+        )
+        .await
+        .expect("ResumeBurn failed");
+
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(result.is_ok(), "Expected success, got error: {result:?}");
+
+        let params = vault_mock
+            .get_last_multi_burn_params()
+            .expect("Expected multi_burn to have been called");
+
+        assert_eq!(params.external_tx_id, Some(retry_external_tx_id));
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Starting on-chain burning process"]
+        ));
     }
 
     #[tokio::test]
@@ -2685,6 +2863,374 @@ mod tests {
         );
     }
 
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_failed_retries_with_fresh_id_on_terminal_fireblocks_failure()
+     {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success().with_fireblocks_tx_status(
+                FireblocksTxStatus::Failed {
+                    detail: "FAILED".to_string(),
+                    sub_status: Some("REJECTED_BY_BLOCKCHAIN".to_string()),
+                    network_tx_hashes: vec![],
+                },
+            ),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let burning = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let Redemption::Burning { metadata, .. } = &burning else {
+            panic!("Expected Burning state, got {burning:?}");
+        };
+        let detected_tx_hash = metadata.detected_tx_hash;
+
+        // Fail with a recorded Fireblocks tx ID so recovery inspects it.
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "Terminal Fireblocks failure".to_string(),
+                fireblocks_tx_id: Some("fb-failed-123".to_string()),
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("Failed to record burn failure");
+
+        manager.recover_burn_failed_redemptions().await;
+
+        // The terminal Fireblocks failure must trigger a replacement burn.
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "Should submit a replacement burn on terminal Fireblocks failure"
+        );
+
+        // The replacement burn must carry a fresh deterministic retry id, since
+        // Fireblocks rejects reusing the original externalTxId.
+        let params = vault_mock
+            .get_last_multi_burn_params()
+            .expect("Expected replacement burn to have been submitted");
+
+        assert_eq!(
+            params.external_tx_id,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &detected_tx_hash,
+                1
+            )),
+            "Replacement burn must use retry-1 externalTxId"
+        );
+
+        let updated_aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated_aggregate, Redemption::Completed { .. }),
+            "Expected Completed state after recovery, got {updated_aggregate:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["terminal failed Fireblocks transaction", "replacement burn"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_recover_burn_failed_escalates_retry_id_from_prior_submission()
+    {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success().with_fireblocks_tx_status(
+                FireblocksTxStatus::Failed {
+                    detail: "FAILED".to_string(),
+                    sub_status: Some("REJECTED_BY_BLOCKCHAIN".to_string()),
+                    network_tx_hashes: vec![],
+                },
+            ),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let burning = create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let Redemption::Burning { metadata, .. } = &burning else {
+            panic!("Expected Burning state, got {burning:?}");
+        };
+        let detected_tx_hash = metadata.detected_tx_hash;
+        let prior_retry_id =
+            Redemption::retry_burn_external_tx_id_typed(&detected_tx_hash, 1);
+
+        // Seed a prior replacement burn submission (retry-1) into history so
+        // recovery must derive the next id by scanning history, not via the
+        // no-prior-submission fallback (which would yield retry-1).
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::BurnTokens {
+                issuer_request_id: issuer_request_id.clone(),
+                vault,
+                burns: vec![MultiBurnEntry {
+                    receipt_id: uint!(99_U256),
+                    burn_shares: uint!(100_000000000000000000_U256),
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
+                dust_shares: uint!(0_U256),
+                owner: TEST_WALLET,
+                external_tx_id: Some(prior_retry_id),
+            },
+        )
+        .await
+        .expect("Failed to seed prior burn submission");
+
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "Replacement burn terminally failed".to_string(),
+                fireblocks_tx_id: Some("mock-fb-burn".to_string()),
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("Failed to record burn failure");
+
+        manager.recover_burn_failed_redemptions().await;
+
+        // The next replacement burn must escalate to retry-2, proving the id is
+        // derived from the recorded submission rather than the retry-1 fallback.
+        let params = vault_mock
+            .get_last_multi_burn_params()
+            .expect("Expected replacement burn to have been submitted");
+
+        assert_eq!(
+            params.external_tx_id,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &detected_tx_hash,
+                2
+            )),
+            "Replacement burn must escalate to retry-2 from the prior retry-1 submission"
+        );
+
+        let updated_aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated_aggregate, Redemption::Completed { .. }),
+            "Expected Completed state after recovery, got {updated_aggregate:?}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_failed_leaves_pending_fireblocks_tx_untouched() {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_fireblocks_tx_status(FireblocksTxStatus::Pending),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "Recorded failure while tx still pending".to_string(),
+                fireblocks_tx_id: Some("fb-pending-123".to_string()),
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("Failed to record burn failure");
+
+        manager.recover_burn_failed_redemptions().await;
+
+        // A pending Fireblocks tx might still land on-chain, so recovery must
+        // not submit a replacement burn (would risk a double burn).
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            0,
+            "Should not submit a burn while the Fireblocks tx is pending"
+        );
+
+        let updated_aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated_aggregate, Redemption::Failed { .. }),
+            "Expected Failed state to be left unchanged, got {updated_aggregate:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["pending Fireblocks transaction", "later recovery pass"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_failed_records_existing_burn_on_completed_tx() {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success().with_fireblocks_tx_status(
+                FireblocksTxStatus::Completed {
+                    tx_hash: b256!(
+                        "0x4545454545454545454545454545454545454545454545454545454545454545"
+                    ),
+                    block_number: 5000,
+                },
+            ),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        cqrs.execute(
+            &issuer_request_id.to_string(),
+            RedemptionCommand::RecordBurnFailure {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "Recorded failure though tx actually completed"
+                    .to_string(),
+                fireblocks_tx_id: Some("fb-completed-123".to_string()),
+                planned_burns: vec![],
+            },
+        )
+        .await
+        .expect("Failed to record burn failure");
+
+        manager.recover_burn_failed_redemptions().await;
+
+        // A completed Fireblocks tx must be recorded, never resubmitted.
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            0,
+            "Should not submit a replacement burn when the prior tx completed"
+        );
+
+        let updated_aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated_aggregate, Redemption::Completed { .. }),
+            "Expected Completed state after recording existing burn, got {updated_aggregate:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["confirming previously submitted Fireblocks transaction"]
+        ));
+    }
+
     #[tokio::test]
     async fn test_recover_burn_failed_skips_when_balance_insufficient() {
         let harness = setup_test_environment().await;
@@ -2893,6 +3439,7 @@ mod tests {
                 }],
                 dust_shares: U256::ZERO,
                 owner: TEST_WALLET,
+                external_tx_id: None,
             },
         )
         .await

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 
-use super::IssuerRedemptionRequestId;
+use super::{BurnExternalTxId, IssuerRedemptionRequestId};
 use crate::Quantity;
 use crate::mint::TokenizationRequestId;
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
@@ -47,6 +47,11 @@ pub(crate) enum RedemptionCommand {
         /// Dust to return to user
         dust_shares: U256,
         owner: Address,
+        /// Optional deterministic Fireblocks `externalTxId` override.
+        /// Used when retrying a replacement burn after a prior accepted
+        /// Fireblocks burn terminally failed.
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
     },
 
     /// Confirms a previously submitted burn transaction.
@@ -102,5 +107,10 @@ pub(crate) enum RedemptionCommand {
         called_at: chrono::DateTime<chrono::Utc>,
         /// Alpaca's `updated_at` for the completed journal.
         alpaca_journal_completed_at: chrono::DateTime<chrono::Utc>,
+        /// Optional deterministic Fireblocks `externalTxId` for the next burn
+        /// submission. Persisted through `BurnResumed` so a retry submission
+        /// that fails before Fireblocks accepts it can be retried idempotently.
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
     },
 }

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
 
-use super::IssuerRedemptionRequestId;
+use super::{BurnExternalTxId, IssuerRedemptionRequestId};
 use crate::mint::{Quantity, TokenizationRequestId};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 
@@ -105,7 +105,7 @@ pub(crate) enum RedemptionEvent {
     /// Persists the backend transaction ID so polling can resume after a restart.
     BurnFireblocksSubmitted {
         issuer_request_id: IssuerRedemptionRequestId,
-        external_tx_id: String,
+        external_tx_id: BurnExternalTxId,
         fireblocks_tx_id: String,
         /// Planned burns at the time of submission (for recovery use).
         planned_burns: Vec<BurnRecord>,
@@ -150,6 +150,10 @@ pub(crate) enum RedemptionEvent {
         /// Alpaca's `updated_at` for the completed journal — the closest
         /// approximation we have to the actual journal completion time.
         alpaca_journal_completed_at: DateTime<Utc>,
+        /// Optional deterministic Fireblocks `externalTxId` for the next burn
+        /// submission. Old events did not carry this field.
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
         resumed_at: DateTime<Utc>,
     },
 }
@@ -382,5 +386,36 @@ mod tests {
         assert_eq!(dust_returned, U256::ZERO);
         assert_eq!(burns.len(), 1);
         assert_eq!(burns[0].receipt_id, uint!(0x42_U256));
+    }
+
+    /// Tests that old BurnResumed events without external_tx_id default to None.
+    #[test]
+    fn test_backwards_compat_burn_resumed_without_external_tx_id() {
+        let json = r#"{
+            "BurnResumed": {
+                "issuer_request_id": "red-abcdef12",
+                "underlying": "AAPL",
+                "token": "tAAPL",
+                "wallet": "0x1234567890abcdef1234567890abcdef12345678",
+                "quantity": "1",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "block_number": 1,
+                "detected_at": "2025-01-01T00:00:00Z",
+                "tokenization_request_id": "tok-1",
+                "alpaca_quantity": "1",
+                "dust_quantity": "0",
+                "called_at": "2025-01-01T00:00:00Z",
+                "alpaca_journal_completed_at": "2025-01-01T00:00:00Z",
+                "resumed_at": "2025-01-01T00:00:00Z"
+            }
+        }"#;
+
+        let event: RedemptionEvent = serde_json::from_str(json).unwrap();
+
+        let RedemptionEvent::BurnResumed { external_tx_id, .. } = event else {
+            panic!("Expected BurnResumed variant");
+        };
+
+        assert_eq!(external_tx_id, None);
     }
 }

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -107,6 +107,45 @@ impl<'de> Deserialize<'de> for IssuerRedemptionRequestId {
         s.parse().map_err(serde::de::Error::custom)
     }
 }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct BurnExternalTxId(String);
+
+impl BurnExternalTxId {
+    pub(crate) const fn from_string(value: String) -> Self {
+        Self(value)
+    }
+
+    pub(crate) fn base(detected_tx_hash: &B256) -> Self {
+        Self(format!("burn-{detected_tx_hash}"))
+    }
+
+    pub(crate) fn retry(detected_tx_hash: &B256, attempt: u32) -> Self {
+        Self(format!(
+            "{}{}{}",
+            Self::base(detected_tx_hash),
+            Redemption::BURN_RETRY_EXTERNAL_TX_MARKER,
+            attempt,
+        ))
+    }
+
+    pub(crate) fn retry_attempt(&self) -> Option<u32> {
+        self.0
+            .rsplit_once(Redemption::BURN_RETRY_EXTERNAL_TX_MARKER)
+            .and_then(|(_, attempt)| attempt.parse().ok())
+    }
+
+    pub(crate) fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for BurnExternalTxId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 use crate::vault::VaultError;
 use crate::vault::{MultiBurnEntry, MultiBurnParams, VaultService};
@@ -155,6 +194,8 @@ pub(crate) enum Redemption {
         dust_quantity: Quantity,
         called_at: DateTime<Utc>,
         alpaca_journal_completed_at: DateTime<Utc>,
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
     },
     /// Burn transaction submitted to signing backend, awaiting on-chain confirmation.
     BurnSubmitted {
@@ -164,7 +205,7 @@ pub(crate) enum Redemption {
         dust_quantity: Quantity,
         called_at: DateTime<Utc>,
         alpaca_journal_completed_at: DateTime<Utc>,
-        external_tx_id: String,
+        external_tx_id: BurnExternalTxId,
         fireblocks_tx_id: String,
         planned_burns: Vec<event::BurnRecord>,
     },
@@ -194,6 +235,7 @@ struct BurnInput {
     burns: Vec<MultiBurnEntry>,
     dust_shares: U256,
     owner: Address,
+    external_tx_id: Option<BurnExternalTxId>,
 }
 
 struct DetectInput {
@@ -214,9 +256,39 @@ struct ResumeBurnInput {
     dust_quantity: Quantity,
     called_at: DateTime<Utc>,
     alpaca_journal_completed_at: DateTime<Utc>,
+    external_tx_id: Option<BurnExternalTxId>,
 }
 
 impl Redemption {
+    const BURN_RETRY_EXTERNAL_TX_MARKER: &'static str = "-retry-";
+
+    pub(crate) fn retry_burn_external_tx_id_typed(
+        detected_tx_hash: &B256,
+        attempt: u32,
+    ) -> BurnExternalTxId {
+        BurnExternalTxId::retry(detected_tx_hash, attempt)
+    }
+
+    pub(crate) fn retry_attempt_from_burn_external_tx_id(
+        external_tx_id: &BurnExternalTxId,
+    ) -> Option<u32> {
+        external_tx_id.retry_attempt()
+    }
+
+    pub(crate) fn next_burn_retry_external_tx_id(
+        detected_tx_hash: &B256,
+        latest_external_tx_id: &BurnExternalTxId,
+    ) -> Result<BurnExternalTxId, RedemptionError> {
+        let attempt =
+            Self::retry_attempt_from_burn_external_tx_id(latest_external_tx_id)
+                .unwrap_or(0)
+                .checked_add(1)
+                .ok_or_else(|| RedemptionError::RetryAttemptOverflow {
+                    latest_external_tx_id: latest_external_tx_id.clone(),
+                })?;
+        Ok(Self::retry_burn_external_tx_id_typed(detected_tx_hash, attempt))
+    }
+
     pub(crate) const fn metadata(&self) -> Option<&RedemptionMetadata> {
         match self {
             Self::Detected { metadata }
@@ -379,12 +451,15 @@ impl Redemption {
                 user: user_wallet,
                 issuer_request_id: issuer_request_id.clone(),
                 detected_tx_hash: metadata.detected_tx_hash,
+                external_tx_id: input.external_tx_id,
             })
             .await?;
 
         Ok(vec![RedemptionEvent::BurnFireblocksSubmitted {
             issuer_request_id,
-            external_tx_id: submitted.external_tx_id,
+            external_tx_id: BurnExternalTxId::from_string(
+                submitted.external_tx_id,
+            ),
             fireblocks_tx_id: submitted.fireblocks_tx_id,
             planned_burns,
             submitted_at: Utc::now(),
@@ -530,6 +605,7 @@ impl Redemption {
             dust_quantity: input.dust_quantity,
             called_at: input.called_at,
             alpaca_journal_completed_at: input.alpaca_journal_completed_at,
+            external_tx_id: input.external_tx_id,
             resumed_at: Utc::now(),
         }])
     }
@@ -659,8 +735,31 @@ impl Redemption {
             dust_quantity: dust_quantity.clone(),
             called_at: *called_at,
             alpaca_journal_completed_at,
+            external_tx_id: None,
         };
     }
+}
+
+pub(crate) fn next_burn_retry_external_tx_id_from_history<'a>(
+    detected_tx_hash: &B256,
+    events: impl DoubleEndedIterator<Item = &'a RedemptionEvent>,
+) -> Result<Option<BurnExternalTxId>, RedemptionError> {
+    events
+        .rev()
+        .find_map(|event| match event {
+            RedemptionEvent::BurnResumed {
+                external_tx_id: Some(external_tx_id),
+                ..
+            } => Some(Ok(external_tx_id.clone())),
+            RedemptionEvent::BurnFireblocksSubmitted {
+                external_tx_id, ..
+            } => Some(Redemption::next_burn_retry_external_tx_id(
+                detected_tx_hash,
+                external_tx_id,
+            )),
+            _ => None,
+        })
+        .transpose()
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -679,6 +778,10 @@ pub(crate) enum RedemptionError {
         "Fireblocks tx ID mismatch. Expected: {expected}, provided: {provided}"
     )]
     FireblocksTxIdMismatch { expected: String, provided: String },
+    #[error(
+        "Burn retry attempt counter overflowed for external tx id: {latest_external_tx_id}"
+    )]
+    RetryAttemptOverflow { latest_external_tx_id: BurnExternalTxId },
 }
 
 impl PartialEq for RedemptionError {
@@ -701,6 +804,10 @@ impl PartialEq for RedemptionError {
                 Self::FireblocksTxIdMismatch { expected: e1, provided: p1 },
                 Self::FireblocksTxIdMismatch { expected: e2, provided: p2 },
             ) => e1 == e2 && p1 == p2,
+            (
+                Self::RetryAttemptOverflow { latest_external_tx_id: a },
+                Self::RetryAttemptOverflow { latest_external_tx_id: b },
+            ) => a == b,
             _ => false,
         }
     }
@@ -767,11 +874,18 @@ impl Aggregate for Redemption {
                 burns,
                 dust_shares,
                 owner,
+                external_tx_id,
             } => {
                 self.handle_burn_tokens(
                     services,
                     issuer_request_id,
-                    BurnInput { vault, burns, dust_shares, owner },
+                    BurnInput {
+                        vault,
+                        burns,
+                        dust_shares,
+                        owner,
+                        external_tx_id,
+                    },
                 )
                 .await
             }
@@ -827,6 +941,7 @@ impl Aggregate for Redemption {
                 dust_quantity,
                 called_at,
                 alpaca_journal_completed_at,
+                external_tx_id,
             } => self.handle_resume_burn(ResumeBurnInput {
                 issuer_request_id,
                 metadata,
@@ -835,6 +950,7 @@ impl Aggregate for Redemption {
                 dust_quantity,
                 called_at,
                 alpaca_journal_completed_at,
+                external_tx_id,
             }),
         }
     }
@@ -935,6 +1051,7 @@ impl Aggregate for Redemption {
                     dust_quantity,
                     called_at,
                     alpaca_journal_completed_at,
+                    external_tx_id: _,
                 } = self.clone()
                 else {
                     return;
@@ -966,6 +1083,7 @@ impl Aggregate for Redemption {
                 dust_quantity,
                 called_at,
                 alpaca_journal_completed_at,
+                external_tx_id,
                 ..
             } => {
                 *self = Self::Burning {
@@ -984,6 +1102,7 @@ impl Aggregate for Redemption {
                     dust_quantity,
                     called_at,
                     alpaca_journal_completed_at,
+                    external_tx_id,
                 };
             }
             RedemptionEvent::TokensBurned {
@@ -1031,8 +1150,9 @@ mod tests {
     use std::sync::Arc;
 
     use super::{
-        BurnRecord, IssuerRedemptionRequestId, Redemption, RedemptionCommand,
-        RedemptionError, RedemptionEvent, RedemptionMetadata,
+        BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, Redemption,
+        RedemptionCommand, RedemptionError, RedemptionEvent,
+        RedemptionMetadata, next_burn_retry_external_tx_id_from_history,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
@@ -1043,6 +1163,81 @@ mod tests {
 
     fn mock_services() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
+    }
+
+    #[test]
+    fn test_next_burn_retry_external_tx_id_advances_from_submission() {
+        let detected_tx_hash = b256!(
+            "0x1111111111111111111111111111111111111111111111111111111111111111"
+        );
+        let events = [RedemptionEvent::BurnFireblocksSubmitted {
+            issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
+            external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
+            fireblocks_tx_id: "fb-1".to_string(),
+            planned_burns: vec![],
+            submitted_at: Utc::now(),
+        }];
+
+        let next = next_burn_retry_external_tx_id_from_history(
+            &detected_tx_hash,
+            events.iter(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            next,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &detected_tx_hash,
+                1
+            ))
+        );
+    }
+
+    #[test]
+    fn test_next_burn_retry_external_tx_id_reuses_unaccepted_retry() {
+        let detected_tx_hash = b256!(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        );
+        let retry_external_tx_id =
+            Redemption::retry_burn_external_tx_id_typed(&detected_tx_hash, 1);
+        let events = [
+            RedemptionEvent::BurnFireblocksSubmitted {
+                issuer_request_id: IssuerRedemptionRequestId::new(
+                    detected_tx_hash,
+                ),
+                external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
+                fireblocks_tx_id: "fb-1".to_string(),
+                planned_burns: vec![],
+                submitted_at: Utc::now(),
+            },
+            RedemptionEvent::BurnResumed {
+                issuer_request_id: IssuerRedemptionRequestId::new(
+                    detected_tx_hash,
+                ),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(1)),
+                tx_hash: detected_tx_hash,
+                block_number: 1,
+                detected_at: Utc::now(),
+                tokenization_request_id: TokenizationRequestId::new("tok-1"),
+                alpaca_quantity: Quantity::new(Decimal::from(1)),
+                dust_quantity: Quantity::new(Decimal::ZERO),
+                called_at: Utc::now(),
+                alpaca_journal_completed_at: Utc::now(),
+                external_tx_id: Some(retry_external_tx_id.clone()),
+                resumed_at: Utc::now(),
+            },
+        ];
+
+        let next = next_burn_retry_external_tx_id_from_history(
+            &detected_tx_hash,
+            events.iter(),
+        )
+        .unwrap();
+
+        assert_eq!(next, Some(retry_external_tx_id));
     }
 
     #[test]
@@ -1431,6 +1626,7 @@ mod tests {
                 dust_quantity,
                 called_at,
                 alpaca_journal_completed_at,
+                external_tx_id: None,
             }
         );
     }
@@ -1534,6 +1730,7 @@ mod tests {
                 }],
                 dust_shares: U256::ZERO,
                 owner,
+                external_tx_id: None,
             });
 
         let events = validator.inspect_result().unwrap();
@@ -1587,6 +1784,7 @@ mod tests {
                 }],
                 dust_shares: U256::ZERO,
                 owner: address!("0x1111111111111111111111111111111111111111"),
+                external_tx_id: None,
             })
             .then_expect_error(RedemptionError::InvalidState {
                 expected: "Burning".to_string(),
@@ -2248,6 +2446,7 @@ mod tests {
             dust_quantity: Quantity::new(Decimal::ZERO),
             called_at: Utc::now(),
             alpaca_journal_completed_at: Utc::now(),
+            external_tx_id: None,
         }
     }
 
@@ -2417,6 +2616,7 @@ mod tests {
             dust_quantity: Quantity::new(Decimal::ZERO),
             called_at: Utc::now(),
             alpaca_journal_completed_at: journal_completed_at,
+            external_tx_id: None,
             resumed_at: Utc::now(),
         });
 

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -750,6 +750,7 @@ mod tests {
                         owner: address!(
                             "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266"
                         ),
+                        external_tx_id: None,
                     },
                 )
                 .await
@@ -1920,6 +1921,7 @@ mod tests {
                 dust_quantity: dust_quantity.clone(),
                 called_at,
                 alpaca_journal_completed_at,
+                external_tx_id: None,
                 resumed_at: Utc::now(),
             },
             metadata: HashMap::default(),

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -5,9 +5,11 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{
-    MintResult, MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
+    MultiBurnResultEntry, ReceiptInformation, SubmittedTx, VaultError,
+    VaultService,
 };
+use crate::redemption::BurnExternalTxId;
 
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -62,6 +64,10 @@ pub(crate) struct MockVaultService {
     share_balance: Arc<Mutex<U256>>,
     #[cfg(test)]
     last_multi_burn_params: Arc<Mutex<Option<MultiBurnParams>>>,
+    /// Status returned by `check_fireblocks_tx`. `None` mirrors the trait
+    /// default (no Fireblocks state), exercising the non-Fireblocks path.
+    #[cfg(test)]
+    fireblocks_tx_status: Arc<Mutex<Option<FireblocksTxStatus>>>,
 }
 
 impl MockVaultService {
@@ -80,6 +86,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             #[cfg(test)]
             last_multi_burn_params: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -95,6 +103,7 @@ impl MockVaultService {
             last_call: Arc::new(Mutex::new(None)),
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -110,6 +119,7 @@ impl MockVaultService {
             last_call: Arc::new(Mutex::new(None)),
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -125,6 +135,7 @@ impl MockVaultService {
             last_call: Arc::new(Mutex::new(None)),
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -140,6 +151,7 @@ impl MockVaultService {
             last_call: Arc::new(Mutex::new(None)),
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -182,6 +194,15 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn with_share_balance(self, balance: U256) -> Self {
         *self.share_balance.lock().unwrap() = balance;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_fireblocks_tx_status(
+        self,
+        status: FireblocksTxStatus,
+    ) -> Self {
+        *self.fireblocks_tx_status.lock().unwrap() = Some(status);
         self
     }
 }
@@ -322,6 +343,20 @@ impl VaultService for MockVaultService {
         }
     }
 
+    async fn check_fireblocks_tx(
+        &self,
+        _fireblocks_tx_id: &str,
+    ) -> Result<Option<FireblocksTxStatus>, VaultError> {
+        #[cfg(test)]
+        {
+            Ok(self.fireblocks_tx_status.lock().unwrap().clone())
+        }
+        #[cfg(not(test))]
+        {
+            Ok(None)
+        }
+    }
+
     async fn submit_burn(
         &self,
         params: MultiBurnParams,
@@ -366,7 +401,10 @@ impl VaultService for MockVaultService {
             });
 
         Ok(SubmittedTx {
-            external_tx_id: "mock-burn".to_string(),
+            external_tx_id: params.external_tx_id.map_or_else(
+                || "mock-burn".to_string(),
+                BurnExternalTxId::into_string,
+            ),
             fireblocks_tx_id: "mock-fb-burn".to_string(),
         })
     }
@@ -667,6 +705,7 @@ mod tests {
             user: address!("0x2222222222222222222222222222222222222222"),
             issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
             detected_tx_hash,
+            external_tx_id: None,
         }
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::mint::{
     IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
 };
-use crate::redemption::IssuerRedemptionRequestId;
+use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
 pub(crate) mod mock;
 pub(crate) mod rain_meta;
@@ -193,6 +193,10 @@ pub(crate) struct MultiBurnParams {
     /// Full transaction hash that triggered this redemption, used for
     /// constructing a collision-resistant Fireblocks `externalTxId`.
     pub(crate) detected_tx_hash: B256,
+    /// Optional deterministic `externalTxId` override for replacement burn
+    /// retries after a previously accepted Fireblocks transaction failed.
+    #[serde(default)]
+    pub(crate) external_tx_id: Option<BurnExternalTxId>,
 }
 
 /// Result of a single burn within a multi-receipt burn operation.

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -13,6 +13,7 @@ use super::{
     SubmittedTx, VaultError, VaultService,
 };
 use crate::bindings::OffchainAssetReceiptVault;
+use crate::redemption::BurnExternalTxId;
 
 /// Alloy-based blockchain service that interacts with the Rain OffchainAssetReceiptVault
 /// contract.
@@ -310,8 +311,6 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
 
         let tx_hash_str = receipt.transaction_hash.to_string();
-        let issuer_id = params.issuer_request_id.to_string();
-
         let result = super::MultiBurnResult {
             tx_hash: receipt.transaction_hash,
             burns,
@@ -323,7 +322,12 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         self.cached_burns.lock().await.insert(tx_hash_str.clone(), result);
 
         Ok(SubmittedTx {
-            external_tx_id: format!("local-burn-{issuer_id}"),
+            external_tx_id: params
+                .external_tx_id
+                .unwrap_or_else(|| {
+                    BurnExternalTxId::base(&params.detected_tx_hash)
+                })
+                .into_string(),
             fireblocks_tx_id: tx_hash_str,
         })
     }
@@ -415,7 +419,7 @@ mod tests {
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
-    use crate::redemption::IssuerRedemptionRequestId;
+    use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
         MultiBurnEntry, MultiBurnParams, ReceiptInformation, VaultError,
@@ -853,6 +857,7 @@ mod tests {
                 user,
                 issuer_request_id: test_issuer_redemption_id(),
                 detected_tx_hash,
+                external_tx_id: None,
             })
             .await;
 
@@ -871,6 +876,65 @@ mod tests {
         assert_eq!(multi_result.burns[0].shares_burned, U256::from(100));
         assert_eq!(multi_result.burns[1].receipt_id, U256::from(2));
         assert_eq!(multi_result.burns[1].shares_burned, U256::from(50));
+    }
+
+    #[tokio::test]
+    async fn test_submit_burn_propagates_external_tx_id_override() {
+        let vault_address = test_vault_address();
+        let owner = test_receiver();
+        let user = address!("0x3333333333333333333333333333333333333333");
+
+        let tx_hash = fixed_bytes!(
+            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        );
+
+        let burns = vec![(U256::from(1), U256::from(100))];
+
+        let receipt = create_multi_withdraw_receipt(
+            vault_address,
+            tx_hash,
+            owner,
+            user,
+            burns.clone(),
+        );
+
+        let asserter = Asserter::new();
+        setup_asserter_for_transaction(&asserter, tx_hash, &receipt);
+
+        let service = create_service_with_asserter(asserter);
+
+        let detected_tx_hash = b256!(
+            "0xabababababababababababababababababababababababababababababababab"
+        );
+        let override_id = "burn-0xabab-retry-2".to_string();
+
+        let submitted = service
+            .submit_burn(MultiBurnParams {
+                vault: vault_address,
+                burns: burns
+                    .iter()
+                    .map(|(receipt_id, burn_shares)| MultiBurnEntry {
+                        receipt_id: *receipt_id,
+                        burn_shares: *burn_shares,
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    })
+                    .collect(),
+                dust_shares: U256::ZERO,
+                owner,
+                user,
+                issuer_request_id: test_issuer_redemption_id(),
+                detected_tx_hash,
+                external_tx_id: Some(BurnExternalTxId::from_string(
+                    override_id.clone(),
+                )),
+            })
+            .await
+            .expect("submit_burn should succeed");
+
+        // A caller-provided externalTxId (used for replacement burn retries)
+        // must propagate verbatim rather than be replaced by the local default.
+        assert_eq!(submitted.external_tx_id, override_id);
     }
 
     #[tokio::test]
@@ -906,6 +970,7 @@ mod tests {
                 detected_tx_hash: b256!(
                     "0xabababababababababababababababababababababababababababababababab"
                 ),
+                external_tx_id: None,
             })
             .await;
 


### PR DESCRIPTION
## Motivation

A production redemption burn reached a terminal Fireblocks failure after Alpaca had already completed the journal. Retrying the same redemption with the original burn `externalTxId` is blocked because Fireblocks treats `externalTxId` as a permanent unique constraint, even for failed transactions.

This PR lets redemption recovery safely submit a replacement burn with a fresh deterministic `externalTxId`, while preserving the existing safety behavior for completed and pending Fireblocks transactions.

Closes [RAI-419](https://linear.app/makeitrain/issue/RAI-419/retry-terminal-failed-redemption-burns-with-fresh-externaltxid).

## Solution

- Thread an optional `external_tx_id` through redemption burn recovery (every new field is `#[serde(default)]` for event/snapshot backward compatibility):
  - `RedemptionCommand::ResumeBurn` and `RedemptionCommand::BurnTokens`
  - `RedemptionEvent::BurnResumed`
  - `Redemption::Burning`
  - `MultiBurnParams`
- Add deterministic burn retry id helpers in `src/redemption/mod.rs`:
  - normal burn id remains `burn-{detected_tx_hash}`
  - replacement burn ids use `burn-{detected_tx_hash}-retry-{n}`
  - `next_burn_retry_external_tx_id_from_history` derives the next id by reverse-scanning event history: it **reuses** an unaccepted retry id (a `BurnResumed` that no `BurnFireblocksSubmitted` followed) so a submission that crashed before Fireblocks accepted it stays idempotent, and **escalates** past an accepted submission (`burn-…-retry-1` → `retry-2`)
  - the attempt counter uses `checked_add`, surfacing a typed `RedemptionError::RetryAttemptOverflow` instead of panicking or wrapping
- Update startup burn recovery in `src/redemption/burn_manager.rs` to inspect the prior Fireblocks burn status before resubmitting:
  - `Completed` (or a non-Fireblocks backend) records/confirms the existing burn
  - `Pending` leaves the redemption for a later recovery pass (avoids a double burn)
  - terminal `Failed` resumes burning with the next replacement `externalTxId`
- Update admin recovery in `src/admin.rs`: derive the next retry `externalTxId` from event history and persist it through `BurnResumed`. The Fireblocks-status inspection is extracted into the `inspect_prior_fireblocks_burn` helper, and the terminal-`Failed` path falls back to `retry-1` when history carries no recorded retry id (e.g. pre-enrichment `BurningFailed` events) so the permanently-reserved base `externalTxId` is never reused.
- Honor a provided replacement `externalTxId` in all `VaultService` backends (Fireblocks, local, mock).
- Extend duplicate `externalTxId` detection to handle Fireblocks' `external tx id ... already exists` wording.
- Update `SPEC.md` and `docs/fireblocks.md` with the burn retry behavior.

Stacked on #163.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Tested with:

- `direnv exec . cargo check`
- `direnv exec . cargo fmt --all -- --check`
- `direnv exec . cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `direnv exec . cargo test -q test_next_burn_retry_external_tx_id`
- `direnv exec . cargo test -q test_handle_burning_started_passes_retry_external_tx_id`
- `direnv exec . cargo test -q test_recover_post_alpaca_persists_retry_external_tx_id`
- `direnv exec . cargo test -q test_recover_post_alpaca_uses_retry_id_fallback_on_terminal_failure`
- `direnv exec . cargo test -q test_recover_burn_failed_retries_with_fresh_id_on_terminal_fireblocks_failure`
- `direnv exec . cargo test -q test_recover_burn_failed_escalates_retry_id_from_prior_submission`
- `direnv exec . cargo test -q test_recover_burn_failed_leaves_pending_fireblocks_tx_untouched`
- `direnv exec . cargo test -q fireblocks::vault_service::tests::duplicate_detection -- --nocapture`
- `direnv exec . cargo test -q redemption`
- `direnv exec . cargo test -q fireblocks`
- `direnv exec . cargo test -q vault`
- `direnv exec . cargo test -q --lib`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic retry identifiers for failed redemption burns and in-process post-recovery resubmission to ensure idempotent retries.

* **Bug Fixes**
  * Improved detection of duplicate submission errors to avoid unnecessary recovery paths.

* **Documentation**
  * Expanded Fireblocks docs: normal and retry externalTxId formats, terminal burn recovery behavior, and idempotency rules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
