### PR TITLE
fix: widen /admin/stuck to catch stale non-terminal aggregates

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -15,8 +15,8 @@ use crate::alpaca::{AlpacaService, RedeemRequestStatus, TokenizationRequest};
 use crate::auth::InternalAuth;
 use crate::mint::{
     IssuerMintRequestId, MintCommand, MintEvent, MintView,
-    TokenizationRequestId, find_all_recoverable_mints,
-    find_by_issuer_request_id, recovery::spawn_scheduled_mint_recovery,
+    TokenizationRequestId, find_by_issuer_request_id,
+    find_stuck as find_stuck_mints, recovery::spawn_scheduled_mint_recovery,
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -25,7 +25,8 @@ use crate::redemption::burn_manager::{
 use crate::redemption::{
     BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, RedemptionCommand,
     RedemptionError, RedemptionEvent, RedemptionMetadata, RedemptionView,
-    find_stuck, next_burn_retry_external_tx_id_from_history,
+    find_stuck as find_stuck_redemptions,
+    next_burn_retry_external_tx_id_from_history,
 };
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{FireblocksTxStatus, VaultService};
@@ -859,6 +860,13 @@ pub(crate) async fn close_mint(
     }))
 }
 
+/// In-progress states that haven't transitioned in this long are reported as
+/// stuck. Most state transitions take seconds (a few minutes at most for a
+/// Fireblocks confirmation), so anything older than this either deadlocked or
+/// was silently skipped by recovery (e.g. `RecoveryOutcome::SkippedManualIntervention`
+/// leaves a redemption in `Burning` indefinitely with no terminal event).
+const STUCK_THRESHOLD: chrono::Duration = chrono::Duration::hours(1);
+
 #[tracing::instrument(skip(
     _auth,
     pool,
