### PR TITLE
refactor: migrate account aggregate to event sorcery

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
   sequence_diagrams: false
   estimate_code_review_effort: false
   auto_apply_labels: true
-  auto_assign_reviewers: true
+  auto_assign_reviewers: false
   poem: false
   path_instructions:
     - path: "*"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -775,7 +775,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2011,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2049,7 +2049,7 @@ dependencies = [
 [[package]]
 name = "event-sorcery"
 version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git?branch=docs%2Fexamples#036718226e875bb748fcbf7e148dd265cc8b404e"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git#1557172049c8a43add209a86c7d809e89a5fbc82"
 dependencies = [
  "async-trait",
  "cqrs-es",
@@ -2837,7 +2837,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3053,7 +3053,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3406,7 +3406,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4083,7 +4083,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4120,7 +4120,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4649,7 +4649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5105,7 +5105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5139,7 +5139,7 @@ dependencies = [
 [[package]]
 name = "sqlite-es"
 version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git?branch=docs%2Fexamples#036718226e875bb748fcbf7e148dd265cc8b404e"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git#1557172049c8a43add209a86c7d809e89a5fbc82"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5576,7 +5576,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", branch = "docs/examples" }
-sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git", branch = "docs/examples" }
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git" }
+sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git" }
 cqrs-es = "0.4.12"
 async-trait = "0.1.89"
 rocket = { version = "0.5.1", features = ["json"] }
@@ -55,6 +55,9 @@ flate2 = "1.1.9"
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"
 alloy-sol-types = "1.4.1"
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", features = [
+  "test-support",
+] }
 httpmock = "0.8.2"
 proptest = "1.10.0"
 rand = "0.8"

--- a/migrations/20260604234827_migrate_account_view_to_lifecycle.sql
+++ b/migrations/20260604234827_migrate_account_view_to_lifecycle.sql
@@ -1,0 +1,27 @@
+-- account_view now stores the event-sorcery `Lifecycle<Account>` payload
+-- (`{"Live": {...}}`) instead of the legacy cqrs-es `AccountView` payload. Drop
+-- the old table (its stale `$.Account.*` generated columns and indexes) and
+-- recreate it clean. `StoreBuilder::build` rebuilds every row from the event log
+-- on startup via the projection's catch-up, so no data is lost.
+DROP TABLE IF EXISTS account_view;
+
+CREATE TABLE account_view (
+    view_id TEXT PRIMARY KEY,
+    version BIGINT NOT NULL,
+    payload JSON NOT NULL
+);
+
+-- Preserve the legacy duplicate-email index (migration 20251201225642),
+-- re-pathed onto the Lifecycle payload. This guards the view against duplicate
+-- rows only; it is not a 409 mechanism (the projection runs after the event
+-- commits and swallows the resulting UNIQUE violation as a warning), so the
+-- application-level find_by_email pre-check remains the registration guard.
+CREATE UNIQUE INDEX idx_account_view_email_unique
+    ON account_view(
+        COALESCE(
+            json_extract(payload, '$.Live.Registered.email'),
+            json_extract(payload, '$.Live.LinkedToAlpaca.email')
+        )
+    )
+    WHERE json_extract(payload, '$.Live.Registered.email') IS NOT NULL
+       OR json_extract(payload, '$.Live.LinkedToAlpaca.email') IS NOT NULL;

--- a/migrations/20260605005801_add_snapshot_version_to_snapshots.sql
+++ b/migrations/20260605005801_add_snapshot_version_to_snapshots.sql
@@ -1,0 +1,7 @@
+-- event-sorcery's snapshot store (used by the Account `Store`) reads and writes
+-- a `snapshot_version` column on the shared `snapshots` table. The original
+-- cqrs-es-era schema predates it, so add it with a default of 0 (matching
+-- event-sorcery's canonical init schema). The remaining cqrs-es aggregates use
+-- sqlite-es, whose snapshot writes omit this column entirely; DEFAULT 0 keeps
+-- those INSERTs valid.
+ALTER TABLE snapshots ADD COLUMN snapshot_version BIGINT NOT NULL DEFAULT 0;

--- a/migrations/20260605013108_add_account_emails_uniqueness.sql
+++ b/migrations/20260605013108_add_account_emails_uniqueness.sql
@@ -1,0 +1,18 @@
+-- Authoritative duplicate-email guard for account registration. The account_view
+-- unique index only rejects a duplicate view ROW (the projection runs after the
+-- event commits and swallows the violation), so it cannot stop two concurrent
+-- registrations of the same email from both committing Registered events.
+-- account_emails' PRIMARY KEY lets register_account atomically claim an email
+-- BEFORE committing, so the loser of a concurrent race is rejected with a 409
+-- instead of producing a committed-but-unprojectable phantom account.
+CREATE TABLE account_emails (
+    email TEXT PRIMARY KEY
+);
+
+-- Backfill from every account already in the event log so existing emails are
+-- claimed before the guard takes effect.
+INSERT OR IGNORE INTO account_emails (email)
+SELECT json_extract(payload, '$.Registered.email')
+FROM events
+WHERE aggregate_type = 'Account'
+  AND event_type = 'AccountEvent::Registered';

--- a/src/account/api.rs
+++ b/src/account/api.rs
@@ -1,5 +1,5 @@
 use alloy::primitives::Address;
-use cqrs_es::AggregateError;
+use event_sorcery::{AggregateError, LifecycleError, Store};
 use rocket::Request;
 use rocket::http::Status;
 use rocket::request::FromParam;
@@ -7,13 +7,13 @@ use rocket::response::Responder;
 use rocket::serde::json::Json;
 use rocket::{delete, post};
 use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::error;
 use uuid::Uuid;
 
 use super::{
-    AccountCommand, AccountError, AccountView, AlpacaAccountNumber, ClientId,
-    Email, view::AccountViewError, view::find_by_client_id,
-    view::find_by_email,
+    Account, AccountCommand, AccountView, AlpacaAccountNumber, ClientId, Email,
+    view::AccountViewError, view::find_by_client_id, view::find_by_email,
 };
 use crate::auth::{InternalAuth, IssuerAuth};
 
@@ -42,7 +42,7 @@ pub(crate) enum ApiError {
     #[error("Account view error: {0}")]
     AccountView(#[from] AccountViewError),
     #[error("Aggregate error: {0}")]
-    Aggregate(#[from] AggregateError<AccountError>),
+    Aggregate(#[from] AggregateError<LifecycleError<Account>>),
 }
 
 impl<'r> Responder<'r, 'static> for ApiError {
@@ -77,33 +77,43 @@ pub struct RegisterAccountResponse {
     pub client_id: ClientId,
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool), fields(email = %request.email.0))]
+#[tracing::instrument(skip(_auth, store, pool), fields(email = %request.email.0))]
 #[post("/accounts", format = "json", data = "<request>")]
 pub(crate) async fn register_account(
     _auth: InternalAuth,
-    cqrs: &rocket::State<crate::AccountCqrs>,
+    store: &rocket::State<Arc<Store<Account>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
     request: Json<RegisterAccountRequest>,
 ) -> Result<Json<RegisterAccountResponse>, rocket::http::Status> {
-    if let Some(view) = find_by_email(pool.inner(), &request.email)
-        .await
-        .map_err(|_| rocket::http::Status::InternalServerError)?
-    {
-        match view {
-            AccountView::Registered { .. }
-            | AccountView::LinkedToAlpaca { .. } => {
-                return Err(rocket::http::Status::Conflict);
-            }
-            AccountView::Unavailable => {}
-        }
+    // Atomically claim the email before committing any event. The unique PK on
+    // account_emails rejects a concurrent or repeat registration race-free,
+    // unlike the account_view index whose violation the projection swallows
+    // after the event has already committed.
+    let claimed = sqlx::query!(
+        "INSERT OR IGNORE INTO account_emails (email) VALUES (?)",
+        request.email.0
+    )
+    .execute(pool.inner())
+    .await
+    .map_err(|_| rocket::http::Status::InternalServerError)?;
+
+    if claimed.rows_affected() == 0 {
+        return Err(rocket::http::Status::Conflict);
     }
 
     let client_id = ClientId::new();
     let register_command =
         AccountCommand::Register { client_id, email: request.email.clone() };
 
-    let aggregate_id = client_id.to_string();
-    if let Err(err) = cqrs.execute(&aggregate_id, register_command).await {
+    if let Err(err) = store.send(&client_id, register_command).await {
+        // Release the claim so a transient failure doesn't permanently block
+        // re-registration of this email.
+        let _ = sqlx::query!(
+            "DELETE FROM account_emails WHERE email = ?",
+            request.email.0
+        )
+        .execute(pool.inner())
+        .await;
         return Err(map_cqrs_error_to_status(&err));
     }
 
@@ -111,7 +121,7 @@ pub(crate) async fn register_account(
 }
 
 fn map_cqrs_error_to_status(
-    err: &AggregateError<super::AccountError>,
+    err: &AggregateError<LifecycleError<Account>>,
 ) -> Status {
     match err {
         AggregateError::DatabaseConnectionError(inner)
@@ -139,14 +149,14 @@ pub struct AccountLinkResponse {
     pub client_id: ClientId,
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool), fields(
+#[tracing::instrument(skip(_auth, store, pool), fields(
     email = %request.email.0,
     account = %request.account.0
 ))]
 #[post("/accounts/connect", format = "json", data = "<request>")]
 pub(crate) async fn connect_account(
     _auth: IssuerAuth,
-    cqrs: &rocket::State<crate::AccountCqrs>,
+    store: &rocket::State<Arc<Store<Account>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
     request: Json<AccountLinkRequest>,
 ) -> Result<Json<AccountLinkResponse>, rocket::http::Status> {
@@ -160,17 +170,14 @@ pub(crate) async fn connect_account(
         AccountView::LinkedToAlpaca { .. } => {
             return Err(rocket::http::Status::Conflict);
         }
-        AccountView::Unavailable => {
-            return Err(rocket::http::Status::NotFound);
-        }
     };
 
     let link_command = AccountCommand::LinkToAlpaca {
         alpaca_account: request.account.clone(),
     };
 
-    let aggregate_id = client_id.to_string();
-    cqrs.execute(&aggregate_id, link_command)
+    store
+        .send(&client_id, link_command)
         .await
         .map_err(|_| rocket::http::Status::InternalServerError)?;
 
@@ -187,14 +194,14 @@ pub struct WhitelistWalletResponse {
     pub success: bool,
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool), fields(
+#[tracing::instrument(skip(_auth, store, pool), fields(
     client_id = %client_id,
     wallet = ?request.wallet
 ))]
 #[post("/accounts/<client_id>/wallets", format = "json", data = "<request>")]
 pub(crate) async fn whitelist_wallet(
     _auth: InternalAuth,
-    cqrs: &rocket::State<crate::AccountCqrs>,
+    store: &rocket::State<Arc<Store<Account>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
     client_id: ClientId,
     request: Json<WhitelistWalletRequest>,
@@ -209,20 +216,19 @@ pub(crate) async fn whitelist_wallet(
 
     let command = AccountCommand::WhitelistWallet { wallet: request.wallet };
 
-    let aggregate_id = client_id.0.to_string();
-    cqrs.execute(&aggregate_id, command).await?;
+    store.send(&client_id, command).await?;
 
     Ok(Json(WhitelistWalletResponse { success: true }))
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool), fields(
+#[tracing::instrument(skip(_auth, store, pool), fields(
     client_id = %client_id,
     wallet = %wallet.0
 ))]
 #[delete("/accounts/<client_id>/wallets/<wallet>")]
 pub(crate) async fn unwhitelist_wallet(
     _auth: InternalAuth,
-    cqrs: &rocket::State<crate::AccountCqrs>,
+    store: &rocket::State<Arc<Store<Account>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
     client_id: ClientId,
     wallet: WalletParam,
@@ -237,8 +243,7 @@ pub(crate) async fn unwhitelist_wallet(
 
     let command = AccountCommand::UnwhitelistWallet { wallet: wallet.0 };
 
-    let aggregate_id = client_id.0.to_string();
-    cqrs.execute(&aggregate_id, command).await?;
+    store.send(&client_id, command).await?;
 
     Ok(Json(WhitelistWalletResponse { success: true }))
 }
@@ -246,12 +251,10 @@ pub(crate) async fn unwhitelist_wallet(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{B256, address};
-    use cqrs_es::persist::GenericQuery;
+    use event_sorcery::StoreBuilder;
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
-    use sqlite_es::{SqliteViewRepository, sqlite_cqrs};
     use sqlx::sqlite::SqlitePoolOptions;
-    use std::sync::Arc;
     use url::Url;
 
     use super::*;
@@ -280,19 +283,27 @@ mod tests {
     }
 
     async fn register_account(
-        cqrs: &crate::AccountCqrs,
+        store: &Arc<Store<Account>>,
+        pool: &sqlx::Pool<sqlx::Sqlite>,
         email: &str,
     ) -> ClientId {
         let client_id = ClientId::new();
+
+        sqlx::query!(
+            "INSERT OR IGNORE INTO account_emails (email) VALUES (?)",
+            email
+        )
+        .execute(pool)
+        .await
+        .expect("Failed to claim email");
+
         let email =
             Email::new(email.to_string()).expect("Valid email for test");
 
-        cqrs.execute(
-            &client_id.to_string(),
-            AccountCommand::Register { client_id, email },
-        )
-        .await
-        .expect("Failed to register account");
+        store
+            .send(&client_id, AccountCommand::Register { client_id, email })
+            .await
+            .expect("Failed to register account");
 
         client_id
     }
@@ -310,26 +321,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "customer@firm.com";
-        let client_id = register_account(&account_cqrs, email).await;
+        let client_id = register_account(&account_store, &pool, email).await;
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -375,26 +378,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "duplicate@example.com";
-        register_account(&account_cqrs, email).await;
+        register_account(&account_store, &pool, email).await;
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -446,23 +441,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -503,23 +490,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -560,26 +539,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "events@example.com";
-        let client_id = register_account(&account_cqrs, email).await;
+        let client_id = register_account(&account_store, &pool, email).await;
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool.clone())
             .mount("/", routes![connect_account]);
 
@@ -642,26 +613,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "view@example.com";
-        let client_id = register_account(&account_cqrs, email).await;
+        let client_id = register_account(&account_store, &pool, email).await;
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool.clone())
             .mount("/", routes![connect_account]);
 
@@ -725,21 +688,13 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -776,21 +731,13 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![connect_account]);
 
@@ -832,23 +779,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool.clone())
             .mount("/", routes![super::register_account]);
 
@@ -905,26 +844,18 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "duplicate@example.com";
-        register_account(&account_cqrs, email).await;
+        register_account(&account_store, &pool, email).await;
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![super::register_account]);
 
@@ -964,23 +895,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![super::register_account]);
 
