### PR TITLE
feat: terminalize redemptions stuck in Burning (force-complete + close)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -250,8 +250,14 @@ Bug fixes and improvements that don't fit into the original phases.
       MintView silently drops ExistingMintRecovered and MintCompleted events
       from MintingFailed state
   - **PR:** [#127](https://github.com/ST0x-Technology/st0x.issuance/pull/127)
-- [ ] [#88](https://github.com/ST0x-Technology/st0x.issuance/issues/88) - Add
+- [x] [#88](https://github.com/ST0x-Technology/st0x.issuance/issues/88) - Add
       automatic recovery for burns detected as already completed on-chain
+  - Closed NOT_PLANNED on GitHub; revived and resolved as
+    [RAI-799](https://linear.app/makeitrain/issue/RAI-799). Resolved via admin
+    paths rather than fully-automatic recovery: `force-complete` records an
+    on-chain-verified burn tx (terminalizes to `Completed`), and `close` (now
+    valid from `Burning`) handles ambiguous cases.
+  - **PR:** [#169](https://github.com/ST0x-Technology/st0x.issuance/pull/169)
 - [ ] [#110](https://github.com/ST0x-Technology/st0x.issuance/issues/110) -
       IssuerRedemptionRequestId has 4-byte ID space with collision risk at scale
 - [x] [#111](https://github.com/ST0x-Technology/st0x.issuance/issues/111) -

--- a/SPEC.md
+++ b/SPEC.md
@@ -343,6 +343,26 @@ on-chain transfer through calling Alpaca to burning tokens.
   Fireblocks accepts it, recovery reuses the same retry id. Emits `BurnResumed`
   event. The admin recovery path immediately invokes burn recovery in-process so
   the on-chain burn does not wait for a service restart.
+- `CloseRedemption { issuer_request_id, reason }` - Admin-close a redemption
+  that cannot be automatically recovered, recording an operator `reason`. Valid
+  from `Failed`, `Burning`, or `BurnSubmitted`. This is the honest terminal path
+  for a redemption whose burn cannot or should not be re-submitted and is
+  **not** verifiable on-chain (e.g. a `Failed -> Burning` recovery regression
+  where no burn ever landed, or an ambiguous case pending off-chain
+  reconciliation). A held receipt reservation is **left in place** (the
+  conservative policy for `Closed`), since an ambiguous burn may still have
+  landed. Emits `RedemptionClosed`.
+- `ForceCompleteBurn { issuer_request_id, burn_tx_hash, block_number, reason }` -
+  Admin-terminalize a redemption stuck in `Burning`/`BurnSubmitted` whose burn
+  **already landed on-chain** but was never recorded (e.g. the bot crashed
+  between the burn and `TokensBurned`). The admin layer verifies the
+  operator-supplied `burn_tx_hash` on-chain first — the receipt must have
+  succeeded and contain a real burn (`Transfer(bot_wallet -> 0x0)`) of the
+  vault's shares — then records the proving tx hash and block number. The
+  receipt reservation is settled (mirror reduced) just like a normal burn
+  completion. Emits `BurnForceCompleted`, transitioning to `Completed`.
+  Ambiguous cases with no verifiable on-chain burn are **not** force-completed;
+  ops use `CloseRedemption` (or reconcile first) instead.
 
 **Events:**
 
@@ -364,6 +384,12 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `BurningFailed` - On-chain burn failed. Carries optional `fireblocks_tx_id`
   and `planned_burns` for recovery of previously submitted transactions
 - `ExistingBurnRecovered` - Existing on-chain burn discovered during recovery
+- `RedemptionClosed` - Admin-closed redemption (terminal). Carries the operator
+  `reason` and `closed_at`. Closed redemptions do not appear in stuck queries.
+- `BurnForceCompleted` - Admin-recorded terminal success for a stuck
+  `Burning`/`BurnSubmitted` redemption whose burn was verified on-chain. Carries
+  the proving `burn_tx_hash`, `block_number`, operator `reason`, and
+  `completed_at`. Transitions to `Completed` (terminal success).
 - `Reprocessed` - Redemption reset to `Detected` state for reprocessing. Carries
   the original `RedemptionMetadata`, the previous state name, and a timestamp.
   Used for audit trail — shows when and from what state a manual reprocess was
@@ -377,18 +403,20 @@ on-chain transfer through calling Alpaca to burning tokens.
 
 **Command -> Event Mappings:**
 
-| Command                 | Events                    | Notes                                      |
-| ----------------------- | ------------------------- | ------------------------------------------ |
-| `DetectRedemption`      | `RedemptionDetected`      | Transfer detected                          |
-| `RecordAlpacaCall`      | `AlpacaCalled`            | Alpaca API called                          |
-| `RecordAlpacaFailure`   | `AlpacaCallFailed`        | Terminal failure                           |
-| `ConfirmAlpacaComplete` | `AlpacaJournalCompleted`  | Journal complete                           |
-| `BurnTokens`            | `BurnFireblocksSubmitted` | Submits to signing backend                 |
-| `ConfirmBurn`           | `TokensBurned`            | Confirms burn, terminal success            |
-| `RecordBurnFailure`     | `BurningFailed`           | Records failure with optional tx metadata  |
-| `RecordExistingBurn`    | `ExistingBurnRecovered`   | Recovery from Failed with known tx         |
-| `Reprocess`             | `Reprocessed`             | Reset to Detected for reprocessing         |
-| `ResumeBurn`            | `BurnResumed`             | Resume to Burning for post-Alpaca recovery |
+| Command                 | Events                    | Notes                                         |
+| ----------------------- | ------------------------- | --------------------------------------------- |
+| `DetectRedemption`      | `RedemptionDetected`      | Transfer detected                             |
+| `RecordAlpacaCall`      | `AlpacaCalled`            | Alpaca API called                             |
+| `RecordAlpacaFailure`   | `AlpacaCallFailed`        | Terminal failure                              |
+| `ConfirmAlpacaComplete` | `AlpacaJournalCompleted`  | Journal complete                              |
+| `BurnTokens`            | `BurnFireblocksSubmitted` | Submits to signing backend                    |
+| `ConfirmBurn`           | `TokensBurned`            | Confirms burn, terminal success               |
+| `RecordBurnFailure`     | `BurningFailed`           | Records failure with optional tx metadata     |
+| `RecordExistingBurn`    | `ExistingBurnRecovered`   | Recovery from Failed with known tx            |
+| `Reprocess`             | `Reprocessed`             | Reset to Detected for reprocessing            |
+| `ResumeBurn`            | `BurnResumed`             | Resume to Burning for post-Alpaca recovery    |
+| `CloseRedemption`       | `RedemptionClosed`        | Admin close from Failed/Burning/BurnSubmitted |
+| `ForceCompleteBurn`     | `BurnForceCompleted`      | Admin terminalize a verified-on-chain burn    |
 
 ### Account Aggregate
 
@@ -1582,12 +1610,21 @@ stateDiagram-v2
     AlpacaCalled --> Burning: ConfirmAlpacaComplete
     AlpacaCalled --> Failed: RecordAlpacaFailure / MarkFailed
     Burning --> Completed: RecordBurnSuccess
+    Burning --> BurnSubmitted: BurnTokens (BurnFireblocksSubmitted)
     Burning --> Failed: RecordBurnFailure / MarkFailed
+    Burning --> Completed: ForceCompleteBurn (admin, verified on-chain)
+    Burning --> Closed: CloseRedemption (admin)
+    BurnSubmitted --> Completed: ConfirmBurn (TokensBurned)
+    BurnSubmitted --> Failed: RecordBurnFailure / MarkFailed
+    BurnSubmitted --> Completed: ForceCompleteBurn (admin, verified on-chain)
+    BurnSubmitted --> Closed: CloseRedemption (admin)
     Failed --> Failed: MarkFailed (re-classify failure)
     Failed --> Detected: Reprocess (pre-Alpaca)
     Failed --> Burning: ResumeBurn (post-Alpaca)
+    Failed --> Closed: CloseRedemption (admin)
     Failed --> [*]
     Completed --> [*]
+    Closed --> [*]
 ```
 
 **Data Structures:**

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,7 +1,7 @@
 use alloy::primitives::B256;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use cqrs_es::{AggregateError, EventStore};
+use cqrs_es::{Aggregate, AggregateError, EventStore};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{get, post};
@@ -29,7 +29,9 @@ use crate::redemption::{
     next_burn_retry_external_tx_id_from_history,
 };
 use crate::tokenized_asset::UnderlyingSymbol;
-use crate::vault::{FireblocksTxStatus, VaultService};
+use crate::vault::{
+    BurnVerification, FireblocksTxStatus, VaultError, VaultService,
+};
 use crate::{
     MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore,
     SqliteEventStore,
@@ -41,6 +43,16 @@ pub(crate) trait RedemptionBurnRecovery: Send + Sync {
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<RecoveryOutcome, BurnManagerError>;
+
+    /// Terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose burn
+    /// already landed on-chain, after verifying `burn_tx_hash` against the
+    /// chain. Returns the on-chain verification for the admin response.
+    async fn force_complete_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        reason: String,
+    ) -> Result<BurnVerification, BurnManagerError>;
 }
 
 #[async_trait]
@@ -50,6 +62,15 @@ impl RedemptionBurnRecovery for BurnManager<SqliteEventStore<Redemption>> {
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
         self.recover_burning_redemption(issuer_request_id).await
+    }
+
+    async fn force_complete_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        reason: String,
+    ) -> Result<BurnVerification, BurnManagerError> {
+        self.force_complete_burn(issuer_request_id, burn_tx_hash, reason).await
     }
 }
 
@@ -680,10 +701,15 @@ pub(crate) struct CloseRedemptionRequest {
     reason: String,
 }
 
-/// Admin endpoint to close a failed redemption that cannot be automatically recovered.
+/// Admin endpoint to close a redemption that cannot be automatically recovered.
 ///
-/// Only valid from `Failed` state. Closed redemptions do not appear in stuck queries.
-#[tracing::instrument(skip(_auth, cqrs))]
+/// Valid from `Failed`, `Burning`, or `BurnSubmitted` — the honest terminal
+/// path for a redemption whose burn is not verifiable on-chain (e.g. a
+/// `Failed -> Burning` recovery regression, or an ambiguous case pending
+/// off-chain reconciliation). For a redemption whose burn *did* land on-chain,
+/// use `/admin/force-complete/redemption` instead. Closed redemptions do not
+/// appear in stuck queries.
+#[tracing::instrument(skip(_auth, cqrs, event_store))]
 #[post(
     "/admin/close/redemption/<issuer_request_id>",
     format = "json",
@@ -692,6 +718,7 @@ pub(crate) struct CloseRedemptionRequest {
 pub(crate) async fn close_redemption(
     _auth: InternalAuth,
     cqrs: &rocket::State<RedemptionCqrs>,
+    event_store: &rocket::State<RedemptionEventStore>,
     issuer_request_id: IssuerRedemptionRequestId,
     body: Json<CloseRedemptionRequest>,
 ) -> Result<Json<ReprocessResponse>, Status> {
@@ -713,16 +740,140 @@ pub(crate) async fn close_redemption(
         map_redemption_error(&err)
     })?;
 
+    let previous_state =
+        redemption_state_before_last_event(event_store.inner(), &aggregate_id)
+            .await?;
+
     info!(target: "admin", aggregate_id = %aggregate_id,
+        previous_state = %previous_state,
         "Redemption closed"
     );
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Redemption,
         aggregate_id,
-        previous_state: "Failed".to_string(),
+        previous_state,
         message: "Redemption closed by admin".to_string(),
     }))
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ForceCompleteRedemptionRequest {
+    /// On-chain transaction hash that burned the redemption's shares. Verified
+    /// against the chain before the redemption is terminalized.
+    burn_tx_hash: B256,
+    /// Operator-supplied audit reason recorded with the terminal event.
+    reason: String,
+}
+
+/// Admin endpoint to terminalize a redemption stuck in `Burning`/`BurnSubmitted`
+/// whose burn already landed on-chain but was never recorded.
+///
+/// The supplied `burn_tx_hash` is verified on-chain (the receipt must have
+/// succeeded and contain a real `Transfer(bot_wallet -> 0x0)` of the vault's
+/// shares) before the redemption is moved to `Completed`, recording the proving
+/// tx hash for audit. Ambiguous cases with no verifiable on-chain burn are
+/// rejected (`422`) — use `/admin/close/redemption` for those.
+#[tracing::instrument(skip(_auth, event_store, burn_recovery))]
+#[post(
+    "/admin/force-complete/redemption/<issuer_request_id>",
+    format = "json",
+    data = "<body>"
+)]
+pub(crate) async fn force_complete_redemption(
+    _auth: InternalAuth,
+    event_store: &rocket::State<RedemptionEventStore>,
+    burn_recovery: &rocket::State<Arc<dyn RedemptionBurnRecovery>>,
+    issuer_request_id: IssuerRedemptionRequestId,
+    body: Json<ForceCompleteRedemptionRequest>,
+) -> Result<Json<ReprocessResponse>, Status> {
+    let aggregate_id = issuer_request_id.to_string();
+    let ForceCompleteRedemptionRequest { burn_tx_hash, reason } =
+        body.into_inner();
+
+    let verification = burn_recovery
+        .force_complete_burn(&issuer_request_id, burn_tx_hash, reason)
+        .await
+        .map_err(|err| {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                error = %err,
+                "Failed to force-complete redemption"
+            );
+            map_burn_manager_error(&err)
+        })?;
+
+    let previous_state =
+        redemption_state_before_last_event(event_store.inner(), &aggregate_id)
+            .await?;
+
+    info!(target: "admin", aggregate_id = %aggregate_id,
+        burn_tx_hash = ?burn_tx_hash,
+        block_number = verification.block_number,
+        previous_state = %previous_state,
+        "Redemption force-completed"
+    );
+
+    Ok(Json(ReprocessResponse {
+        aggregate_type: AggregateKind::Redemption,
+        aggregate_id,
+        previous_state,
+        message: format!(
+            "Force-completed: burn verified on-chain at block {} ({} shares)",
+            verification.block_number, verification.shares_burned
+        ),
+    }))
+}
+
+/// Reconstructs a redemption's state immediately *before* its most recent event
+/// — the state the just-applied terminal command transitioned from — for admin
+/// response/audit reporting.
+///
+/// Read *after* the terminal command commits, not as a preflight load, so it
+/// cannot report a state the command never observed: background recovery and the
+/// transfer poller can advance the aggregate between a preflight read and the
+/// command. Both terminal admin commands (`CloseRedemption`, `ForceCompleteBurn`)
+/// append exactly one event, so replaying every event except the last yields the
+/// pre-transition state. An aggregate with no prior events resolves to
+/// `Uninitialized`.
+async fn redemption_state_before_last_event(
+    event_store: &RedemptionEventStore,
+    aggregate_id: &str,
+) -> Result<String, Status> {
+    let events =
+        event_store.load_events(aggregate_id).await.map_err(|err| {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                error = %err,
+                "Failed to load redemption events"
+            );
+            Status::InternalServerError
+        })?;
+
+    let mut prior = Redemption::default();
+    let pre_terminal = events.len().saturating_sub(1);
+    for envelope in events.into_iter().take(pre_terminal) {
+        prior.apply(envelope.payload);
+    }
+
+    Ok(prior.state_name().to_string())
+}
+
+/// Maps a burn-manager failure to an HTTP status for the force-complete
+/// endpoint. A bad operator-supplied hash or wrong aggregate state is a client
+/// error (`422`); an on-chain/RPC failure is `502`; anything else is `500`.
+const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
+    match err {
+        BurnManagerError::Vault(
+            VaultError::InvalidReceipt
+            | VaultError::NotABurn { .. }
+            | VaultError::Reverted { .. },
+        )
+        | BurnManagerError::InvalidAggregateState { .. }
+        | BurnManagerError::Cqrs(AggregateError::UserError(_)) => {
+            Status::UnprocessableEntity
+        }
+        BurnManagerError::Vault(_) => Status::BadGateway,
+        _ => Status::InternalServerError,
+    }
 }
 
 #[tracing::instrument(skip(_auth, cqrs, event_store, pool))]
@@ -1539,9 +1690,20 @@ mod tests {
         Fails,
     }
 
+    /// Configurable result for `MockBurnRecovery::force_complete_burn`.
+    #[derive(Clone, Copy)]
+    enum MockForceResult {
+        /// On-chain verification succeeded; report this block number.
+        Verified,
+        /// The operator-supplied hash is not a verifiable burn.
+        NotABurn,
+    }
+
     struct MockBurnRecovery {
         calls: AtomicUsize,
         result: MockBurnResult,
+        force_calls: AtomicUsize,
+        force_result: MockForceResult,
     }
 
     impl Default for MockBurnRecovery {
@@ -1551,6 +1713,8 @@ mod tests {
                 result: MockBurnResult::Succeeds(
                     super::RecoveryOutcome::Executed,
                 ),
+                force_calls: AtomicUsize::new(0),
+                force_result: MockForceResult::Verified,
             }
         }
     }
@@ -1558,6 +1722,10 @@ mod tests {
     impl MockBurnRecovery {
         fn calls(&self) -> usize {
             self.calls.load(Ordering::Relaxed)
+        }
+
+        fn force_calls(&self) -> usize {
+            self.force_calls.load(Ordering::Relaxed)
         }
     }
 
@@ -1572,6 +1740,26 @@ mod tests {
                 MockBurnResult::Succeeds(outcome) => Ok(outcome),
                 MockBurnResult::Fails => {
                     Err(super::BurnManagerError::SharesOverflow)
+                }
+            }
+        }
+
+        async fn force_complete_burn(
+            &self,
+            _issuer_request_id: &IssuerRedemptionRequestId,
+            burn_tx_hash: alloy::primitives::B256,
+            _reason: String,
+        ) -> Result<super::BurnVerification, super::BurnManagerError> {
+            self.force_calls.fetch_add(1, Ordering::Relaxed);
+            match self.force_result {
+                MockForceResult::Verified => Ok(super::BurnVerification {
+                    block_number: 45_989_009,
+                    shares_burned: alloy::primitives::U256::from(17u64),
+                }),
+                MockForceResult::NotABurn => {
+                    Err(super::BurnManagerError::Vault(
+                        super::VaultError::NotABurn { tx_hash: burn_tx_hash },
+                    ))
                 }
             }
         }
@@ -2647,6 +2835,214 @@ mod tests {
         ));
     }
 
+    /// Drives a redemption to `Burning` state (post-journal, pre-burn) — the
+    /// state stuck redemptions wedge in.
+    async fn setup_burning(
+        cqrs: &Arc<SqliteCqrs<Redemption>>,
+    ) -> RedemptionMetadata {
+        let metadata = test_metadata();
+        let alpaca_data = test_alpaca_data();
+        let aggregate_id = metadata.issuer_request_id.to_string();
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::Detect {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                underlying: metadata.underlying.clone(),
+                token: metadata.token.clone(),
+                wallet: metadata.wallet,
+                quantity: metadata.quantity.clone(),
+                tx_hash: metadata.detected_tx_hash,
+                block_number: metadata.block_number,
+            },
+        )
+        .await
+        .expect("Detect failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::RecordAlpacaCall {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                tokenization_request_id: alpaca_data
+                    .tokenization_request_id
+                    .clone(),
+                alpaca_quantity: alpaca_data.alpaca_quantity.clone(),
+                dust_quantity: alpaca_data.dust_quantity.clone(),
+            },
+        )
+        .await
+        .expect("RecordAlpacaCall failed");
+
+        cqrs.execute(
+            &aggregate_id,
+            RedemptionCommand::ConfirmAlpacaComplete {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+            },
+        )
+        .await
+        .expect("ConfirmAlpacaComplete failed");
+
+        metadata
+    }
+
+    fn force_complete_rocket(
+        event_store: TestEventStore,
+        burn_recovery: Arc<dyn super::RedemptionBurnRecovery>,
+    ) -> rocket::Rocket<rocket::Build> {
+        use crate::alpaca::service::AlpacaConfig;
+        use crate::auth::{FailedAuthRateLimiter, test_auth_config};
+        use crate::config::{Config, LogLevel};
+        use crate::fireblocks::SignerConfig;
+        use alloy::primitives::B256;
+        use url::Url;
+
+        let config = Config {
+            database_url: "sqlite::memory:".to_string(),
+            database_max_connections: 5,
+            rpc_url: Url::parse("wss://localhost:8545").unwrap(),
+            chain_id: crate::test_utils::ANVIL_CHAIN_ID,
+            signer: SignerConfig::Local(B256::ZERO),
+            backfill_start_block: 0,
+            auth: test_auth_config().unwrap(),
+            log_level: LogLevel::Debug,
+            hyperdx: None,
+            alpaca: AlpacaConfig::test_default(),
+            subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
+            receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
+        };
+
+        rocket::build()
+            .manage(config)
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(event_store)
+            .manage(burn_recovery)
+            .mount("/", rocket::routes![super::force_complete_redemption])
+    }
+
+    async fn dispatch_force_complete(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        body: &str,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+
+        let response = client
+            .post(format!(
+                "/admin/force-complete/redemption/{issuer_request_id}"
+            ))
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(body)
+            .dispatch()
+            .await;
+
+        let status = response.status();
+        let body = response.into_string().await.unwrap();
+        (status, body)
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_force_complete_records_verified_burn() {
+        let pool = setup_pool().await;
+        let (cqrs, event_store) = setup_cqrs(&pool);
+        let metadata = setup_burning(&cqrs).await;
+
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket = force_complete_rocket(event_store, burn_recovery_state);
+        let body = r#"{"burn_tx_hash":"0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf","reason":"burn confirmed on-chain"}"#;
+
+        let (status, body) =
+            dispatch_force_complete(rocket, &metadata.issuer_request_id, body)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        // Response reports the proven block and the true previous state.
+        assert!(body.contains("Force-completed"), "body: {body}");
+        assert!(body.contains("45989009"), "body: {body}");
+        assert!(body.contains("Burning"), "body: {body}");
+        assert_eq!(burn_recovery.force_calls(), 1);
+        assert!(logs_contain_at!(Level::INFO, &["Redemption force-completed"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_force_complete_unverifiable_returns_422() {
+        let pool = setup_pool().await;
+        let (cqrs, event_store) = setup_cqrs(&pool);
+        let metadata = setup_burning(&cqrs).await;
+
+        // Verification fails: the operator-supplied hash is not a burn.
+        let burn_recovery = Arc::new(MockBurnRecovery {
+            force_result: MockForceResult::NotABurn,
+            ..Default::default()
+        });
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket = force_complete_rocket(event_store, burn_recovery_state);
+        let body = r#"{"burn_tx_hash":"0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf","reason":"not actually a burn"}"#;
+
+        let (status, _body) =
+            dispatch_force_complete(rocket, &metadata.issuer_request_id, body)
+                .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(burn_recovery.force_calls(), 1);
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &["Failed to force-complete redemption"]
+        ));
+    }
+
+    #[test]
+    fn map_burn_manager_error_classifies_statuses() {
+        use super::map_burn_manager_error;
+
+        let tx = alloy::primitives::B256::ZERO;
+
+        assert_eq!(
+            map_burn_manager_error(&super::BurnManagerError::Vault(
+                super::VaultError::NotABurn { tx_hash: tx }
+            )),
+            Status::UnprocessableEntity
+        );
+        assert_eq!(
+            map_burn_manager_error(&super::BurnManagerError::Vault(
+                super::VaultError::Reverted { tx_hash: tx }
+            )),
+            Status::UnprocessableEntity
+        );
+        assert_eq!(
+            map_burn_manager_error(
+                &super::BurnManagerError::InvalidAggregateState {
+                    current_state: "Completed".to_string()
+                }
+            ),
+            Status::UnprocessableEntity
+        );
+        // A hash that resolves to no receipt (or one that doesn't prove a burn)
+        // is an unverifiable operator-supplied input, not an upstream failure.
+        assert_eq!(
+            map_burn_manager_error(&super::BurnManagerError::Vault(
+                super::VaultError::InvalidReceipt
+            )),
+            Status::UnprocessableEntity
+        );
+        assert_eq!(
+            map_burn_manager_error(&super::BurnManagerError::SharesOverflow),
+            Status::InternalServerError
+        );
+    }
+
     /// Stub VaultService that returns a pre-canned `FireblocksTxStatus` for a
     /// specific tx id and `None` for everything else. Lets us drive
     /// `enrich_with_fireblocks_status` without spinning up Fireblocks.
@@ -2711,6 +3107,16 @@ mod tests {
             _fireblocks_tx_id: &str,
             _dust_shares: alloy::primitives::U256,
         ) -> Result<crate::vault::MultiBurnResult, crate::vault::VaultError>
+        {
+            unimplemented!("not used in enrichment tests")
+        }
+
+        async fn verify_burn_tx(
+            &self,
+            _vault: alloy::primitives::Address,
+            _owner: alloy::primitives::Address,
+            _tx_hash: alloy::primitives::B256,
+        ) -> Result<crate::vault::BurnVerification, crate::vault::VaultError>
         {
             unimplemented!("not used in enrichment tests")
         }

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -24,8 +24,9 @@ use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
 use crate::vault::rain_meta::OaSchemaCache;
 use crate::vault::{
-    MintResult, MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
+    MultiBurnResultEntry, ReceiptInformation, SubmittedTx, VaultError,
+    VaultService, verify_burn_in_receipt,
 };
 
 /// Fireblocks-specific errors that can occur during vault operations.
@@ -831,6 +832,17 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let tx_hash = self.wait_for_completion(fireblocks_tx_id).await?;
 
         self.parse_burn_receipt(tx_hash, dust_shares).await
+    }
+
+    async fn verify_burn_tx(
+        &self,
+        vault: Address,
+        owner: Address,
+        tx_hash: B256,
+    ) -> Result<BurnVerification, VaultError> {
+        let receipt = self.fetch_receipt(tx_hash).await?;
+
+        verify_burn_in_receipt(&receipt, vault, owner, tx_hash)
     }
 
     async fn check_fireblocks_tx(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -465,6 +465,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 mint::confirm_journal,
                 admin::recover_redemption,
                 admin::close_redemption,
+                admin::force_complete_redemption,
                 admin::reprocess_mint,
                 admin::close_mint,
                 admin::list_stuck,

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -2052,8 +2052,9 @@ pub(crate) mod tests {
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
-        ReceiptInformation, SubmittedTx, VaultError, VaultService,
+        BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
+        MultiBurnResult, ReceiptInformation, SubmittedTx, VaultError,
+        VaultService,
     };
 
     pub(super) const VAULT: Address =
@@ -2140,6 +2141,15 @@ pub(crate) mod tests {
         ) -> Result<MultiBurnResult, VaultError> {
             Err(VaultError::InvalidReceipt)
         }
+
+        async fn verify_burn_tx(
+            &self,
+            _vault: Address,
+            _owner: Address,
+            _tx_hash: B256,
+        ) -> Result<BurnVerification, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
     }
 
     /// Vault whose prior Fireblocks tx is terminally failed and whose retry
@@ -2198,6 +2208,15 @@ pub(crate) mod tests {
             _fireblocks_tx_id: &str,
             _expected_dust_shares: U256,
         ) -> Result<MultiBurnResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn verify_burn_tx(
+            &self,
+            _vault: Address,
+            _owner: Address,
+            _tx_hash: B256,
+        ) -> Result<BurnVerification, VaultError> {
             Err(VaultError::InvalidReceipt)
         }
     }

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -330,7 +330,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, U256, address, b256, uint};
+    use alloy::primitives::{Address, B256, U256, address, b256, uint};
     use chrono::Utc;
     use cqrs_es::AggregateContext;
     use rust_decimal::Decimal;
@@ -348,8 +348,9 @@ mod tests {
     };
     use crate::test_utils::log_count_at;
     use crate::vault::{
-        FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
-        ReceiptInformation, SubmittedTx, VaultError, VaultService,
+        BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
+        MultiBurnResult, ReceiptInformation, SubmittedTx, VaultError,
+        VaultService,
     };
 
     /// Vault whose Fireblocks transaction never finalizes — every status check
@@ -404,6 +405,15 @@ mod tests {
             _fireblocks_tx_id: &str,
             _expected_dust_shares: U256,
         ) -> Result<MultiBurnResult, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn verify_burn_tx(
+            &self,
+            _vault: Address,
+            _owner: Address,
+            _tx_hash: B256,
+        ) -> Result<BurnVerification, VaultError> {
             Err(VaultError::InvalidReceipt)
         }
     }

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -22,7 +22,8 @@ use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
 use crate::vault::{
-    FireblocksTxStatus, MultiBurnEntry, VaultError, VaultService,
+    BurnVerification, FireblocksTxStatus, MultiBurnEntry, VaultError,
+    VaultService,
 };
 
 /// Outcome of recovering a single redemption stuck in a burning state.
@@ -171,6 +172,77 @@ where
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
         self.recover_single_burning(issuer_request_id).await
+    }
+
+    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
+    /// burn already landed on-chain but was never recorded (e.g. a crash
+    /// between the burn and `TokensBurned`).
+    ///
+    /// Verifies the operator-supplied `burn_tx_hash` on-chain — the receipt
+    /// must have succeeded and contain a real `Transfer(bot_wallet -> 0x0)` of
+    /// the vault's shares — before recording the proving terminal event and
+    /// transitioning the redemption to `Completed`. The held receipt
+    /// reservation is then settled (mirror reduced), exactly as a normal burn
+    /// completion would. Returns the on-chain verification so the caller can
+    /// report the proven block number and burned shares.
+    ///
+    /// Ambiguous cases with no verifiable on-chain burn fail here (`NotABurn`)
+    /// and must be resolved via `CloseRedemption` (or off-chain reconciliation)
+    /// instead — they are never silently force-completed.
+    pub(crate) async fn force_complete_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        reason: String,
+    ) -> Result<BurnVerification, BurnManagerError> {
+        let context =
+            self.store.load_aggregate(&issuer_request_id.to_string()).await?;
+
+        let underlying = match context.aggregate() {
+            Redemption::Burning { metadata, .. }
+            | Redemption::BurnSubmitted { metadata, .. } => {
+                metadata.underlying.clone()
+            }
+            other => {
+                return Err(BurnManagerError::InvalidAggregateState {
+                    current_state: aggregate_state_name(other).to_string(),
+                });
+            }
+        };
+
+        let vault = find_vault_by_underlying(&self.view_pool, &underlying)
+            .await?
+            .ok_or(BurnManagerError::AssetNotFound { underlying })?;
+
+        // Verify the burn actually landed on-chain before recording a terminal
+        // success — never trust the operator-supplied hash blindly.
+        let verification = self
+            .vault_service
+            .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
+            .await?;
+
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
+            burn_tx_hash = ?burn_tx_hash,
+            block_number = verification.block_number,
+            shares_burned = %verification.shares_burned,
+            "Force-completing stuck Burning redemption: burn verified on-chain"
+        );
+
+        self.cqrs
+            .execute(
+                &issuer_request_id.to_string(),
+                RedemptionCommand::ForceCompleteBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    burn_tx_hash,
+                    block_number: verification.block_number,
+                    reason,
+                },
+            )
+            .await?;
+
+        self.settle_reserved_burn(vault, issuer_request_id).await;
+
+        Ok(verification)
     }
 
     /// Resolves receipt reservations left dangling by a missed settlement —
@@ -668,8 +740,8 @@ where
                 // Check on-chain balance before attempting burn. If the bot has insufficient
                 // shares, the burn likely already succeeded on-chain but we crashed before
                 // recording it. Skip this redemption to avoid recording a false failure.
-                // Manual intervention required to resolve.
-                // TODO: Implement automatic recovery - see #88
+                // Resolve manually via the admin `force-complete` endpoint (records the
+                // verified burn tx) for landed burns, or `close` for ambiguous cases.
                 let on_chain_balance = self
                     .vault_service
                     .get_share_balance(vault, self.bot_wallet)
@@ -1315,8 +1387,8 @@ mod tests {
         CqrsReceiptService, ReceiptId, ReceiptInventory,
         ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
     };
-    use crate::redemption::IssuerRedemptionRequestId;
     use crate::redemption::view::RedemptionView;
+    use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::view::TokenizedAssetView;
     use crate::tokenized_asset::{
@@ -1659,6 +1731,251 @@ mod tests {
                 .is_empty(),
             "successful burn must leave no dangling reservation"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_force_complete_burn_records_verified_burn() {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burn(45_989_009, uint!(17_U256)),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        // Seed a held reservation so the test fails if force-complete stops
+        // settling inventory after terminalizing the aggregate.
+        harness
+            .discover_receipt(
+                vault,
+                uint!(42_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(42_U256),
+                    shares_burned: uint!(17_U256),
+                }],
+            )
+            .await
+            .expect("seeding reservation should succeed");
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![issuer_request_id.clone()],
+            "reservation should be held before force-complete"
+        );
+
+        let burn_tx_hash = b256!(
+            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+        );
+
+        let verification = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                burn_tx_hash,
+                "burn confirmed on-chain".to_string(),
+            )
+            .await
+            .expect("force-complete should succeed");
+
+        // Block number and shares are taken from the on-chain verification,
+        // not the operator.
+        assert_eq!(verification.block_number, 45_989_009);
+        assert_eq!(verification.shares_burned, uint!(17_U256));
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        let Redemption::Completed { burn_tx_hash: recorded, .. } = updated
+        else {
+            panic!("Expected Completed state, got {updated:?}");
+        };
+        assert_eq!(recorded, burn_tx_hash);
+
+        // Force-complete must settle (consume) the held reservation; if the
+        // settle wiring were removed the reservation would linger here.
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "force-complete must leave no dangling reservation"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Force-completing stuck Burning redemption", "verified on-chain"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_rejects_unverifiable_burn() {
+        let vault_mock =
+            Arc::new(MockVaultService::new_success().with_unverifiable_burn());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                b256!(
+                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+                ),
+                "operator hash is not a burn".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            BurnManagerError::Vault(VaultError::NotABurn { .. })
+        ));
+
+        // An unverifiable hash must NOT terminalize — the redemption stays
+        // Burning for manual reconciliation.
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Burning { .. }),
+            "Expected Burning state, got {updated:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_rejects_reverted_tx() {
+        let vault_mock =
+            Arc::new(MockVaultService::new_success().with_reverted_burn());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(
+            cqrs,
+            store,
+            &issuer_request_id,
+        )
+        .await;
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                b256!(
+                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+                ),
+                "operator hash reverted".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            BurnManagerError::Vault(VaultError::Reverted { .. })
+        ));
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Burning { .. }),
+            "Expected Burning state, got {updated:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_rejects_non_burning_state() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { cqrs, store, receipt_service, pool, .. } = &harness;
+
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            cqrs.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        // An unknown redemption is Uninitialized — force-complete must refuse
+        // before ever touching the chain.
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                b256!(
+                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+                ),
+                "wrong state".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            BurnManagerError::InvalidAggregateState { .. }
+        ));
+        assert_eq!(vault_mock.get_multi_burn_call_count(), 0);
     }
 
     #[traced_test]

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -88,10 +88,21 @@ pub(crate) enum RedemptionCommand {
         planned_burns: Vec<super::BurnRecord>,
         block_number: u64,
     },
-    /// Admin-closes a failed redemption that cannot be automatically recovered.
-    /// Only valid from `Failed` state.
+    /// Admin-closes a redemption that cannot be automatically recovered.
+    /// Valid from `Failed`, `Burning`, or `BurnSubmitted`. The honest terminal
+    /// path for a redemption whose burn is not verifiable on-chain.
     CloseRedemption {
         issuer_request_id: IssuerRedemptionRequestId,
+        reason: String,
+    },
+    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
+    /// burn already landed on-chain. The admin layer verifies `burn_tx_hash`
+    /// on-chain before issuing this command; the aggregate records it as the
+    /// proving tx hash and transitions to `Completed`.
+    ForceCompleteBurn {
+        issuer_request_id: IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        block_number: u64,
         reason: String,
     },
     /// Resumes a post-Alpaca failed redemption directly to Burning state.

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -130,6 +130,19 @@ pub(crate) enum RedemptionEvent {
         reason: String,
         closed_at: DateTime<Utc>,
     },
+    /// Admin-recorded terminal success for a redemption stuck in
+    /// `Burning`/`BurnSubmitted` whose burn already landed on-chain but was
+    /// never recorded (e.g. a crash between the burn and `TokensBurned`). The
+    /// admin layer verifies `burn_tx_hash` on-chain before this event is
+    /// emitted. Transitions to `Completed`, recording the proving tx hash for
+    /// audit.
+    BurnForceCompleted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        block_number: u64,
+        reason: String,
+        completed_at: DateTime<Utc>,
+    },
     /// Post-Alpaca failed redemption resumed directly to Burning state.
     /// Used when Alpaca was already called and the journal eventually completed,
     /// but the bot had already timed out and marked the redemption as Failed.
@@ -195,6 +208,9 @@ impl DomainEvent for RedemptionEvent {
             Self::RedemptionClosed { .. } => {
                 "RedemptionEvent::RedemptionClosed".to_string()
             }
+            Self::BurnForceCompleted { .. } => {
+                "RedemptionEvent::BurnForceCompleted".to_string()
+            }
         }
     }
 
@@ -251,6 +267,22 @@ mod tests {
 
         assert_eq!(event.event_type(), "RedemptionEvent::TokensBurned");
         assert_eq!(event.event_version(), "2.0");
+    }
+
+    #[test]
+    fn test_burn_force_completed_event_type() {
+        let event = RedemptionEvent::BurnForceCompleted {
+            issuer_request_id: test_redemption_id(),
+            burn_tx_hash: b256!(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            ),
+            block_number: 1000,
+            reason: "admin recovery".to_string(),
+            completed_at: Utc::now(),
+        };
+
+        assert_eq!(event.event_type(), "RedemptionEvent::BurnForceCompleted");
+        assert_eq!(event.event_version(), "1.0");
     }
 
     #[test]

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -312,7 +312,7 @@ impl Redemption {
         }
     }
 
-    const fn state_name(&self) -> &'static str {
+    pub(crate) const fn state_name(&self) -> &'static str {
         match self {
             Self::Uninitialized => "Uninitialized",
             Self::Detected { .. } => "Detected",
@@ -640,27 +640,71 @@ impl Redemption {
         }])
     }
 
+    /// Admin-closes a redemption that cannot be auto-recovered. Valid from
+    /// `Failed`, `Burning`, or `BurnSubmitted` — the honest terminal path for a
+    /// redemption whose burn cannot/should not be re-submitted and is not
+    /// verifiable on-chain. Widening beyond `Failed` covers redemptions stuck in
+    /// `Burning` (including the `Failed -> Burning` recovery regression, which
+    /// would otherwise strand a previously-closeable redemption).
     fn handle_close_redemption(
         &self,
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let Self::Failed { .. } = self else {
+        if !matches!(
+            self,
+            Self::Failed { .. }
+                | Self::Burning { .. }
+                | Self::BurnSubmitted { .. }
+        ) {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
                     RedemptionError::AlreadyCompleted { issuer_request_id }
                 }
                 _ => RedemptionError::InvalidState {
-                    expected: "Failed".to_string(),
+                    expected: "Failed, Burning, or BurnSubmitted".to_string(),
                     found: self.state_name().to_string(),
                 },
             });
-        };
+        }
 
         Ok(vec![RedemptionEvent::RedemptionClosed {
             issuer_request_id,
             reason,
             closed_at: Utc::now(),
+        }])
+    }
+
+    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
+    /// burn already landed on-chain but was never recorded. The admin layer
+    /// verifies `burn_tx_hash` on-chain before issuing this command, so the
+    /// aggregate trusts the supplied tx hash and block number and records the
+    /// proving terminal event, transitioning to `Completed`.
+    fn handle_force_complete_burn(
+        &self,
+        issuer_request_id: IssuerRedemptionRequestId,
+        burn_tx_hash: B256,
+        block_number: u64,
+        reason: String,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
+            return Err(match self {
+                Self::Completed { .. } | Self::Closed { .. } => {
+                    RedemptionError::AlreadyCompleted { issuer_request_id }
+                }
+                _ => RedemptionError::InvalidState {
+                    expected: "Burning or BurnSubmitted".to_string(),
+                    found: self.state_name().to_string(),
+                },
+            });
+        }
+
+        Ok(vec![RedemptionEvent::BurnForceCompleted {
+            issuer_request_id,
+            burn_tx_hash,
+            block_number,
+            reason,
+            completed_at: Utc::now(),
         }])
     }
 
@@ -930,6 +974,17 @@ impl Aggregate for Redemption {
                 issuer_request_id,
                 reason,
             } => self.handle_close_redemption(issuer_request_id, reason),
+            RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash,
+                block_number,
+                reason,
+            } => self.handle_force_complete_burn(
+                issuer_request_id,
+                burn_tx_hash,
+                block_number,
+                reason,
+            ),
             RedemptionCommand::Reprocess { issuer_request_id, metadata } => {
                 self.handle_reprocess(issuer_request_id, metadata)
             }
@@ -1135,6 +1190,18 @@ impl Aggregate for Redemption {
                 closed_at,
             } => {
                 *self = Self::Closed { issuer_request_id, reason, closed_at };
+            }
+            RedemptionEvent::BurnForceCompleted {
+                issuer_request_id,
+                burn_tx_hash,
+                completed_at,
+                ..
+            } => {
+                *self = Self::Completed {
+                    issuer_request_id,
+                    burn_tx_hash,
+                    completed_at,
+                };
             }
         }
     }
@@ -1861,6 +1928,289 @@ mod tests {
                 error: "Some error".to_string(),
                 fireblocks_tx_id: None,
                 planned_burns: vec![],
+            })
+            .then_expect_error(RedemptionError::InvalidState {
+                expected: "Burning or BurnSubmitted".to_string(),
+                found: "Uninitialized".to_string(),
+            });
+    }
+
+    /// Events that drive a redemption into the `Burning` state, for tests that
+    /// exercise admin terminalization paths (close / force-complete).
+    fn burning_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Vec<RedemptionEvent> {
+        vec![
+            RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("ARKK"),
+                token: TokenSymbol::new("tARKK"),
+                wallet: address!("0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"),
+                quantity: Quantity::new(Decimal::from(17)),
+                tx_hash: b256!(
+                    "0x4444444444444444444444444444444444444444444444444444444444444444"
+                ),
+                block_number: 45_000_000,
+                detected_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new(
+                    "alp-arkk-799",
+                ),
+                alpaca_quantity: Quantity::new(Decimal::from(17)),
+                dust_quantity: Quantity::new(Decimal::ZERO),
+                called_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id: issuer_request_id.clone(),
+                alpaca_journal_completed_at: Utc::now(),
+            },
+        ]
+    }
+
+    fn burn_submitted_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Vec<RedemptionEvent> {
+        let mut events = burning_given_events(issuer_request_id);
+        events.push(RedemptionEvent::BurnFireblocksSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: BurnExternalTxId::base(&b256!(
+                "0x4444444444444444444444444444444444444444444444444444444444444444"
+            )),
+            fireblocks_tx_id: "fb-799".to_string(),
+            planned_burns: vec![],
+            submitted_at: Utc::now(),
+        });
+        events
+    }
+
+    #[test]
+    fn test_close_redemption_from_burning_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let reason = "QQQM share accounting unverified".to_string();
+
+        let validator = RedemptionTestFramework::with(mock_services())
+            .given(burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: reason.clone(),
+            });
+
+        let events = validator.inspect_result().unwrap();
+        assert_eq!(events.len(), 1);
+
+        let RedemptionEvent::RedemptionClosed {
+            issuer_request_id: event_id,
+            reason: event_reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected RedemptionClosed event, got {:?}", &events[0]);
+        };
+
+        assert_eq!(event_id, &issuer_request_id);
+        assert_eq!(event_reason, &reason);
+    }
+
+    #[test]
+    fn test_close_redemption_from_failed_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let mut given = burning_given_events(&issuer_request_id);
+        given.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "burn reverted".to_string(),
+            failed_at: Utc::now(),
+            fireblocks_tx_id: None,
+            planned_burns: vec![],
+        });
+
+        let validator = RedemptionTestFramework::with(mock_services())
+            .given(given)
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "unrecoverable".to_string(),
+            });
+
+        let events = validator.inspect_result().unwrap();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(&events[0], RedemptionEvent::RedemptionClosed { .. }));
+    }
+
+    #[test]
+    fn test_close_redemption_from_burn_submitted_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let reason = "submitted burn unverifiable on-chain".to_string();
+
+        let validator = RedemptionTestFramework::with(mock_services())
+            .given(burn_submitted_given_events(&issuer_request_id))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: reason.clone(),
+            });
+
+        let events = validator.inspect_result().unwrap();
+        assert_eq!(events.len(), 1);
+
+        let RedemptionEvent::RedemptionClosed {
+            issuer_request_id: event_id,
+            reason: event_reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected RedemptionClosed event, got {:?}", &events[0]);
+        };
+
+        assert_eq!(event_id, &issuer_request_id);
+        assert_eq!(event_reason, &reason);
+    }
+
+    #[test]
+    fn test_close_redemption_from_detected_fails() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        RedemptionTestFramework::with(mock_services())
+            .given(vec![RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("ARKK"),
+                token: TokenSymbol::new("tARKK"),
+                wallet: address!(
+                    "0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
+                ),
+                quantity: Quantity::new(Decimal::from(17)),
+                tx_hash: b256!(
+                    "0x4444444444444444444444444444444444444444444444444444444444444444"
+                ),
+                block_number: 45_000_000,
+                detected_at: Utc::now(),
+            }])
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "too early".to_string(),
+            })
+            .then_expect_error(RedemptionError::InvalidState {
+                expected: "Failed, Burning, or BurnSubmitted".to_string(),
+                found: "Detected".to_string(),
+            });
+    }
+
+    #[test]
+    fn test_force_complete_burn_from_burning_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = b256!(
+            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+        );
+        let block_number = 45_989_009;
+        let reason = "burn confirmed on-chain, unrecorded".to_string();
+
+        let validator = RedemptionTestFramework::with(mock_services())
+            .given(burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                burn_tx_hash,
+                block_number,
+                reason: reason.clone(),
+            });
+
+        let events = validator.inspect_result().unwrap();
+        assert_eq!(events.len(), 1);
+
+        let RedemptionEvent::BurnForceCompleted {
+            issuer_request_id: event_id,
+            burn_tx_hash: event_tx_hash,
+            block_number: event_block,
+            reason: event_reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BurnForceCompleted event, got {:?}", &events[0]);
+        };
+
+        assert_eq!(event_id, &issuer_request_id);
+        assert_eq!(event_tx_hash, &burn_tx_hash);
+        assert_eq!(event_block, &block_number);
+        assert_eq!(event_reason, &reason);
+    }
+
+    #[test]
+    fn test_force_complete_burn_from_burn_submitted_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = b256!(
+            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+        );
+        let block_number = 45_989_009;
+        let reason = "submitted burn confirmed on-chain".to_string();
+
+        let validator = RedemptionTestFramework::with(mock_services())
+            .given(burn_submitted_given_events(&issuer_request_id))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                burn_tx_hash,
+                block_number,
+                reason: reason.clone(),
+            });
+
+        let events = validator.inspect_result().unwrap();
+        assert_eq!(events.len(), 1);
+
+        let RedemptionEvent::BurnForceCompleted {
+            issuer_request_id: event_id,
+            burn_tx_hash: event_tx_hash,
+            block_number: event_block,
+            reason: event_reason,
+            ..
+        } = &events[0]
+        else {
+            panic!("Expected BurnForceCompleted event, got {:?}", &events[0]);
+        };
+
+        assert_eq!(event_id, &issuer_request_id);
+        assert_eq!(event_tx_hash, &burn_tx_hash);
+        assert_eq!(event_block, &block_number);
+        assert_eq!(event_reason, &reason);
+    }
+
+    #[test]
+    fn test_force_complete_burn_transitions_to_completed() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = b256!(
+            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+        );
+
+        let mut redemption = Redemption::default();
+        for event in burning_given_events(&issuer_request_id) {
+            redemption.apply(event);
+        }
+
+        redemption.apply(RedemptionEvent::BurnForceCompleted {
+            issuer_request_id,
+            burn_tx_hash,
+            block_number: 45_989_009,
+            reason: "verified".to_string(),
+            completed_at: Utc::now(),
+        });
+
+        let Redemption::Completed { burn_tx_hash: stored, .. } = redemption
+        else {
+            panic!("Expected Completed state, got {}", redemption.state_name());
+        };
+
+        assert_eq!(stored, burn_tx_hash);
+    }
+
+    #[test]
+    fn test_force_complete_burn_from_wrong_state_fails() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        RedemptionTestFramework::with(mock_services())
+            .given_no_previous_events()
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: b256!(
+                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+                ),
+                block_number: 45_989_009,
+                reason: "nope".to_string(),
             })
             .then_expect_error(RedemptionError::InvalidState {
                 expected: "Burning or BurnSubmitted".to_string(),

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -422,6 +422,20 @@ impl View<Redemption> for RedemptionView {
                     closed_at: *closed_at,
                 };
             }
+            RedemptionEvent::BurnForceCompleted {
+                issuer_request_id,
+                burn_tx_hash,
+                block_number,
+                completed_at,
+                ..
+            } => {
+                *self = Self::Completed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    burn_tx_hash: *burn_tx_hash,
+                    block_number: *block_number,
+                    completed_at: *completed_at,
+                };
+            }
         }
     }
 }
@@ -2160,5 +2174,46 @@ mod tests {
         assert_eq!(view_id, issuer_request_id);
         assert_eq!(view_reason, reason);
         assert_eq!(view_closed_at, closed_at);
+    }
+
+    #[test]
+    fn test_burn_force_completed_projects_to_completed() {
+        let mut view = RedemptionView::default();
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = b256!(
+            "0x6666666666666666666666666666666666666666666666666666666666666666"
+        );
+        let block_number = 88888;
+        let completed_at = Utc::now();
+
+        view.update(&EventEnvelope::<Redemption> {
+            aggregate_id: issuer_request_id.to_string(),
+            sequence: 1,
+            payload: RedemptionEvent::BurnForceCompleted {
+                issuer_request_id: issuer_request_id.clone(),
+                burn_tx_hash,
+                block_number,
+                reason: "admin recovery".to_string(),
+                completed_at,
+            },
+            metadata: HashMap::default(),
+        });
+
+        let RedemptionView::Completed {
+            issuer_request_id: view_id,
+            burn_tx_hash: view_tx_hash,
+            block_number: view_block_number,
+            completed_at: view_completed_at,
+        } = view
+        else {
+            panic!(
+                "Expected Completed view after BurnForceCompleted, got {view:?}"
+            );
+        };
+
+        assert_eq!(view_id, issuer_request_id);
+        assert_eq!(view_tx_hash, burn_tx_hash);
+        assert_eq!(view_block_number, block_number);
+        assert_eq!(view_completed_at, completed_at);
     }
 }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -1,13 +1,13 @@
-use alloy::primitives::{Address, Bytes, U256, b256};
+use alloy::primitives::{Address, B256, Bytes, U256, b256};
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{
-    FireblocksTxStatus, MintResult, MultiBurnParams, MultiBurnResult,
-    MultiBurnResultEntry, ReceiptInformation, SubmittedTx, VaultError,
-    VaultService,
+    BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
+    MultiBurnResult, MultiBurnResultEntry, ReceiptInformation, SubmittedTx,
+    VaultError, VaultService,
 };
 use crate::redemption::BurnExternalTxId;
 
@@ -42,6 +42,29 @@ enum MockBehavior {
     SubmitRevert,
 }
 
+/// Configured outcome for `verify_burn_tx` in tests, exercising the admin
+/// force-complete path's on-chain verification of an operator-supplied tx hash.
+#[cfg(test)]
+#[derive(Clone)]
+enum MockVerifyBurn {
+    /// The tx proves a burn: return this block number and shares burned.
+    Verified { block_number: u64, shares_burned: U256 },
+    /// The tx succeeded but contains no matching burn.
+    NotABurn,
+    /// The tx reverted on-chain.
+    Reverted,
+}
+
+#[cfg(test)]
+impl Default for MockVerifyBurn {
+    fn default() -> Self {
+        Self::Verified {
+            block_number: 45_989_009,
+            shares_burned: U256::from(1u8),
+        }
+    }
+}
+
 /// Mock blockchain service for testing.
 ///
 /// This mock is NOT behind `#[cfg(test)]` because `setup_test_rocket()` (used by E2E tests
@@ -68,6 +91,10 @@ pub(crate) struct MockVaultService {
     /// default (no Fireblocks state), exercising the non-Fireblocks path.
     #[cfg(test)]
     fireblocks_tx_status: Arc<Mutex<Option<FireblocksTxStatus>>>,
+    /// Outcome returned by `verify_burn_tx`. Defaults to a successful
+    /// verification, exercising the admin force-complete happy path.
+    #[cfg(test)]
+    verify_burn: Arc<Mutex<MockVerifyBurn>>,
 }
 
 impl MockVaultService {
@@ -88,6 +115,8 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
         }
     }
 
@@ -104,6 +133,7 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
         }
     }
 
@@ -120,6 +150,7 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
         }
     }
 
@@ -136,6 +167,7 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
         }
     }
 