@@ -874,43 +882,48 @@ pub(crate) async fn list_stuck(
     redemption_event_store: &rocket::State<RedemptionEventStore>,
     vault_service: &rocket::State<Arc<dyn VaultService>>,
 ) -> Result<Json<StuckResponse>, Status> {
+    let now = Utc::now();
     let mut stuck = Vec::new();
 
-    // Stuck redemptions (Failed and BurnFailed)
-    let stuck_redemptions = find_stuck(pool.inner()).await.map_err(|err| {
-        error!(target: "admin", error = %err, "Failed to query stuck redemptions");
-        Status::InternalServerError
-    })?;
+    let stuck_redemptions =
+        find_stuck_redemptions(pool.inner()).await.map_err(|err| {
+            error!(target: "admin", error = %err, "Failed to query stuck redemptions");
+            Status::InternalServerError
+        })?;
 
     for (issuer_redemption_request_id, view) in stuck_redemptions {
+        let Some((class, timestamp)) = redemption_stuck_info(&view) else {
+            continue;
+        };
+        if !is_stuck(class, timestamp, now) {
+            continue;
+        }
+
         let history = redemption_history_summary(
             redemption_event_store.inner(),
             &issuer_redemption_request_id.to_string(),
         )
         .await;
 
-        if let Some(entry) = stuck_redemption_entry(
-            &issuer_redemption_request_id,
-            &view,
-            history,
-        ) {
+        if let Some(entry) =
+            stuck_redemption_entry(&issuer_redemption_request_id, view, history)
+        {
             stuck.push(entry);
         }
     }
 
-    // Stuck mints (recoverable states)
-    let recoverable_mints =
-        find_all_recoverable_mints(pool.inner()).await.map_err(|err| {
-            error!(target: "admin", error = %err, "Failed to query recoverable mints");
-            Status::InternalServerError
-        })?;
+    let stuck_mints = find_stuck_mints(pool.inner()).await.map_err(|err| {
+        error!(target: "admin", error = %err, "Failed to query stuck mints");
+        Status::InternalServerError
+    })?;
 
-    for (issuer_mint_request_id, view) in recoverable_mints {
-        let Some((tokenization_request_id, state, detail, timestamp)) =
-            mint_view_summary(&view)
-        else {
+    for (issuer_mint_request_id, view) in stuck_mints {
+        let Some(summary) = mint_view_summary(&view) else {
             continue;
         };
+        if !is_stuck(summary.class, summary.timestamp, now) {
+            continue;
+        }
 
         let (underlying, quantity) = mint_view_asset(&view);
         let mint_history = mint_history_summary(
@@ -922,10 +935,10 @@ pub(crate) async fn list_stuck(
         stuck.push(StuckAggregate {
             aggregate_type: AggregateKind::Mint,
             aggregate_id: issuer_mint_request_id.to_string(),
-            tokenization_request_id,
-            state,
-            detail,
-            timestamp,
+            tokenization_request_id: summary.tokenization_request_id,
+            state: summary.state,
+            detail: summary.detail,
+            timestamp: summary.timestamp,
             underlying,
             quantity,
             tx_hash: mint_history.tx_hash,
@@ -938,6 +951,61 @@ pub(crate) async fn list_stuck(
         .await;
 
     Ok(Json(StuckResponse { stuck }))
+}
+
+/// Classification of a non-terminal view used to decide whether it counts as
+/// stuck right now.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StuckClass {
+    /// Aggregate is mid-flow. Only counts as stuck once it sits in this state
+    /// longer than [`STUCK_THRESHOLD`].
+    InProgress,
+    /// Aggregate landed in a terminal-failure state. Always counts as stuck
+    /// regardless of age — these never self-resolve.
+    TerminalFail,
+}
+
+fn is_stuck(
+    class: StuckClass,
+    timestamp: DateTime<Utc>,
+    now: DateTime<Utc>,
+) -> bool {
+    match class {
+        StuckClass::TerminalFail => true,
+        StuckClass::InProgress => {
+            now.signed_duration_since(timestamp) >= STUCK_THRESHOLD
+        }
+    }
+}
+
+/// Returns the stuck-classification and state-entered timestamp for a view
+/// the operator may need to act on, or `None` for terminal/Unavailable
+/// variants that never appear in `/admin/stuck`. Fusing the classification
+/// and timestamp into a single `Option` keeps the type system enforcing
+/// that callers never observe a timestamp without a class, eliminating the
+/// possibility of a sentinel value on a financial admin path.
+const fn redemption_stuck_info(
+    view: &RedemptionView,
+) -> Option<(StuckClass, DateTime<Utc>)> {
+    use StuckClass::{InProgress, TerminalFail};
+    match view {
+        RedemptionView::Detected { detected_entered_at, .. } => {
+            Some((InProgress, *detected_entered_at))
+        }
+        RedemptionView::AlpacaCalled { called_at, .. } => {
+            Some((InProgress, *called_at))
+        }
+        RedemptionView::Burning { burning_entered_at, .. } => {
+            Some((InProgress, *burning_entered_at))
+        }
+        RedemptionView::Failed { failed_at, .. }
+        | RedemptionView::BurnFailed { failed_at, .. } => {
+            Some((TerminalFail, *failed_at))
+        }
+        RedemptionView::Unavailable
+        | RedemptionView::Completed { .. }
+        | RedemptionView::Closed { .. } => None,
+    }
 }
 
 /// Best-effort enrichment: for every stuck entry with a `fireblocks_tx_id`,
@@ -976,7 +1044,7 @@ async fn enrich_with_fireblocks_status(
 
 fn stuck_redemption_entry(
     issuer_redemption_request_id: &IssuerRedemptionRequestId,
-    view: &RedemptionView,
+    view: RedemptionView,
     history: RedemptionHistorySummary,
 ) -> Option<StuckAggregate> {
     let (
@@ -989,11 +1057,72 @@ fn stuck_redemption_entry(
         tx_hash,
         fireblocks_tx_id,
     ) = match view {
+        RedemptionView::Detected {
+            underlying,
+            quantity,
+            tx_hash,
+            detected_entered_at,
+            ..
+        } => (
+            None,
+            "Detected".to_string(),
+            "Waiting to call Alpaca".to_string(),
+            detected_entered_at,
+            Some(underlying),
+            Some(quantity),
+            Some(tx_hash),
+            history.fireblocks_tx_id,
+        ),
+        RedemptionView::AlpacaCalled {
+            tokenization_request_id,
+            underlying,
+            quantity,
+            tx_hash,
+            called_at,
+            ..
+        } => (
+            Some(tokenization_request_id),
+            "AlpacaCalled".to_string(),
+            "Waiting for Alpaca journal".to_string(),
+            called_at,
+            Some(underlying),
+            Some(quantity),
+            Some(tx_hash),
+            history.fireblocks_tx_id,
+        ),
+        RedemptionView::Burning {
+            tokenization_request_id,
+            underlying,
+            quantity,
+            tx_hash,
+            burning_entered_at,
+            ..
+        } => {
+            // BurnFireblocksSubmitted intentionally leaves the view in
+            // Burning. The detail string is what operators read first, so
+            // distinguish pre- vs post-submission by whether a Fireblocks
+            // tx id has been recorded in event history.
+            let detail = if history.fireblocks_tx_id.is_some() {
+                "Waiting for burn confirmation".to_string()
+            } else {
+                "Waiting for burn submission".to_string()
+            };
+            (
+                Some(tokenization_request_id),
+                "Burning".to_string(),
+                detail,
+                burning_entered_at,
+                Some(underlying),
+                Some(quantity),
+                Some(tx_hash),
+                history.fireblocks_tx_id,
+            )
+        }
         RedemptionView::Failed { reason, failed_at, .. } => (
             history.tokenization_request_id,
             "Failed".to_string(),
-            reason.clone(),
-            *failed_at,
+            reason,
+            failed_at,
             history.underlying,
             history.quantity,
             history.tx_hash,
@@ -1009,19 +1138,20 @@ fn stuck_redemption_entry(
             fireblocks_tx_id,
             ..
         } => (
-            Some(tokenization_request_id.clone()),
+            Some(tokenization_request_id),
             "BurnFailed".to_string(),
-            error.clone(),
-            *failed_at,
-            Some(underlying.clone()),
-            Some(quantity.clone()),
-            Some(*tx_hash),
-            fireblocks_tx_id.clone().or(history.fireblocks_tx_id),
+            error,
+            failed_at,
+            Some(underlying),
+            Some(quantity),
+            Some(tx_hash),
+            fireblocks_tx_id.or(history.fireblocks_tx_id),
         ),
-        // find_stuck only returns Failed/BurnFailed; surface any other
-        // variant as a real mismatch rather than fabricating placeholder
-        // data that could mislead operators.
-        _ => return None,
+        // Terminal/Unavailable variants never reach here — list_stuck gates
+        // on redemption_stuck_info which returns None for them.
+        RedemptionView::Unavailable
+        | RedemptionView::Completed { .. }
+        | RedemptionView::Closed { .. } => return None,
     };
 
     Some(StuckAggregate {
@@ -1065,13 +1195,29 @@ async fn redemption_history_summary(
         }
     };
 
+    redemption_history_summary_from_events(
+        events.into_iter().map(|event| event.payload),
+    )
+}
+
+/// Pure reduce: builds a `RedemptionHistorySummary` from an ordered sequence
+/// of `RedemptionEvent`s. Split out from `redemption_history_summary` so the
+/// branching (especially the Reprocess/Resume fireblocks-id reset) is
+/// unit-testable without an event store.
+fn redemption_history_summary_from_events(
+    events: impl IntoIterator<Item = RedemptionEvent>,
+) -> RedemptionHistorySummary {
     let mut summary = RedemptionHistorySummary::default();
     for event in events {
-        match event.payload {
+        match event {
             RedemptionEvent::Detected {
                 underlying, quantity, tx_hash, ..
+            } => {
+                summary.underlying = Some(underlying);
+                summary.quantity = Some(quantity);
+                summary.tx_hash = Some(tx_hash);
             }
-            | RedemptionEvent::Reprocessed {
+            RedemptionEvent::Reprocessed {
                 underlying,
                 quantity,
                 tx_hash,
@@ -1086,6 +1232,12 @@ async fn redemption_history_summary(
                 summary.underlying = Some(underlying);
                 summary.quantity = Some(quantity);
                 summary.tx_hash = Some(tx_hash);
+                // Reprocess/Resume starts a fresh attempt — any prior
+                // Fireblocks submission belongs to the previous attempt
+                // and must not bleed into the current Burning row's
+                // operator-facing detail. A subsequent
+                // `BurnFireblocksSubmitted` re-sets the field.
+                summary.fireblocks_tx_id = None;
             }
             RedemptionEvent::AlpacaCalled {
                 tokenization_request_id, ..
@@ -1112,52 +1264,90 @@ async fn redemption_history_summary(
     summary
 }
 
-fn mint_view_summary(
-    view: &MintView,
-) -> Option<(Option<TokenizationRequestId>, String, String, DateTime<Utc>)> {
+/// Projection of a non-terminal `MintView` used to populate a `StuckAggregate`.
+/// Two adjacent `String` slots (`state`, `detail`) would be position-swappable
+/// in a tuple; the named struct prevents that.
+#[derive(Debug)]
+struct MintStuckSummary {
+    class: StuckClass,
+    tokenization_request_id: Option<TokenizationRequestId>,
+    state: String,
+    detail: String,
+    timestamp: DateTime<Utc>,
+}
+
+fn mint_view_summary(view: &MintView) -> Option<MintStuckSummary> {
+    use StuckClass::{InProgress, TerminalFail};
     match view {
+        MintView::Initiated {
+            tokenization_request_id, initiated_at, ..
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "Initiated".to_string(),
+            detail: "Waiting for journal confirmation".to_string(),
+            timestamp: *initiated_at,
+        }),
         MintView::JournalConfirmed {
             tokenization_request_id,
             journal_confirmed_at,
             ..
-        } => Some((
-            Some(tokenization_request_id.clone()),
-            "JournalConfirmed".to_string(),
-            "Waiting for deposit".to_string(),
-            *journal_confirmed_at,
-        )),
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "JournalConfirmed".to_string(),
+            detail: "Waiting for deposit".to_string(),
+            timestamp: *journal_confirmed_at,
+        }),
+        MintView::JournalRejected {
+            tokenization_request_id,
+            reason,
+            rejected_at,
+            ..
+        } => Some(MintStuckSummary {
+            class: TerminalFail,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "JournalRejected".to_string(),
+            detail: reason.clone(),
+            timestamp: *rejected_at,
+        }),
         MintView::Minting {
             tokenization_request_id,
             minting_started_at,
             ..
-        } => Some((
-            Some(tokenization_request_id.clone()),
-            "Minting".to_string(),
-            "Deposit in progress".to_string(),
-            *minting_started_at,
-        )),
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "Minting".to_string(),
+            detail: "Deposit in progress".to_string(),
+            timestamp: *minting_started_at,
+        }),
         MintView::MintingFailed {
             tokenization_request_id,
             error,
             failed_at,
             ..
-        } => Some((
-            Some(tokenization_request_id.clone()),
-            "MintingFailed".to_string(),
-            error.clone(),
-            *failed_at,
-        )),
+        } => Some(MintStuckSummary {
+            class: TerminalFail,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "MintingFailed".to_string(),
+            detail: error.clone(),
+            timestamp: *failed_at,
+        }),
         MintView::CallbackPending {
             tokenization_request_id,
             minted_at,
             ..
-        } => Some((
-            Some(tokenization_request_id.clone()),
-            "CallbackPending".to_string(),
-            "Waiting for callback".to_string(),
-            *minted_at,
-        )),
-        _ => None,
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "CallbackPending".to_string(),
+            detail: "Waiting for callback".to_string(),
+            timestamp: *minted_at,
+        }),
+        MintView::NotFound
+        | MintView::Completed { .. }
+        | MintView::Closed { .. } => None,
     }
 }
 
@@ -1165,13 +1355,17 @@ fn mint_view_asset(
     view: &MintView,
 ) -> (Option<UnderlyingSymbol>, Option<Quantity>) {
     match view {
-        MintView::JournalConfirmed { underlying, quantity, .. }
+        MintView::Initiated { underlying, quantity, .. }
+        | MintView::JournalConfirmed { underlying, quantity, .. }
+        | MintView::JournalRejected { underlying, quantity, .. }
         | MintView::Minting { underlying, quantity, .. }
         | MintView::MintingFailed { underlying, quantity, .. }
         | MintView::CallbackPending { underlying, quantity, .. } => {
             (Some(underlying.clone()), Some(quantity.clone()))
         }
-        _ => (None, None),
+        MintView::NotFound
+        | MintView::Completed { .. }
+        | MintView::Closed { .. } => (None, None),
     }
 }
 
@@ -1491,7 +1685,7 @@ mod tests {
 
         let entry = super::stuck_redemption_entry(
             &metadata.issuer_request_id,
-            &view,
+            view,
             history,
         )
         .expect("failed redemption should produce stuck entry");
@@ -1537,7 +1731,7 @@ mod tests {
 
         let entry = super::stuck_redemption_entry(
             &metadata.issuer_request_id,
-            &view,
+            view,
             super::RedemptionHistorySummary::default(),
         )
         .expect("burn failed redemption should produce stuck entry");
@@ -2630,5 +2824,606 @@ mod tests {
         assert_eq!(json["detail"], "Failed");
         assert_eq!(json["sub_status"], "BLOCKED_BY_POLICY");
         assert_eq!(json["network_tx_hashes"][0], "0xdeadbeef");
+    }
+
+    #[test]
+    fn is_stuck_terminal_fail_always_true_regardless_of_age() {
+        let now = Utc::now();
+        let just_now = now;
+        let long_ago = now - chrono::Duration::days(30);
+
+        assert!(super::is_stuck(
+            super::StuckClass::TerminalFail,
+            just_now,
+            now
+        ));
+        assert!(super::is_stuck(
+            super::StuckClass::TerminalFail,
+            long_ago,
+            now
+        ));
+    }
+
+    #[test]
+    fn is_stuck_in_progress_uses_one_hour_threshold() {
+        let now = Utc::now();
+
+        // Just under threshold — not stuck yet.
+        let fresh = now - chrono::Duration::minutes(59);
+        assert!(!super::is_stuck(super::StuckClass::InProgress, fresh, now));
+
+        // Exactly at threshold — stuck.
+        let at_threshold = now - super::STUCK_THRESHOLD;
+        assert!(super::is_stuck(
+            super::StuckClass::InProgress,
+            at_threshold,
+            now
+        ));
+
+        // Older than threshold — stuck.
+        let old = now - chrono::Duration::hours(13);
+        assert!(super::is_stuck(super::StuckClass::InProgress, old, now));
+    }
+
+    #[test]
+    fn redemption_stuck_info_classifies_and_timestamps_each_variant() {
+        use super::RedemptionView::{
+            AlpacaCalled, BurnFailed, Burning, Closed, Completed, Detected,
+            Failed, Unavailable,
+        };
+        use super::StuckClass::{InProgress, TerminalFail};
+
+        let metadata = test_metadata();
+        let issuer = metadata.issuer_request_id.clone();
+        let underlying = metadata.underlying.clone();
+        let token = metadata.token.clone();
+        let quantity = metadata.quantity.clone();
+        let tx_hash = metadata.detected_tx_hash;
+        let block_number = metadata.block_number;
+        let detected_at = metadata.detected_at;
+        let called_at = Utc::now();
+        let burning_entered_at = Utc::now();
+        let failed_at = Utc::now();
+        let burn_failed_at = Utc::now();
+        let tok_id = TokenizationRequestId::new("tok-1");
+
+        // Detected → InProgress with detected_entered_at. Use a distinct
+        // (later) value than detected_at so the projection unambiguously
+        // selects detected_entered_at — this is the post-reprocess clock.
+        let detected_entered_at = detected_at + chrono::Duration::days(7);
+        let detected = Detected {
+            issuer_request_id: issuer.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            wallet: metadata.wallet,
+            quantity: quantity.clone(),
+            tx_hash,
+            block_number,
+            detected_at,
+            detected_entered_at,
+        };
+        assert_eq!(
+            super::redemption_stuck_info(&detected),
+            Some((InProgress, detected_entered_at))
+        );
+
+        // AlpacaCalled → InProgress with called_at.
+        let alpaca_called = AlpacaCalled {
+            issuer_request_id: issuer.clone(),
+            tokenization_request_id: tok_id.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            wallet: metadata.wallet,
+            quantity: quantity.clone(),
+            alpaca_quantity: quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash,
+            block_number,
+            detected_at,
+            called_at,
+        };
+        assert_eq!(
+            super::redemption_stuck_info(&alpaca_called),
+            Some((InProgress, called_at))
+        );
+
+        // Burning → InProgress with burning_entered_at (NOT
+        // alpaca_journal_completed_at, which would lag for resumed
+        // redemptions). Use a distinct journal-completion time to make the
+        // distinction observable.
+        let burning = Burning {
+            issuer_request_id: issuer.clone(),
+            tokenization_request_id: tok_id.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            wallet: metadata.wallet,
+            alpaca_quantity: quantity.clone(),
+            quantity: quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash,
+            block_number,
+            detected_at,
+            called_at,
+            alpaca_journal_completed_at: detected_at,
+            burning_entered_at,
+        };
+        assert_eq!(
+            super::redemption_stuck_info(&burning),
+            Some((InProgress, burning_entered_at))
+        );
+
+        // Failed → TerminalFail with failed_at.
+        let failed = Failed {
+            issuer_request_id: issuer.clone(),
+            reason: "x".to_string(),
+            failed_at,
+        };
+        assert_eq!(
+            super::redemption_stuck_info(&failed),
+            Some((TerminalFail, failed_at))
+        );
+
+        // BurnFailed → TerminalFail with failed_at. Exercises the exact
+        // variant that motivated this PR (the original red-79631d72 /
+        // red-742f9f3a incident).
+        let burn_failed = BurnFailed {
+            issuer_request_id: issuer.clone(),
+            tokenization_request_id: tok_id,
+            underlying,
+            token,
+            wallet: metadata.wallet,
+            quantity: quantity.clone(),
+            alpaca_quantity: quantity,
+            dust_quantity: Quantity::default(),
+            tx_hash,
+            block_number,
+            detected_at,
+            called_at,
+            alpaca_journal_completed_at: detected_at,
+            error: "burn failed".to_string(),
+            failed_at: burn_failed_at,
+            fireblocks_tx_id: None,
+            planned_burns: vec![],
+        };
+        assert_eq!(
+            super::redemption_stuck_info(&burn_failed),
+            Some((TerminalFail, burn_failed_at))
+        );
+
+        // Terminal/Unavailable do not appear.
+        assert_eq!(super::redemption_stuck_info(&Unavailable), None);
+        assert_eq!(
+            super::redemption_stuck_info(&Completed {
+                issuer_request_id: issuer.clone(),
+                burn_tx_hash: tx_hash,
+                block_number,
+                completed_at: failed_at,
+            }),
+            None
+        );
+        assert_eq!(
+            super::redemption_stuck_info(&Closed {
+                issuer_request_id: issuer,
+                reason: "x".to_string(),
+                closed_at: failed_at,
+            }),
+            None
+        );
+    }
+
+    #[test]
+    fn stuck_redemption_entry_handles_in_progress_variants() {
+        let metadata = test_metadata();
+        let detected_at = metadata.detected_at;
+
+        // Use distinct timestamps so the projection unambiguously selects
+        // detected_entered_at (the post-reprocess clock) over detected_at.
+        let detected_entered_at = detected_at + chrono::Duration::days(3);
+        let detected_view = RedemptionView::Detected {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            underlying: metadata.underlying.clone(),
+            token: metadata.token.clone(),
+            wallet: metadata.wallet,
+            quantity: metadata.quantity.clone(),
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at,
+            detected_entered_at,
+        };
+
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            detected_view,
+            super::RedemptionHistorySummary::default(),
+        )
+        .expect("Detected view should produce a stuck entry");
+
+        assert_eq!(entry.aggregate_type, AggregateKind::Redemption);
+        assert_eq!(entry.state, "Detected");
+        assert_eq!(entry.detail, "Waiting to call Alpaca");
+        assert_eq!(entry.timestamp, detected_entered_at);
+        assert_eq!(entry.tokenization_request_id, None);
+        assert_eq!(entry.underlying, Some(metadata.underlying.clone()));
+        assert_eq!(entry.quantity, Some(metadata.quantity.clone()));
+        assert_eq!(entry.tx_hash, Some(metadata.detected_tx_hash));
+
+        let called_at = Utc::now();
+        let tok_id = TokenizationRequestId::new("tok-progress");
+        let alpaca_called_view = RedemptionView::AlpacaCalled {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            tokenization_request_id: tok_id.clone(),
+            underlying: metadata.underlying.clone(),
+            token: metadata.token.clone(),
+            wallet: metadata.wallet,
+            quantity: metadata.quantity.clone(),
+            alpaca_quantity: metadata.quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at,
+            called_at,
+        };
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            alpaca_called_view,
+            super::RedemptionHistorySummary::default(),
+        )
+        .expect("AlpacaCalled view should produce a stuck entry");
+        assert_eq!(entry.state, "AlpacaCalled");
+        assert_eq!(entry.detail, "Waiting for Alpaca journal");
+        assert_eq!(entry.timestamp, called_at);
+        assert_eq!(entry.tokenization_request_id, Some(tok_id.clone()));
+
+        // Use distinct timestamps so the projection unambiguously selects
+        // burning_entered_at (the post-resume clock) over
+        // alpaca_journal_completed_at.
+        let journal_completed_at = Utc::now() - chrono::Duration::days(7);
+        let burning_entered_at = Utc::now();
+        let burning_view = RedemptionView::Burning {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            tokenization_request_id: tok_id.clone(),
+            underlying: metadata.underlying.clone(),
+            token: metadata.token.clone(),
+            wallet: metadata.wallet,
+            quantity: metadata.quantity.clone(),
+            alpaca_quantity: metadata.quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at,
+            called_at,
+            alpaca_journal_completed_at: journal_completed_at,
+            burning_entered_at,
+        };
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            burning_view,
+            super::RedemptionHistorySummary::default(),
+        )
+        .expect("Burning view should produce a stuck entry");
+        assert_eq!(entry.state, "Burning");
+        // No prior submission recorded → pre-submission detail.
+        assert_eq!(entry.detail, "Waiting for burn submission");
+        assert_eq!(entry.timestamp, burning_entered_at);
+        assert_eq!(entry.tokenization_request_id, Some(tok_id.clone()));
+
+        // Same Burning view, but history shows a prior Fireblocks
+        // submission — the detail should flip to "Waiting for burn
+        // confirmation" so operators don't see misleading "submission"
+        // text on a post-submission row. BurnFireblocksSubmitted leaves
+        // the view in Burning, so this branch is the only signal.
+        let burning_view_with_history = RedemptionView::Burning {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            tokenization_request_id: tok_id,
+            underlying: metadata.underlying.clone(),
+            token: metadata.token.clone(),
+            wallet: metadata.wallet,
+            quantity: metadata.quantity.clone(),
+            alpaca_quantity: metadata.quantity.clone(),
+            dust_quantity: Quantity::default(),
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at,
+            called_at,
+            alpaca_journal_completed_at: journal_completed_at,
+            burning_entered_at,
+        };
+        let history_with_fb = super::RedemptionHistorySummary {
+            fireblocks_tx_id: Some("fb-tx-burn-1".to_string()),
+            ..super::RedemptionHistorySummary::default()
+        };
+        let entry = super::stuck_redemption_entry(
+            &metadata.issuer_request_id,
+            burning_view_with_history,
+            history_with_fb,
+        )
+        .expect("Burning view should produce a stuck entry");
+        assert_eq!(entry.state, "Burning");
+        assert_eq!(entry.detail, "Waiting for burn confirmation");
+        assert_eq!(entry.fireblocks_tx_id, Some("fb-tx-burn-1".to_string()));
+    }
+
+    #[test]
+    fn mint_view_summary_classifies_and_timestamps_each_variant() {
+        use super::StuckClass::{InProgress, TerminalFail};
+        use crate::mint::{ClientId, MintView, Network};
+
+        let issuer_request_id = crate::mint::IssuerMintRequestId::random();
+        let tokenization_request_id = TokenizationRequestId::new("alp-stuck-1");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let network = Network::new("base");
+        let client_id = ClientId::new();
+        let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let quantity = crate::mint::Quantity::new(Decimal::from(100));
+        let initiated_at = Utc::now() - chrono::Duration::hours(3);
+        let journal_confirmed_at = Utc::now() - chrono::Duration::hours(2);
+        let rejected_at = Utc::now() - chrono::Duration::hours(1);
+        let minting_started_at = Utc::now() - chrono::Duration::minutes(45);
+        let minted_at = Utc::now() - chrono::Duration::minutes(30);
+        let failed_at = Utc::now() - chrono::Duration::minutes(15);
+
+        let initiated = MintView::Initiated {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+        };
+        let s = super::mint_view_summary(&initiated)
+            .expect("Initiated should produce a summary");
+        assert_eq!(s.class, InProgress);
+        assert_eq!(s.state, "Initiated");
+        assert_eq!(s.detail, "Waiting for journal confirmation");
+        assert_eq!(s.timestamp, initiated_at);
+        assert_eq!(
+            s.tokenization_request_id,
+            Some(tokenization_request_id.clone())
+        );
+
+        let confirmed = MintView::JournalConfirmed {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+        };
+        let s = super::mint_view_summary(&confirmed)
+            .expect("JournalConfirmed should produce a summary");
+        assert_eq!(s.class, InProgress);
+        assert_eq!(s.state, "JournalConfirmed");
+        assert_eq!(s.detail, "Waiting for deposit");
+        assert_eq!(s.timestamp, journal_confirmed_at);
+
+        let rejected = MintView::JournalRejected {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+            reason: "Alpaca rejected".to_string(),
+            rejected_at,
+        };
+        let s = super::mint_view_summary(&rejected)
+            .expect("JournalRejected should produce a summary");
+        assert_eq!(s.class, TerminalFail);
+        assert_eq!(s.state, "JournalRejected");
+        assert_eq!(s.detail, "Alpaca rejected");
+        assert_eq!(s.timestamp, rejected_at);
+
+        let minting = MintView::Minting {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            minting_started_at,
+        };
+        let s = super::mint_view_summary(&minting).unwrap();
+        assert_eq!(s.class, InProgress);
+        assert_eq!(s.state, "Minting");
+        assert_eq!(s.detail, "Deposit in progress");
+        assert_eq!(s.timestamp, minting_started_at);
+
+        let callback_pending = MintView::CallbackPending {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: tokenization_request_id.clone(),
+            quantity: quantity.clone(),
+            underlying: underlying.clone(),
+            token: token.clone(),
+            network: network.clone(),
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            receipt_id: U256::from(1u64),
+            shares_minted: U256::from(100u64),
+            gas_used: None,
+            block_number: 1,
+            minted_at,
+        };
+        let s = super::mint_view_summary(&callback_pending).unwrap();
+        assert_eq!(s.class, InProgress);
+        assert_eq!(s.state, "CallbackPending");
+        assert_eq!(s.detail, "Waiting for callback");
+        assert_eq!(s.timestamp, minted_at);
+
+        let minting_failed = MintView::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            error: "deposit failed".to_string(),
+            failed_at,
+        };
+        let s = super::mint_view_summary(&minting_failed).unwrap();
+        assert_eq!(s.class, TerminalFail);
+        assert_eq!(s.state, "MintingFailed");
+        assert_eq!(s.detail, "deposit failed");
+        assert_eq!(s.timestamp, failed_at);
+
+        // Terminal/NotFound do not produce a summary.
+        assert!(super::mint_view_summary(&MintView::NotFound).is_none());
+        assert!(
+            super::mint_view_summary(&MintView::Completed {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("alp-completed"),
+                quantity: crate::mint::Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::new("base"),
+                client_id: ClientId::new(),
+                wallet: address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+                initiated_at: failed_at,
+                journal_confirmed_at: failed_at,
+                tx_hash: b256!(
+                    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                receipt_id: U256::from(2u64),
+                shares_minted: U256::from(100u64),
+                gas_used: None,
+                block_number: 1,
+                minted_at: failed_at,
+                completed_at: failed_at,
+            })
+            .is_none(),
+            "Completed must not produce a stuck summary"
+        );
+        assert!(
+            super::mint_view_summary(&MintView::Closed {
+                issuer_request_id,
+                reason: "closed by admin".to_string(),
+                closed_at: failed_at,
+            })
+            .is_none()
+        );
+    }
+
+    /// Regression: an iter-3 fix branches the Burning detail string on
+    /// `history.fireblocks_tx_id.is_some()`. Without the iter-4 fix to
+    /// `redemption_history_summary`, a previously-failed Fireblocks tx
+    /// would survive across a `BurnResumed` and mislabel the freshly
+    /// resumed (but not-yet-submitted) Burning row as "Waiting for burn
+    /// confirmation".
+    #[test]
+    fn redemption_history_summary_clears_fireblocks_tx_id_on_burn_resumed() {
+        use crate::redemption::{BurnExternalTxId, RedemptionEvent};
+
+        let issuer = IssuerRedemptionRequestId::random();
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let quantity = Quantity::new(Decimal::from(100));
+        let tx_hash = b256!(
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+        let now = Utc::now();
+        let tok_id = TokenizationRequestId::new("tok-resume-1");
+
+        // Sequence: a full Burning attempt that failed during Fireblocks
+        // confirmation, then operator-initiated BurnResumed putting us
+        // back into Burning with NO new submission yet.
+        let events = vec![
+            RedemptionEvent::Detected {
+                issuer_request_id: issuer.clone(),
+                underlying: underlying.clone(),
+                token: token.clone(),
+                wallet,
+                quantity: quantity.clone(),
+                tx_hash,
+                block_number: 1,
+                detected_at: now,
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer.clone(),
+                tokenization_request_id: tok_id.clone(),
+                alpaca_quantity: quantity.clone(),
+                dust_quantity: Quantity::default(),
+                called_at: now,
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id: issuer.clone(),
+                alpaca_journal_completed_at: now,
+            },
+            RedemptionEvent::BurnFireblocksSubmitted {
+                issuer_request_id: issuer.clone(),
+                external_tx_id: BurnExternalTxId::from_string(format!(
+                    "burn-{tx_hash}"
+                )),
+                fireblocks_tx_id: "fb-old-attempt".to_string(),
+                planned_burns: vec![],
+                submitted_at: now,
+            },
+            RedemptionEvent::BurningFailed {
+                issuer_request_id: issuer.clone(),
+                error: "fireblocks failed".to_string(),
+                failed_at: now,
+                fireblocks_tx_id: Some("fb-old-attempt".to_string()),
+                planned_burns: vec![],
+            },
+            RedemptionEvent::RedemptionFailed {
+                issuer_request_id: issuer.clone(),
+                reason: "burn failed".to_string(),
+                failed_at: now,
+            },
+            // Operator resumes the burn — no new BurnFireblocksSubmitted
+            // has happened yet.
+            RedemptionEvent::BurnResumed {
+                issuer_request_id: issuer,
+                underlying,
+                token,
+                wallet,
+                quantity,
+                tx_hash,
+                block_number: 1,
+                detected_at: now,
+                tokenization_request_id: tok_id.clone(),
+                alpaca_quantity: Quantity::default(),
+                dust_quantity: Quantity::default(),
+                called_at: now,
+                alpaca_journal_completed_at: now,
+                external_tx_id: None,
+                resumed_at: now,
+            },
+        ];
+
+        let summary = super::redemption_history_summary_from_events(events);
+
+        // BurnResumed must clear the prior failed Fireblocks tx id so the
+        // stuck-row detail string reflects "Waiting for burn submission"
+        // (not "Waiting for burn confirmation") for the new attempt.
+        assert_eq!(
+            summary.fireblocks_tx_id, None,
+            "BurnResumed must clear prior fireblocks_tx_id from summary"
+        );
+        // tokenization_request_id is preserved (it doesn't reset).
+        assert_eq!(summary.tokenization_request_id, Some(tok_id));
     }
 }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -34,7 +34,7 @@ pub(crate) use cmd::{MintCommand, MintRecoveryMode};
 pub(crate) use event::MintEvent;
 pub(crate) use view::{
     MintView, find_all_recoverable_mints, find_by_issuer_request_id,
-    replay_mint_view,
+    find_stuck, replay_mint_view,
 };
 
 /// Services required by the Mint aggregate for command handling.

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -560,7 +560,7 @@ pub(crate) async fn find_by_issuer_request_id(
     let issuer_request_id_str = issuer_request_id.to_string();
     let row = sqlx::query!(
         r#"
-        SELECT payload as "payload: String"
+        SELECT payload as "payload!: String"
         FROM mint_view
         WHERE view_id = ?
         "#,
@@ -586,12 +586,47 @@ pub(crate) async fn find_all_recoverable_mints(
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
     let rows = sqlx::query!(
         r#"
-        SELECT view_id as "view_id!: String", payload as "payload: String"
+        SELECT view_id as "view_id!: String", payload as "payload!: String"
         FROM mint_view
         WHERE json_extract(payload, '$.JournalConfirmed') IS NOT NULL
            OR json_extract(payload, '$.Minting') IS NOT NULL
            OR json_extract(payload, '$.MintingFailed') IS NOT NULL
            OR json_extract(payload, '$.CallbackPending') IS NOT NULL
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            let view: MintView = serde_json::from_str(&row.payload)?;
+            let id = Uuid::parse_str(&row.view_id)?;
+            Ok((IssuerMintRequestId::new(id), view))
+        })
+        .collect()
+}
+
+/// Finds all mints that are not in a terminal state.
+///
+/// Returns every mint whose view sits in `Initiated`, `JournalConfirmed`,
+/// `JournalRejected`, `Minting`, `CallbackPending`, or `MintingFailed` — i.e.
+/// anything that hasn't reached `Completed` or `Closed`. Callers
+/// (`/admin/stuck`) apply the staleness gate and decide which entries the
+/// operator must act on. Differs from `find_all_recoverable_mints`, which is
+/// limited to the states the automated recovery loop knows how to drive.
+pub(crate) async fn find_stuck(
+    pool: &Pool<Sqlite>,
+) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
+    let rows = sqlx::query!(
+        r#"
+        SELECT view_id as "view_id!: String", payload as "payload!: String"
+        FROM mint_view
+        WHERE json_extract(payload, '$.Initiated')        IS NOT NULL
+           OR json_extract(payload, '$.JournalConfirmed') IS NOT NULL
+           OR json_extract(payload, '$.JournalRejected')  IS NOT NULL
+           OR json_extract(payload, '$.Minting')          IS NOT NULL
+           OR json_extract(payload, '$.CallbackPending')  IS NOT NULL
+           OR json_extract(payload, '$.MintingFailed')    IS NOT NULL
         "#
     )
     .fetch_all(pool)
@@ -1923,6 +1958,138 @@ mod tests {
     async fn test_find_all_recoverable_mints_returns_empty_when_none() {
         let pool = setup_test_db().await;
         let results = find_all_recoverable_mints(&pool).await.unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_find_stuck_returns_all_non_terminal_variants() {
+        let harness = TestHarness::new().await;
+        let now = Utc::now();
+
+        // Seed the 4 recoverable variants (JournalConfirmed, Minting,
+        // MintingFailed, CallbackPending).
+        let recoverable_ids = seed_recoverable_mint_views(&harness).await;
+
+        // Seed Initiated and JournalRejected (non-terminal-but-not-recoverable).
+        let initiated_fields = test_mint_fields();
+        let initiated_id = initiated_fields.issuer_request_id.clone();
+        harness
+            .insert_view(
+                &initiated_id,
+                &MintView::Initiated {
+                    issuer_request_id: initiated_fields.issuer_request_id,
+                    tokenization_request_id: initiated_fields
+                        .tokenization_request_id,
+                    quantity: initiated_fields.quantity,
+                    underlying: initiated_fields.underlying,
+                    token: initiated_fields.token,
+                    network: initiated_fields.network,
+                    client_id: initiated_fields.client_id,
+                    wallet: initiated_fields.wallet,
+                    initiated_at: initiated_fields.initiated_at,
+                },
+            )
+            .await;
+
+        let rejected_fields = test_mint_fields();
+        let rejected_id = rejected_fields.issuer_request_id.clone();
+        harness
+            .insert_view(
+                &rejected_id,
+                &MintView::JournalRejected {
+                    issuer_request_id: rejected_fields.issuer_request_id,
+                    tokenization_request_id: rejected_fields
+                        .tokenization_request_id,
+                    quantity: rejected_fields.quantity,
+                    underlying: rejected_fields.underlying,
+                    token: rejected_fields.token,
+                    network: rejected_fields.network,
+                    client_id: rejected_fields.client_id,
+                    wallet: rejected_fields.wallet,
+                    initiated_at: rejected_fields.initiated_at,
+                    reason: "Alpaca rejected the journal".to_string(),
+                    rejected_at: now,
+                },
+            )
+            .await;
+
+        // Seed a Completed mint that must NOT appear.
+        let completed_fields = test_mint_fields();
+        let completed_id = completed_fields.issuer_request_id.clone();
+        harness.insert_view(&completed_id, &MintView::Completed {
+            issuer_request_id: completed_fields.issuer_request_id,
+            tokenization_request_id: completed_fields.tokenization_request_id,
+            quantity: completed_fields.quantity,
+            underlying: completed_fields.underlying,
+            token: completed_fields.token,
+            network: completed_fields.network,
+            client_id: completed_fields.client_id,
+            wallet: completed_fields.wallet,
+            initiated_at: completed_fields.initiated_at,
+            journal_confirmed_at: now,
+            tx_hash: b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
+            receipt_id: uint!(2_U256),
+            shares_minted: uint!(100_000000000000000000_U256),
+            gas_used: Some(50000),
+            block_number: 1001,
+            minted_at: now,
+            completed_at: now,
+        }).await;
+
+        // Seed a Closed mint that must NOT appear.
+        let closed_fields = test_mint_fields();
+        let closed_id = closed_fields.issuer_request_id.clone();
+        harness
+            .insert_view(
+                &closed_id,
+                &MintView::Closed {
+                    issuer_request_id: closed_fields.issuer_request_id,
+                    reason: "closed by admin".to_string(),
+                    closed_at: now,
+                },
+            )
+            .await;
+
+        let results = find_stuck(&harness.pool).await.unwrap();
+        let result_ids: Vec<_> =
+            results.iter().map(|(id, _)| id.clone()).collect();
+
+        assert_eq!(
+            results.len(),
+            6,
+            "Expected 6 non-terminal mints, got ids: {result_ids:?}"
+        );
+        for id in &recoverable_ids {
+            assert!(result_ids.contains(id), "Should include {id}");
+        }
+        assert!(result_ids.contains(&initiated_id), "Should include Initiated");
+        assert!(
+            result_ids.contains(&rejected_id),
+            "Should include JournalRejected"
+        );
+        assert!(
+            !result_ids.contains(&completed_id),
+            "Completed must be filtered out"
+        );
+        assert!(
+            !result_ids.contains(&closed_id),
+            "Closed must be filtered out"
+        );
+
+        let state_names: Vec<_> =
+            results.iter().map(|(_, view)| view.state_name()).collect();
+        assert!(state_names.contains(&"Initiated"));
+        assert!(state_names.contains(&"JournalConfirmed"));
+        assert!(state_names.contains(&"JournalRejected"));
+        assert!(state_names.contains(&"Minting"));
+        assert!(state_names.contains(&"MintingFailed"));
+        assert!(state_names.contains(&"CallbackPending"));
+    }
+
+    #[tokio::test]
+    async fn test_find_stuck_returns_empty_when_none() {
+        let pool = setup_test_db().await;
+        let results = find_stuck(&pool).await.unwrap();
         assert!(results.is_empty());
     }
 }

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -27,6 +27,12 @@ pub(crate) enum RedemptionView {
         tx_hash: B256,
         block_number: u64,
         detected_at: DateTime<Utc>,
+        /// When the view most recently entered `Detected`. Matches
+        /// `detected_at` on first detection; updated to `reprocessed_at`
+        /// when `Reprocessed` re-enters this state, so admin triage and the
+        /// staleness gate reflect the latest entry rather than the
+        /// original detection.
+        detected_entered_at: DateTime<Utc>,
     },
     AlpacaCalled {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -56,6 +62,12 @@ pub(crate) enum RedemptionView {
         detected_at: DateTime<Utc>,
         called_at: DateTime<Utc>,
         alpaca_journal_completed_at: DateTime<Utc>,
+        /// When the view most recently entered `Burning`. Matches
+        /// `alpaca_journal_completed_at` on the happy path; updated to
+        /// `resumed_at` when `BurnResumed` re-enters this state, so admin
+        /// triage and the staleness gate reflect the latest entry rather than
+        /// the original journal completion.
+        burning_entered_at: DateTime<Utc>,
     },
     Completed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -175,6 +187,7 @@ impl RedemptionView {
             detected_at: *detected_at,
             called_at: *called_at,
             alpaca_journal_completed_at,
+            burning_entered_at: alpaca_journal_completed_at,
         };
     }
 
@@ -199,6 +212,7 @@ impl RedemptionView {
             detected_at,
             called_at,
             alpaca_journal_completed_at,
+            burning_entered_at: _,
         } = self
         else {
             return;
@@ -238,8 +252,20 @@ impl View<Redemption> for RedemptionView {
                 tx_hash,
                 block_number,
                 detected_at,
+            } => {
+                *self = Self::Detected {
+                    issuer_request_id: issuer_request_id.clone(),
+                    underlying: underlying.clone(),
+                    token: token.clone(),
+                    wallet: *wallet,
+                    quantity: quantity.clone(),
+                    tx_hash: *tx_hash,
+                    block_number: *block_number,
+                    detected_at: *detected_at,
+                    detected_entered_at: *detected_at,
+                };
             }
-            | RedemptionEvent::Reprocessed {
+            RedemptionEvent::Reprocessed {
                 issuer_request_id,
                 underlying,
                 token,
@@ -248,6 +274,7 @@ impl View<Redemption> for RedemptionView {
                 tx_hash,
                 block_number,
                 detected_at,
+                reprocessed_at,
                 ..
             } => {
                 *self = Self::Detected {
@@ -259,6 +286,7 @@ impl View<Redemption> for RedemptionView {
                     tx_hash: *tx_hash,
                     block_number: *block_number,
                     detected_at: *detected_at,
+                    detected_entered_at: *reprocessed_at,
                 };
             }
             RedemptionEvent::AlpacaCalled {
@@ -331,6 +359,7 @@ impl View<Redemption> for RedemptionView {
                 dust_quantity,
                 called_at,
                 alpaca_journal_completed_at,
+                resumed_at,
                 ..
             } => {
                 *self = Self::Burning {
@@ -347,6 +376,7 @@ impl View<Redemption> for RedemptionView {
                     detected_at: *detected_at,
                     called_at: *called_at,
                     alpaca_journal_completed_at: *alpaca_journal_completed_at,
+                    burning_entered_at: *resumed_at,
                 };
             }
             RedemptionEvent::TokensBurned {
@@ -544,10 +574,12 @@ pub(crate) async fn find_burn_failed(
         .collect()
 }
 
-/// Finds all redemptions in Failed or BurnFailed states.
+/// Finds all redemptions that are not in a terminal state.
 ///
-/// These are redemptions that have terminally failed and need manual
-/// intervention via the reprocess endpoint.
+/// Returns every redemption whose view sits in `Detected`, `AlpacaCalled`,
+/// `Burning`, `Failed`, or `BurnFailed` — i.e. anything that hasn't reached
+/// `Completed` or `Closed`. Callers (`/admin/stuck`) apply the staleness gate
+/// and decide which entries the operator must act on.
 pub(crate) async fn find_stuck(
     pool: &Pool<Sqlite>,
 ) -> Result<Vec<(IssuerRedemptionRequestId, RedemptionView)>, RedemptionViewError>
@@ -556,8 +588,11 @@ pub(crate) async fn find_stuck(
         r#"
         SELECT view_id as "view_id!: String", payload as "payload!: String"
         FROM redemption_view
-        WHERE json_extract(payload, '$.Failed') IS NOT NULL
-           OR json_extract(payload, '$.BurnFailed') IS NOT NULL
+        WHERE json_extract(payload, '$.Detected')     IS NOT NULL
+           OR json_extract(payload, '$.AlpacaCalled') IS NOT NULL
+           OR json_extract(payload, '$.Burning')      IS NOT NULL
+           OR json_extract(payload, '$.Failed')       IS NOT NULL
+           OR json_extract(payload, '$.BurnFailed')   IS NOT NULL
         "#
     )
     .fetch_all(pool)
@@ -819,6 +854,7 @@ mod tests {
             tx_hash: view_tx_hash,
             block_number: view_block_number,
             detected_at: view_detected_at,
+            detected_entered_at: view_detected_entered_at,
         } = view
         else {
             panic!("Expected Detected view, got {view:?}");
@@ -832,6 +868,9 @@ mod tests {
         assert_eq!(view_tx_hash, tx_hash);
         assert_eq!(view_block_number, block_number);
         assert_eq!(view_detected_at, detected_at);
+        // On first Detection, detected_entered_at mirrors detected_at — the
+        // view has not yet been reprocessed.
+        assert_eq!(view_detected_entered_at, detected_at);
     }
 
     #[test]
@@ -988,6 +1027,7 @@ mod tests {
             detected_at: view_detected_at,
             called_at: view_called_at,
             alpaca_journal_completed_at: view_alpaca_journal_completed_at,
+            burning_entered_at: view_burning_entered_at,
         } = view
         else {
             panic!("Expected Burning view, got {view:?}");
@@ -1009,6 +1049,10 @@ mod tests {
             view_alpaca_journal_completed_at,
             alpaca_journal_completed_at
         );
+        // On the AlpacaJournalCompleted (happy) path, burning_entered_at
+        // mirrors alpaca_journal_completed_at — the view has not yet been
+        // resumed.
+        assert_eq!(view_burning_entered_at, alpaca_journal_completed_at);
     }
 
     #[test]
@@ -1694,11 +1738,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_stuck_returns_failed_and_burn_failed() {
+    async fn test_find_stuck_returns_all_non_terminal_variants() {
         let harness = TestHarness::new().await;
         let TestHarness { pool, cqrs } = &harness;
 
-        // Detected — not stuck
+        // Detected — stuck candidate (in-progress)
         let detected_id = IssuerRedemptionRequestId::random();
         harness
             .detect_redemption(
@@ -1711,7 +1755,36 @@ mod tests {
             )
             .await;
 
-        // Failed (AlpacaCallFailed) — stuck
+        // AlpacaCalled — stuck candidate (in-progress)
+        let alpaca_called_id = IssuerRedemptionRequestId::random();
+        harness
+            .detect_redemption(
+                &alpaca_called_id,
+                "GOOG",
+                address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+                30,
+                b256!("0x4444444444444444444444444444444444444444444444444444444444444444"),
+                11111,
+            )
+            .await;
+        harness.call_alpaca(&alpaca_called_id, "tok-alp-called").await;
+
+        // Burning — stuck candidate (in-progress)
+        let burning_id = IssuerRedemptionRequestId::random();
+        harness
+            .detect_redemption(
+                &burning_id,
+                "MSFT",
+                address!("0xdddddddddddddddddddddddddddddddddddddddd"),
+                40,
+                b256!("0x5555555555555555555555555555555555555555555555555555555555555555"),
+                22222,
+            )
+            .await;
+        harness.call_alpaca(&burning_id, "tok-burning").await;
+        harness.confirm_alpaca_complete(&burning_id).await;
+
+        // Failed (AlpacaCallFailed) — stuck (terminal fail)
         let failed_id = IssuerRedemptionRequestId::random();
         harness
             .detect_redemption(
@@ -1775,27 +1848,64 @@ mod tests {
         harness.confirm_alpaca_complete(&completed_id).await;
         harness.burn_tokens(&completed_id).await;
 
+        // Closed — not stuck (admin close path). CloseRedemption requires
+        // the aggregate to be Failed first.
+        let closed_id = IssuerRedemptionRequestId::random();
+        harness
+            .detect_redemption(
+                &closed_id,
+                "NFLX",
+                address!("0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"),
+                10,
+                b256!("0x6666666666666666666666666666666666666666666666666666666666666666"),
+                33333,
+            )
+            .await;
+        cqrs.execute(
+            &closed_id.to_string(),
+            RedemptionCommand::RecordAlpacaFailure {
+                issuer_request_id: closed_id.clone(),
+                error: "alpaca down".to_string(),
+            },
+        )
+        .await
+        .expect("Failed to fail redemption before close");
+        cqrs.execute(
+            &closed_id.to_string(),
+            RedemptionCommand::CloseRedemption {
+                issuer_request_id: closed_id.clone(),
+                reason: "closed by admin".to_string(),
+            },
+        )
+        .await
+        .expect("Failed to close redemption");
+
         let result = find_stuck(pool).await.unwrap();
 
-        assert_eq!(result.len(), 2, "Expected 2 stuck (Failed + BurnFailed)");
-
         let ids: Vec<_> = result.iter().map(|(id, _)| id.clone()).collect();
-        assert!(ids.contains(&failed_id), "Should include Failed redemption");
-        assert!(
-            ids.contains(&burn_failed_id),
-            "Should include BurnFailed redemption"
+        assert_eq!(
+            result.len(),
+            5,
+            "Expected 5 non-terminal redemptions, got ids: {ids:?}"
         );
+        assert!(ids.contains(&detected_id));
+        assert!(ids.contains(&alpaca_called_id));
+        assert!(ids.contains(&burning_id));
+        assert!(ids.contains(&failed_id));
+        assert!(ids.contains(&burn_failed_id));
+        assert!(!ids.contains(&completed_id), "Completed must be filtered out");
+        assert!(!ids.contains(&closed_id), "Closed must be filtered out");
     }
 
     #[tokio::test]
-    async fn test_find_stuck_returns_empty_when_none_stuck() {
+    async fn test_find_stuck_returns_empty_when_only_completed() {
         let harness = TestHarness::new().await;
         let TestHarness { pool, .. } = &harness;
 
-        let detected_id = IssuerRedemptionRequestId::random();
+        let completed_id = IssuerRedemptionRequestId::random();
         harness
             .detect_redemption(
-                &detected_id,
+                &completed_id,
                 "AAPL",
                 address!("0x1234567890abcdef1234567890abcdef12345678"),
                 100,
@@ -1803,6 +1913,9 @@ mod tests {
                 12345,
             )
             .await;
+        harness.call_alpaca(&completed_id, "tok-only-completed").await;
+        harness.confirm_alpaca_complete(&completed_id).await;
+        harness.burn_tokens(&completed_id).await;
 
         let result = find_stuck(pool).await.unwrap();
         assert!(result.is_empty());
@@ -1852,7 +1965,9 @@ mod tests {
 
         assert!(matches!(view, RedemptionView::Failed { .. }));
 
-        // Reprocess back to Detected
+        // Reprocess back to Detected. Use a reprocessed_at distinct from
+        // detected_at so the projection's distinction is observable.
+        let reprocessed_at = detected_at + chrono::Duration::days(2);
         view.update(&make_detected_envelope(
             &id,
             3,
@@ -1866,13 +1981,15 @@ mod tests {
                 block_number,
                 detected_at,
                 previous_state: "Failed".to_string(),
-                reprocessed_at: Utc::now(),
+                reprocessed_at,
             },
         ));
 
         let RedemptionView::Detected {
             issuer_request_id: view_id,
             underlying: view_underlying,
+            detected_at: view_detected_at,
+            detected_entered_at: view_detected_entered_at,
             ..
         } = view
         else {
@@ -1881,6 +1998,11 @@ mod tests {
 
         assert_eq!(view_id, issuer_request_id);
         assert_eq!(view_underlying, underlying);
+        // Reprocessed preserves the original detected_at for audit, but
+        // updates detected_entered_at to reprocessed_at so the staleness
+        // gate (and admin triage timestamp) reflects the most recent entry.
+        assert_eq!(view_detected_at, detected_at);
+        assert_eq!(view_detected_entered_at, reprocessed_at);
     }
 
     #[test]
@@ -1904,6 +2026,7 @@ mod tests {
         let called_at = Utc::now();
         let alpaca_journal_completed_at = Utc::now();
 
+        let resumed_at = Utc::now();
         view.update(&EventEnvelope::<Redemption> {
             aggregate_id: issuer_request_id.to_string(),
             sequence: 1,
@@ -1922,7 +2045,7 @@ mod tests {
                 called_at,
                 alpaca_journal_completed_at,
                 external_tx_id: None,
-                resumed_at: Utc::now(),
+                resumed_at,
             },
             metadata: HashMap::default(),
         });
@@ -1941,6 +2064,7 @@ mod tests {
             detected_at: view_detected_at,
             called_at: view_called_at,
             alpaca_journal_completed_at: view_journal_completed_at,
+            burning_entered_at: view_burning_entered_at,
         } = view
         else {
             panic!("Expected Burning view after BurnResumed, got {view:?}");
@@ -1959,6 +2083,9 @@ mod tests {
         assert_eq!(view_detected_at, detected_at);
         assert_eq!(view_called_at, called_at);
         assert_eq!(view_journal_completed_at, alpaca_journal_completed_at);
+        // BurnResumed re-enters Burning, so burning_entered_at tracks
+        // resumed_at — NOT the (older) alpaca_journal_completed_at.
+        assert_eq!(view_burning_entered_at, resumed_at);
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`/admin/stuck` returned `[]` on prod even though two redemptions had been sitting in `Burning` for over a week with no operator visibility:

- `red-79631d72` — ARKK, 17.08 shares, `AlpacaJournalCompleted` 2026-05-14 (13d)
- `red-742f9f3a` — QQQM, 1.57 shares, `BurnResumed` after admin recovery 2026-05-20 (7d)

Root cause: `find_stuck` only returned redemptions in `Failed`/`BurnFailed`. Neither aggregate ever emitted a terminal failure event, because `BurnManager::recover_single_burning` (`src/redemption/burn_manager.rs:678-696`) intentionally bails out when `on_chain_balance < total_shares_needed` — returning `RecoveryOutcome::SkippedManualIntervention` to avoid double-burning a transaction that may have already landed. The WARN log was the only signal, and the endpoint stayed empty.

The same gap applies to mints stuck in `Initiated` / `JournalConfirmed` / `Minting` / `CallbackPending` without a terminal event.

Closes [RAI-699](https://linear.app/makeitrain/issue/RAI-699/adminstuck-endpoint-misses-stuck-non-terminal-aggregates).

## Solution

Widen `/admin/stuck` to flag any aggregate that hasn't reached a terminal state and either has landed in a terminal-failure state (always listed) or has been sitting in an in-progress state longer than `STUCK_THRESHOLD = 1h` (every legitimate state transition takes seconds to a few minutes).

**Query layer**

- `src/redemption/view.rs::find_stuck` — widened SQL to return every redemption in `Detected`, `AlpacaCalled`, `Burning`, `Failed`, or `BurnFailed` (everything but `Completed`/`Closed`/`Unavailable`).
- `src/mint/view.rs::find_stuck` — new sibling that returns every mint in `Initiated`, `JournalConfirmed`, `JournalRejected`, `Minting`, `CallbackPending`, or `MintingFailed`. `find_all_recoverable_mints` is left untouched — the auto-recovery loop only knows how to drive its current four states, and feeding it the others would break that contract.

**Classification & projection (`src/admin.rs::list_stuck`)**

- `redemption_stuck_info(view) -> Option<(StuckClass, DateTime<Utc>)>` and `mint_view_summary(view) -> Option<MintStuckSummary>` classify each view as `InProgress` or `TerminalFail` and emit the state-entered timestamp in one step — there's no separate timestamp helper to forget, so no sentinel value can ever exist for a terminal/unavailable variant.
- `is_stuck` keeps every `TerminalFail` and gates every `InProgress` on `now - state_timestamp >= STUCK_THRESHOLD`.
- `MintStuckSummary` is a named struct (not a tuple): adjacent `String` fields (`state`, `detail`) are position-safe by construction.
- `stuck_redemption_entry` takes the view by value and moves its fields out; the in-progress arms (`Detected`/`AlpacaCalled`/`Burning`) project directly from the view, falling back to event-history only for `Failed`.
- For `Burning`, the operator-facing `detail` branches on `history.fireblocks_tx_id`: pre-submission shows "Waiting for burn submission", post-submission shows "Waiting for burn confirmation".

**View-side timestamps for "most recent entry"**

To make the staleness gate and operator-facing timestamp reflect the *latest* entry into a state (not the original detection or journal completion):

- `RedemptionView::Burning` gains `burning_entered_at`. Set from `alpaca_journal_completed_at` on the happy path; from `BurnResumed.resumed_at` when a redemption resumes burning. `redemption_stuck_info` and `stuck_redemption_entry` both read this field.
- `RedemptionView::Detected` gains `detected_entered_at`. Set from `detected_at` on first detection; from `Reprocessed.reprocessed_at` when an operator reprocesses a stuck redemption — otherwise a freshly reprocessed redemption would immediately re-trip the 1h gate from the original detection time, masking the recovery attempt.
- View backfill: `replay_redemption_view`/`replay_mint_view` already run on startup (`src/lib.rs:291-292`) and rebuild the view from events, so the new fields populate correctly on the first deploy without a serde default.

**History-scan correctness**

- `redemption_history_summary` is split into a pure `redemption_history_summary_from_events` reducer (testable without an event store) plus a thin async loader.
- On `Reprocessed` or `BurnResumed`, the reducer resets `summary.fireblocks_tx_id = None`: a fresh attempt must not inherit a prior failed/submitted Fireblocks tx id, otherwise the new Burning detail would mislabel a not-yet-submitted retry as "Waiting for burn confirmation".

A follow-up worth flagging separately: `SkippedManualIntervention` should probably become a first-class state/event so this class of stuck aggregate surfaces directly instead of relying on the staleness heuristic. Out of scope here.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

New tests in `src/admin.rs`:

- `is_stuck_terminal_fail_always_true_regardless_of_age`
- `is_stuck_in_progress_uses_one_hour_threshold` (boundary at 59m / exactly 1h / 13h)
- `redemption_stuck_info_classifies_and_timestamps_each_variant` — exhaustively covers all 8 variants including `BurnFailed`, asserting both `StuckClass` and the state-entered timestamp; uses distinct `alpaca_journal_completed_at` vs `burning_entered_at` to verify the projection picks the right field.
- `mint_view_summary_classifies_and_timestamps_each_variant` — covers all 6 in-progress + terminal-fail variants plus `Completed`/`Closed`/`NotFound` returning `None`, with `detail` assertions to pin the named-struct positional invariant.
- `stuck_redemption_entry_handles_in_progress_variants` — exercises projection for `Detected`/`AlpacaCalled`/`Burning`, plus a second `Burning` case where `history.fireblocks_tx_id.is_some()` flips the detail to "Waiting for burn confirmation".
- `redemption_history_summary_clears_fireblocks_tx_id_on_burn_resumed` — regression test for the event sequence Detected → AlpacaCalled → AlpacaJournalCompleted → BurnFireblocksSubmitted → BurningFailed → RedemptionFailed → BurnResumed; asserts the summary returns `fireblocks_tx_id: None` so the freshly resumed Burning row doesn't mislabel.

New tests in view modules:

- `src/redemption/view.rs::test_find_stuck_returns_all_non_terminal_variants` — seeds Detected / AlpacaCalled / Burning / Failed / BurnFailed (via real CQRS), asserts all five appear and Completed/Closed are filtered out.
- `src/redemption/view.rs::test_find_stuck_returns_empty_when_only_completed`.
- `src/mint/view.rs::test_find_stuck_returns_all_non_terminal_variants` — seeds all 6 in-progress/terminal-fail variants, asserts Completed/Closed filtered out.
- Extended `test_view_updates_on_detected_event` and `test_view_updates_on_burn_resumed_event` to assert `detected_entered_at`/`burning_entered_at` are sourced from the right event field on each transition; new assertions in `test_view_updates_on_reprocessed_event` verify `detected_at` is preserved for audit while `detected_entered_at` advances to `reprocessed_at`.

Tested with:

- `cargo test --workspace` (644 lib + 21 integration/e2e, all green)
- `cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Implemented time-based stuck transaction classification using a 1-hour threshold
  * Enhanced state transition tracking with timestamps for improved visibility into transaction progression
  * Improved stuck transaction detection and aggregation for both redemptions and mints

* **Bug Fixes**
  * Fixed transaction metadata handling during retries to prevent incorrect state labeling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ST0x-Technology/st0x.issuance/pull/166?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->