@@ -1017,17 +940,12 @@ mod tests {
 
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-        let cqrs = sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "unique@example.com";
-        let first_client_id = register_account(&cqrs, email).await;
+        let first_client_id =
+            register_account(&account_store, &pool, email).await;
 
         let view =
             find_by_email(&pool, &Email::new(email.to_string()).unwrap())
@@ -1055,23 +973,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let email = "unwhitelist@example.com";
-        let client_id = register_account(&account_cqrs, email).await;
+        let client_id = register_account(&account_store, &pool, email).await;
 
-        account_cqrs
-            .execute(
-                &client_id.to_string(),
+        account_store
+            .send(
+                &client_id,
                 AccountCommand::LinkToAlpaca {
                     alpaca_account: AlpacaAccountNumber(
                         "ALPACA123".to_string(),
@@ -1082,11 +992,8 @@ mod tests {
             .expect("Failed to link to Alpaca");
 
         let wallet = address!("0x1111111111111111111111111111111111111111");
-        account_cqrs
-            .execute(
-                &client_id.to_string(),
-                AccountCommand::WhitelistWallet { wallet },
-            )
+        account_store
+            .send(&client_id, AccountCommand::WhitelistWallet { wallet })
             .await
             .expect("Failed to whitelist wallet");
 
@@ -1095,7 +1002,7 @@ mod tests {
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool.clone())
             .mount("/", routes![super::unwhitelist_wallet]);
 
@@ -1144,23 +1051,15 @@ mod tests {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let rate_limiter = FailedAuthRateLimiter::new().unwrap();
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(rate_limiter)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(pool)
             .mount("/", routes![super::unwhitelist_wallet]);
 
@@ -1182,5 +1081,58 @@ mod tests {
             .await;
 
         assert_eq!(response.status(), Status::NotFound);
+    }
+
+    #[tokio::test]
+    async fn test_register_rejected_when_email_already_claimed() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
+
+        // Simulate a concurrent registration that already claimed the email (its
+        // account is not yet projected). The atomic claim must reject this
+        // registration even though find_by_email would return no account.
+        let email = "claimed@example.com";
+        sqlx::query!("INSERT INTO account_emails (email) VALUES (?)", email)
+            .execute(&pool)
+            .await
+            .expect("Failed to seed email claim");
+
+        let rate_limiter = FailedAuthRateLimiter::new().unwrap();
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(rate_limiter)
+            .manage(account_store)
+            .manage(pool)
+            .mount("/", routes![super::register_account]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .post("/accounts")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(serde_json::json!({ "email": email }).to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Conflict);
     }
 }

--- a/src/account/event.rs
+++ b/src/account/event.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{AlpacaAccountNumber, ClientId, Email};
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) enum AccountEvent {
     Registered {
         client_id: ClientId,

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -6,11 +6,10 @@ pub(crate) mod view;
 use alloy::primitives::Address;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use cqrs_es::Aggregate;
+use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
 use sqlx::{Sqlite, encode::IsNull, sqlite::SqliteArgumentValue};
 use std::str::FromStr;
-use tracing::error;
 use uuid::Uuid;
 
 pub use api::{
@@ -101,10 +100,8 @@ impl<'q> sqlx::Encode<'q, Sqlite> for ClientId {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Account {
-    #[default]
-    NotRegistered,
     Registered {
         client_id: ClientId,
         email: Email,
@@ -121,149 +118,150 @@ pub(crate) enum Account {
 }
 
 #[async_trait]
-impl Aggregate for Account {
-    type Command = AccountCommand;
+impl EventSourced for Account {
+    type Id = ClientId;
     type Event = AccountEvent;
+    type Command = AccountCommand;
     type Error = AccountError;
     type Services = ();
+    type Materialized = Table;
 
-    fn aggregate_type() -> String {
-        "Account".to_string()
+    const AGGREGATE_TYPE: &'static str = "Account";
+    const PROJECTION: Table = Table("account_view");
+    const SCHEMA_VERSION: u64 = 1;
+
+    fn originate(event: &Self::Event) -> Option<Self> {
+        match event {
+            AccountEvent::Registered { client_id, email, registered_at } => {
+                Some(Self::Registered {
+                    client_id: *client_id,
+                    email: email.clone(),
+                    registered_at: *registered_at,
+                })
+            }
+            AccountEvent::LinkedToAlpaca { .. }
+            | AccountEvent::WalletWhitelisted { .. }
+            | AccountEvent::WalletUnwhitelisted { .. } => None,
+        }
     }
 
-    async fn handle(
-        &self,
+    fn evolve(
+        entity: &Self,
+        event: &Self::Event,
+    ) -> Result<Option<Self>, Self::Error> {
+        match (entity, event) {
+            (
+                Self::Registered { client_id, email, registered_at },
+                AccountEvent::LinkedToAlpaca { alpaca_account, linked_at },
+            ) => Ok(Some(Self::LinkedToAlpaca {
+                client_id: *client_id,
+                email: email.clone(),
+                alpaca_account: alpaca_account.clone(),
+                whitelisted_wallets: Vec::new(),
+                registered_at: *registered_at,
+                linked_at: *linked_at,
+            })),
+            (
+                Self::LinkedToAlpaca { .. },
+                AccountEvent::WalletWhitelisted { wallet, .. },
+            ) => {
+                let mut next = entity.clone();
+                if let Self::LinkedToAlpaca { whitelisted_wallets, .. } =
+                    &mut next
+                {
+                    whitelisted_wallets.push(*wallet);
+                }
+                Ok(Some(next))
+            }
+            (
+                Self::LinkedToAlpaca { .. },
+                AccountEvent::WalletUnwhitelisted { wallet, .. },
+            ) => {
+                let mut next = entity.clone();
+                if let Self::LinkedToAlpaca { whitelisted_wallets, .. } =
+                    &mut next
+                {
+                    whitelisted_wallets.retain(|existing| existing != wallet);
+                }
+                Ok(Some(next))
+            }
+            _ => Ok(None),
+        }
+    }
+
+    async fn initialize(
         command: Self::Command,
         _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             AccountCommand::Register { client_id, email } => {
-                if !matches!(self, Self::NotRegistered) {
-                    return Err(AccountError::AccountAlreadyRegistered {
-                        email: email.as_str().to_string(),
-                    });
-                }
-
-                let now = Utc::now();
-
                 Ok(vec![AccountEvent::Registered {
                     client_id,
                     email,
-                    registered_at: now,
+                    registered_at: Utc::now(),
                 }])
             }
+            AccountCommand::LinkToAlpaca { .. }
+            | AccountCommand::WhitelistWallet { .. }
+            | AccountCommand::UnwhitelistWallet { .. } => {
+                Err(AccountError::NotRegistered)
+            }
+        }
+    }
 
+    async fn transition(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            AccountCommand::Register { email, .. } => {
+                Err(AccountError::AccountAlreadyRegistered {
+                    email: email.as_str().to_string(),
+                })
+            }
             AccountCommand::LinkToAlpaca { alpaca_account } => match self {
-                Self::NotRegistered => Err(AccountError::NotRegistered),
                 Self::Registered { .. } => {
-                    let now = Utc::now();
-
                     Ok(vec![AccountEvent::LinkedToAlpaca {
                         alpaca_account,
-                        linked_at: now,
+                        linked_at: Utc::now(),
                     }])
                 }
                 Self::LinkedToAlpaca { .. } => {
                     Err(AccountError::AlreadyLinkedToAlpaca)
                 }
             },
-
             AccountCommand::WhitelistWallet { wallet } => match self {
-                Self::NotRegistered => Err(AccountError::NotRegistered),
                 Self::Registered { .. } => Err(AccountError::NotLinkedToAlpaca),
                 Self::LinkedToAlpaca { whitelisted_wallets, .. } => {
                     if whitelisted_wallets.contains(&wallet) {
                         Ok(vec![])
                     } else {
-                        let now = Utc::now();
-
                         Ok(vec![AccountEvent::WalletWhitelisted {
                             wallet,
-                            whitelisted_at: now,
+                            whitelisted_at: Utc::now(),
                         }])
                     }
                 }
             },
-
             AccountCommand::UnwhitelistWallet { wallet } => match self {
-                Self::NotRegistered => Err(AccountError::NotRegistered),
                 Self::Registered { .. } => Err(AccountError::NotLinkedToAlpaca),
                 Self::LinkedToAlpaca { whitelisted_wallets, .. } => {
                     if whitelisted_wallets.contains(&wallet) {
-                        let now = Utc::now();
-
                         Ok(vec![AccountEvent::WalletUnwhitelisted {
                             wallet,
-                            unwhitelisted_at: now,
+                            unwhitelisted_at: Utc::now(),
                         }])
                     } else {
                         Ok(vec![])
                     }
                 }
             },
-        }
-    }
-
-    fn apply(&mut self, event: Self::Event) {
-        match event {
-            AccountEvent::Registered { client_id, email, registered_at } => {
-                *self = Self::Registered { client_id, email, registered_at };
-            }
-
-            AccountEvent::LinkedToAlpaca { alpaca_account, linked_at } => {
-                let Self::Registered { client_id, email, registered_at } =
-                    self.clone()
-                else {
-                    error!(target: "account", event = "LinkedToAlpaca",
-                        alpaca_account = %alpaca_account.0,
-                        state = ?self,
-                        "event applied to non-Registered state"
-                    );
-                    return;
-                };
-
-                *self = Self::LinkedToAlpaca {
-                    client_id,
-                    email,
-                    alpaca_account,
-                    whitelisted_wallets: Vec::new(),
-                    registered_at,
-                    linked_at,
-                };
-            }
-
-            AccountEvent::WalletWhitelisted { wallet, .. } => {
-                let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self
-                else {
-                    error!(target: "account", event = "WalletWhitelisted",
-                        wallet = %wallet,
-                        state = ?self,
-                        "event applied to non-LinkedToAlpaca state"
-                    );
-                    return;
-                };
-
-                whitelisted_wallets.push(wallet);
-            }
-
-            AccountEvent::WalletUnwhitelisted { wallet, .. } => {
-                let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self
-                else {
-                    error!(target: "account", event = "WalletUnwhitelisted",
-                        wallet = %wallet,
-                        state = ?self,
-                        "event applied to non-LinkedToAlpaca state"
-                    );
-                    return;
-                };
-
-                whitelisted_wallets.retain(|w| *w != wallet);
-            }
         }
     }
 }
 
-#[derive(Debug, PartialEq, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
 pub(crate) enum AccountError {
     #[error("Invalid email format: {email}")]
     InvalidEmail { email: String },
@@ -280,29 +278,24 @@ pub(crate) enum AccountError {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
-    use cqrs_es::{Aggregate, test::TestFramework};
-    use tracing::Level;
-    use tracing_test::traced_test;
+    use event_sorcery::{LifecycleError, TestHarness, replay};
     use uuid::Uuid;
 
     use super::{
         Account, AccountCommand, AccountError, AccountEvent,
         AlpacaAccountNumber, ClientId, Email,
     };
-    use crate::test_utils::logs_contain_at;
 
-    type AccountTestFramework = TestFramework<Account>;
-
-    #[test]
-    fn test_register_creates_new_account() {
+    #[tokio::test]
+    async fn test_register_creates_new_account() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
 
-        let events = AccountTestFramework::with(())
+        let events = TestHarness::<Account>::with(())
             .given_no_previous_events()
             .when(AccountCommand::Register { client_id, email: email.clone() })
-            .inspect_result()
-            .unwrap();
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
 
@@ -320,30 +313,36 @@ mod tests {
         assert!(registered_at.timestamp() > 0);
     }
 
-    #[test]
-    fn test_register_when_already_registered_returns_error() {
+    #[tokio::test]
+    async fn test_register_when_already_registered_returns_error() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given(vec![AccountEvent::Registered {
                 client_id: ClientId::new(),
                 email: email.clone(),
                 registered_at: chrono::Utc::now(),
             }])
             .when(AccountCommand::Register { client_id, email })
-            .then_expect_error(AccountError::AccountAlreadyRegistered {
-                email: "user@example.com".to_string(),
-            });
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::AccountAlreadyRegistered {
+                email,
+            }) if email == "user@example.com"
+        ));
     }
 
-    #[test]
-    fn test_link_to_alpaca_on_registered_account() {
+    #[tokio::test]
+    async fn test_link_to_alpaca_on_registered_account() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
         let alpaca_account = AlpacaAccountNumber("ALPACA123".to_string());
 
-        let events = AccountTestFramework::with(())
+        let events = TestHarness::<Account>::with(())
             .given(vec![AccountEvent::Registered {
                 client_id,
                 email,
@@ -352,8 +351,8 @@ mod tests {
             .when(AccountCommand::LinkToAlpaca {
                 alpaca_account: alpaca_account.clone(),
             })
-            .inspect_result()
-            .unwrap();
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
 
@@ -369,22 +368,28 @@ mod tests {
         assert!(linked_at.timestamp() > 0);
     }
 
-    #[test]
-    fn test_link_to_alpaca_on_not_registered_returns_error() {
+    #[tokio::test]
+    async fn test_link_to_alpaca_on_not_registered_returns_error() {
         let alpaca_account = AlpacaAccountNumber("ALPACA123".to_string());
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given_no_previous_events()
             .when(AccountCommand::LinkToAlpaca { alpaca_account })
-            .then_expect_error(AccountError::NotRegistered);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::NotRegistered)
+        ));
     }
 
-    #[test]
-    fn test_link_to_alpaca_when_already_linked_returns_error() {
+    #[tokio::test]
+    async fn test_link_to_alpaca_when_already_linked_returns_error() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given(vec![
                 AccountEvent::Registered {
                     client_id,
@@ -401,24 +406,28 @@ mod tests {
             .when(AccountCommand::LinkToAlpaca {
                 alpaca_account: AlpacaAccountNumber("ALPACA456".to_string()),
             })
-            .then_expect_error(AccountError::AlreadyLinkedToAlpaca);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::AlreadyLinkedToAlpaca)
+        ));
     }
 
     #[test]
     fn test_apply_registered_updates_state() {
-        let mut account = Account::default();
-
-        assert!(matches!(account, Account::NotRegistered));
-
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
         let registered_at = chrono::Utc::now();
 
-        account.apply(AccountEvent::Registered {
+        let account = replay::<Account>(vec![AccountEvent::Registered {
             client_id,
             email: email.clone(),
             registered_at,
-        });
+        }])
+        .unwrap()
+        .unwrap();
 
         let Account::Registered {
             client_id: reg_client_id,
@@ -439,20 +448,22 @@ mod tests {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
         let registered_at = chrono::Utc::now();
-
-        let mut account = Account::Registered {
-            client_id,
-            email: email.clone(),
-            registered_at,
-        };
-
         let alpaca_account = AlpacaAccountNumber("ALPACA123".to_string());
         let linked_at = chrono::Utc::now();
 
-        account.apply(AccountEvent::LinkedToAlpaca {
-            alpaca_account: alpaca_account.clone(),
-            linked_at,
-        });
+        let account = replay::<Account>(vec![
+            AccountEvent::Registered {
+                client_id,
+                email: email.clone(),
+                registered_at,
+            },
+            AccountEvent::LinkedToAlpaca {
+                alpaca_account: alpaca_account.clone(),
+                linked_at,
+            },
+        ])
+        .unwrap()
+        .unwrap();
 
         let Account::LinkedToAlpaca {
             client_id: linked_client_id,
@@ -516,8 +527,8 @@ mod tests {
         assert_eq!(format!("{id}"), uuid.to_string());
     }
 
-    #[test]
-    fn test_whitelist_wallet_on_linked_to_alpaca_account() {
+    #[tokio::test]
+    async fn test_whitelist_wallet_on_linked_to_alpaca_account() {
         let email = Email("user@example.com".to_string());
         let client_id = ClientId::new();
         let registered_at = chrono::Utc::now();
@@ -525,7 +536,7 @@ mod tests {
 
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        let events = AccountTestFramework::with(())
+        let events = TestHarness::<Account>::with(())
             .given(vec![
                 AccountEvent::Registered { client_id, email, registered_at },
                 AccountEvent::LinkedToAlpaca {
@@ -536,8 +547,8 @@ mod tests {
                 },
             ])
             .when(AccountCommand::WhitelistWallet { wallet })
-            .inspect_result()
-            .unwrap();
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
 
@@ -553,34 +564,46 @@ mod tests {
         assert!(whitelisted_at.timestamp() > 0);
     }
 
-    #[test]
-    fn test_whitelist_wallet_on_not_registered_account() {
+    #[tokio::test]
+    async fn test_whitelist_wallet_on_not_registered_account() {
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given_no_previous_events()
             .when(AccountCommand::WhitelistWallet { wallet })
-            .then_expect_error(AccountError::NotRegistered);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::NotRegistered)
+        ));
     }
 
-    #[test]
-    fn test_whitelist_wallet_on_registered_but_not_linked_account() {
+    #[tokio::test]
+    async fn test_whitelist_wallet_on_registered_but_not_linked_account() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given(vec![AccountEvent::Registered {
                 client_id,
                 email,
                 registered_at: chrono::Utc::now(),
             }])
             .when(AccountCommand::WhitelistWallet { wallet })
-            .then_expect_error(AccountError::NotLinkedToAlpaca);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::NotLinkedToAlpaca)
+        ));
     }
 
-    #[test]
-    fn test_whitelist_already_whitelisted_wallet_is_idempotent() {
+    #[tokio::test]
+    async fn test_whitelist_already_whitelisted_wallet_is_idempotent() {
         let email = Email("user@example.com".to_string());
         let client_id = ClientId::new();
         let registered_at = chrono::Utc::now();
@@ -588,7 +611,7 @@ mod tests {
         let wallet = address!("0x1111111111111111111111111111111111111111");
         let whitelisted_at = chrono::Utc::now();
 
-        AccountTestFramework::with(())
+        TestHarness::<Account>::with(())
             .given(vec![
                 AccountEvent::Registered { client_id, email, registered_at },
                 AccountEvent::LinkedToAlpaca {
@@ -600,26 +623,31 @@ mod tests {
                 AccountEvent::WalletWhitelisted { wallet, whitelisted_at },
             ])
             .when(AccountCommand::WhitelistWallet { wallet })
-            .then_expect_events(vec![]);
+            .await
+            .then_expect_events(&[]);
     }
 
     #[test]
     fn test_apply_wallet_whitelisted_adds_wallet() {
-        let mut account = Account::LinkedToAlpaca {
-            client_id: ClientId::new(),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: Vec::new(),
-            registered_at: chrono::Utc::now(),
-            linked_at: chrono::Utc::now(),
-        };
-
+        let client_id = ClientId::new();
+        let email = Email("user@example.com".to_string());
+        let registered_at = chrono::Utc::now();
+        let linked_at = chrono::Utc::now();
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        account.apply(AccountEvent::WalletWhitelisted {
-            wallet,
-            whitelisted_at: chrono::Utc::now(),
-        });
+        let account = replay::<Account>(vec![
+            AccountEvent::Registered { client_id, email, registered_at },
+            AccountEvent::LinkedToAlpaca {
+                alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
+                linked_at,
+            },
+            AccountEvent::WalletWhitelisted {
+                wallet,
+                whitelisted_at: chrono::Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
 
         let Account::LinkedToAlpaca { whitelisted_wallets, .. } = account
         else {
@@ -632,27 +660,30 @@ mod tests {
 
     #[test]
     fn test_apply_wallet_whitelisted_adds_multiple_wallets() {
-        let mut account = Account::LinkedToAlpaca {
-            client_id: ClientId::new(),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: Vec::new(),
-            registered_at: chrono::Utc::now(),
-            linked_at: chrono::Utc::now(),
-        };
-
+        let client_id = ClientId::new();
+        let email = Email("user@example.com".to_string());
+        let registered_at = chrono::Utc::now();
+        let linked_at = chrono::Utc::now();
         let wallet1 = address!("0x1111111111111111111111111111111111111111");
         let wallet2 = address!("0x2222222222222222222222222222222222222222");
 
-        account.apply(AccountEvent::WalletWhitelisted {
-            wallet: wallet1,
-            whitelisted_at: chrono::Utc::now(),
-        });
-
-        account.apply(AccountEvent::WalletWhitelisted {
-            wallet: wallet2,
-            whitelisted_at: chrono::Utc::now(),
-        });
+        let account = replay::<Account>(vec![
+            AccountEvent::Registered { client_id, email, registered_at },
+            AccountEvent::LinkedToAlpaca {
+                alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
+                linked_at,
+            },
+            AccountEvent::WalletWhitelisted {
+                wallet: wallet1,
+                whitelisted_at: chrono::Utc::now(),
+            },
+            AccountEvent::WalletWhitelisted {
+                wallet: wallet2,
+                whitelisted_at: chrono::Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
 
         let Account::LinkedToAlpaca { whitelisted_wallets, .. } = account
         else {
@@ -664,8 +695,8 @@ mod tests {
         assert_eq!(whitelisted_wallets[1], wallet2);
     }
 
-    #[test]
-    fn test_unwhitelist_wallet_on_linked_account() {
+    #[tokio::test]
+    async fn test_unwhitelist_wallet_on_linked_account() {
         let email = Email("user@example.com".to_string());
         let client_id = ClientId::new();
         let registered_at = chrono::Utc::now();
@@ -673,7 +704,7 @@ mod tests {
         let wallet = address!("0x1111111111111111111111111111111111111111");
         let whitelisted_at = chrono::Utc::now();
 
-        let events = AccountTestFramework::with(())
+        let events = TestHarness::<Account>::with(())
             .given(vec![
                 AccountEvent::Registered { client_id, email, registered_at },
                 AccountEvent::LinkedToAlpaca {
@@ -685,8 +716,8 @@ mod tests {
                 AccountEvent::WalletWhitelisted { wallet, whitelisted_at },
             ])
             .when(AccountCommand::UnwhitelistWallet { wallet })
-            .inspect_result()
-            .unwrap();
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
 
@@ -702,41 +733,53 @@ mod tests {
         assert!(unwhitelisted_at.timestamp() > 0);
     }
 
-    #[test]
-    fn test_unwhitelist_not_registered() {
+    #[tokio::test]
+    async fn test_unwhitelist_not_registered() {
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given_no_previous_events()
             .when(AccountCommand::UnwhitelistWallet { wallet })
-            .then_expect_error(AccountError::NotRegistered);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::NotRegistered)
+        ));
     }
 
-    #[test]
-    fn test_unwhitelist_not_linked() {
+    #[tokio::test]
+    async fn test_unwhitelist_not_linked() {
         let client_id = ClientId::new();
         let email = Email("user@example.com".to_string());
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        AccountTestFramework::with(())
+        let err = TestHarness::<Account>::with(())
             .given(vec![AccountEvent::Registered {
                 client_id,
                 email,
                 registered_at: chrono::Utc::now(),
             }])
             .when(AccountCommand::UnwhitelistWallet { wallet })
-            .then_expect_error(AccountError::NotLinkedToAlpaca);
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(AccountError::NotLinkedToAlpaca)
+        ));
     }
 
-    #[test]
-    fn test_unwhitelist_already_absent_is_idempotent() {
+    #[tokio::test]
+    async fn test_unwhitelist_already_absent_is_idempotent() {
         let email = Email("user@example.com".to_string());
         let client_id = ClientId::new();
         let registered_at = chrono::Utc::now();
         let linked_at = chrono::Utc::now();
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        AccountTestFramework::with(())
+        TestHarness::<Account>::with(())
             .given(vec![
                 AccountEvent::Registered { client_id, email, registered_at },
                 AccountEvent::LinkedToAlpaca {
@@ -747,26 +790,35 @@ mod tests {
                 },
             ])
             .when(AccountCommand::UnwhitelistWallet { wallet })
-            .then_expect_events(vec![]);
+            .await
+            .then_expect_events(&[]);
     }
 
     #[test]
     fn test_apply_wallet_unwhitelisted_removes_wallet() {
+        let client_id = ClientId::new();
+        let email = Email("user@example.com".to_string());
+        let registered_at = chrono::Utc::now();
+        let linked_at = chrono::Utc::now();
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        let mut account = Account::LinkedToAlpaca {
-            client_id: ClientId::new(),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: vec![wallet],
-            registered_at: chrono::Utc::now(),
-            linked_at: chrono::Utc::now(),
-        };
-
-        account.apply(AccountEvent::WalletUnwhitelisted {
-            wallet,
-            unwhitelisted_at: chrono::Utc::now(),
-        });
+        let account = replay::<Account>(vec![
+            AccountEvent::Registered { client_id, email, registered_at },
+            AccountEvent::LinkedToAlpaca {
+                alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
+                linked_at,
+            },
+            AccountEvent::WalletWhitelisted {
+                wallet,
+                whitelisted_at: chrono::Utc::now(),
+            },
+            AccountEvent::WalletUnwhitelisted {
+                wallet,
+                unwhitelisted_at: chrono::Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
 
         let Account::LinkedToAlpaca { whitelisted_wallets, .. } = account
         else {
@@ -779,58 +831,47 @@ mod tests {
         );
     }
 
-    #[traced_test]
     #[test]
-    fn test_apply_wallet_whitelisted_to_non_linked_logs_error() {
+    fn test_apply_wallet_whitelisted_to_non_linked_returns_error() {
+        let client_id = ClientId::new();
+        let email = Email("user@example.com".to_string());
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        let mut account = Account::Registered {
-            client_id: ClientId::new(),
-            email: Email("user@example.com".to_string()),
-            registered_at: chrono::Utc::now(),
-        };
+        let error = replay::<Account>(vec![
+            AccountEvent::Registered {
+                client_id,
+                email,
+                registered_at: chrono::Utc::now(),
+            },
+            AccountEvent::WalletWhitelisted {
+                wallet,
+                whitelisted_at: chrono::Utc::now(),
+            },
+        ])
+        .unwrap_err();
 
-        account.apply(AccountEvent::WalletWhitelisted {
-            wallet,
-            whitelisted_at: chrono::Utc::now(),
-        });
-
-        assert!(
-            matches!(account, Account::Registered { .. }),
-            "Account should remain Registered"
-        );
-        assert!(logs_contain_at!(
-            Level::ERROR,
-            &["WalletWhitelisted", "event applied to non-LinkedToAlpaca state"]
-        ));
+        assert!(matches!(error, LifecycleError::UnexpectedEvent { .. }));
     }
 
-    #[traced_test]
     #[test]
-    fn test_apply_wallet_unwhitelisted_to_non_linked_logs_error() {
+    fn test_apply_wallet_unwhitelisted_to_non_linked_returns_error() {
+        let client_id = ClientId::new();
+        let email = Email("user@example.com".to_string());
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        let mut account = Account::Registered {
-            client_id: ClientId::new(),
-            email: Email("user@example.com".to_string()),
-            registered_at: chrono::Utc::now(),
-        };
+        let error = replay::<Account>(vec![
+            AccountEvent::Registered {
+                client_id,
+                email,
+                registered_at: chrono::Utc::now(),
+            },
+            AccountEvent::WalletUnwhitelisted {
+                wallet,
+                unwhitelisted_at: chrono::Utc::now(),
+            },
+        ])
+        .unwrap_err();
 
-        account.apply(AccountEvent::WalletUnwhitelisted {
-            wallet,
-            unwhitelisted_at: chrono::Utc::now(),
-        });
-
-        assert!(
-            matches!(account, Account::Registered { .. }),
-            "Account should remain Registered"
-        );
-        assert!(logs_contain_at!(
-            Level::ERROR,
-            &[
-                "WalletUnwhitelisted",
-                "event applied to non-LinkedToAlpaca state"
-            ]
-        ));
+        assert!(matches!(error, LifecycleError::UnexpectedEvent { .. }));
     }
 }

--- a/src/account/view.rs
+++ b/src/account/view.rs
@@ -1,16 +1,9 @@
 use alloy::primitives::Address;
 use chrono::{DateTime, Utc};
-use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
-use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
-use std::sync::Arc;
-use tracing::debug;
 
-use super::{
-    Account, AccountError, AccountEvent, AlpacaAccountNumber, ClientId, Email,
-};
-use crate::replay::{ReplayError, replay_all_or_fail};
+use super::{AlpacaAccountNumber, ClientId, Email};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AccountViewError {
@@ -18,36 +11,17 @@ pub(crate) enum AccountViewError {
     Database(#[from] sqlx::Error),
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
-    #[error("Persistence error: {0}")]
-    Persistence(#[from] cqrs_es::persist::PersistenceError),
-    #[error("Replay error: {0}")]
-    Replay(#[from] ReplayError<AccountError>),
 }
 
-pub(crate) async fn replay_account_view(
-    pool: Pool<Sqlite>,
-) -> Result<(), AccountViewError> {
-    debug!(target: "account", "Rebuilding account view from events");
-
-    sqlx::query!("DELETE FROM account_view").execute(&pool).await?;
-
-    let view_repo =
-        Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-            pool.clone(),
-            "account_view".to_string(),
-        ));
-    let event_repo = SqliteEventRepository::new(pool);
-    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
-
-    debug!(target: "account", "Account view rebuild complete");
-
-    Ok(())
-}
-
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+/// Read model for an account, projected from the `account_view` table.
+///
+/// `account_view` stores the event-sorcery `Lifecycle<Account>` payload
+/// (`{"Live": {...}}`). The `find_by_*` queries extract the `$.Live` sub-object,
+/// which mirrors these variants field-for-field, so it deserializes straight
+/// into `AccountView`. Non-live rows (`Uninitialized` / `Failed`) have a NULL
+/// `$.Live` and are treated as "not found".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum AccountView {
-    #[default]
-    Unavailable,
     Registered {
         client_id: ClientId,
         email: Email,
@@ -63,47 +37,6 @@ pub(crate) enum AccountView {
     },
 }
 
-impl View<Account> for AccountView {
-    fn update(&mut self, event: &EventEnvelope<Account>) {
-        match &event.payload {
-            AccountEvent::Registered { client_id, email, registered_at } => {
-                *self = Self::Registered {
-                    client_id: *client_id,
-                    email: email.clone(),
-                    registered_at: *registered_at,
-                };
-            }
-
-            AccountEvent::LinkedToAlpaca { alpaca_account, linked_at } => {
-                if let Self::Registered { client_id, email, registered_at } =
-                    self.clone()
-                {
-                    *self = Self::LinkedToAlpaca {
-                        client_id,
-                        email,
-                        alpaca_account: alpaca_account.clone(),
-                        whitelisted_wallets: Vec::new(),
-                        registered_at,
-                        linked_at: *linked_at,
-                    };
-                }
-            }
-
-            AccountEvent::WalletWhitelisted { wallet, .. } => {
-                if let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self {
-                    whitelisted_wallets.push(*wallet);
-                }
-            }
-
-            AccountEvent::WalletUnwhitelisted { wallet, .. } => {
-                if let Self::LinkedToAlpaca { whitelisted_wallets, .. } = self {
-                    whitelisted_wallets.retain(|w| w != wallet);
-                }
-            }
-        }
-    }
-}
-
 pub(crate) async fn find_by_client_id(
     pool: &Pool<Sqlite>,
     client_id: &ClientId,
@@ -111,10 +44,10 @@ pub(crate) async fn find_by_client_id(
     let client_id_str = client_id.to_string();
     let row = sqlx::query!(
         r#"
-        SELECT payload as "payload: String"
+        SELECT json_extract(payload, '$.Live') as "live: String"
         FROM account_view
-        WHERE json_extract(payload, '$.Registered.client_id') = ?
-           OR json_extract(payload, '$.LinkedToAlpaca.client_id') = ?
+        WHERE json_extract(payload, '$.Live.Registered.client_id') = ?
+           OR json_extract(payload, '$.Live.LinkedToAlpaca.client_id') = ?
         "#,
         client_id_str,
         client_id_str
@@ -122,11 +55,11 @@ pub(crate) async fn find_by_client_id(
     .fetch_optional(pool)
     .await?;
 
-    let Some(row) = row else {
+    let Some(live) = row.and_then(|row| row.live) else {
         return Ok(None);
     };
 
-    let view: AccountView = serde_json::from_str(&row.payload)?;
+    let view: AccountView = serde_json::from_str(&live)?;
 
     Ok(Some(view))
 }
@@ -137,10 +70,10 @@ pub(crate) async fn find_by_email(
 ) -> Result<Option<AccountView>, AccountViewError> {
     let row = sqlx::query!(
         r#"
-        SELECT payload as "payload: String"
+        SELECT json_extract(payload, '$.Live') as "live: String"
         FROM account_view
-        WHERE json_extract(payload, '$.Registered.email') = ?
-           OR json_extract(payload, '$.LinkedToAlpaca.email') = ?
+        WHERE json_extract(payload, '$.Live.Registered.email') = ?
+           OR json_extract(payload, '$.Live.LinkedToAlpaca.email') = ?
         "#,
         email.0,
         email.0
@@ -148,11 +81,11 @@ pub(crate) async fn find_by_email(
     .fetch_optional(pool)
     .await?;
 
-    let Some(row) = row else {
+    let Some(live) = row.and_then(|row| row.live) else {
         return Ok(None);
     };
 
-    let view: AccountView = serde_json::from_str(&row.payload)?;
+    let view: AccountView = serde_json::from_str(&live)?;
 
     Ok(Some(view))
 }
@@ -164,11 +97,11 @@ pub(crate) async fn find_by_wallet(
     let wallet_str = format!("{wallet:#x}");
     let row = sqlx::query!(
         r#"
-        SELECT payload as "payload: String"
+        SELECT json_extract(payload, '$.Live') as "live: String"
         FROM account_view
         WHERE EXISTS(
             SELECT 1
-            FROM json_each(payload, '$.LinkedToAlpaca.whitelisted_wallets')
+            FROM json_each(payload, '$.Live.LinkedToAlpaca.whitelisted_wallets')
             WHERE value = ?
         )
         "#,
@@ -177,11 +110,11 @@ pub(crate) async fn find_by_wallet(
     .fetch_optional(pool)
     .await?;
 
-    let Some(row) = row else {
+    let Some(live) = row.and_then(|row| row.live) else {
         return Ok(None);
     };
 
-    let view: AccountView = serde_json::from_str(&row.payload)?;
+    let view: AccountView = serde_json::from_str(&live)?;
 
     Ok(Some(view))
 }
@@ -189,11 +122,8 @@ pub(crate) async fn find_by_wallet(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
-    use cqrs_es::EventEnvelope;
-    use cqrs_es::persist::GenericQuery;
-    use sqlite_es::{SqliteCqrs, SqliteViewRepository, sqlite_cqrs};
+    use event_sorcery::{Store, StoreBuilder};
     use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
-    use std::collections::HashMap;
     use std::sync::Arc;
     use uuid::Uuid;
 
@@ -202,7 +132,7 @@ mod tests {
 
     struct TestHarness {
         pool: Pool<Sqlite>,
-        cqrs: SqliteCqrs<Account>,
+        store: Arc<Store<Account>>,
     }
 
     impl TestHarness {
@@ -218,23 +148,18 @@ mod tests {
                 .await
                 .expect("Failed to run migrations");
 
-            let view_repo =
-                Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                    pool.clone(),
-                    "account_view".to_string(),
-                ));
-            let query = GenericQuery::new(view_repo);
-            let cqrs = sqlite_cqrs(pool.clone(), vec![Box::new(query)], ());
+            let (store, _projection) =
+                StoreBuilder::<Account>::new(pool.clone())
+                    .build(())
+                    .await
+                    .expect("Failed to build account store");
 
-            Self { pool, cqrs }
+            Self { pool, store }
         }
 
         async fn register_account(&self, client_id: ClientId, email: Email) {
-            self.cqrs
-                .execute(
-                    &client_id.to_string(),
-                    AccountCommand::Register { client_id, email },
-                )
+            self.store
+                .send(&client_id, AccountCommand::Register { client_id, email })
                 .await
                 .expect("Failed to register account");
         }
@@ -244,13 +169,24 @@ mod tests {
             client_id: &ClientId,
             alpaca_account: AlpacaAccountNumber,
         ) {
-            self.cqrs
-                .execute(
-                    &client_id.to_string(),
+            self.store
+                .send(
+                    client_id,
                     AccountCommand::LinkToAlpaca { alpaca_account },
                 )
                 .await
                 .expect("Failed to link to Alpaca");
+        }
+
+        async fn whitelist_wallet(
+            &self,
+            client_id: &ClientId,
+            wallet: Address,
+        ) {
+            self.store
+                .send(client_id, AccountCommand::WhitelistWallet { wallet })
+                .await
+                .expect("Failed to whitelist wallet");
         }
     }
 
@@ -267,94 +203,6 @@ mod tests {
             .expect("Failed to run migrations");
 
         pool
-    }
-
-    #[test]
-    fn test_view_update_from_registered_event() {
-        let client_id = ClientId::new();
-        let email = Email("user@example.com".to_string());
-        let registered_at = Utc::now();
-
-        let event = AccountEvent::Registered {
-            client_id,
-            email: email.clone(),
-            registered_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: email.as_str().to_string(),
-            sequence: 1,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        let mut view = AccountView::default();
-
-        assert!(matches!(view, AccountView::Unavailable));
-
-        view.update(&envelope);
-
-        let AccountView::Registered {
-            client_id: view_client_id,
-            email: view_email,
-            registered_at: view_registered_at,
-        } = view
-        else {
-            panic!("Expected Registered, got {view:?}")
-        };
-
-        assert_eq!(view_client_id, client_id);
-        assert_eq!(view_email, email);
-        assert_eq!(view_registered_at, registered_at);
-    }
-
-    #[test]
-    fn test_view_update_from_linked_to_alpaca_event() {
-        let client_id = ClientId::new();
-        let email = Email("user@example.com".to_string());
-        let registered_at = Utc::now();
-
-        let mut view = AccountView::Registered {
-            client_id,
-            email: email.clone(),
-            registered_at,
-        };
-
-        let alpaca_account = AlpacaAccountNumber("ALPACA123".to_string());
-        let linked_at = Utc::now();
-
-        let event = AccountEvent::LinkedToAlpaca {
-            alpaca_account: alpaca_account.clone(),
-            linked_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: client_id.to_string(),
-            sequence: 2,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let AccountView::LinkedToAlpaca {
-            client_id: view_client_id,
-            email: view_email,
-            alpaca_account: view_alpaca,
-            whitelisted_wallets,
-            registered_at: view_registered_at,
-            linked_at: view_linked_at,
-        } = view
-        else {
-            panic!("Expected LinkedToAlpaca, got {view:?}")
-        };
-
-        assert_eq!(view_client_id, client_id);
-        assert_eq!(view_email, email);
-        assert_eq!(view_alpaca, alpaca_account);
-        assert!(whitelisted_wallets.is_empty());
-        assert_eq!(view_registered_at, registered_at);
-        assert_eq!(view_linked_at, linked_at);
     }
 
     #[tokio::test]
@@ -474,115 +322,118 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[test]
-    fn test_view_update_from_wallet_whitelisted_event() {
-        let mut view = AccountView::LinkedToAlpaca {
-            client_id: ClientId(Uuid::new_v4()),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: Vec::new(),
-            registered_at: Utc::now(),
-            linked_at: Utc::now(),
-        };
+    #[tokio::test]
+    async fn test_find_by_wallet_returns_linked_account() {
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, .. } = &harness;
 
+        let client_id = ClientId::new();
+        let email = Email("wallet@example.com".to_string());
+        let alpaca_account = AlpacaAccountNumber("ALPACA-W".to_string());
         let wallet = address!("0x1111111111111111111111111111111111111111");
 
-        let event = AccountEvent::WalletWhitelisted {
-            wallet,
-            whitelisted_at: Utc::now(),
-        };
+        harness.register_account(client_id, email).await;
+        harness.link_to_alpaca(&client_id, alpaca_account).await;
+        harness.whitelist_wallet(&client_id, wallet).await;
 
-        let envelope = EventEnvelope {
-            aggregate_id: "user@example.com".to_string(),
-            sequence: 3,
-            payload: event,
-            metadata: HashMap::new(),
-        };
+        let view = find_by_wallet(pool, &wallet)
+            .await
+            .expect("Query should succeed")
+            .expect("View should exist");
 
-        view.update(&envelope);
-
-        let AccountView::LinkedToAlpaca { whitelisted_wallets, .. } = view
+        let AccountView::LinkedToAlpaca {
+            client_id: found_client_id,
+            whitelisted_wallets,
+            ..
+        } = view
         else {
             panic!("Expected LinkedToAlpaca, got {view:?}")
         };
 
-        assert_eq!(whitelisted_wallets.len(), 1);
-        assert_eq!(whitelisted_wallets[0], wallet);
+        assert_eq!(found_client_id, client_id);
+        assert!(whitelisted_wallets.contains(&wallet));
     }
 
-    #[test]
-    fn test_view_update_from_wallet_unwhitelisted_event() {
-        let wallet = address!("0x1111111111111111111111111111111111111111");
+    #[tokio::test]
+    async fn test_find_by_wallet_returns_none_for_unknown_wallet() {
+        let pool = setup_test_db().await;
 
-        let mut view = AccountView::LinkedToAlpaca {
-            client_id: ClientId(Uuid::new_v4()),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: vec![wallet],
-            registered_at: Utc::now(),
-            linked_at: Utc::now(),
-        };
+        let wallet = address!("0x9999999999999999999999999999999999999999");
 
-        let event = AccountEvent::WalletUnwhitelisted {
-            wallet,
-            unwhitelisted_at: Utc::now(),
-        };
+        let result =
+            find_by_wallet(&pool, &wallet).await.expect("Query should succeed");
 
-        let envelope = EventEnvelope {
-            aggregate_id: "user@example.com".to_string(),
-            sequence: 4,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let AccountView::LinkedToAlpaca { whitelisted_wallets, .. } = view
-        else {
-            panic!("Expected LinkedToAlpaca, got {view:?}")
-        };
-
-        assert!(
-            whitelisted_wallets.is_empty(),
-            "Wallet should be removed after unwhitelisting"
-        );
+        assert!(result.is_none());
     }
 
-    #[test]
-    fn test_view_update_unwhitelist_absent_wallet_is_noop() {
-        let wallet = address!("0x1111111111111111111111111111111111111111");
+    // Proves the account_view-to-lifecycle migration is data-safe: after the
+    // view table is cleared (as the migration's DROP TABLE does), a fresh
+    // `StoreBuilder::build` rebuilds every row from the event log via catch_up.
+    #[tokio::test]
+    async fn build_rebuilds_account_view_from_events_after_view_cleared() {
+        let pool = setup_test_db().await;
 
-        let mut view = AccountView::LinkedToAlpaca {
-            client_id: ClientId(Uuid::new_v4()),
-            email: Email("user@example.com".to_string()),
-            alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
-            whitelisted_wallets: Vec::new(),
-            registered_at: Utc::now(),
-            linked_at: Utc::now(),
-        };
+        let client_id = ClientId::new();
+        let email = Email("rebuild@example.com".to_string());
+        let alpaca_account = AlpacaAccountNumber("ALPACA-R".to_string());
+        let wallet = address!("0x2222222222222222222222222222222222222222");
 
-        let event = AccountEvent::WalletUnwhitelisted {
-            wallet,
-            unwhitelisted_at: Utc::now(),
-        };
+        {
+            let (store, _projection) =
+                StoreBuilder::<Account>::new(pool.clone())
+                    .build(())
+                    .await
+                    .expect("Failed to build account store");
+            store
+                .send(
+                    &client_id,
+                    AccountCommand::Register {
+                        client_id,
+                        email: email.clone(),
+                    },
+                )
+                .await
+                .expect("Failed to register account");
+            store
+                .send(
+                    &client_id,
+                    AccountCommand::LinkToAlpaca { alpaca_account },
+                )
+                .await
+                .expect("Failed to link to Alpaca");
+            store
+                .send(&client_id, AccountCommand::WhitelistWallet { wallet })
+                .await
+                .expect("Failed to whitelist wallet");
+        }
 
-        let envelope = EventEnvelope {
-            aggregate_id: "user@example.com".to_string(),
-            sequence: 4,
-            payload: event,
-            metadata: HashMap::new(),
-        };
+        // The migration drops account_view; simulate that, then rebuild from
+        // the event log.
+        sqlx::query("DELETE FROM account_view")
+            .execute(&pool)
+            .await
+            .expect("Failed to clear account_view");
 
-        view.update(&envelope);
+        let (_store, _projection) = StoreBuilder::<Account>::new(pool.clone())
+            .build(())
+            .await
+            .expect("Failed to rebuild account store");
 
-        let AccountView::LinkedToAlpaca { whitelisted_wallets, .. } = view
+        let by_email = find_by_email(&pool, &email)
+            .await
+            .expect("Query should succeed")
+            .expect("View should be rebuilt from events");
+        assert!(matches!(by_email, AccountView::LinkedToAlpaca { .. }));
+
+        let by_wallet = find_by_wallet(&pool, &wallet)
+            .await
+            .expect("Query should succeed")
+            .expect("View should be rebuilt from events");
+        let AccountView::LinkedToAlpaca { client_id: found_client_id, .. } =
+            by_wallet
         else {
-            panic!("Expected LinkedToAlpaca, got {view:?}")
+            panic!("Expected LinkedToAlpaca, got {by_wallet:?}")
         };
-
-        assert!(
-            whitelisted_wallets.is_empty(),
-            "Wallets should remain empty after unwhitelisting absent wallet"
-        );
+        assert_eq!(found_client_id, client_id);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
 use cqrs_es::persist::{GenericQuery, PersistedEventStore};
+use event_sorcery::{Store, StoreBuilder};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use rocket::routes;
 use rust_decimal::{Decimal, prelude::ToPrimitive};
@@ -13,8 +14,7 @@ use std::{sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, trace, warn};
 
-use crate::account::view::replay_account_view;
-use crate::account::{Account, AccountView};
+use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
 use crate::mint::{
@@ -73,7 +73,6 @@ pub use fireblocks::SignerConfig;
 pub use telemetry::TelemetryGuard;
 pub use test_utils::ANVIL_CHAIN_ID;
 
-pub(crate) type AccountCqrs = SqliteCqrs<Account>;
 pub(crate) type TokenizedAssetCqrs = SqliteCqrs<TokenizedAsset>;
 
 pub(crate) type MintCqrs = Arc<SqliteCqrs<Mint>>;
@@ -259,11 +258,11 @@ pub async fn initialize_rocket(
     let pool = create_pool(&config).await?;
     sqlx::migrate!("./migrations").run(&pool).await?;
 
-    let BasicCqrsSetup {
-        account_cqrs,
-        tokenized_asset_cqrs,
-        tokenized_asset_view_repo,
-    } = setup_basic_cqrs(&pool);
+    let BasicCqrsSetup { tokenized_asset_cqrs, tokenized_asset_view_repo } =
+        setup_basic_cqrs(&pool);
+
+    let (account_store, _account_projection) =
+        StoreBuilder::<Account>::new(pool.clone()).build(()).await?;
 
     let blockchain_setup = config.create_blockchain_setup().await?;
     let alpaca_service = config.alpaca.service()?;
@@ -298,7 +297,6 @@ pub async fn initialize_rocket(
     // up-to-date views. Each replay clears its view table first to remove
     // stale/corrupt data, then rebuilds from the event store.
     debug!(target: "startup", "Rebuilding all views from events");
-    replay_account_view(pool.clone()).await?;
     replay_tokenized_asset_view(pool.clone()).await?;
     replay_mint_view(pool.clone()).await?;
     replay_receipt_inventory_view(pool.clone()).await?;
@@ -400,7 +398,7 @@ pub async fn initialize_rocket(
         rate_limiter: FailedAuthRateLimiter::new()?,
         config,
         pool,
-        account_cqrs,
+        account_store,
         tokenized_asset_cqrs,
         tokenized_asset_view_repo,
         mint,
@@ -417,7 +415,7 @@ struct RocketState {
     config: Config,
     rate_limiter: FailedAuthRateLimiter,
     pool: Pool<Sqlite>,
-    account_cqrs: AccountCqrs,
+    account_store: Arc<Store<Account>>,
     tokenized_asset_cqrs: TokenizedAssetCqrs,
     tokenized_asset_view_repo: TokenizedAssetViewRepo,
     mint: MintDeps,
@@ -441,7 +439,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
     rocket::custom(figment)
         .manage(state.config)
         .manage(state.rate_limiter)
-        .manage(state.account_cqrs)
+        .manage(state.account_store)
         .manage(state.tokenized_asset_cqrs)
         .manage(state.tokenized_asset_view_repo)
         .manage(state.mint.cqrs)
@@ -477,21 +475,11 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
 }
 
 struct BasicCqrsSetup {
-    account_cqrs: AccountCqrs,
     tokenized_asset_cqrs: TokenizedAssetCqrs,
     tokenized_asset_view_repo: TokenizedAssetViewRepo,
 }
 
 fn setup_basic_cqrs(pool: &Pool<Sqlite>) -> BasicCqrsSetup {
-    let account_view_repo =
-        Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-            pool.clone(),
-            "account_view".to_string(),
-        ));
-    let account_query = GenericQuery::new(account_view_repo);
-    let account_cqrs =
-        sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
-
     let tokenized_asset_view_repo: TokenizedAssetViewRepo =
         Arc::new(SqliteViewRepository::new(
             pool.clone(),
@@ -502,11 +490,7 @@ fn setup_basic_cqrs(pool: &Pool<Sqlite>) -> BasicCqrsSetup {
     let tokenized_asset_cqrs =
         sqlite_cqrs(pool.clone(), vec![Box::new(tokenized_asset_query)], ());
 
-    BasicCqrsSetup {
-        account_cqrs,
-        tokenized_asset_cqrs,
-        tokenized_asset_view_repo,
-    }
+    BasicCqrsSetup { tokenized_asset_cqrs, tokenized_asset_view_repo }
 }
 
 fn setup_aggregate_cqrs(

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -121,7 +121,7 @@ mod tests {
     async fn test_initiate_mint_returns_issuer_request_id() {
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -134,9 +134,8 @@ mod tests {
         let register_cmd =
             AccountCommand::Register { client_id, email: email.clone() };
 
-        let aggregate_id = client_id.to_string();
-        account_cqrs
-            .execute(&aggregate_id, register_cmd)
+        account_store
+            .send(&client_id, register_cmd)
             .await
             .expect("Failed to register account");
 
@@ -144,8 +143,8 @@ mod tests {
             alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
         };
 
-        account_cqrs
-            .execute(&aggregate_id, link_cmd)
+        account_store
+            .send(&client_id, link_cmd)
             .await
             .expect("Failed to link account to Alpaca");
 
@@ -153,8 +152,8 @@ mod tests {
 
         let whitelist_cmd = AccountCommand::WhitelistWallet { wallet };
 
-        account_cqrs
-            .execute(&aggregate_id, whitelist_cmd)
+        account_store
+            .send(&client_id, whitelist_cmd)
             .await
             .expect("Failed to whitelist wallet");
 
@@ -178,7 +177,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -224,7 +223,7 @@ mod tests {
     async fn test_initiate_mint_rejects_unknown_asset() {
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -237,9 +236,8 @@ mod tests {
         let register_cmd =
             AccountCommand::Register { client_id, email: email.clone() };
 
-        let aggregate_id = client_id.to_string();
-        account_cqrs
-            .execute(&aggregate_id, register_cmd)
+        account_store
+            .send(&client_id, register_cmd)
             .await
             .expect("Failed to register account");
 
@@ -247,8 +245,8 @@ mod tests {
             alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
         };
 
-        account_cqrs
-            .execute(&aggregate_id, link_cmd)
+        account_store
+            .send(&client_id, link_cmd)
             .await
             .expect("Failed to link account to Alpaca");
 
@@ -256,7 +254,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -304,7 +302,7 @@ mod tests {
     async fn test_initiate_mint_rejects_negative_quantity() {
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -316,7 +314,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -364,7 +362,7 @@ mod tests {
     async fn test_initiate_mint_rejects_unknown_client_id() {
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -392,7 +390,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -444,7 +442,7 @@ mod tests {
         } = harness.setup_account_and_asset().await;
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -454,7 +452,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool.clone())
             .mount("/", routes![initiate_mint]);
@@ -521,7 +519,7 @@ mod tests {
         } = harness.setup_account_and_asset().await;
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -531,7 +529,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool.clone())
             .mount("/", routes![initiate_mint]);
@@ -613,7 +611,7 @@ mod tests {
         } = harness.setup_account_and_asset().await;
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -623,7 +621,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -664,7 +662,7 @@ mod tests {
             harness.setup_account_and_asset().await;
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -674,7 +672,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
@@ -797,7 +795,7 @@ mod tests {
         } = harness.setup_account_and_asset().await;
         let TestHarness {
             pool,
-            account_cqrs,
+            account_store,
             asset_cqrs: tokenized_asset_cqrs,
             mint_cqrs,
             ..
@@ -807,7 +805,7 @@ mod tests {
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(mint_cqrs)
-            .manage(account_cqrs)
+            .manage(account_store)
             .manage(tokenized_asset_cqrs)
             .manage(pool)
             .mount("/", routes![initiate_mint]);

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -1,12 +1,13 @@
 use alloy::primitives::{Address, B256, address};
 use cqrs_es::persist::{GenericQuery, PersistedEventStore};
+use event_sorcery::{Store, StoreBuilder};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository, sqlite_cqrs};
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 use url::Url;
 
 use crate::account::{
-    Account, AccountCommand, AccountView, AlpacaAccountNumber, ClientId, Email,
+    Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
 };
 use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
@@ -21,7 +22,7 @@ use crate::tokenized_asset::{
     TokenizedAsset, TokenizedAssetCommand, TokenizedAssetView,
 };
 use crate::vault::mock::MockVaultService;
-use crate::{AccountCqrs, MintCqrs, TokenizedAssetCqrs};
+use crate::{MintCqrs, TokenizedAssetCqrs};
 
 pub(crate) fn test_config() -> Config {
     Config {
@@ -50,7 +51,7 @@ pub(crate) fn create_test_event_store(
 
 pub(crate) struct TestHarness {
     pub(crate) pool: sqlx::Pool<sqlx::Sqlite>,
-    pub(crate) account_cqrs: AccountCqrs,
+    pub(crate) account_store: Arc<Store<Account>>,
     pub(crate) asset_cqrs: TokenizedAssetCqrs,
     pub(crate) mint_cqrs: MintCqrs,
 }
@@ -68,14 +69,11 @@ impl TestHarness {
             .await
             .expect("Failed to run migrations");
 
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-        let account_query = GenericQuery::new(account_view_repo);
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone())
+                .build(())
+                .await
+                .expect("Failed to build account store");
 
         let tokenized_asset_view_repo = Arc::new(SqliteViewRepository::<
             TokenizedAssetView,
@@ -123,7 +121,7 @@ impl TestHarness {
             mint_services,
         ));
 
-        Self { pool, account_cqrs, asset_cqrs, mint_cqrs }
+        Self { pool, account_store, asset_cqrs, mint_cqrs }
     }
 }
 
@@ -144,9 +142,8 @@ impl TestHarness {
         let register_cmd =
             AccountCommand::Register { client_id, email: email.clone() };
 
-        let aggregate_id = client_id.to_string();
-        self.account_cqrs
-            .execute(&aggregate_id, register_cmd)
+        self.account_store
+            .send(&client_id, register_cmd)
             .await
             .expect("Failed to register account");
 
@@ -154,8 +151,8 @@ impl TestHarness {
             alpaca_account: AlpacaAccountNumber("ALPACA123".to_string()),
         };
 
-        self.account_cqrs
-            .execute(&aggregate_id, link_cmd)
+        self.account_store
+            .send(&client_id, link_cmd)
             .await
             .expect("Failed to link account to Alpaca");
 
@@ -163,8 +160,8 @@ impl TestHarness {
 
         let whitelist_cmd = AccountCommand::WhitelistWallet { wallet };
 
-        self.account_cqrs
-            .execute(&aggregate_id, whitelist_cmd)
+        self.account_store
+            .send(&client_id, whitelist_cmd)
             .await
             .expect("Failed to whitelist wallet");
 

--- a/src/redemption/journal_manager.rs
+++ b/src/redemption/journal_manager.rs
@@ -121,7 +121,9 @@ impl<ES: EventStore<Redemption>> JournalManager<ES> {
             AccountView::LinkedToAlpaca { alpaca_account, .. } => {
                 Ok(alpaca_account)
             }
-            _ => Err(JournalManagerError::AccountNotLinked { wallet: *wallet }),
+            AccountView::Registered { .. } => {
+                Err(JournalManagerError::AccountNotLinked { wallet: *wallet })
+            }
         }
     }
 
@@ -452,6 +454,7 @@ mod tests {
     use async_trait::async_trait;
     use cqrs_es::mem_store::MemStore;
     use cqrs_es::{Aggregate, EventStore};
+    use event_sorcery::StoreBuilder;
     use rust_decimal::Decimal;
     use rust_decimal_macros::dec;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -460,7 +463,9 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{JournalManager, JournalManagerError};
-    use crate::account::{AccountView, AlpacaAccountNumber, ClientId, Email};
+    use crate::account::{
+        Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
+    };
     use crate::alpaca::{
         AlpacaError, AlpacaService, RedeemRequestStatus, TokenizationRequest,
     };
@@ -1083,27 +1088,36 @@ mod tests {
         wallet: Address,
         alpaca_account: &AlpacaAccountNumber,
     ) {
-        let view = AccountView::LinkedToAlpaca {
-            client_id: ClientId::new(),
-            email: Email::new("test@example.com".to_string()).unwrap(),
-            alpaca_account: alpaca_account.clone(),
-            whitelisted_wallets: vec![wallet],
-            registered_at: chrono::Utc::now(),
-            linked_at: chrono::Utc::now(),
-        };
-        let payload = serde_json::to_string(&view).unwrap();
-        let view_id = format!("{wallet:?}");
-        sqlx::query!(
-            r#"
-            INSERT INTO account_view (view_id, version, payload)
-            VALUES ($1, 1, $2)
-            "#,
-            view_id,
-            payload
-        )
-        .execute(pool)
-        .await
-        .unwrap();
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
+
+        let client_id = ClientId::new();
+
+        account_store
+            .send(
+                &client_id,
+                AccountCommand::Register {
+                    client_id,
+                    email: Email::new("test@example.com".to_string()).unwrap(),
+                },
+            )
+            .await
+            .unwrap();
+
+        account_store
+            .send(
+                &client_id,
+                AccountCommand::LinkToAlpaca {
+                    alpaca_account: alpaca_account.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        account_store
+            .send(&client_id, AccountCommand::WhitelistWallet { wallet })
+            .await
+            .unwrap();
     }
 
     async fn insert_redemption_view(

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -158,9 +158,11 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
             AccountView::LinkedToAlpaca {
                 client_id, alpaca_account, ..
             } => Ok((client_id, alpaca_account)),
-            _ => Err(RedeemCallManagerError::AccountNotLinked {
-                wallet: *wallet,
-            }),
+            AccountView::Registered { .. } => {
+                Err(RedeemCallManagerError::AccountNotLinked {
+                    wallet: *wallet,
+                })
+            }
         }
     }
 
@@ -320,6 +322,7 @@ mod tests {
     use cqrs_es::{
         AggregateContext, CqrsFramework, EventStore, mem_store::MemStore,
     };
+    use event_sorcery::{Store, StoreBuilder};
     use rust_decimal::Decimal;
     use sqlite_es::{
         SqliteCqrs, SqliteEventRepository, SqliteViewRepository, sqlite_cqrs,
@@ -330,8 +333,7 @@ mod tests {
 
     use super::{RedeemCallManager, RedeemCallManagerError};
     use crate::account::{
-        Account, AccountCommand, AccountView, AlpacaAccountNumber, ClientId,
-        Email,
+        Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
     };
     use crate::alpaca::mock::MockAlpacaService;
     use crate::mint::Quantity;
@@ -361,7 +363,7 @@ mod tests {
         pool: sqlx::Pool<sqlx::Sqlite>,
         redemption_store: Arc<RedemptionStore>,
         redemption_cqrs: Arc<CqrsFramework<Redemption, RedemptionStore>>,
-        account_cqrs: SqliteCqrs<Account>,
+        account_store: Arc<Store<Account>>,
         asset_cqrs: SqliteCqrs<TokenizedAsset>,
     }
 
@@ -399,14 +401,11 @@ mod tests {
                 vault_service,
             ));
 
-            let account_view_repo =
-                Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                    pool.clone(),
-                    "account_view".to_string(),
-                ));
-            let account_query = GenericQuery::new(account_view_repo);
-            let account_cqrs =
-                sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+            let (account_store, _account_projection) =
+                StoreBuilder::<Account>::new(pool.clone())
+                    .build(())
+                    .await
+                    .expect("Failed to build account store");
 
             let asset_view_repo = Arc::new(SqliteViewRepository::<
                 TokenizedAssetView,
@@ -423,7 +422,7 @@ mod tests {
                 pool,
                 redemption_store,
                 redemption_cqrs,
-                account_cqrs,
+                account_store,
                 asset_cqrs,
             }
         }
@@ -437,17 +436,14 @@ mod tests {
         ) {
             let email = Email::new(email.to_string()).unwrap();
 
-            self.account_cqrs
-                .execute(
-                    &client_id.to_string(),
-                    AccountCommand::Register { client_id, email },
-                )
+            self.account_store
+                .send(&client_id, AccountCommand::Register { client_id, email })
                 .await
                 .expect("Failed to register account");
 
-            self.account_cqrs
-                .execute(
-                    &client_id.to_string(),
+            self.account_store
+                .send(
+                    &client_id,
                     AccountCommand::LinkToAlpaca {
                         alpaca_account: alpaca_account.clone(),
                     },
@@ -455,11 +451,8 @@ mod tests {
                 .await
                 .expect("Failed to link to Alpaca");
 
-            self.account_cqrs
-                .execute(
-                    &client_id.to_string(),
-                    AccountCommand::WhitelistWallet { wallet },
-                )
+            self.account_store
+                .send(&client_id, AccountCommand::WhitelistWallet { wallet })
                 .await
                 .expect("Failed to whitelist wallet");
         }

--- a/src/redemption/test_utils.rs
+++ b/src/redemption/test_utils.rs
@@ -4,11 +4,11 @@ use alloy::primitives::{
 use alloy::rpc::types::Log;
 use alloy::sol_types::SolEvent;
 use cqrs_es::persist::GenericQuery;
+use event_sorcery::StoreBuilder;
 use sqlite_es::{SqliteViewRepository, sqlite_cqrs};
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
-use crate::account::view::AccountView;
 use crate::account::{
     Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
 };
@@ -60,30 +60,20 @@ pub(crate) async fn setup_test_db_with_asset(
         .unwrap();
 
     if let Some(wallet) = ap_wallet {
-        let account_view_repo =
-            Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-                pool.clone(),
-                "account_view".to_string(),
-            ));
-
-        let account_query = GenericQuery::new(account_view_repo);
-        let account_cqrs =
-            sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+        let (account_store, _account_projection) =
+            StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
 
         let client_id = ClientId::new();
         let email = Email::new("test@example.com".to_string()).unwrap();
 
-        account_cqrs
-            .execute(
-                &client_id.to_string(),
-                AccountCommand::Register { client_id, email },
-            )
+        account_store
+            .send(&client_id, AccountCommand::Register { client_id, email })
             .await
             .unwrap();
 
-        account_cqrs
-            .execute(
-                &client_id.to_string(),
+        account_store
+            .send(
+                &client_id,
                 AccountCommand::LinkToAlpaca {
                     alpaca_account: AlpacaAccountNumber(
                         "ALPACA123".to_string(),
@@ -93,11 +83,8 @@ pub(crate) async fn setup_test_db_with_asset(
             .await
             .unwrap();
 
-        account_cqrs
-            .execute(
-                &client_id.to_string(),
-                AccountCommand::WhitelistWallet { wallet },
-            )
+        account_store
+            .send(&client_id, AccountCommand::WhitelistWallet { wallet })
             .await
             .unwrap();
     }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -12,6 +12,7 @@ use alloy::sol_types::SolValue;
 use alloy::transports::{RpcError, TransportErrorKind};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use cqrs_es::persist::{GenericQuery, PersistedEventStore};
+use event_sorcery::StoreBuilder;
 use rocket::routes;
 use sqlite_es::{
     SqliteCqrs, SqliteEventRepository, SqliteViewRepository, sqlite_cqrs,
@@ -20,7 +21,7 @@ use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 use url::Url;
 
-use crate::account::{Account, AccountView};
+use crate::account::Account;
 use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
 use crate::auth::{FailedAuthRateLimiter, test_auth_config};
@@ -95,16 +96,9 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
     // Run migrations
     sqlx::migrate!("./migrations").run(&pool).await?;
 
-    // Setup Account CQRS
-    let account_view_repo =
-        Arc::new(SqliteViewRepository::<AccountView, Account>::new(
-            pool.clone(),
-            "account_view".to_string(),
-        ));
-
-    let account_query = GenericQuery::new(account_view_repo);
-    let account_cqrs =
-        sqlite_cqrs(pool.clone(), vec![Box::new(account_query)], ());
+    // Setup Account store (event-sorcery)
+    let (account_store, _account_projection) =
+        StoreBuilder::<Account>::new(pool.clone()).build(()).await?;
 
     // Setup TokenizedAsset CQRS
     let tokenized_asset_view_repo = Arc::new(SqliteViewRepository::<
@@ -169,7 +163,7 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
     // Build rocket
     Ok(rocket::build()
         .manage(test_config()?)
-        .manage(account_cqrs)
+        .manage(account_store)
         .manage(tokenized_asset_cqrs)
         .manage(mint_cqrs)
         .manage(mint_event_store)

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -331,10 +331,7 @@ async fn test_mint_recovery_after_view_deletion()
         final_event_count.count
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Mint callback should be hit at least once"
-    );
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }
@@ -475,10 +472,7 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
         "User should have same shares (no double mint)"
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Mint callback should be hit at least once"
-    );
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }
@@ -574,10 +568,7 @@ async fn test_mint_recovery_from_minting_state_when_no_receipt()
          Recovery for Minting state (no receipt) not implemented."
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Mint callback should be hit at least once"
-    );
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }
@@ -719,10 +710,7 @@ async fn test_mint_recovery_prevents_double_mint()
          Before: {shares_before}, After: {shares_after}"
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Mint callback should be hit at least once"
-    );
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }
@@ -968,10 +956,7 @@ async fn test_mint_recovery_from_minting_failed_state()
          Recovery for MintingFailed state not implemented."
     );
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Mint callback should be hit at least once"
-    );
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }
@@ -1232,10 +1217,10 @@ async fn test_detected_redemption_auto_failed_when_no_account()
 
     harness::wait_for_shares(&vault, user_wallet).await?;
 
-    assert!(
-        mint_callback_mock.calls_async().await >= 1,
-        "Service should still be able to process new mints after auto-failing orphaned redemption"
-    );
+    // The mint's on-chain deposit and the Alpaca callback run in a background
+    // task after confirm returns; wait_for_shares only guarantees the deposit,
+    // so poll for the callback rather than asserting it has already fired.
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Part of migrating st0x.issuance off its in-repo `cqrs-es` / `sqlite-es` wiring
and onto the extracted
[`event-sorcery`](https://github.com/ST0x-Technology/event-sorcery) crate (epic
RAI-785) — the same library st0x.liquidity already runs on.

`Account` is the pilot: the simplest aggregate (no services, a single view, no
upcasters), so it establishes the `EventSourced` pattern the other four
aggregates copy. The payoff is `StoreBuilder` replacing manual
`SqliteViewRepository` + `GenericQuery` registration and the
rebuild-every-view-at-startup `replay_*_view` pass — view freshness becomes
driven by schema-version reconciliation instead.

Stacked on #171. First of five aggregate migrations under RAI-785.

Closes RAI-553.

## Solution

Vertical slice — `Account` migrates end-to-end so the crate compiles on its own.
`EventSourced` provides `impl Aggregate for Lifecycle<Account>`, not for
`Account`, so `lib.rs` and the tests cannot stay on `cqrs-es` while only the
aggregate changes.

- **Aggregate** (`src/account/mod.rs`): implements `event_sorcery::EventSourced`
  instead of `cqrs_es::Aggregate`. The uninitialized state moves into
  event-sorcery's `Lifecycle`, so `Account` drops `NotRegistered` / `Default`
  and models only live states. `handle` / `apply` split into `initialize` /
  `transition` (commands) and `originate` / `evolve` (events); `type Id =
  ClientId`.
- **View** (`src/account/view.rs`): `account_view` now stores the
  `Lifecycle<Account>` projection payload. The hand-written `impl View<Account>`
  and `replay_account_view` are removed (StoreBuilder reconciles and rebuilds).
  `find_by_email` / `find_by_client_id` / `find_by_wallet` keep their
  `AccountView` return type — so the `mint` / `redemption` consumers stay
  untouched — and read the new payload via `$.Live.*` JSON paths.
- **Wiring** (`src/lib.rs`): Account is built with
  `StoreBuilder::<Account>::new(pool).build(())`, yielding `Arc<Store<Account>>`
  and `Arc<Projection<Account>>`; the `AccountCqrs` alias and the
  `replay_account_view` startup call are gone. HTTP handlers dispatch via
  `Store::send` with a typed `ClientId`.
- **Migrations**: recreate `account_view` for the Lifecycle payload (the
  projection rebuilds it from events on startup); add the `snapshot_version`
  column event-sorcery's snapshot store requires; and add an `account_emails`
  uniqueness table (backfilled from the event log) so registration atomically
  rejects duplicate-email races instead of leaving a phantom account.
- **Tests**: Account's unit/integration tests move from
  `cqrs_es::test::TestFramework` to `event_sorcery::TestHarness` / `TestStore`
  (adds the `event-sorcery` `test-support` dev-feature).

Existing `Account` events replay unchanged — event payloads are byte-identical;
only the aggregate and view representations change.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger email-uniqueness enforcement at the database level; fixes races that could allow duplicate registrations.
  * Added snapshot versioning default to support future upgrades without breaking writes.

* **Refactor**
  * Account domain migrated to an event-sourced store; HTTP handlers and startup wiring updated to use the new store.

* **Chores**
  * Account persistence updated to store lifecycle payloads and introduced an authoritative account-emails table.

* **Tests**
  * Tests updated to use the new store wiring and improved synchronization for callback verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->