@@ -152,6 +184,7 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
         }
     }
 
@@ -194,6 +227,35 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn with_share_balance(self, balance: U256) -> Self {
         *self.share_balance.lock().unwrap() = balance;
+        self
+    }
+
+    /// Configures `verify_burn_tx` to report the operator-supplied tx as a
+    /// burn of `shares_burned` at `block_number`.
+    #[cfg(test)]
+    pub(crate) fn with_verified_burn(
+        self,
+        block_number: u64,
+        shares_burned: U256,
+    ) -> Self {
+        *self.verify_burn.lock().unwrap() =
+            MockVerifyBurn::Verified { block_number, shares_burned };
+        self
+    }
+
+    /// Configures `verify_burn_tx` to report the operator-supplied tx as not a
+    /// burn (succeeded on-chain but no matching `Transfer(owner -> 0x0)`).
+    #[cfg(test)]
+    pub(crate) fn with_unverifiable_burn(self) -> Self {
+        *self.verify_burn.lock().unwrap() = MockVerifyBurn::NotABurn;
+        self
+    }
+
+    /// Configures `verify_burn_tx` to report the operator-supplied tx as
+    /// reverted on-chain.
+    #[cfg(test)]
+    pub(crate) fn with_reverted_burn(self) -> Self {
+        *self.verify_burn.lock().unwrap() = MockVerifyBurn::Reverted;
         self
     }
 
