### PR TITLE
fix: fail fast when view replay swallows per-event errors

### DIFF
--- a/docs/cqrs.md
+++ b/docs/cqrs.md
@@ -108,24 +108,28 @@ impl View<MyAggregate> for MyView {
 }
 ```
 
-## Re-projecting Views with QueryReplay
+## Re-projecting Views with `replay_all_or_fail`
 
-When you add a new view or need to rebuild an existing one from events, use
-`QueryReplay`:
+When you add a new view or need to rebuild an existing one from events, use the
+shared `crate::replay::replay_all_or_fail` helper:
 
 ```rust
-use cqrs_es::persist::QueryReplay;
+use crate::replay::replay_all_or_fail;
 
 pub async fn replay_my_view(pool: Pool<Sqlite>) -> Result<(), MyError> {
+    // Clear the target view first so the rebuild starts from a clean slate.
+    sqlx::query!("DELETE FROM my_view").execute(&pool).await?;
+
     let view_repo = Arc::new(SqliteViewRepository::<MyView, MyAggregate>::new(
         pool.clone(),
         "my_view".to_string(),
     ));
-    let query = GenericQuery::new(view_repo);
     let event_repo = SqliteEventRepository::new(pool);
 
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    // Pass the SAME upcasters registered on this aggregate's live event store
+    // (`vec![]` if it registers none) — otherwise legacy event versions the
+    // live store upcasts successfully would deserialize-fail here.
+    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
 
     Ok(())
 }
@@ -134,6 +138,14 @@ pub async fn replay_my_view(pool: Pool<Sqlite>) -> Result<(), MyError> {
 This replays ALL events through the view's `update()` method, rebuilding the
 entire view from scratch. It's idempotent - running it multiple times produces
 the same result.
+
+**Do NOT call `QueryReplay::replay_all()` directly.** Without an installed error
+handler, `cqrs-es` delivers per-event failures (deserialization, stream reads,
+view writes) to an optional handler and **silently drops them when none is set**
+— `replay_all()` then returns `Ok(())` regardless, leaving a view partially or
+fully un-rebuilt while startup reports success. `replay_all_or_fail` installs
+collecting handlers on both silent-drop points and fails fast with a typed
+`ReplayError::EventsDropped` instead.
 
 **Call replay at startup** to ensure views are up-to-date with any schema
 changes.

--- a/src/account/view.rs
+++ b/src/account/view.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::Address;
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay};
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
@@ -11,6 +10,7 @@ use tracing::debug;
 use super::{
     Account, AccountError, AccountEvent, AlpacaAccountNumber, ClientId, Email,
 };