@@ -471,6 +533,35 @@ impl VaultService for MockVaultService {
                     });
                 Ok(result)
             }
+        }
+    }
+
+    #[cfg_attr(not(test), allow(unused_variables))]
+    async fn verify_burn_tx(
+        &self,
+        _vault: Address,
+        _owner: Address,
+        tx_hash: B256,
+    ) -> Result<BurnVerification, VaultError> {
+        #[cfg(test)]
+        {
+            use MockVerifyBurn::{NotABurn, Reverted, Verified};
+
+            let outcome = self.verify_burn.lock().unwrap().clone();
+            match outcome {
+                Verified { block_number, shares_burned } => {
+                    Ok(BurnVerification { block_number, shares_burned })
+                }
+                NotABurn => Err(VaultError::NotABurn { tx_hash }),
+                Reverted => Err(VaultError::Reverted { tx_hash }),
+            }
+        }
+        #[cfg(not(test))]
+        {
+            Ok(BurnVerification {
+                block_number: 0,
+                shares_burned: U256::from(1u8),
+            })
         }
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,8 +1,10 @@
 use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
+use crate::bindings::OffchainAssetReceiptVault;
 use crate::mint::{
     IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
 };
@@ -108,6 +110,83 @@ pub(crate) trait VaultService: Send + Sync {
         fireblocks_tx_id: &str,
         dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError>;
+
+    /// Verifies an operator-supplied burn transaction hash on-chain.
+    ///
+    /// Fetches the receipt for `tx_hash` and confirms it proves a burn of
+    /// `vault` shares by `owner` — a successful transaction emitting at least
+    /// one `Transfer(owner -> 0x0)` from the vault share token. Used by the
+    /// admin force-complete path to terminalize a redemption stuck in `Burning`
+    /// whose burn already landed on-chain but was never recorded.
+    async fn verify_burn_tx(
+        &self,
+        vault: Address,
+        owner: Address,
+        tx_hash: B256,
+    ) -> Result<BurnVerification, VaultError>;
+}
+
+/// Proof that a burn transaction landed on-chain, returned by
+/// [`VaultService::verify_burn_tx`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BurnVerification {
+    /// Block number the burn transaction was included in.
+    pub(crate) block_number: u64,
+    /// Total shares burned by the owner in this transaction (sum of all
+    /// matching `Transfer(owner -> 0x0)` events). Reported for audit logging;
+    /// the operator is responsible for confirming the amount off-chain.
+    pub(crate) shares_burned: U256,
+}
+
+/// Verifies that `receipt` proves `owner` burned shares of the `vault` share
+/// token (one or more `Transfer(owner -> 0x0)` events emitted by `vault`).
+///
+/// A burn emits an ERC-20 `Transfer(owner, address(0), shares)` from the vault
+/// share token. Reference chain: `redeem()` -> `ReceiptVault._withdraw()` ->
+/// `_burn(owner, shares)` -> `ERC20Upgradeable._update(owner, 0x0, shares)`
+/// emits `Transfer(owner, 0x0, shares)`. Mirrors the mint-skip check in
+/// `redemption/transfer.rs`, which treats `from == 0x0` as a mint.
+pub(crate) fn verify_burn_in_receipt(
+    receipt: &TransactionReceipt,
+    vault: Address,
+    owner: Address,
+    tx_hash: B256,
+) -> Result<BurnVerification, VaultError> {
+    if !receipt.status() {
+        return Err(VaultError::Reverted { tx_hash });
+    }
+
+    let mut shares_burned = U256::ZERO;
+    let mut found_burn = false;
+
+    for log in receipt.inner.logs() {
+        if log.address() != vault {
+            continue;
+        }
+
+        let Ok(decoded) =
+            log.log_decode::<OffchainAssetReceiptVault::Transfer>()
+        else {
+            continue;
+        };
+
+        let transfer = decoded.data();
+        if transfer.from == owner && transfer.to == Address::ZERO {
+            found_burn = true;
+            shares_burned = shares_burned
+                .checked_add(transfer.value)
+                .ok_or(VaultError::InvalidReceipt)?;
+        }
+    }
+
+    if !found_burn {
+        return Err(VaultError::NotABurn { tx_hash });
+    }
+
+    let block_number =
+        receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
+
+    Ok(BurnVerification { block_number, shares_burned })
 }
 
 /// Status of a Fireblocks transaction, as returned by `check_fireblocks_tx`.