+use crate::replay::{ReplayError, replay_all_or_fail};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AccountViewError {
@@ -20,8 +20,8 @@ pub(crate) enum AccountViewError {
     Deserialization(#[from] serde_json::Error),
     #[error("Persistence error: {0}")]
     Persistence(#[from] cqrs_es::persist::PersistenceError),
-    #[error("Aggregate error: {0}")]
-    Aggregate(#[from] cqrs_es::AggregateError<AccountError>),
+    #[error("Replay error: {0}")]
+    Replay(#[from] ReplayError<AccountError>),
 }
 
 pub(crate) async fn replay_account_view(
@@ -36,11 +36,8 @@ pub(crate) async fn replay_account_view(
             pool.clone(),
             "account_view".to_string(),
         ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
 
     debug!(target: "account", "Account view rebuild complete");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub(crate) mod config;
 pub(crate) mod fireblocks;
 pub(crate) mod poll_checkpoint;
 pub mod receipt_inventory;
+pub(crate) mod replay;
 pub(crate) mod telemetry;
 pub(crate) mod vault;
 

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::{Address, B256, U256};
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay};
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
@@ -10,9 +9,10 @@ use tracing::debug;
 use uuid::Uuid;
 
 use super::{
-    ClientId, IssuerMintRequestId, Mint, MintEvent, Network, Quantity,
-    TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+    ClientId, IssuerMintRequestId, Mint, MintError, MintEvent, Network,
+    Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
 };
+use crate::replay::{ReplayError, replay_all_or_fail};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MintViewError {
@@ -21,16 +21,16 @@ pub(crate) enum MintViewError {
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
     #[error("Replay error: {0}")]
-    Replay(#[from] cqrs_es::AggregateError<super::MintError>),
+    Replay(#[from] ReplayError<MintError>),
     #[error("UUID parse error: {0}")]
     Uuid(#[from] uuid::Error),
 }
 
 /// Replays all `Mint` events through the `mint_view`.
 ///
-/// Uses `QueryReplay` to re-project the view from existing events in the event store.
-/// This is used at startup to ensure the view is in sync with events after manual
-/// event store modifications or schema changes.
+/// Re-projects the view from existing events in the event store. This is used at
+/// startup to ensure the view is in sync with events after manual event store
+/// modifications or schema changes.
 pub async fn replay_mint_view(pool: Pool<Sqlite>) -> Result<(), MintViewError> {
     debug!(target: "mint", "Rebuilding mint view from events");
 
@@ -40,11 +40,8 @@ pub async fn replay_mint_view(pool: Pool<Sqlite>) -> Result<(), MintViewError> {
         pool.clone(),
         "mint_view".to_string(),
     ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
 
     debug!(target: "mint", "Mint view rebuild complete");
 

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::{Bytes, TxHash, U256};
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay};
 use cqrs_es::{AggregateError, EventEnvelope, View};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -11,9 +10,11 @@ use tracing::debug;
 
 use super::{ReceiptId, ReceiptInventoryError, Shares, SharesOverflow};
 use crate::redemption::IssuerRedemptionRequestId;
+use crate::redemption::upcaster::create_tokens_burned_upcaster;
 use crate::redemption::{
     BurnRecord, Redemption, RedemptionError, RedemptionEvent,
 };
+use crate::replay::{ReplayError, replay_all_or_fail};
 use crate::vault::ReceiptInformation;
 
 /// Tracks burn operations for a redemption.
@@ -74,7 +75,7 @@ pub(crate) enum BurnTrackingError {
     #[error("Database error: {0}")]
     Database(#[from] sqlx::Error),
     #[error("Replay error: {0}")]
-    Replay(#[from] AggregateError<RedemptionError>),
+    Replay(#[from] ReplayError<RedemptionError>),
     #[error("ReceiptInventory aggregate error: {0}")]
     ReceiptInventory(#[from] AggregateError<ReceiptInventoryError>),
     #[error(
@@ -201,8 +202,8 @@ pub(crate) fn plan_burn(
 
 /// Replays all `Redemption` events through the `receipt_burns_view`.
 ///
-/// Uses `QueryReplay` to re-project the view from existing events in the event store.
-/// This is used at startup to recover view state after the view schema was added.
+/// Re-projects the view from existing events in the event store. This is used at
+/// startup to recover view state after the view schema was added.
 ///
 /// # Errors
 ///
@@ -219,11 +220,13 @@ pub(crate) async fn replay_receipt_burns_view(
             pool.clone(),
             "receipt_burns_view".to_string(),
         ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(
+        event_repo,
+        view_repo,
+        vec![create_tokens_burned_upcaster()],
+    )
+    .await?;
 
     debug!(target: "receipt", "Receipt burns view rebuild complete");
 
@@ -233,6 +236,7 @@ pub(crate) async fn replay_receipt_burns_view(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{U256, address, b256, uint};
+    use cqrs_es::persist::GenericQuery;
     use proptest::prelude::*;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -1,6 +1,5 @@
 use alloy::primitives::U256;
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay};
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
@@ -9,6 +8,7 @@ use std::sync::Arc;
 use tracing::debug;
 
 use crate::mint::{Mint, MintError, MintEvent};
+use crate::replay::{ReplayError, replay_all_or_fail};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 
 #[derive(Debug, thiserror::Error)]
@@ -31,13 +31,13 @@ pub(crate) enum ReceiptInventoryReplayError {
     Database(#[from] sqlx::Error),
 
     #[error("Replay error: {0}")]
-    Replay(#[from] cqrs_es::AggregateError<MintError>),
+    Replay(#[from] ReplayError<MintError>),
 }
 
 /// Replays all `Mint` events through the `receipt_inventory_view`.
 ///
-/// Uses `QueryReplay` to re-project the view from existing events in the event
-/// store. This runs at startup so receipts activated through historical
+/// Re-projects the view from existing events in the event store. This runs at
+/// startup so receipts activated through historical
 /// `MintEvent::ExistingMintRecovered` events — which earlier code ignored —
 /// are rebuilt as `Active` instead of left stale in `Pending`.
 pub(crate) async fn replay_receipt_inventory_view(
@@ -52,11 +52,8 @@ pub(crate) async fn replay_receipt_inventory_view(
             pool.clone(),
             "receipt_inventory_view".to_string(),
         ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
 
     debug!(target: "receipt", "Receipt inventory view rebuild complete");
 

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -1,7 +1,6 @@
 use alloy::primitives::{Address, B256};
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay};
-use cqrs_es::{AggregateError, EventEnvelope, View};
+use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
@@ -11,7 +10,9 @@ use tracing::debug;
 
 use super::IssuerRedemptionRequestId;
 use crate::mint::{Quantity, TokenizationRequestId};
+use crate::redemption::upcaster::create_tokens_burned_upcaster;
 use crate::redemption::{Redemption, RedemptionError, RedemptionEvent};
+use crate::replay::{ReplayError, replay_all_or_fail};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -449,13 +450,13 @@ pub(crate) enum RedemptionViewError {
     #[error(transparent)]
     IssuerRequestIdParse(#[from] super::IssuerRedemptionRequestIdParseError),
     #[error("Replay error: {0}")]
-    Replay(#[from] AggregateError<RedemptionError>),
+    Replay(#[from] ReplayError<RedemptionError>),
 }
 
 /// Replays all `Redemption` events through the `redemption_view`.
 ///
-/// Uses `QueryReplay` to re-project the view from existing events in the event store.
-/// This is used at startup to ensure the view includes new fields (alpaca_quantity,
+/// Re-projects the view from existing events in the event store. This is used at
+/// startup to ensure the view includes new fields (alpaca_quantity,
 /// dust_quantity) that were added after the original events were stored.
 pub async fn replay_redemption_view(
     pool: Pool<Sqlite>,
@@ -469,11 +470,13 @@ pub async fn replay_redemption_view(
             pool.clone(),
             "redemption_view".to_string(),
         ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(
+        event_repo,
+        view_repo,
+        vec![create_tokens_burned_upcaster()],
+    )
+    .await?;
 
     debug!(target: "redemption", "Redemption view rebuild complete");
 

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -1,0 +1,523 @@
+use cqrs_es::persist::{
+    EventUpcaster, GenericQuery, PersistenceError, QueryReplay,
+};
+use cqrs_es::{Aggregate, AggregateError, View};
+use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
+use std::sync::{Arc, Mutex};
+use tracing::{debug, error};
+
+/// Errors raised while rebuilding a view by replaying committed events.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReplayError<E: std::error::Error + 'static> {
+    /// The event stream itself failed to open. Unreachable with the pinned
+    /// sqlite-es (which always returns `Ok` from `stream_all_events` and routes
+    /// read failures through the per-event handler as [`Self::EventsDropped`]);
+    /// reserved for backends that surface stream-open errors eagerly.
+    #[error(transparent)]
+    Aggregate(#[from] AggregateError<E>),
+
+    /// `dropped` is a lower bound, not an exact count. A row-level stream
+    /// read error (e.g. an unreadable column or non-JSON payload) closes the
+    /// event stream, so any events after the failed row are skipped without
+    /// ever reaching a handler and are not counted here. View-dispatch and
+    /// deserialization failures that do not close the stream are counted
+    /// exactly.
+    #[error(
+        "replay dropped at least {dropped} event(s) while rebuilding the view; first error: {first}"
+    )]
+    EventsDropped { dropped: usize, first: PersistenceError },
+}
+
+/// Accumulates per-event replay failures surfaced by the cqrs-es error
+/// handlers. Only the count and the first error are retained — full per-event
+/// detail goes to the DEBUG logs — so a systemic failure (e.g. a missing view
+/// table that fails every event's dispatch) cannot grow memory without bound.
+#[derive(Default)]
+struct DroppedEvents {
+    count: usize,
+    first: Option<PersistenceError>,
+}
+
+/// Replays all committed events of aggregate `A` into the view managed by
+/// `view_repo`, failing fast if any per-event error would otherwise be silently
+/// dropped.
+///
+/// `cqrs-es` delivers per-event failures (event deserialization, stream reads,
+/// view writes) to optional error handlers on both [`QueryReplay`] and the
+/// [`GenericQuery`]. With no handler installed those failures are discarded and
+/// `replay_all` still returns `Ok(())`, so a single malformed or unupcastable
+/// historical event can leave a projection partially rebuilt while startup
+/// reports success (verified in `cqrs-es-0.4.12`: `persist/replay.rs:103-107`
+/// and `persist/generic_query.rs:125-129`). Both handlers return `()` and
+/// cannot abort the stream, so this collects every dropped error and converts a
+/// non-empty collection into a typed failure once the replay completes.
+///
+/// `upcasters` must match those registered on the aggregate's live event store,
+/// otherwise legacy event versions that the live store upcasts successfully
+/// would deserialize-fail here and abort startup. Pass an empty `Vec` for
+/// aggregates whose store registers none.
+pub(crate) async fn replay_all_or_fail<V, A>(
+    event_repo: SqliteEventRepository,
+    view_repo: Arc<SqliteViewRepository<V, A>>,
+    upcasters: Vec<Box<dyn EventUpcaster>>,
+) -> Result<(), ReplayError<A::Error>>
+where
+    V: View<A>,
+    A: Aggregate,
+    A::Error: 'static,
+{
+    let dropped_errors: Arc<Mutex<DroppedEvents>> =
+        Arc::new(Mutex::new(DroppedEvents::default()));
+
+    let mut query = GenericQuery::new(view_repo);
+    let dispatch_errors = dropped_errors.clone();
+    query.use_error_handler(Box::new(move |error| {
+        debug!(target: "startup", %error, "dropped event during view dispatch");
+        if let Ok(mut dropped) = dispatch_errors.lock() {
+            dropped.count += 1;
+            dropped.first.get_or_insert(error);
+        }
+    }));
+
+    let mut replay =
+        QueryReplay::new(event_repo, query).with_upcasters(upcasters);
+    let stream_errors = dropped_errors.clone();
+    replay.use_error_handler(Box::new(move |error| {
+        debug!(target: "startup", %error, "dropped event during stream read");
+        if let Ok(mut dropped) = stream_errors.lock() {
+            dropped.count += 1;
+            dropped.first.get_or_insert(error);
+        }
+    }));
+
+    // With the pinned sqlite-es, `stream_all_events` always returns `Ok` and
+    // delivers DB/stream failures through the stream channel to the handler
+    // above (surfacing as `EventsDropped`), so this `?` does not fire on a
+    // missing or unreadable event store. It is kept as a forward-compatible
+    // guard: if a future event-store backend returns the stream-open error
+    // eagerly, it maps to `ReplayError::Aggregate` rather than being swallowed.
+    replay.replay_all().await?;
+
+    let dropped = std::mem::take(
+        &mut *dropped_errors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner),
+    );
+
+    if let Some(first) = dropped.first {
+        let dropped = dropped.count;
+        error!(
+            target: "startup",
+            dropped,
+            %first,
+            "view replay dropped events; aborting startup so the incomplete projection is never served"
+        );
+
+        return Err(ReplayError::EventsDropped { dropped, first });
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::{Pool, Sqlite};
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::mint::{Mint, MintView};
+    use crate::redemption::upcaster::create_tokens_burned_upcaster;
+    use crate::redemption::{Redemption, RedemptionView};
+    use crate::test_utils::logs_contain_at;
+
+    /// A legacy v1.0 `TokensBurned` payload — top-level `receipt_id`/
+    /// `shares_burned` with no `burns` array. It only deserializes into the
+    /// current `RedemptionEvent` after `create_tokens_burned_upcaster` runs.
+    const LEGACY_TOKENS_BURNED_V1: &str = r#"{
+        "TokensBurned": {
+            "issuer_request_id": "red-abcd1234",
+            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+            "receipt_id": "0x42",
+            "shares_burned": "0x100",
+            "dust_returned": "0x0",
+            "gas_used": 1000,
+            "block_number": 5,
+            "burned_at": "2025-01-01T00:00:00Z"
+        }
+    }"#;
+
+    async fn migrated_pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    async fn seed_event(
+        pool: &Pool<Sqlite>,
+        aggregate_type: &str,
+        event_type: &str,
+        event_version: &str,
+        payload: &str,
+    ) {
+        seed_event_at(
+            pool,
+            aggregate_type,
+            "agg-1",
+            1,
+            event_type,
+            event_version,
+            payload,
+        )
+        .await;
+    }
+
+    async fn seed_event_at(
+        pool: &Pool<Sqlite>,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        event_version: &str,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (?, ?, ?, ?, ?, ?, '{}')
+            ",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(event_version)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .expect("Failed to seed event");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_fails_fast_on_malformed_event() {
+        let pool = migrated_pool().await;
+
+        // A Mint event whose payload cannot deserialize into MintEvent, so the
+        // stream delivers a per-event error the handler must surface.
+        seed_event(
+            &pool,
+            "Mint",
+            "MintEvent::Garbage",
+            "1.0",
+            r#"{"NonexistentVariant":{}}"#,
+        )
+        .await;
+
+        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
+            pool.clone(),
+            "mint_view".to_string(),
+        ));
+        let event_repo = SqliteEventRepository::new(pool);
+
+        let error = replay_all_or_fail(event_repo, view_repo, vec![])
+            .await
+            .expect_err("replay should fail on a malformed event");
+
+        let ReplayError::EventsDropped { dropped, first } = &error else {
+            panic!("expected EventsDropped, got {error:?}");
+        };
+        assert_eq!(*dropped, 1);
+        assert!(
+            first.to_string().contains("NonexistentVariant"),
+            "first error should name the bad variant, got: {first}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["view replay dropped events", "aborting startup"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["dropped event during stream read"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_fails_fast_on_view_write_error() {
+        let pool = migrated_pool().await;
+
+        // A valid (post-upcast) event so the stream yields Ok and dispatch runs.
+        seed_event(
+            &pool,
+            "Redemption",
+            "RedemptionEvent::TokensBurned",
+            "1.0",
+            LEGACY_TOKENS_BURNED_V1,
+        )
+        .await;
+
+        // Remove the target view table so the view-write path inside dispatch
+        // fails, exercising the GenericQuery error handler.
+        sqlx::query("DROP TABLE redemption_view")
+            .execute(&pool)
+            .await
+            .expect("Failed to drop redemption_view");
+
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
+        let event_repo = SqliteEventRepository::new(pool);
+
+        let error = replay_all_or_fail(
+            event_repo,
+            view_repo,
+            vec![create_tokens_burned_upcaster()],
+        )
+        .await
+        .expect_err("replay should fail when the view table is missing");
+
+        assert!(
+            matches!(error, ReplayError::EventsDropped { dropped: 1, .. }),
+            "expected EventsDropped, got {error:?}"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["dropped event during view dispatch"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["view replay dropped events"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_upcasts_legacy_events_instead_of_dropping_them() {
+        let pool = migrated_pool().await;
+
+        // Without the upcaster this v1.0 payload deserialize-fails and would be
+        // dropped; with it, the replay must rebuild the view cleanly.
+        seed_event(
+            &pool,
+            "Redemption",
+            "RedemptionEvent::TokensBurned",
+            "1.0",
+            LEGACY_TOKENS_BURNED_V1,
+        )
+        .await;
+
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
+        let event_repo = SqliteEventRepository::new(pool.clone());
+
+        replay_all_or_fail(
+            event_repo,
+            view_repo,
+            vec![create_tokens_burned_upcaster()],
+        )
+        .await
+        .expect("legacy event should upcast and replay without being dropped");
+
+        let payload: String =
+            sqlx::query_scalar("SELECT payload FROM redemption_view")
+                .fetch_one(&pool)
+                .await
+                .expect("redemption_view should hold the rebuilt row");
+        // The upcast event must actually project its fields, not just insert an
+        // empty row — assert a value carried by LEGACY_TOKENS_BURNED_V1 landed
+        // in the rebuilt view.
+        assert!(
+            payload.contains("red-abcd1234"),
+            "rebuilt view should carry the upcast event's issuer_request_id, got: {payload}"
+        );
+    }
+
+    #[tokio::test]
+    async fn replay_succeeds_on_empty_store() {
+        let pool = migrated_pool().await;
+
+        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
+            pool.clone(),
+            "mint_view".to_string(),
+        ));
+        let event_repo = SqliteEventRepository::new(pool.clone());
+
+        replay_all_or_fail(event_repo, view_repo, vec![])
+            .await
+            .expect("an empty event store is not a replay failure");
+
+        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mint_view")
+            .fetch_one(&pool)
+            .await
+            .expect("mint_view should be queryable");
+        assert_eq!(
+            rows, 0,
+            "a replay over no events must leave the view empty"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_drops_legacy_event_without_upcaster() {
+        let pool = migrated_pool().await;
+
+        // The same v1.0 payload the upcast test replays cleanly — but with no
+        // upcaster it cannot deserialize, proving the positive upcast test
+        // detects the upcaster's work rather than an event that happens to
+        // deserialize regardless.
+        seed_event(
+            &pool,
+            "Redemption",
+            "RedemptionEvent::TokensBurned",
+            "1.0",
+            LEGACY_TOKENS_BURNED_V1,
+        )
+        .await;
+
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
+        let event_repo = SqliteEventRepository::new(pool);
+
+        let error =
+            replay_all_or_fail(event_repo, view_repo, vec![]).await.expect_err(
+                "a legacy event with no upcaster must not be dropped silently",
+            );
+
+        assert!(
+            matches!(error, ReplayError::EventsDropped { dropped: 1, .. }),
+            "expected EventsDropped, got {error:?}"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["view replay dropped events"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["dropped event during stream read"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_counts_every_dropped_event() {
+        let pool = migrated_pool().await;
+
+        // Two events under distinct aggregates so each dispatches separately;
+        // dropping the view table fails every dispatch, so the count must
+        // reflect both, not just the first.
+        for aggregate_id in ["agg-1", "agg-2"] {
+            seed_event_at(
+                &pool,
+                "Redemption",
+                aggregate_id,
+                1,
+                "RedemptionEvent::TokensBurned",
+                "1.0",
+                LEGACY_TOKENS_BURNED_V1,
+            )
+            .await;
+        }
+
+        sqlx::query("DROP TABLE redemption_view")
+            .execute(&pool)
+            .await
+            .expect("Failed to drop redemption_view");
+
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
+        let event_repo = SqliteEventRepository::new(pool);
+
+        let error = replay_all_or_fail(
+            event_repo,
+            view_repo,
+            vec![create_tokens_burned_upcaster()],
+        )
+        .await
+        .expect_err("replay should fail when the view table is missing");
+
+        let ReplayError::EventsDropped { dropped, .. } = &error else {
+            panic!("expected EventsDropped, got {error:?}");
+        };
+        assert_eq!(
+            *dropped, 2,
+            "both dispatch failures must be counted, not just the first"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["view replay dropped events"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["dropped event during view dispatch"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replay_fails_fast_when_event_store_is_unreadable() {
+        let pool = migrated_pool().await;
+
+        // Drop the event store entirely. sqlite-es surfaces the resulting DB
+        // error through the stream as a single per-event read failure, so it
+        // reaches the QueryReplay handler and becomes EventsDropped rather than
+        // silently rebuilding an empty view — a catastrophic store failure
+        // must still abort startup, never report a clean rebuild.
+        sqlx::query("DROP TABLE events")
+            .execute(&pool)
+            .await
+            .expect("Failed to drop events");
+
+        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
+            pool.clone(),
+            "mint_view".to_string(),
+        ));
+        let event_repo = SqliteEventRepository::new(pool);
+
+        let error = replay_all_or_fail(event_repo, view_repo, vec![])
+            .await
+            .expect_err("an unreadable event store must abort the replay");
+
+        assert!(
+            matches!(error, ReplayError::EventsDropped { dropped: 1, .. }),
+            "expected EventsDropped {{ dropped: 1 }}, got {error:?}"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["view replay dropped events"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["dropped event during stream read"]
+        ));
+    }
+}

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::Address;
 use chrono::{DateTime, Utc};
-use cqrs_es::persist::{GenericQuery, QueryReplay, ViewRepository};
+use cqrs_es::persist::ViewRepository;
 use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
@@ -12,6 +12,7 @@ use super::{
     Network, TokenSymbol, TokenizedAsset, TokenizedAssetError,
     TokenizedAssetEvent, UnderlyingSymbol,
 };
+use crate::replay::{ReplayError, replay_all_or_fail};
 
 pub(crate) type TokenizedAssetViewRepo =
     Arc<SqliteViewRepository<TokenizedAssetView, TokenizedAsset>>;
@@ -24,15 +25,15 @@ pub(crate) enum TokenizedAssetViewError {
     Deserialization(#[from] serde_json::Error),
     #[error("Persistence error: {0}")]
     Persistence(#[from] cqrs_es::persist::PersistenceError),
-    #[error("Aggregate error: {0}")]
-    Aggregate(#[from] cqrs_es::AggregateError<TokenizedAssetError>),
+    #[error("Replay error: {0}")]
+    Replay(#[from] ReplayError<TokenizedAssetError>),
 }
 
 /// Replays all `TokenizedAsset` events through the `tokenized_asset_view`.
 ///
-/// Uses `QueryReplay` to re-project the view from existing events in the event store.
-/// This is used at startup to ensure the view is in sync with events after manual
-/// event store modifications or schema changes.
+/// Re-projects the view from existing events in the event store. This is used at
+/// startup to ensure the view is in sync with events after manual event store
+/// modifications or schema changes.
 pub(crate) async fn replay_tokenized_asset_view(
     pool: Pool<Sqlite>,
 ) -> Result<(), TokenizedAssetViewError> {
@@ -47,11 +48,8 @@ pub(crate) async fn replay_tokenized_asset_view(
         pool.clone(),
         "tokenized_asset_view".to_string(),
     ));
-    let query = GenericQuery::new(view_repo);
-
     let event_repo = SqliteEventRepository::new(pool);
-    let replay = QueryReplay::new(event_repo, query);
-    replay.replay_all().await?;
+    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
 
     debug!(target: "asset", view = "tokenized_asset_view", "View rebuild complete");
 


### PR DESCRIPTION
## Motivation

All six startup view-replay functions rebuilt their CQRS projection by calling `QueryReplay::replay_all()` without installing an error handler. Per cqrs-es behaviour, per-event errors (deserialization failures, event-stream read errors, view-write errors) are delivered to an optional `error_handler` and **silently dropped when none is set** — `replay_all()` then returns `Ok(())` regardless, and each function logs "rebuild complete".

Consequence: a single malformed or unupcastable historical event could leave a projection partially or fully un-rebuilt at startup while startup reported success — recreating the exact stale-projection class of bug these replays exist to prevent, with no operator-visible signal.

Tracked in [RAI-801](https://linear.app/makeitrain/issue/RAI-801/view-replay-functions-silently-swallow-per-event-errors-no-queryreplay).

## Solution

Introduce a shared `replay_all_or_fail` helper (`src/replay.rs`) and route all six replay functions through it, replacing the duplicated `GenericQuery::new` + `QueryReplay::new` + `replay_all()` blocks with a single call.

The helper installs error-collecting handlers on **both** silent-drop points cqrs-es exposes — the `QueryReplay` (stream read / event deserialization) and the underlying `GenericQuery` (view load/write during dispatch) — funnelling both into one shared `Arc<Mutex<Vec<PersistenceError>>>`. Both handlers are `Fn(PersistenceError)` that return `()` and cannot abort the stream, so the helper collects every dropped error and, once `replay_all()` completes, fails fast with a typed `ReplayError::EventsDropped { dropped, first }` instead of letting startup report success on a partial projection. Each dropped event is logged at DEBUG; the terminal failure is logged at ERROR.

While threading callers through the helper, the replay path is also made upcaster-aware: `replay_all_or_fail` takes a `Vec<Box<dyn EventUpcaster>>` and the two `Redemption`-aggregate replays (`replay_redemption_view`, `replay_receipt_burns_view`) now pass `create_tokens_burned_upcaster()` to match the live event store (`lib.rs:588`). Without this, the new fail-fast behaviour would abort startup on legitimate legacy `TokensBurned` v1.0 events that the live store upcasts successfully — a latent gap the previous silent-drop behaviour masked. The other four replays register no upcasters and pass an empty `Vec`.

Each per-feature view error enum now carries `Replay(#[from] ReplayError<AggregateErr>)` in place of the previous `AggregateError` variant.

## Testing

Three new unit tests in `src/replay.rs` (in-memory SQLite, seeding only the `events` table per the e2e setup rule):

- `replay_fails_fast_on_malformed_event` — a malformed `Mint` payload exercises the `QueryReplay` stream/deserialization handler; asserts `EventsDropped { dropped: 1 }`, that the first error names the bad variant, and both the DEBUG per-event and ERROR terminal logs.
- `replay_fails_fast_on_view_write_error` — a valid (upcast) event with the target view table dropped exercises the `GenericQuery` dispatch/view-write handler; asserts `EventsDropped` and the dispatch-path DEBUG log.
- `replay_upcasts_legacy_events_instead_of_dropping_them` — a legacy v1.0 `TokensBurned` event replays cleanly (proving the upcaster is threaded through) and rebuilds the view row.

All 667 lib tests pass; clippy (`-D warnings`) and `fmt --check` clean; Rainix CI green.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved view rebuild reliability with enhanced error tracking and reporting for dropped events during replay.
  * Unified view projection rebuild logic across account, mint, receipt inventory, redemption, and tokenized asset modules for more consistent error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->