@@ -319,6 +398,11 @@ pub(crate) enum VaultError {
     /// held for it must be released.
     #[error("Transaction reverted on-chain: {tx_hash:?}")]
     Reverted { tx_hash: B256 },
+    /// Transaction was mined and succeeded but does not prove the expected
+    /// burn — it contains no `Transfer(owner -> 0x0)` of the vault's shares.
+    /// The operator-supplied hash cannot terminalize the redemption.
+    #[error("Transaction is not a burn of the expected shares: {tx_hash:?}")]
+    NotABurn { tx_hash: B256 },
     /// Contract call error
     #[error(transparent)]
     Contract(#[from] alloy::contract::Error),
@@ -340,6 +424,7 @@ pub(crate) enum VaultError {
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::address;
     use chrono::Utc;
     use rust_decimal_macros::dec;
 
@@ -413,5 +498,150 @@ mod tests {
             serde_json::from_slice(&json_bytes).unwrap();
 
         assert!(decoded["notes"].is_null());
+    }
+
+    const BOT_WALLET: Address = alloy::primitives::address!(
+        "0x1111111111111111111111111111111111111111"
+    );
+    const VAULT: Address = alloy::primitives::address!(
+        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    );
+    const BURN_TX: B256 = alloy::primitives::b256!(
+        "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
+    );
+
+    /// Builds a receipt containing the given `(contract, from, to, value)`
+    /// Transfer events, with the given on-chain success status.
+    fn transfer_receipt(
+        success: bool,
+        block_number: u64,
+        transfers: Vec<(Address, Address, Address, U256)>,
+    ) -> TransactionReceipt {
+        use alloy::consensus::{
+            Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
+        };
+        use alloy::primitives::{Bloom, IntoLogData};
+
+        let logs: Vec<alloy::rpc::types::Log> = transfers
+            .into_iter()
+            .enumerate()
+            .map(|(index, (contract, from, to, value))| {
+                let transfer =
+                    OffchainAssetReceiptVault::Transfer { from, to, value };
+
+                alloy::rpc::types::Log {
+                    inner: alloy::primitives::Log {
+                        address: contract,
+                        data: transfer.into_log_data(),
+                    },
+                    block_hash: None,
+                    block_number: Some(block_number),
+                    block_timestamp: None,
+                    transaction_hash: Some(BURN_TX),
+                    transaction_index: Some(0),
+                    log_index: Some(index as u64),
+                    removed: false,
+                }
+            })
+            .collect();
+
+        let consensus_receipt: Receipt<alloy::rpc::types::Log> = Receipt {
+            status: Eip658Value::Eip658(success),
+            cumulative_gas_used: 0x8000,
+            logs,
+        };
+
+        TransactionReceipt {
+            transaction_hash: BURN_TX,
+            transaction_index: Some(0),
+            block_hash: None,
+            block_number: Some(block_number),
+            from: BOT_WALLET,
+            to: Some(VAULT),
+            gas_used: 0x8000,
+            effective_gas_price: 0,
+            contract_address: None,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                consensus_receipt,
+                Bloom::default(),
+            )),
+        }
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_accepts_owner_to_zero_transfer() {
+        let receipt = transfer_receipt(
+            true,
+            45_989_009,
+            vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
+        );
+
+        let verification =
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+                .unwrap();
+
+        assert_eq!(verification.block_number, 45_989_009);
+        assert_eq!(verification.shares_burned, U256::from(17u64));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_sums_multiple_burns_ignoring_noise() {
+        let other = address!("0x2222222222222222222222222222222222222222");
+        let other_vault =
+            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![
+                // A genuine burn by the bot on this vault.
+                (VAULT, BOT_WALLET, Address::ZERO, U256::from(10u64)),
+                // A second burn fragment by the bot on this vault.
+                (VAULT, BOT_WALLET, Address::ZERO, U256::from(5u64)),
+                // Burn by someone else — ignored.
+                (VAULT, other, Address::ZERO, U256::from(99u64)),
+                // Bot transfer to a user (not a burn) — ignored.
+                (VAULT, BOT_WALLET, other, U256::from(99u64)),
+                // Burn on a different vault — ignored.
+                (other_vault, BOT_WALLET, Address::ZERO, U256::from(99u64)),
+            ],
+        );
+
+        let verification =
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+                .unwrap();
+
+        assert_eq!(verification.shares_burned, U256::from(15u64));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_reverted_tx() {
+        let receipt = transfer_receipt(
+            false,
+            100,
+            vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
+        );
+
+        let err = verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+            .unwrap_err();
+
+        assert!(matches!(err, VaultError::Reverted { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_non_burn_tx() {
+        let user = address!("0x3333333333333333333333333333333333333333");
+        // Successful tx, but the bot only transferred to a user — no burn.
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![(VAULT, BOT_WALLET, user, U256::from(17u64))],
+        );
+
+        let err = verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+            .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
     }
 }

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -9,8 +9,9 @@ use tracing::debug;
 
 use super::rain_meta::OaSchemaCache;
 use super::{
-    MintResult, MultiBurnResult, MultiBurnResultEntry, ReceiptInformation,
-    SubmittedTx, VaultError, VaultService,
+    BurnVerification, MintResult, MultiBurnResult, MultiBurnResultEntry,
+    ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    verify_burn_in_receipt,
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
@@ -393,6 +394,21 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
                 .block_number
                 .ok_or(VaultError::InvalidReceipt)?,
         })
+    }
+
+    async fn verify_burn_tx(
+        &self,
+        vault: Address,
+        owner: Address,
+        tx_hash: B256,
+    ) -> Result<BurnVerification, VaultError> {
+        let receipt = self
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(VaultError::InvalidReceipt)?;
+
+        verify_burn_in_receipt(&receipt, vault, owner, tx_hash)
     }
 }
 


### PR DESCRIPTION
## Motivation

Redemptions can wedge permanently in `Burning` when the on-chain burn already happened (or the shares are otherwise gone) but the bot crashed before recording `TokensBurned`. There was no admin path to resolve them, so they re-flagged on `/admin/stuck` and survived every restart:

- **Re-submit** (startup recovery / `recover_single_burning`): the burn is `withdraw()` from the bot wallet, which holds 0 shares, so it reverts. Recovery correctly detects `on_chain_balance < total_shares_needed` and skips with `SkippedManualIntervention`, leaving the redemption in `Burning` with no terminal event.
- **`POST /admin/recover/redemption`**: re-verifies the journal with Alpaca first; for aged-out requests Alpaca returns "Tokenization request not found" → `502`. Can't proceed.
- **`POST /admin/close/redemption`**: `CloseRedemption` was code-gated to `Failed` only, so a `Burning` redemption returned `422 InvalidState`.

This is the gap GitHub #88 described but never built (closed NOT_PLANNED), revived as [RAI-799](https://linear.app/makeitrain/issue/RAI-799). A `recover` attempt that moves a redemption `Failed → Burning` and then skips the burn also made previously-closeable redemptions *un*-closeable — a secondary symptom of the same gap.

## Solution

Two safe, auditable terminal paths, plus removal of the stale `TODO: see #88` at `burn_manager.rs`.

**Close path — ambiguous / regression cases.** `Redemption::handle_close_redemption` now accepts `Burning` and `BurnSubmitted` in addition to `Failed`, recording `RedemptionClosed` with the operator reason. This is the honest terminal path when the burn is *not* verifiable on-chain: it un-strands the `Failed → Burning` recovery regression and covers cases pending off-chain reconciliation. The held receipt reservation is deliberately left in place (the existing conservative policy for `Closed`), since an ambiguous burn may still have landed.

**Force-complete path — verified-on-chain cases.**

- New `ForceCompleteBurn` command + `BurnForceCompleted` event (`cmd.rs`, `event.rs`, `mod.rs`, `view.rs`) recording the proving `burn_tx_hash` + `block_number`, transitioning the aggregate and view to `Completed`.
- New `VaultService::verify_burn_tx` plus the shared `verify_burn_in_receipt` helper (`vault/mod.rs`), implemented for both backends (`vault/service.rs`, `fireblocks/vault_service.rs`). It fetches the receipt and confirms it succeeded and contains a real `Transfer(bot_wallet → 0x0)` of the vault's shares before anything is recorded — the operator-supplied hash is never trusted blindly. A new `VaultError::NotABurn` covers a mined-but-not-a-burn tx.
- `BurnManager::force_complete_burn` (`redemption/burn_manager.rs`) orchestrates: load aggregate (must be `Burning`/`BurnSubmitted`), resolve the vault, verify on-chain, execute `ForceCompleteBurn`, then settle the held receipt reservation (mirror reduced) exactly as a normal burn completion.
- New `POST /admin/force-complete/redemption/<id>` taking `{ burn_tx_hash, reason }` (`admin.rs`, route registered in `lib.rs`). Bad/non-burn/reverted hashes and wrong states return `422`; ambiguous cases are never auto-completed.

Both `/admin/close/redemption` and `/admin/force-complete/redemption` now report the true previous aggregate state in their response (via the new `redemption_state_name` helper and a `pub(crate)` `state_name`), instead of the old hard-coded `"Failed"`.

Docs: `SPEC.md` updated with the new command/event/state-machine transitions (and the previously-undocumented `CloseRedemption`/`RedemptionClosed`); `ROADMAP.md` marks #88 resolved via this PR.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Test coverage: aggregate Given-When-Then for close/force-complete from each relevant state (`redemption/mod.rs`); `BurnManager::force_complete_burn` against a real CQRS + receipt service with mock vault outcomes — verified, unverifiable (`NotABurn`), reverted, and wrong-state (`burn_manager.rs`); `verify_burn_in_receipt` against hand-built receipts covering owner→0x0 sums, noise filtering, reverted, and non-burn (`vault/mod.rs`); admin HTTP endpoint tests for `200` happy path, `422` on unverifiable burn, and the status-mapping helper (`admin.rs`). Full `cargo test --workspace`, `clippy -D warnings`, and `fmt` pass. No Anvil e2e test added — this is a single-aggregate, admin-triggered operation, not multi-aggregate/startup orchestration, so it doesn't meet this repo's strict e2e bar and is fully covered by the layers above.

Closes [RAI-799](https://linear.app/makeitrain/issue/RAI-799).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin endpoint to force-complete redemptions that experienced on-chain burns but were not recorded; verifies the burn transaction and records completion.
  * Extended admin close endpoint to handle redemptions in burning states for ambiguous recovery cases.

* **Documentation**
  * Updated specification for new admin recovery commands and corresponding events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->