### PR TITLE
refactor: migrate receipt inventory aggregate to event-sorcery

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,9 +79,6 @@ pub(crate) type MintEventStore =
 pub(crate) type RedemptionCqrs = Arc<SqliteCqrs<Redemption>>;
 pub(crate) type RedemptionEventStore =
     Arc<PersistedEventStore<SqliteEventRepository, Redemption>>;
-type ReceiptInventoryCqrs = Arc<SqliteCqrs<ReceiptInventory>>;
-type ReceiptInventoryEventStore =
-    Arc<PersistedEventStore<SqliteEventRepository, ReceiptInventory>>;
 
 pub(crate) type SqliteEventStore<A> =
     PersistedEventStore<SqliteEventRepository, A>;
@@ -90,12 +87,6 @@ struct AggregateCqrsSetup {
     mint: MintDeps,
     redemption_cqrs: RedemptionCqrs,
     redemption_event_store: RedemptionEventStore,
-    receipt_inventory: ReceiptInventoryDeps,
-}
-
-struct ReceiptInventoryDeps {
-    cqrs: ReceiptInventoryCqrs,
-    event_store: ReceiptInventoryEventStore,
 }
 
 struct MintDeps {
@@ -261,6 +252,9 @@ pub async fn initialize_rocket(
     let (account_store, _account_projection) =
         StoreBuilder::<Account>::new(pool.clone()).build(()).await?;
 
+    let receipt_inventory_store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+
     let blockchain_setup = config.create_blockchain_setup().await?;
     let alpaca_service = config.alpaca.service()?;
     let bot_wallet = config.signer.address().await?;
@@ -268,24 +262,21 @@ pub async fn initialize_rocket(
 
     let vault_service_for_rocket = blockchain_setup.vault_service.clone();
 
-    let AggregateCqrsSetup {
-        mint,
-        redemption_cqrs,
-        redemption_event_store,
-        receipt_inventory,
-    } = setup_aggregate_cqrs(
-        &pool,
-        blockchain_setup.vault_service.clone(),
-        alpaca_service.clone(),
-        bot_wallet,
-    );
+    let AggregateCqrsSetup { mint, redemption_cqrs, redemption_event_store } =
+        setup_aggregate_cqrs(
+            &pool,
+            &receipt_inventory_store,
+            blockchain_setup.vault_service.clone(),
+            alpaca_service.clone(),
+            bot_wallet,
+        );
 
     let managers = setup_redemption_managers(
         &config,
         blockchain_setup.vault_service,
         &redemption_cqrs,
         &redemption_event_store,
-        &receipt_inventory,
+        &receipt_inventory_store,
         &pool,
         bot_wallet,
     )?;
@@ -304,7 +295,7 @@ pub async fn initialize_rocket(
     let vault_configs = run_all_receipt_backfills(
         &pool,
         blockchain_setup.http_provider.clone(),
-        &receipt_inventory.cqrs,
+        &receipt_inventory_store,
         bot_wallet,
         config.backfill_start_block,
     )
@@ -320,8 +311,7 @@ pub async fn initialize_rocket(
     if let Err(error) = run_startup_reconciliation(
         blockchain_setup.http_provider.clone(),
         &vault_receipt_pairs,
-        &receipt_inventory.cqrs,
-        receipt_inventory.event_store.as_ref(),
+        &receipt_inventory_store,
         bot_wallet,
     )
     .await
@@ -358,7 +348,7 @@ pub async fn initialize_rocket(
         pool: pool.clone(),
         provider: blockchain_setup.http_provider.clone(),
         vault_configs: vault_configs.clone(),
-        receipt_inventory_cqrs: receipt_inventory.cqrs.clone(),
+        receipt_inventory_store: receipt_inventory_store.clone(),
         bot_wallet,
         backfill_start_block: config.backfill_start_block,
         receipt_poll_interval: config.receipt_poll_interval,
@@ -469,23 +459,14 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
 
 fn setup_aggregate_cqrs(
     pool: &Pool<Sqlite>,
+    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     vault_service: Arc<dyn vault::VaultService>,
     alpaca_service: Arc<dyn AlpacaService>,
     bot_wallet: Address,
 ) -> AggregateCqrsSetup {
-    // Create receipt inventory first since MintServices depends on it
-    let receipt_inventory_cqrs =
-        Arc::new(sqlite_cqrs(pool.clone(), vec![], ()));
-    let receipt_inventory_event_store =
-        Arc::new(PersistedEventStore::new_event_store(
-            SqliteEventRepository::new(pool.clone()),
-        ));
-
     // Create MintServices with all dependencies
-    let receipt_service = Arc::new(CqrsReceiptService::new(
-        receipt_inventory_event_store.clone(),
-        receipt_inventory_cqrs.clone(),
-    ));
+    let receipt_service =
+        Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
     let mint_services = MintServices {
         vault: vault_service.clone(),
         alpaca: alpaca_service,
@@ -550,10 +531,6 @@ fn setup_aggregate_cqrs(
         mint: MintDeps { cqrs: mint_cqrs, event_store: mint_event_store },
         redemption_cqrs,
         redemption_event_store,
-        receipt_inventory: ReceiptInventoryDeps {
-            cqrs: receipt_inventory_cqrs,
-            event_store: receipt_inventory_event_store,
-        },
     }
 }
 
@@ -562,7 +539,7 @@ fn setup_redemption_managers(
     blockchain_service: Arc<dyn vault::VaultService>,
     redemption_cqrs: &RedemptionCqrs,
     redemption_event_store: &RedemptionEventStore,
-    receipt_inventory: &ReceiptInventoryDeps,
+    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     pool: &Pool<Sqlite>,
     bot_wallet: Address,
 ) -> Result<RedemptionManagers, anyhow::Error> {
@@ -580,10 +557,8 @@ fn setup_redemption_managers(
         pool.clone(),
     ));
 
-    let receipt_service = Arc::new(CqrsReceiptService::new(
-        receipt_inventory.event_store.clone(),
-        receipt_inventory.cqrs.clone(),
-    ));
+    let receipt_service =
+        Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
 
     let burn = Arc::new(BurnManager::new(
         blockchain_service,
@@ -729,7 +704,7 @@ struct VaultBackfillConfig {
 async fn run_all_receipt_backfills<P: Provider + Clone>(
     pool: &Pool<Sqlite>,
     provider: P,
-    receipt_inventory_cqrs: &ReceiptInventoryCqrs,
+    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
     backfill_start_block: u64,
 ) -> Result<Vec<VaultBackfillConfig>, anyhow::Error> {
@@ -756,7 +731,7 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
                     vault,
                     backfill_start_block,
                     &underlying.0,
-                    receipt_inventory_cqrs,
+                    receipt_inventory_store,
                     bot_wallet,
                 )
                 .await
@@ -773,7 +748,7 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
     vault: Address,
     backfill_start_block: u64,
     underlying: &str,
-    receipt_inventory_cqrs: &ReceiptInventoryCqrs,
+    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
 ) -> Result<VaultBackfillConfig, anyhow::Error> {
     let vault_contract =
@@ -804,7 +779,7 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
         receipt_contract,
         bot_wallet,
         vault,
-        receipt_inventory_cqrs.clone(),
+        receipt_inventory_store.clone(),
         pool.clone(),
         NoOpItnHandler,
     );
@@ -842,7 +817,7 @@ fn next_receipt_backfill_block(
 struct PeriodicBackfillCtx<'a, P, H> {
     pool: &'a Pool<Sqlite>,
     provider: &'a P,
-    receipt_inventory_cqrs: &'a ReceiptInventoryCqrs,
+    receipt_inventory_store: &'a Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
     backfill_start_block: u64,
     handler: &'a H,
@@ -878,7 +853,7 @@ where
         config.receipt_contract,
         ctx.bot_wallet,
         config.vault,
-        ctx.receipt_inventory_cqrs.clone(),
+        ctx.receipt_inventory_store.clone(),
         ctx.pool.clone(),
         ctx.handler,
     );
@@ -904,7 +879,7 @@ struct PeriodicBackfillSpawn<P, H> {
     pool: Pool<Sqlite>,
     provider: P,
     vault_configs: Vec<VaultBackfillConfig>,
-    receipt_inventory_cqrs: ReceiptInventoryCqrs,
+    receipt_inventory_store: Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
     backfill_start_block: u64,
     receipt_poll_interval: Duration,
@@ -920,7 +895,7 @@ where
         pool,
         provider,
         vault_configs,
-        receipt_inventory_cqrs,
+        receipt_inventory_store,
         bot_wallet,
         backfill_start_block,
         receipt_poll_interval,
@@ -941,7 +916,7 @@ where
         let ctx = PeriodicBackfillCtx {
             pool: &pool,
             provider: &provider,
-            receipt_inventory_cqrs: &receipt_inventory_cqrs,
+            receipt_inventory_store: &receipt_inventory_store,
             bot_wallet,
             backfill_start_block,
             handler: &handler,

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, B256, address};
 use cqrs_es::persist::{GenericQuery, PersistedEventStore};
-use event_sorcery::{Store, StoreBuilder};
+use event_sorcery::{Store, StoreBuilder, test_store};
 use sqlite_es::{SqliteEventRepository, SqliteViewRepository, sqlite_cqrs};
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
@@ -18,7 +18,7 @@ use crate::fireblocks::SignerConfig;
 use crate::mint::{
     Mint, MintServices, MintView, Network, TokenSymbol, UnderlyingSymbol,
 };
-use crate::receipt_inventory::CqrsReceiptService;
+use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
 use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
 use crate::vault::mock::MockVaultService;
 
@@ -79,12 +79,8 @@ impl TestHarness {
                 .await
                 .expect("Failed to build tokenized asset store");
 
-        let receipt_inventory_event_store = {
-            let event_repo = SqliteEventRepository::new(pool.clone());
-            Arc::new(PersistedEventStore::new_event_store(event_repo))
-        };
-        let receipt_inventory_cqrs =
-            Arc::new(sqlite_cqrs(pool.clone(), vec![], ()));
+        let receipt_inventory_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
         let mint_services = MintServices {
@@ -93,8 +89,7 @@ impl TestHarness {
             pool: pool.clone(),
             bot,
             receipts: Arc::new(CqrsReceiptService::new(
-                receipt_inventory_event_store,
-                receipt_inventory_cqrs,
+                receipt_inventory_store,
             )),
         };
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -2163,7 +2163,7 @@ pub(crate) mod tests {
         Aggregate, AggregateContext, CqrsFramework, EventStore,
         event_sink::EventSink, mem_store::MemStore, test::TestFramework,
     };
-    use event_sorcery::StoreBuilder;
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -2357,8 +2357,7 @@ pub(crate) mod tests {
     pub(super) struct MintTestFixture {
         pub(super) mint_cqrs: Arc<CqrsFramework<Mint, MemStore<Mint>>>,
         pub(super) mint_store: Arc<MemStore<Mint>>,
-        pub(super) receipt_cqrs:
-            Arc<CqrsFramework<ReceiptInventory, MemStore<ReceiptInventory>>>,
+        pub(super) receipt_store: Arc<Store<ReceiptInventory>>,
     }
 
     impl MintTestFixture {
@@ -2399,19 +2398,13 @@ pub(crate) mod tests {
                 .unwrap();
 
             let receipt_store =
-                Arc::new(MemStore::<ReceiptInventory>::default());
-            let receipt_cqrs = Arc::new(CqrsFramework::new(
-                (*receipt_store).clone(),
-                vec![],
-                (),
-            ));
+                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
             let services = MintServices {
                 vault,
                 alpaca: Arc::new(MockAlpacaService::new_success()),
                 receipts: Arc::new(CqrsReceiptService::new(
-                    receipt_store,
-                    receipt_cqrs.clone(),
+                    receipt_store.clone(),
                 )),
                 pool: pool.clone(),
                 bot: BOT,
@@ -2424,7 +2417,7 @@ pub(crate) mod tests {
                 services,
             ));
 
-            Self { mint_cqrs, mint_store, receipt_cqrs }
+            Self { mint_cqrs, mint_store, receipt_store }
         }
 
         pub(super) async fn seed_mint_events(
@@ -2496,25 +2489,28 @@ pub(crate) mod tests {
             .expect("Failed to create runtime");
 
         let pool = rt.block_on(async {
-            SqlitePoolOptions::new()
+            let pool = SqlitePoolOptions::new()
                 .max_connections(1)
                 .connect(":memory:")
                 .await
-                .expect("Failed to create in-memory database")
+                .expect("Failed to create in-memory database");
+
+            sqlx::migrate!()
+                .run(&pool)
+                .await
+                .expect("Failed to run migrations");
+
+            pool
         });
 
-        let receipt_store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let receipt_cqrs =
-            Arc::new(CqrsFramework::new((*receipt_store).clone(), vec![], ()));
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
         MintServices {
             vault: Arc::new(MockVaultService::new_success()),
             alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(
-                receipt_store,
-                receipt_cqrs,
-            )),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
             bot,
         }
@@ -4084,17 +4080,13 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let receipt_store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let receipt_cqrs =
-            Arc::new(CqrsFramework::new((*receipt_store).clone(), vec![], ()));
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
         let services = MintServices {
             vault: Arc::new(MockVaultService::new_success()),
             alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(
-                receipt_store,
-                receipt_cqrs,
-            )),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
             bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
         };

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -549,9 +549,9 @@ mod tests {
         );
 
         fixture
-            .receipt_cqrs
-            .execute(
-                &VAULT.to_string(),
+            .receipt_store
+            .send(
+                &VAULT,
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(42_U256)),
                     balance: Shares::from(

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -643,14 +643,12 @@ mod tests {
     use alloy::primitives::{address, b256, uint};
     use cqrs_es::EventEnvelope;
     use cqrs_es::persist::GenericQuery;
+    use event_sorcery::test_store;
     use rust_decimal::Decimal;
     use sqlite_es::{SqliteCqrs, SqliteViewRepository, sqlite_cqrs};
     use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
     use std::collections::HashMap;
     use std::sync::Arc;
-
-    use cqrs_es::CqrsFramework;
-    use cqrs_es::mem_store::MemStore;
 
     use super::*;
     use crate::alpaca::mock::MockAlpacaService;
@@ -677,22 +675,14 @@ mod tests {
                 .expect("Failed to run migrations");
 
             let receipt_store =
-                Arc::new(MemStore::<ReceiptInventory>::default());
-            let receipt_cqrs = Arc::new(CqrsFramework::new(
-                (*receipt_store).clone(),
-                vec![],
-                (),
-            ));
+                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
             let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
             let mint_services = MintServices {
                 vault: Arc::new(MockVaultService::new_success()),
                 alpaca: Arc::new(MockAlpacaService::new_success()),
                 pool: pool.clone(),
                 bot,
-                receipts: Arc::new(CqrsReceiptService::new(
-                    receipt_store,
-                    receipt_cqrs,
-                )),
+                receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
             };
 
             let view_repo =

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -3,7 +3,8 @@ use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::SolEvent;
 use alloy::transports::{RpcError, TransportErrorKind};
 use async_trait::async_trait;
-use cqrs_es::{AggregateError, CqrsFramework, EventStore};
+use cqrs_es::AggregateError;
+use event_sorcery::Store;
 use futures::{StreamExt, stream};
 use itertools::Itertools;
 use sqlx::{Pool, Sqlite};
@@ -44,19 +45,15 @@ fn block_ranges(
 ///
 /// This handles receipts minted outside our system (e.g., manual operations)
 /// and receipts transferred to the bot wallet from other addresses.
-pub(crate) struct ReceiptBackfiller<
-    ProviderType,
-    ReceiptInventoryStore,
-    Handler,
-> where
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
+pub(crate) struct ReceiptBackfiller<ProviderType, Handler>
+where
     Handler: ItnReceiptHandler,
 {
     provider: ProviderType,
     receipt_contract: Address,
     bot_wallet: Address,
     vault: Address,
-    cqrs: Arc<CqrsFramework<ReceiptInventory, ReceiptInventoryStore>>,
+    store: Arc<Store<ReceiptInventory>>,
     pool: Pool<Sqlite>,
     handler: Handler,
 }
@@ -88,10 +85,8 @@ pub(crate) enum BackfillError {
     Checkpoint(#[from] CheckpointError),
 }
 
-impl<ProviderType, ReceiptInventoryStore, Handler>
-    ReceiptBackfiller<ProviderType, ReceiptInventoryStore, Handler>
+impl<ProviderType, Handler> ReceiptBackfiller<ProviderType, Handler>
 where
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
     Handler: ItnReceiptHandler,
 {
     pub(crate) const fn new(
@@ -99,7 +94,7 @@ where
         receipt_contract: Address,
         bot_wallet: Address,
         vault: Address,
-        cqrs: Arc<CqrsFramework<ReceiptInventory, ReceiptInventoryStore>>,
+        store: Arc<Store<ReceiptInventory>>,
         pool: Pool<Sqlite>,
         handler: Handler,
     ) -> Self {
@@ -108,18 +103,16 @@ where
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store,
             pool,
             handler,
         }
     }
 }
 
-impl<ProviderType, ReceiptInventoryStore, Handler>
-    ReceiptBackfiller<ProviderType, ReceiptInventoryStore, Handler>
+impl<ProviderType, Handler> ReceiptBackfiller<ProviderType, Handler>
 where
     ProviderType: alloy::providers::Provider + Clone + Send + Sync,
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
     Handler: ItnReceiptHandler,
 {
     /// Scans historic Deposit and ERC-1155 transfer events to discover
@@ -463,9 +456,9 @@ where
             Some(discovery.receipt_information.clone())
         };
 
-        self.cqrs
-            .execute(
-                &self.vault.to_string(),
+        self.store
+            .send(
+                &self.vault,
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: discovery.receipt_id,
                     balance: Shares::from(current_balance),
@@ -481,9 +474,9 @@ where
         // For already-known receipts, DiscoverReceipt is a no-op. Reconcile
         // ensures the aggregate reflects the current on-chain balance (e.g.,
         // after an inbound transfer increases the balance).
-        self.cqrs
-            .execute(
-                &self.vault.to_string(),
+        self.store
+            .send(
+                &self.vault,
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: discovery.receipt_id,
                     on_chain_balance: Shares::from(current_balance),
@@ -518,9 +511,9 @@ where
             .call()
             .await?;
 
-        self.cqrs
-            .execute(
-                &self.vault.to_string(),
+        self.store
+            .send(
+                &self.vault,
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id,
                     on_chain_balance: Shares::from(on_chain_balance),
@@ -651,9 +644,7 @@ mod tests {
     use alloy::rpc::types::Log;
     use alloy::signers::local::PrivateKeySigner;
     use alloy::sol_types::SolEvent;
-    use cqrs_es::{
-        AggregateContext, CqrsFramework, EventStore, mem_store::MemStore,
-    };
+    use event_sorcery::{Store, test_store};
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::{Pool, Sqlite};
     use std::sync::Arc;
@@ -664,11 +655,9 @@ mod tests {
     use crate::poll_checkpoint;
     use crate::receipt_inventory::{
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
-        Shares,
+        Shares, load_inventory,
     };
     use crate::test_utils::logs_contain_at;
-
-    type TestStore = MemStore<ReceiptInventory>;
 
     async fn setup_test_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()
@@ -727,12 +716,10 @@ mod tests {
         }
     }
 
-    async fn setup_cqrs()
-    -> (Arc<CqrsFramework<ReceiptInventory, TestStore>>, Pool<Sqlite>) {
-        let cqrs =
-            Arc::new(CqrsFramework::new(MemStore::default(), vec![], ()));
+    async fn setup_store() -> (Arc<Store<ReceiptInventory>>, Pool<Sqlite>) {
         let pool = setup_test_pool().await;
-        (cqrs, pool)
+        let store = Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        (store, pool)
     }
 
     /// Pushes empty responses for the inbound transfer, withdraw, and
@@ -754,22 +741,11 @@ mod tests {
         }
     }
 
-    async fn setup_cqrs_with_store() -> (
-        Arc<CqrsFramework<ReceiptInventory, TestStore>>,
-        Arc<TestStore>,
-        Pool<Sqlite>,
-    ) {
-        let store = Arc::new(MemStore::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        let pool = setup_test_pool().await;
-        (cqrs, store, pool)
-    }
-
     #[tokio::test]
     #[traced_test]
     async fn backfill_discovers_receipt_from_historic_deposit() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, pool) = setup_cqrs().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(42);
         let balance = U256::from(1000);
@@ -807,7 +783,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store,
             pool.clone(),
             NoOpItnHandler,
         );
@@ -838,7 +814,7 @@ mod tests {
     #[tokio::test]
     async fn backfill_is_idempotent() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(42);
         let balance = U256::from(1000);
@@ -875,7 +851,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs.clone(),
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -886,10 +862,10 @@ mod tests {
 
         // After the first run the aggregate has exactly one Discovered event
         // and the SQL checkpoint matches the chain head.
-        let mut ctx_after_first =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
+        let inventory_after_first =
+            load_inventory(&store, &vault).await.unwrap();
         assert_eq!(
-            ctx_after_first.aggregate().receipts_with_balance().len(),
+            inventory_after_first.receipts_with_balance().len(),
             1,
             "first run should produce exactly one receipt"
         );
@@ -919,7 +895,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -931,10 +907,10 @@ mod tests {
         // After the second run the aggregate still has exactly one receipt
         // (no duplicate Discovered event applied) and the checkpoint is
         // unchanged.
-        let mut ctx_after_second =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
+        let inventory_after_second =
+            load_inventory(&store, &vault).await.unwrap();
         assert_eq!(
-            ctx_after_second.aggregate().receipts_with_balance().len(),
+            inventory_after_second.receipts_with_balance().len(),
             1,
             "second run must not produce a duplicate receipt"
         );
@@ -954,7 +930,7 @@ mod tests {
     #[traced_test]
     async fn backfill_skips_zero_balance_receipts() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, pool) = setup_cqrs().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(99);
         let deposit_amount = U256::from(500);
@@ -992,7 +968,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store,
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1023,7 +999,7 @@ mod tests {
     #[tokio::test]
     async fn backfill_uses_current_onchain_balance_not_deposit_amount() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(77);
         let original_deposit = U256::from(1000);
@@ -1062,7 +1038,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1072,8 +1048,8 @@ mod tests {
 
         assert_eq!(result.processed_count, 1);
 
-        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = ctx.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
 
         assert_eq!(receipts.len(), 1);
         assert_eq!(receipts[0].available_balance.inner(), current_balance);
@@ -1082,7 +1058,7 @@ mod tests {
     #[tokio::test]
     async fn backfill_filters_deposits_by_owner() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, pool) = setup_cqrs().await;
+        let (store, pool) = setup_store().await;
         let other_wallet =
             address!("0x4444444444444444444444444444444444444444");
 
@@ -1136,7 +1112,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store,
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1151,7 +1127,7 @@ mod tests {
     #[traced_test]
     async fn backfill_emits_checkpoint_after_processing() {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
-        let (cqrs, _store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(42);
         let balance = U256::from(1000);
@@ -1189,7 +1165,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store,
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1392,7 +1368,7 @@ mod tests {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
         let other_wallet =
             address!("0x4444444444444444444444444444444444444444");
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(55);
         let balance = U256::from(750);
@@ -1434,7 +1410,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1446,8 +1422,8 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify the receipt was actually discovered with correct ID and balance
-        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = ctx.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1, "Should discover exactly one receipt");
         assert_eq!(
             receipts[0].receipt_id,
@@ -1466,7 +1442,7 @@ mod tests {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
         let other_wallet =
             address!("0x4444444444444444444444444444444444444444");
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let tx_hash = b256!(
             "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -1518,7 +1494,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1533,9 +1509,9 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify: aggregate has no receipts at all
-        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
         assert!(
-            ctx.aggregate().receipts_with_balance().is_empty(),
+            inventory.receipts_with_balance().is_empty(),
             "No receipts should be discovered from outbound/mint transfers"
         );
     }
@@ -1545,7 +1521,7 @@ mod tests {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
         let other_wallet =
             address!("0x4444444444444444444444444444444444444444");
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id = U256::from(88);
         let balance = U256::from(500);
@@ -1602,7 +1578,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1613,8 +1589,8 @@ mod tests {
         // Should only process once despite appearing in both Deposit and Transfer
         assert_eq!(result.processed_count, 1);
 
-        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = ctx.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert_eq!(
             receipts.len(),
             1,
@@ -1639,29 +1615,30 @@ mod tests {
         let (receipt_contract, bot_wallet, vault) = test_addresses();
         let other_wallet =
             address!("0x4444444444444444444444444444444444444444");
-        let (cqrs, store, pool) = setup_cqrs_with_store().await;
+        let (store, pool) = setup_store().await;
 
         let receipt_id_raw = U256::from(55);
         let stale_balance = U256::from(500);
         let new_on_chain_balance = U256::from(750);
 
         // Seed aggregate with a receipt at a stale lower balance
-        cqrs.execute(
-            &vault.to_string(),
-            ReceiptInventoryCommand::DiscoverReceipt {
-                receipt_id: ReceiptId::from(receipt_id_raw),
-                balance: Shares::from(stale_balance),
-                block_number: 50,
-                tx_hash: b256!(
-                    "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
-                ),
-                source: ReceiptSource::External,
-                receipt_info: None,
-                receipt_info_bytes: None,
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(receipt_id_raw),
+                    balance: Shares::from(stale_balance),
+                    block_number: 50,
+                    tx_hash: b256!(
+                        "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+                    ),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
 
         // Inbound transfer log (someone sent tokens to bot_wallet)
         let transfer_log = create_transfer_single_log(
@@ -1701,7 +1678,7 @@ mod tests {
             receipt_contract,
             bot_wallet,
             vault,
-            cqrs,
+            store.clone(),
             pool.clone(),
             NoOpItnHandler,
         );
@@ -1711,8 +1688,8 @@ mod tests {
         assert_eq!(result.processed_count, 1);
 
         // Verify balance was reconciled upward from 500 to 750
-        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = ctx.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
             receipts[0].available_balance,

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -7,10 +7,8 @@ pub(crate) mod view;
 
 use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
 use async_trait::async_trait;
-use cqrs_es::{
-    Aggregate, AggregateContext, AggregateError, CqrsFramework, EventStore,
-    event_sink::EventSink,
-};
+use cqrs_es::AggregateError;
+use event_sorcery::{EventSourced, LifecycleError, Nil, SendError, Store};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -22,6 +20,7 @@ use crate::mint::IssuerMintRequestId;
 use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 use crate::vault::rain_meta;
+use backfill::BackfillError;
 pub(crate) use backfill::ItnReceiptHandler;
 use burn_tracking::plan_burn;
 pub(crate) use burn_tracking::{
@@ -29,6 +28,7 @@ pub(crate) use burn_tracking::{
 };
 pub(crate) use cmd::ReceiptInventoryCommand;
 pub(crate) use event::{ReceiptInventoryEvent, ReceiptSource};
+use reconcile::ReconcileError;
 pub(crate) use view::{ReceiptInventoryView, replay_receipt_inventory_view};
 
 /// Receipt data recovered from the inventory for mint recovery.
@@ -126,7 +126,7 @@ impl std::fmt::Display for Shares {
 }
 
 /// Overflow error for Shares arithmetic.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
 #[error("Shares overflow: {lhs} + {rhs} exceeds U256::MAX")]
 pub(crate) struct SharesOverflow {
     pub(crate) lhs: Shares,
@@ -308,41 +308,104 @@ pub(crate) enum ReceiptRegistrationError {
 }
 
 /// Implementation of ReceiptService using the ReceiptInventory aggregate.
-pub(crate) struct CqrsReceiptService<ES>
-where
-    ES: EventStore<ReceiptInventory>,
-{
-    store: Arc<ES>,
-    cqrs: Arc<CqrsFramework<ReceiptInventory, ES>>,
+pub(crate) struct CqrsReceiptService {
+    store: Arc<Store<ReceiptInventory>>,
 }
 
-impl<ES> CqrsReceiptService<ES>
-where
-    ES: EventStore<ReceiptInventory>,
-{
-    pub(crate) const fn new(
-        store: Arc<ES>,
-        cqrs: Arc<CqrsFramework<ReceiptInventory, ES>>,
-    ) -> Self {
-        Self { store, cqrs }
+impl CqrsReceiptService {
+    pub(crate) const fn new(store: Arc<Store<ReceiptInventory>>) -> Self {
+        Self { store }
+    }
+}
+
+/// Loads a vault's receipt inventory, treating an absent event stream as an
+/// empty inventory.
+///
+/// This is the single home of that domain rule: an uninitialized vault
+/// behaves exactly like a vault holding no receipts (`originate` is total for
+/// the same reason). Every read of the aggregate must go through this helper
+/// rather than re-encoding `load(..)?.unwrap_or_default()` at the call site,
+/// so a future reader cannot silently diverge on the `None` case.
+pub(crate) async fn load_inventory(
+    store: &Store<ReceiptInventory>,
+    vault: &Address,
+) -> Result<ReceiptInventory, SendError<ReceiptInventory>> {
+    Ok(store.load(vault).await?.unwrap_or_default())
+}
+
+/// Translates an `event_sorcery` send/load error back into the
+/// `AggregateError<ReceiptInventoryError>` the service contract exposes.
+///
+/// Command-handler domain errors arrive as
+/// `UserError(LifecycleError::Apply(domain))` and are unwrapped to the bare
+/// domain error; `AggregateConflict` is preserved so `BurnManager`'s
+/// optimistic-concurrency retry keeps matching it. Lifecycle errors that can
+/// only arise from event-application corruption (never from a command) are
+/// surfaced as `UnexpectedError`.
+fn to_aggregate_error(
+    error: SendError<ReceiptInventory>,
+) -> AggregateError<ReceiptInventoryError> {
+    match error {
+        AggregateError::UserError(LifecycleError::Apply(domain)) => {
+            AggregateError::UserError(domain)
+        }
+        AggregateError::UserError(lifecycle) => {
+            AggregateError::UnexpectedError(Box::new(lifecycle))
+        }
+        AggregateError::AggregateConflict => AggregateError::AggregateConflict,
+        AggregateError::DatabaseConnectionError(source) => {
+            AggregateError::DatabaseConnectionError(source)
+        }
+        AggregateError::DeserializationError(source) => {
+            AggregateError::DeserializationError(source)
+        }
+        AggregateError::UnexpectedError(source) => {
+            AggregateError::UnexpectedError(source)
+        }
+    }
+}
+
+impl From<SendError<ReceiptInventory>> for ReceiptRegistrationError {
+    fn from(error: SendError<ReceiptInventory>) -> Self {
+        to_aggregate_error(error).into()
+    }
+}
+
+impl From<SendError<ReceiptInventory>> for ReceiptLookupError {
+    fn from(error: SendError<ReceiptInventory>) -> Self {
+        to_aggregate_error(error).into()
+    }
+}
+
+impl From<SendError<ReceiptInventory>> for BurnTrackingError {
+    fn from(error: SendError<ReceiptInventory>) -> Self {
+        to_aggregate_error(error).into()
+    }
+}
+
+impl From<SendError<ReceiptInventory>> for BackfillError {
+    fn from(error: SendError<ReceiptInventory>) -> Self {
+        to_aggregate_error(error).into()
+    }
+}
+
+impl From<SendError<ReceiptInventory>> for ReconcileError {
+    fn from(error: SendError<ReceiptInventory>) -> Self {
+        to_aggregate_error(error).into()
     }
 }
 
 #[async_trait]
-impl<ES> ReceiptService for CqrsReceiptService<ES>
-where
-    ES: EventStore<ReceiptInventory> + Send + Sync,
-    ES::AC: Send,
-{
+impl ReceiptService for CqrsReceiptService {
     async fn register_minted_receipt(
         &self,
         params: MintedReceiptParams,
     ) -> Result<(), ReceiptRegistrationError> {
         let issuer_request_id = params.receipt_info.issuer_request_id.clone();
 
-        self.cqrs
-            .execute(
-                &params.vault.to_string(),
+        self.store
+            .send(
+                &params.vault,
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: params.receipt_id,
                     balance: params.shares,
@@ -365,10 +428,9 @@ where
         shares_to_burn: Shares,
         dust: Shares,
     ) -> Result<BurnPlan, BurnTrackingError> {
-        let mut context = self.store.load_aggregate(&vault.to_string()).await?;
+        let inventory = load_inventory(&self.store, &vault).await?;
 
-        let receipts = context
-            .aggregate()
+        let receipts = inventory
             .receipts_with_balance_excluding(redemption_issuer_request_id);
         plan_burn(receipts, shares_to_burn, dust)
     }
@@ -379,9 +441,9 @@ where
         redemption_issuer_request_id: IssuerRedemptionRequestId,
         burns: Vec<BurnRecord>,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.cqrs
-            .execute(
-                &vault.to_string(),
+        self.store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::ReserveBurn {
                     redemption_issuer_request_id,
                     burns,
@@ -397,9 +459,9 @@ where
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.cqrs
-            .execute(
-                &vault.to_string(),
+        self.store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::ReleaseBurn {
                     redemption_issuer_request_id,
                 },
@@ -414,9 +476,9 @@ where
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.cqrs
-            .execute(
-                &vault.to_string(),
+        self.store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::SettleBurn {
                     redemption_issuer_request_id,
                 },
@@ -430,8 +492,8 @@ where
         &self,
         vault: Address,
     ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError> {
-        let mut context = self.store.load_aggregate(&vault.to_string()).await?;
-        Ok(context.aggregate().reserved_redemptions())
+        let inventory = load_inventory(&self.store, &vault).await?;
+        Ok(inventory.reserved_redemptions())
     }
 
     async fn find_by_issuer_request_id(
@@ -439,12 +501,7 @@ where
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
     ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
-        let receipt_inventory = self
-            .store
-            .load_aggregate(&vault.to_string())
-            .await?
-            .aggregate()
-            .clone();
+        let receipt_inventory = load_inventory(&self.store, vault).await?;
 
         let Some(receipt_id) =
             receipt_inventory.find_by_issuer_request_id(issuer_request_id)
@@ -569,11 +626,11 @@ impl ReceiptInventory {
     /// also covers a receipt already at zero balance — preserved by the
     /// zero-drain reconcile guard — so it is depleted once its last reservation
     /// resolves rather than lingering empty forever.
-    fn depletion_receipt_ids_after_clearing(
+    fn depletions_after_clearing(
         &self,
         redemption: &IssuerRedemptionRequestId,
         consume_balance: bool,
-    ) -> Vec<ReceiptId> {
+    ) -> Vec<ReceiptInventoryEvent> {
         self.receipts
             .iter()
             .filter_map(|(receipt_id, metadata)| {
@@ -593,7 +650,9 @@ impl ReceiptInventory {
                     metadata.balance
                 };
 
-                post_balance.is_zero().then_some(*receipt_id)
+                post_balance.is_zero().then_some(
+                    ReceiptInventoryEvent::Depleted { receipt_id: *receipt_id },
+                )
             })
             .collect()
     }
@@ -646,7 +705,7 @@ pub(crate) fn determine_source(
     )
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
 pub(crate) enum ReceiptInventoryError {
     #[error("Unknown receipt {receipt_id}")]
     UnknownReceipt { receipt_id: ReceiptId },
@@ -663,20 +722,11 @@ pub(crate) enum ReceiptInventoryError {
     },
 }
 
-impl Aggregate for ReceiptInventory {
-    type Command = ReceiptInventoryCommand;
-    type Event = ReceiptInventoryEvent;
-    type Error = ReceiptInventoryError;
-    type Services = ();
-
-    const TYPE: &'static str = "ReceiptInventory";
-
-    async fn handle(
-        &mut self,
-        command: Self::Command,
-        _services: &Self::Services,
-        sink: &EventSink<Self>,
-    ) -> Result<(), Self::Error> {
+impl ReceiptInventory {
+    fn handle_command(
+        &self,
+        command: ReceiptInventoryCommand,
+    ) -> Result<Vec<ReceiptInventoryEvent>, ReceiptInventoryError> {
         match command {
             ReceiptInventoryCommand::DiscoverReceipt {
                 receipt_id,
@@ -688,22 +738,18 @@ impl Aggregate for ReceiptInventory {
                 receipt_info_bytes,
             } => {
                 if self.receipts.contains_key(&receipt_id) {
-                    return Ok(());
+                    return Ok(vec![]);
                 }
 
-                sink.write(
-                    ReceiptInventoryEvent::Discovered {
-                        receipt_id,
-                        balance,
-                        block_number,
-                        tx_hash,
-                        source,
-                        receipt_info,
-                        receipt_info_bytes,
-                    },
-                    self,
-                )
-                .await;
+                Ok(vec![ReceiptInventoryEvent::Discovered {
+                    receipt_id,
+                    balance,
+                    block_number,
+                    tx_hash,
+                    source,
+                    receipt_info,
+                    receipt_info_bytes,
+                }])
             }
 
             ReceiptInventoryCommand::ReconcileBalance {
@@ -711,12 +757,11 @@ impl Aggregate for ReceiptInventory {
                 on_chain_balance,
             } => {
                 let Some(metadata) = self.receipts.get(&receipt_id) else {
-                    return Ok(());
+                    return Ok(vec![]);
                 };
 
                 let mirror = metadata.balance;
                 let available = metadata.available();
-                let reserved_empty = metadata.reserved.is_empty();
 
                 // While a submitted burn is pending, on-chain legitimately
                 // sits between `available` (all reservations settled) and
@@ -724,38 +769,26 @@ impl Aggregate for ReceiptInventory {
                 // "no external change" so reconciliation never clobbers a
                 // reservation — settlement, not reconciliation, consumes it.
                 if (available..=mirror).contains(&on_chain_balance) {
-                    if mirror.is_zero() {
-                        write_depletion_if_unreserved(
-                            sink,
-                            self,
-                            receipt_id,
-                            reserved_empty,
-                        )
-                        .await;
-                    }
-
-                    return Ok(());
+                    return Ok(if mirror.is_zero() {
+                        depletion_events(receipt_id, metadata)
+                    } else {
+                        vec![]
+                    });
                 }
 
-                sink.write(
-                    ReceiptInventoryEvent::BalanceReconciled {
-                        receipt_id,
-                        previous_balance: mirror,
-                        on_chain_balance,
-                    },
-                    self,
-                )
-                .await;
+                let reconciled = ReceiptInventoryEvent::BalanceReconciled {
+                    receipt_id,
+                    previous_balance: mirror,
+                    on_chain_balance,
+                };
 
-                if on_chain_balance.is_zero() {
-                    write_depletion_if_unreserved(
-                        sink,
-                        self,
-                        receipt_id,
-                        reserved_empty,
-                    )
-                    .await;
-                }
+                let depletion = if on_chain_balance.is_zero() {
+                    depletion_events(receipt_id, metadata)
+                } else {
+                    vec![]
+                };
+
+                Ok(std::iter::once(reconciled).chain(depletion).collect())
             }
 
             ReceiptInventoryCommand::ReserveBurn {
@@ -790,14 +823,10 @@ impl Aggregate for ReceiptInventory {
                     }
                 }
 
-                sink.write(
-                    ReceiptInventoryEvent::BurnReserved {
-                        redemption_issuer_request_id,
-                        burns,
-                    },
-                    self,
-                )
-                .await;
+                Ok(vec![ReceiptInventoryEvent::BurnReserved {
+                    redemption_issuer_request_id,
+                    burns,
+                }])
             }
 
             // Release restores a reservation without touching the mirror
@@ -810,29 +839,19 @@ impl Aggregate for ReceiptInventory {
                 redemption_issuer_request_id,
             } => {
                 if !self.holds_reservation(&redemption_issuer_request_id) {
-                    return Ok(());
+                    return Ok(vec![]);
                 }
 
-                let depleted = self.depletion_receipt_ids_after_clearing(
+                let depletions = self.depletions_after_clearing(
                     &redemption_issuer_request_id,
                     false,
                 );
 
-                sink.write(
-                    ReceiptInventoryEvent::BurnReleased {
-                        redemption_issuer_request_id,
-                    },
-                    self,
-                )
-                .await;
-
-                for receipt_id in depleted {
-                    sink.write(
-                        ReceiptInventoryEvent::Depleted { receipt_id },
-                        self,
-                    )
-                    .await;
-                }
+                Ok(std::iter::once(ReceiptInventoryEvent::BurnReleased {
+                    redemption_issuer_request_id,
+                })
+                .chain(depletions)
+                .collect())
             }
 
             // Settle consumes a reservation after its burn confirmed on-chain:
@@ -842,36 +861,24 @@ impl Aggregate for ReceiptInventory {
                 redemption_issuer_request_id,
             } => {
                 if !self.holds_reservation(&redemption_issuer_request_id) {
-                    return Ok(());
+                    return Ok(vec![]);
                 }
 
-                let depleted = self.depletion_receipt_ids_after_clearing(
+                let depletions = self.depletions_after_clearing(
                     &redemption_issuer_request_id,
                     true,
                 );
 
-                sink.write(
-                    ReceiptInventoryEvent::BurnSettled {
-                        redemption_issuer_request_id,
-                    },
-                    self,
-                )
-                .await;
-
-                for receipt_id in depleted {
-                    sink.write(
-                        ReceiptInventoryEvent::Depleted { receipt_id },
-                        self,
-                    )
-                    .await;
-                }
+                Ok(std::iter::once(ReceiptInventoryEvent::BurnSettled {
+                    redemption_issuer_request_id,
+                })
+                .chain(depletions)
+                .collect())
             }
         }
-
-        Ok(())
     }
 
-    fn apply(&mut self, event: Self::Event) {
+    fn apply_event(&mut self, event: ReceiptInventoryEvent) {
         match event {
             ReceiptInventoryEvent::Discovered {
                 receipt_id,
@@ -1021,28 +1028,89 @@ impl Aggregate for ReceiptInventory {
     }
 }
 
-/// Writes `Depleted` when a zero-balance receipt has no outstanding reservations.
+#[async_trait]
+impl EventSourced for ReceiptInventory {
+    type Id = Address;
+    type Event = ReceiptInventoryEvent;
+    type Command = ReceiptInventoryCommand;
+    type Error = ReceiptInventoryError;
+    type Services = ();
+    type Materialized = Nil;
+
+    const AGGREGATE_TYPE: &'static str = "ReceiptInventory";
+    const PROJECTION: Nil = Nil;
+    const SCHEMA_VERSION: u64 = 1;
+
+    // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
+    // and event-sorcery hardwires snapshot-every-N with no off switch, so
+    // usize::MAX makes the next-snapshot threshold unreachable. The proper
+    // fix is for event-sorcery to take the snapshot policy explicitly from
+    // the consumer, including the option to disable snapshotting entirely.
+    //
+    // Replay-cost note for whoever profiles a slow mint/redemption path:
+    // without snapshots every send/load replays the vault's full event
+    // stream, and `evolve` clones the whole inventory per event (its `&Self`
+    // signature forces it), so loads cost O(events x receipts) and the
+    // per-vault stream only ever grows.
+    const SNAPSHOT_SIZE: usize = usize::MAX;
+
+    /// Originate is total: the empty `Self::default()` is both the
+    /// uninitialized seed and a valid live state, so any first event yields a
+    /// valid inventory. `Discovered` inserts a receipt; any other genesis event
+    /// applies as a no-op against the empty default (only `BurnReserved` with
+    /// burns logs a WARN), matching the old infallible replay. Returning
+    /// `None` here would make a stream whose first event isn't `Discovered`
+    /// fail to load instead of yielding an empty inventory.
+    fn originate(event: &Self::Event) -> Option<Self> {
+        let mut inventory = Self::default();
+        inventory.apply_event(event.clone());
+        Some(inventory)
+    }
+
+    fn evolve(
+        entity: &Self,
+        event: &Self::Event,
+    ) -> Result<Option<Self>, Self::Error> {
+        let mut next = entity.clone();
+        next.apply_event(event.clone());
+        Ok(Some(next))
+    }
+
+    async fn initialize(
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        Self::default().handle_command(command)
+    }
+
+    async fn transition(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        self.handle_command(command)
+    }
+}
+
+/// Decides whether a receipt that has reached zero balance should be depleted.
 ///
 /// A receipt that still holds a reservation is preserved (with a WARN) instead
 /// of depleted: removing it would silently discard the reservation and turn a
 /// later settle/release into a no-op. A pending settle/release or the startup
 /// reservation recovery resolves it instead.
-async fn write_depletion_if_unreserved(
-    sink: &EventSink<ReceiptInventory>,
-    aggregate: &mut ReceiptInventory,
+fn depletion_events(
     receipt_id: ReceiptId,
-    reserved_empty: bool,
-) {
-    if reserved_empty {
-        sink.write(ReceiptInventoryEvent::Depleted { receipt_id }, aggregate)
-            .await;
-        return;
+    metadata: &ReceiptMetadata,
+) -> Vec<ReceiptInventoryEvent> {
+    if metadata.reserved.is_empty() {
+        return vec![ReceiptInventoryEvent::Depleted { receipt_id }];
     }
 
     warn!(target: "receipt", receipt_id = %receipt_id,
         "Receipt reached zero balance while still holding reservations; \
          preserving it so the reservation can resolve"
     );
+    vec![]
 }
 
 fn required_burns_by_receipt(
@@ -1064,7 +1132,7 @@ fn required_burns_by_receipt(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Bytes, TxHash, address, b256};
-    use cqrs_es::{CqrsFramework, EventStore, mem_store::MemStore};
+    use event_sorcery::test_store;
     use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
@@ -1088,17 +1156,6 @@ mod tests {
     /// test — i.e. the "another redemption is planning" viewpoint.
     fn planning_redemption() -> IssuerRedemptionRequestId {
         "red-00000000".parse().unwrap()
-    }
-
-    fn make_metadata(balance: u64) -> ReceiptMetadata {
-        ReceiptMetadata {
-            balance: make_shares(balance),
-            reserved: HashMap::new(),
-            tx_hash: TxHash::ZERO,
-            block_number: 0,
-            receipt_info: None,
-            receipt_info_bytes: None,
-        }
     }
 
     fn discover_receipt_cmd(
@@ -1136,33 +1193,51 @@ mod tests {
         }
     }
 
-    async fn handle_command(
+    async fn setup_store() -> Arc<Store<ReceiptInventory>> {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+        Arc::new(test_store::<ReceiptInventory>(pool, ()))
+    }
+
+    /// Runs a command against the aggregate and applies the produced events,
+    /// so test state is only ever built through the public command API.
+    async fn drive(
         aggregate: &mut ReceiptInventory,
         command: ReceiptInventoryCommand,
-    ) -> Result<Vec<ReceiptInventoryEvent>, ReceiptInventoryError> {
-        let sink = EventSink::default();
-        aggregate.handle(command, &(), &sink).await?;
-        Ok(sink.collect().await)
+    ) -> Vec<ReceiptInventoryEvent> {
+        let events = aggregate.transition(command, &()).await.unwrap();
+        for event in events.clone() {
+            aggregate.apply_event(event);
+        }
+        events
     }
 
     #[tokio::test]
     async fn test_discover_receipt_emits_discovered_event() {
-        let mut aggregate = ReceiptInventory::default();
+        let aggregate = ReceiptInventory::default();
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -1184,99 +1259,44 @@ mod tests {
         );
 
         // First discovery succeeds
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
         // Second discovery is idempotent - returns Ok with no events
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(200),
-                2000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(200),
+                    2000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(events.is_empty());
     }
 
-    #[test]
-    fn test_apply_discovered_adds_to_state() {
-        let mut aggregate = ReceiptInventory::default();
-        let tx_hash = b256!(
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
-            receipt_id: make_receipt_id(42),
-            balance: make_shares(100),
-            block_number: 1000,
-            tx_hash,
-            source: ReceiptSource::External,
-            receipt_info: None,
-            receipt_info_bytes: None,
-        });
-
-        assert_eq!(aggregate.receipts.len(), 1);
-
-        assert_eq!(
-            aggregate.receipts.get(&make_receipt_id(42)).map(|m| m.balance),
-            Some(make_shares(100))
-        );
-    }
-
-    #[test]
-    fn test_apply_discovered_stores_receipt_info() {
-        let mut aggregate = ReceiptInventory::default();
-        let tx_hash = b256!(
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        let issuer_request_id = IssuerMintRequestId::random();
-        let receipt_info = ReceiptInformation::new(
-            TokenizationRequestId::new("tok-test"),
-            issuer_request_id.clone(),
-            UnderlyingSymbol::new("AAPL"),
-            Quantity(Decimal::new(100, 0)),
-            Utc::now(),
-            None,
-        );
-
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
-            receipt_id: make_receipt_id(42),
-            balance: make_shares(100),
-            block_number: 1000,
-            tx_hash,
-            source: ReceiptSource::Itn { issuer_request_id },
-            receipt_info: Some(Box::new(receipt_info.clone())),
-            receipt_info_bytes: None,
-        });
-
-        let receipts = aggregate.receipts_with_balance();
-        assert_eq!(receipts.len(), 1);
-        assert_eq!(receipts[0].receipt_info, Some(receipt_info));
-    }
-
     #[tokio::test]
     async fn test_discover_receipt_with_receipt_info_roundtrips() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = CqrsFramework::new((*store).clone(), vec![], ());
+        let store = setup_store().await;
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -1291,24 +1311,24 @@ mod tests {
             Some("test notes".to_string()),
         );
 
-        cqrs.execute(
-            &vault.to_string(),
-            ReceiptInventoryCommand::DiscoverReceipt {
-                receipt_id: make_receipt_id(99),
-                balance: make_shares(500),
-                block_number: 2000,
-                tx_hash,
-                source: ReceiptSource::Itn { issuer_request_id },
-                receipt_info: Some(Box::new(receipt_info.clone())),
-                receipt_info_bytes: None,
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: make_receipt_id(99),
+                    balance: make_shares(500),
+                    block_number: 2000,
+                    tx_hash,
+                    source: ReceiptSource::Itn { issuer_request_id },
+                    receipt_info: Some(Box::new(receipt_info.clone())),
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = context.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
             receipts[0].receipt_info,
@@ -1317,188 +1337,114 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_apply_depleted_removes_receipt() {
-        let mut aggregate = ReceiptInventory::default();
-        aggregate.receipts.insert(make_receipt_id(42), make_metadata(0));
+    #[tokio::test]
+    async fn test_non_discovered_genesis_event_loads_as_empty_inventory() {
+        let store = setup_store().await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
-        aggregate.apply(ReceiptInventoryEvent::Depleted {
-            receipt_id: make_receipt_id(42),
-        });
-
-        assert!(!aggregate.receipts.contains_key(&make_receipt_id(42)));
-    }
-
-    #[test]
-    fn test_receipts_with_balance_returns_all_receipts() {
-        let mut aggregate = ReceiptInventory::default();
-        aggregate.receipts.insert(make_receipt_id(1), make_metadata(100));
-        aggregate.receipts.insert(make_receipt_id(2), make_metadata(200));
-
-        let receipts = aggregate.receipts_with_balance();
-
-        assert_eq!(receipts.len(), 2);
-
-        let total: Shares = receipts
-            .iter()
-            .map(|receipt| receipt.available_balance)
-            .try_fold(Shares::new(U256::ZERO), |acc, shares| acc + shares)
+        // ReserveBurn with no burns aggregates to an empty required-by-receipt
+        // map, so it skips the receipt-existence check and emits BurnReserved as
+        // a genesis event — a non-Discovered first event on a fresh vault.
+        // originate must treat the empty default as a valid live state and yield
+        // an empty inventory, not fail the load with EventCantOriginate (every
+        // read goes through `load_inventory`, where a load error propagates
+        // instead of degrading to an empty inventory).
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::ReserveBurn {
+                    redemption_issuer_request_id: "red-00000000"
+                        .parse()
+                        .unwrap(),
+                    burns: vec![],
+                },
+            )
+            .await
             .unwrap();
-        assert_eq!(total, make_shares(300));
-    }
 
-    #[test]
-    fn test_receipts_with_balance_empty_aggregate() {
-        let aggregate = ReceiptInventory::default();
+        let inventory = store
+            .load(&vault)
+            .await
+            .expect("load must not fail on a non-Discovered genesis event")
+            .expect("a persisted stream must materialize an inventory");
 
-        let receipts = aggregate.receipts_with_balance();
-
-        assert!(receipts.is_empty());
+        assert!(
+            inventory.receipts_with_balance().is_empty(),
+            "an empty ReserveBurn must leave the inventory empty"
+        );
     }
 
     #[tokio::test]
     async fn test_find_by_issuer_request_id_returns_receipt_when_itn_receipt_exists()
      {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = CqrsFramework::new((*store).clone(), vec![], ());
+        let store = setup_store().await;
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
         let issuer_request_id = IssuerMintRequestId::random();
 
-        cqrs.execute(
-            &vault.to_string(),
-            discover_itn_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-                issuer_request_id.clone(),
-            ),
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &vault,
+                discover_itn_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                    issuer_request_id.clone(),
+                ),
+            )
+            .await
+            .unwrap();
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let found =
-            context.aggregate().find_by_issuer_request_id(&issuer_request_id);
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let found = inventory.find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, Some(make_receipt_id(42)));
     }
 
     #[tokio::test]
     async fn test_find_by_issuer_request_id_returns_none_when_not_exists() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
+        let store = setup_store().await;
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let found =
-            context.aggregate().find_by_issuer_request_id(&issuer_request_id);
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let found = inventory.find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, None);
     }
 
     #[tokio::test]
     async fn test_find_by_issuer_request_id_returns_none_for_external_receipts()
     {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = CqrsFramework::new((*store).clone(), vec![], ());
+        let store = setup_store().await;
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
         // Discover an external receipt (no issuer_request_id)
-        cqrs.execute(
-            &vault.to_string(),
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &vault,
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+            )
+            .await
+            .unwrap();
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let aggregate = context.aggregate();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
 
         // External receipts should not be indexed by issuer_request_id
         let random_id = IssuerMintRequestId::random();
-        assert_eq!(aggregate.find_by_issuer_request_id(&random_id), None);
+        assert_eq!(inventory.find_by_issuer_request_id(&random_id), None);
 
         // But the receipt itself should exist
-        assert_eq!(aggregate.receipts.len(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_itn_receipt_is_indexed_in_itn_receipts_map() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = CqrsFramework::new((*store).clone(), vec![], ());
-        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        let tx_hash = b256!(
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        let issuer_request_id = IssuerMintRequestId::random();
-
-        cqrs.execute(
-            &vault.to_string(),
-            discover_itn_receipt_cmd(
-                make_receipt_id(99),
-                make_shares(500),
-                2000,
-                tx_hash,
-                issuer_request_id.clone(),
-            ),
-        )
-        .await
-        .unwrap();
-
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let aggregate = context.aggregate();
-
-        // Verify the receipt is in both maps
-        assert_eq!(aggregate.receipts.len(), 1);
-        assert_eq!(aggregate.itn_receipts.len(), 1);
-        assert_eq!(
-            aggregate.itn_receipts.get(&issuer_request_id),
-            Some(&make_receipt_id(99))
-        );
-    }
-
-    #[tokio::test]
-    async fn test_external_receipt_not_in_itn_receipts_map() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = CqrsFramework::new((*store).clone(), vec![], ());
-        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
-        let tx_hash = b256!(
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-
-        cqrs.execute(
-            &vault.to_string(),
-            discover_receipt_cmd(
-                make_receipt_id(77),
-                make_shares(300),
-                1500,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
-
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let aggregate = context.aggregate();
-
-        // Receipt exists but not in itn_receipts
-        assert_eq!(aggregate.receipts.len(), 1);
-        assert_eq!(aggregate.itn_receipts.len(), 0);
+        assert_eq!(inventory.receipts.len(), 1);
     }
 
     #[test]
@@ -1591,29 +1537,61 @@ mod tests {
 
     async fn setup_receipt_service_with_receipts(
         receipts: Vec<(u64, u64)>,
-    ) -> CqrsReceiptService<MemStore<ReceiptInventory>> {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
+    ) -> CqrsReceiptService {
+        let store = setup_store().await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
         for (i, (id, balance)) in receipts.into_iter().enumerate() {
-            cqrs.execute(
-                &address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
-                    .to_string(),
-                discover_receipt_cmd(
-                    make_receipt_id(id),
-                    make_shares(balance),
-                    1000 + i as u64,
-                    tx_hash,
-                ),
-            )
-            .await
-            .unwrap();
+            store
+                .send(
+                    &vault,
+                    discover_receipt_cmd(
+                        make_receipt_id(id),
+                        make_shares(balance),
+                        1000 + i as u64,
+                        tx_hash,
+                    ),
+                )
+                .await
+                .unwrap();
         }
 
-        CqrsReceiptService::new(store, cqrs)
+        CqrsReceiptService::new(store)
+    }
+
+    #[test]
+    fn test_aggregate_conflict_survives_error_translation() {
+        // BurnManager::reserve_with_conflict_retry matches on
+        // ReceiptRegistrationError::Aggregate(AggregateError::AggregateConflict)
+        // to retry optimistic-concurrency conflicts on the same vault. The store
+        // surfaces those conflicts as SendError::AggregateConflict; this locks in
+        // that the translation preserves the variant rather than collapsing it
+        // into UnexpectedError, which would silently break the retry and fail
+        // concurrent redemptions terminally.
+        let translated = to_aggregate_error(
+            SendError::<ReceiptInventory>::AggregateConflict,
+        );
+        assert!(
+            matches!(translated, AggregateError::AggregateConflict),
+            "AggregateConflict must pass through to_aggregate_error unchanged"
+        );
+
+        let registration_error = ReceiptRegistrationError::from(
+            SendError::<ReceiptInventory>::AggregateConflict,
+        );
+        assert!(
+            matches!(
+                registration_error,
+                ReceiptRegistrationError::Aggregate(
+                    AggregateError::AggregateConflict
+                )
+            ),
+            "the From<SendError> conversion BurnManager relies on must \
+             preserve AggregateConflict"
+        );
     }
 
     #[tokio::test]
@@ -1900,7 +1878,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_preserves_pending_reservation() {
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
+        aggregate.apply_event(ReceiptInventoryEvent::Discovered {
             receipt_id: make_receipt_id(42),
             balance: make_shares(100),
             block_number: 1,
@@ -1909,7 +1887,7 @@ mod tests {
             receipt_info: None,
             receipt_info_bytes: None,
         });
-        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+        aggregate.apply_event(ReceiptInventoryEvent::BurnReserved {
             redemption_issuer_request_id: "red-00000001".parse().unwrap(),
             burns: vec![burn(42, 100)],
         });
@@ -1920,15 +1898,16 @@ mod tests {
             "fully reserved receipt must be unavailable"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(100),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(100),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.is_empty(),
@@ -1937,7 +1916,7 @@ mod tests {
         );
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
         assert_eq!(
@@ -1953,7 +1932,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_no_op_for_landed_unsettled_burn() {
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
+        aggregate.apply_event(ReceiptInventoryEvent::Discovered {
             receipt_id: make_receipt_id(42),
             balance: make_shares(100),
             block_number: 1,
@@ -1962,21 +1941,22 @@ mod tests {
             receipt_info: None,
             receipt_info_bytes: None,
         });
-        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+        aggregate.apply_event(ReceiptInventoryEvent::BurnReserved {
             redemption_issuer_request_id: "red-00000001".parse().unwrap(),
             burns: vec![burn(42, 60)],
         });
 
         // available = 40, mirror = 100; the burn of 60 lands -> on-chain 40.
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(40),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(40),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.is_empty(),
@@ -1990,7 +1970,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_external_drain_below_available_reconciles() {
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
+        aggregate.apply_event(ReceiptInventoryEvent::Discovered {
             receipt_id: make_receipt_id(42),
             balance: make_shares(100),
             block_number: 1,
@@ -1999,21 +1979,22 @@ mod tests {
             receipt_info: None,
             receipt_info_bytes: None,
         });
-        aggregate.apply(ReceiptInventoryEvent::BurnReserved {
+        aggregate.apply_event(ReceiptInventoryEvent::BurnReserved {
             redemption_issuer_request_id: "red-00000001".parse().unwrap(),
             burns: vec![burn(42, 30)],
         });
 
         // available = 70; on-chain 50 < 70 -> external drain.
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(50),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(50),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -2030,32 +2011,42 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_reconcile_preserves_reservation_at_zero_mirror() {
+        // Given is built from events (the canonical ES setup): an out-of-band
+        // external drain (BalanceReconciled to zero on a reserved receipt)
+        // legitimately produces a zero-mirror receipt that still holds a
+        // reservation. Applying events directly — rather than driving the
+        // commands — keeps the setup WARN-free, so the WARN assertion below is
+        // attributable only to the command under test.
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
+        aggregate.apply_event(ReceiptInventoryEvent::Discovered {
             receipt_id: make_receipt_id(42),
-            balance: make_shares(0),
+            balance: make_shares(100),
             block_number: 1,
             tx_hash: TxHash::ZERO,
             source: ReceiptSource::External,
             receipt_info: None,
             receipt_info_bytes: None,
         });
-        aggregate
-            .receipts
-            .get_mut(&make_receipt_id(42))
-            .unwrap()
-            .reserved
-            .insert("red-00000001".parse().unwrap(), make_shares(50));
+        aggregate.apply_event(ReceiptInventoryEvent::BurnReserved {
+            redemption_issuer_request_id: "red-00000001".parse().unwrap(),
+            burns: vec![burn(42, 70)],
+        });
+        aggregate.apply_event(ReceiptInventoryEvent::BalanceReconciled {
+            receipt_id: make_receipt_id(42),
+            previous_balance: make_shares(100),
+            on_chain_balance: make_shares(0),
+        });
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(0),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2075,32 +2066,36 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_zero_drain_preserves_reservation() {
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
-            receipt_id: make_receipt_id(42),
-            balance: make_shares(100),
-            block_number: 1,
-            tx_hash: TxHash::ZERO,
-            source: ReceiptSource::External,
-            receipt_info: None,
-            receipt_info_bytes: None,
-        });
-        aggregate
-            .receipts
-            .get_mut(&make_receipt_id(42))
-            .unwrap()
-            .reserved
-            .insert("red-00000001".parse().unwrap(), make_shares(70));
-
-        // available = 30; an external drain to 0 is below it (out of band).
-        let events = handle_command(
+        drive(
             &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(0),
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1,
+                TxHash::ZERO,
+            ),
+        )
+        .await;
+        drive(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReserveBurn {
+                redemption_issuer_request_id: "red-00000001".parse().unwrap(),
+                burns: vec![burn(42, 70)],
             },
         )
-        .await
-        .unwrap();
+        .await;
+
+        // available = 30; an external drain to 0 is below it (out of band).
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(
             events.len(),
@@ -2114,7 +2109,7 @@ mod tests {
         ));
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
         assert!(
@@ -2151,10 +2146,8 @@ mod tests {
         // must be cleared. Checking internals distinguishes a real settlement
         // from merely leaving the reservation in place (which would leave the
         // same 40 available but a stale 100 mirror).
-        let mut context =
-            service.store.load_aggregate(&vault.to_string()).await.unwrap();
-        let metadata = context
-            .aggregate()
+        let inventory = load_inventory(&service.store, &vault).await.unwrap();
+        let metadata = inventory
             .receipts
             .get(&make_receipt_id(1))
             .expect("receipt should remain after partial settlement");
@@ -2189,10 +2182,9 @@ mod tests {
             .unwrap();
         service.settle_burn(vault, redemption_id).await.unwrap();
 
-        let mut context =
-            service.store.load_aggregate(&vault.to_string()).await.unwrap();
+        let inventory = load_inventory(&service.store, &vault).await.unwrap();
         assert!(
-            context.aggregate().receipts_with_balance().is_empty(),
+            inventory.receipts_with_balance().is_empty(),
             "a fully settled receipt must be depleted and removed"
         );
     }
@@ -2205,30 +2197,44 @@ mod tests {
         let redemption_id: IssuerRedemptionRequestId =
             "red-00000001".parse().unwrap();
         let mut aggregate = ReceiptInventory::default();
-        aggregate.apply(ReceiptInventoryEvent::Discovered {
-            receipt_id: make_receipt_id(1),
-            balance: make_shares(0),
-            block_number: 1,
-            tx_hash: TxHash::ZERO,
-            source: ReceiptSource::External,
-            receipt_info: None,
-            receipt_info_bytes: None,
-        });
-        aggregate
-            .receipts
-            .get_mut(&make_receipt_id(1))
-            .unwrap()
-            .reserved
-            .insert(redemption_id.clone(), make_shares(100));
-
-        let events = handle_command(
+        drive(
             &mut aggregate,
-            ReceiptInventoryCommand::ReleaseBurn {
-                redemption_issuer_request_id: redemption_id,
+            discover_receipt_cmd(
+                make_receipt_id(1),
+                make_shares(100),
+                1,
+                TxHash::ZERO,
+            ),
+        )
+        .await;
+        drive(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReserveBurn {
+                redemption_issuer_request_id: redemption_id.clone(),
+                burns: vec![burn(1, 70)],
             },
         )
-        .await
-        .unwrap();
+        .await;
+        // Out-of-band drain to zero: the reconcile guard preserves the
+        // reserved receipt at a zero mirror balance.
+        drive(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(1),
+                on_chain_balance: make_shares(0),
+            },
+        )
+        .await;
+
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReleaseBurn {
+                    redemption_issuer_request_id: redemption_id,
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.iter().any(|event| matches!(
@@ -2240,7 +2246,7 @@ mod tests {
         );
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
         assert!(
@@ -2391,20 +2397,18 @@ mod tests {
 
         service.settle_burn(vault, redemption_id).await.unwrap();
 
-        let mut context =
-            service.store.load_aggregate(&vault.to_string()).await.unwrap();
-        let aggregate = context.aggregate();
+        let inventory = load_inventory(&service.store, &vault).await.unwrap();
 
         // Receipt 1's stale reservation was cleared by the retry, so settle
         // left it untouched; only receipt 2 was consumed (and depleted).
-        let receipt_1 = aggregate
+        let receipt_1 = inventory
             .receipts
             .get(&make_receipt_id(1))
             .expect("receipt 1 must remain untouched");
         assert_eq!(receipt_1.balance, make_shares(100));
         assert!(receipt_1.reserved.is_empty());
         assert!(
-            !aggregate.receipts.contains_key(&make_receipt_id(2)),
+            !inventory.receipts.contains_key(&make_receipt_id(2)),
             "receipt 2 was settled to zero and depleted"
         );
     }
@@ -2568,31 +2572,33 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(100),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(100),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2607,31 +2613,33 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(50),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(50),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -2654,31 +2662,33 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(100),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(0),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 2);
         assert!(matches!(
@@ -2696,17 +2706,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_reconcile_unknown_receipt_emits_no_events() {
-        let mut aggregate = ReceiptInventory::default();
+        let aggregate = ReceiptInventory::default();
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(99),
-                on_chain_balance: make_shares(0),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(99),
+                    on_chain_balance: make_shares(0),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2721,31 +2732,33 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = handle_command(
-            &mut aggregate,
-            discover_receipt_cmd(
-                make_receipt_id(42),
-                make_shares(50),
-                1000,
-                tx_hash,
-            ),
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                discover_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(50),
+                    1000,
+                    tx_hash,
+                ),
+                &(),
+            )
+            .await
+            .unwrap();
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
-        let events = handle_command(
-            &mut aggregate,
-            ReceiptInventoryCommand::ReconcileBalance {
-                receipt_id: make_receipt_id(42),
-                on_chain_balance: make_shares(100),
-            },
-        )
-        .await
-        .unwrap();
+        let events = aggregate
+            .transition(
+                ReceiptInventoryCommand::ReconcileBalance {
+                    receipt_id: make_receipt_id(42),
+                    on_chain_balance: make_shares(100),
+                },
+                &(),
+            )
+            .await
+            .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -2758,7 +2771,7 @@ mod tests {
         ));
 
         for event in events {
-            aggregate.apply(event);
+            aggregate.apply_event(event);
         }
 
         let receipts = aggregate.receipts_with_balance();
@@ -2768,9 +2781,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_minted_receipt_makes_receipt_available_for_burn() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        let service = CqrsReceiptService::new(store.clone(), cqrs);
+        let store = setup_store().await;
+        let service = CqrsReceiptService::new(store.clone());
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -2809,9 +2821,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_minted_receipt_is_findable_by_issuer_request_id() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        let service = CqrsReceiptService::new(store.clone(), cqrs);
+        let store = setup_store().await;
+        let service = CqrsReceiptService::new(store.clone());
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -2848,9 +2859,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_minted_receipt_is_idempotent() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        let service = CqrsReceiptService::new(store.clone(), cqrs);
+        let store = setup_store().await;
+        let service = CqrsReceiptService::new(store.clone());
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
@@ -2875,9 +2885,8 @@ mod tests {
                 .expect("Registration should succeed (idempotent)");
         }
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = context.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
 
         assert_eq!(
             receipts.len(),
@@ -2888,9 +2897,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_register_minted_receipt_stores_receipt_info() {
-        let store = Arc::new(MemStore::<ReceiptInventory>::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        let service = CqrsReceiptService::new(store.clone(), cqrs);
+        let store = setup_store().await;
+        let service = CqrsReceiptService::new(store.clone());
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -2912,9 +2920,8 @@ mod tests {
             .await
             .expect("Registration should succeed");
 
-        let mut context =
-            store.load_aggregate(&vault.to_string()).await.unwrap();
-        let receipts = context.aggregate().receipts_with_balance();
+        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
             receipts[0].receipt_info,

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -1,13 +1,14 @@
 use alloy::primitives::Address;
 use alloy::providers::Provider;
-use cqrs_es::{AggregateContext, AggregateError, CqrsFramework, EventStore};
+use cqrs_es::AggregateError;
+use event_sorcery::Store;
 use futures::{StreamExt, stream};
 use std::sync::Arc;
 use tracing::{debug, info, trace};
 
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
-    ReceiptInventoryError, Shares,
+    ReceiptInventoryError, Shares, load_inventory,
 };
 use crate::bindings::Receipt;
 
@@ -24,42 +25,36 @@ pub(crate) struct ReconcileResult {
 pub(crate) enum ReconcileError {
     #[error("Contract call error: {0}")]
     ContractCall(#[from] alloy::contract::Error),
+    // Store operations surface SQLite failures as
+    // `AggregateError::DatabaseConnectionError` inside this variant; there is
+    // no separate persistence error path.
     #[error("CQRS error: {0}")]
     Aggregate(#[from] AggregateError<ReceiptInventoryError>),
-    #[error("Persistence error: {0}")]
-    Persistence(#[from] cqrs_es::persist::PersistenceError),
 }
 
-pub(crate) struct ReceiptReconciler<Node, ReceiptInventoryStore>
-where
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
-{
+pub(crate) struct ReceiptReconciler<Node> {
     provider: Node,
     receipt_contract: Address,
     bot_wallet: Address,
     vault: Address,
-    cqrs: Arc<CqrsFramework<ReceiptInventory, ReceiptInventoryStore>>,
+    store: Arc<Store<ReceiptInventory>>,
 }
 
-impl<Node, ReceiptInventoryStore> ReceiptReconciler<Node, ReceiptInventoryStore>
-where
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
-{
+impl<Node> ReceiptReconciler<Node> {
     pub(crate) const fn new(
         provider: Node,
         receipt_contract: Address,
         bot_wallet: Address,
         vault: Address,
-        cqrs: Arc<CqrsFramework<ReceiptInventory, ReceiptInventoryStore>>,
+        store: Arc<Store<ReceiptInventory>>,
     ) -> Self {
-        Self { provider, receipt_contract, bot_wallet, vault, cqrs }
+        Self { provider, receipt_contract, bot_wallet, vault, store }
     }
 }
 
-impl<Node, ReceiptInventoryStore> ReceiptReconciler<Node, ReceiptInventoryStore>
+impl<Node> ReceiptReconciler<Node>
 where
     Node: Provider + Clone + Send + Sync,
-    ReceiptInventoryStore: EventStore<ReceiptInventory>,
 {
     /// Reconciles receipt inventory balances with on-chain state.
     ///
@@ -68,13 +63,10 @@ where
     /// for any mismatches (emitting ExternalBurnDetected events).
     pub(crate) async fn reconcile(
         &self,
-        event_store: &ReceiptInventoryStore,
     ) -> Result<ReconcileResult, ReconcileError> {
-        let mut aggregate_context =
-            event_store.load_aggregate(&self.vault.to_string()).await?;
+        let inventory = load_inventory(&self.store, &self.vault).await?;
 
-        let receipts: Vec<_> = aggregate_context
-            .aggregate()
+        let receipts: Vec<_> = inventory
             .receipts_with_balance()
             .into_iter()
             .map(|receipt| (receipt.receipt_id, receipt.available_balance))
@@ -160,9 +152,9 @@ where
             "Balance mismatch detected"
         );
 
-        self.cqrs
-            .execute(
-                &self.vault.to_string(),
+        self.store
+            .send(
+                &self.vault,
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id,
                     on_chain_balance: on_chain_shares,
@@ -174,29 +166,25 @@ where
     }
 }
 
-pub(crate) async fn run_startup_reconciliation<
-    P: Provider + Clone,
-    ES: EventStore<ReceiptInventory>,
->(
+pub(crate) async fn run_startup_reconciliation<P: Provider + Clone>(
     provider: P,
     vault_receipt_contracts: &[(Address, Address)],
-    cqrs: &Arc<CqrsFramework<ReceiptInventory, ES>>,
-    event_store: &ES,
+    store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
 ) -> Result<(), ReconcileError> {
     let results = stream::iter(vault_receipt_contracts.iter().copied())
         .then(|(vault, receipt_contract)| {
             let provider = provider.clone();
-            let cqrs = cqrs.clone();
+            let store = store.clone();
             async move {
                 let result = ReceiptReconciler::new(
                     provider,
                     receipt_contract,
                     bot_wallet,
                     vault,
-                    cqrs,
+                    store,
                 )
-                .reconcile(event_store)
+                .reconcile()
                 .await;
 
                 (vault, receipt_contract, result)
@@ -250,8 +238,8 @@ mod tests {
     use alloy::primitives::{Address, U256, b256, uint};
     use alloy::providers::ProviderBuilder;
     use alloy::sol_types::SolEvent;
-    use cqrs_es::mem_store::MemStore;
-    use cqrs_es::{AggregateContext, CqrsFramework, EventStore};
+    use event_sorcery::test_store;
+    use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
 
     use super::*;
@@ -261,43 +249,48 @@ mod tests {
     };
     use crate::test_utils::LocalEvm;
 
-    type TestStore = MemStore<ReceiptInventory>;
-    type TestCqrs = CqrsFramework<ReceiptInventory, TestStore>;
-
-    fn setup_cqrs() -> (Arc<TestCqrs>, Arc<TestStore>) {
-        let store = Arc::new(MemStore::default());
-        let cqrs = Arc::new(CqrsFramework::new((*store).clone(), vec![], ()));
-        (cqrs, store)
+    async fn setup_store() -> Arc<Store<ReceiptInventory>> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+        Arc::new(test_store::<ReceiptInventory>(pool, ()))
     }
 
     async fn seed_receipt(
-        cqrs: &TestCqrs,
+        store: &Arc<Store<ReceiptInventory>>,
         vault: Address,
         receipt_id: U256,
         balance: U256,
     ) {
-        cqrs.execute(
-            &vault.to_string(),
-            ReceiptInventoryCommand::DiscoverReceipt {
-                receipt_id: ReceiptId::from(receipt_id),
-                balance: Shares::from(balance),
-                block_number: 1,
-                tx_hash: b256!(
-                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-                source: ReceiptSource::External,
-                receipt_info: None,
-                receipt_info_bytes: None,
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(receipt_id),
+                    balance: Shares::from(balance),
+                    block_number: 1,
+                    tx_hash: b256!(
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    ),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
     async fn test_reconcile_empty_aggregate_returns_zero_counts() {
         let evm = LocalEvm::new().await.unwrap();
-        let (cqrs, store) = setup_cqrs();
+        let store = setup_store().await;
 
         let provider =
             ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
@@ -313,10 +306,10 @@ mod tests {
             receipt_contract,
             evm.wallet_address,
             evm.vault_address,
-            cqrs,
+            store,
         );
 
-        let result = reconciler.reconcile(store.as_ref()).await.unwrap();
+        let result = reconciler.reconcile().await.unwrap();
 
         assert_eq!(result.checked, 0);
         assert_eq!(result.mismatches, 0);
@@ -325,7 +318,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_detects_stale_receipt_with_zero_on_chain_balance() {
         let evm = LocalEvm::new().await.unwrap();
-        let (cqrs, store) = setup_cqrs();
+        let store = setup_store().await;
 
         let provider =
             ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
@@ -340,26 +333,31 @@ mod tests {
         let stale_receipt_id = uint!(0xff_U256);
         let stale_balance =
             U256::from(100) * U256::from(10).pow(U256::from(18));
-        seed_receipt(&cqrs, evm.vault_address, stale_receipt_id, stale_balance)
-            .await;
+        seed_receipt(
+            &store,
+            evm.vault_address,
+            stale_receipt_id,
+            stale_balance,
+        )
+        .await;
 
         let reconciler = ReceiptReconciler::new(
             provider,
             receipt_contract,
             evm.wallet_address,
             evm.vault_address,
-            cqrs.clone(),
+            store.clone(),
         );
 
-        let result = reconciler.reconcile(store.as_ref()).await.unwrap();
+        let result = reconciler.reconcile().await.unwrap();
 
         assert_eq!(result.checked, 1, "Should have checked 1 receipt");
         assert_eq!(result.mismatches, 1, "Should have detected 1 mismatch");
 
         // Verify the aggregate was updated — receipt should be depleted
-        let mut context =
-            store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
-        let receipts = context.aggregate().receipts_with_balance();
+        let inventory =
+            load_inventory(&store, &evm.vault_address).await.unwrap();
+        let receipts = inventory.receipts_with_balance();
         assert!(
             receipts.is_empty(),
             "Stale receipt should be removed after reconciliation"
@@ -369,7 +367,7 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_matching_balance_reports_no_mismatch() {
         let evm = LocalEvm::new().await.unwrap();
-        let (cqrs, store) = setup_cqrs();
+        let store = setup_store().await;
 
         let provider =
             ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
@@ -434,17 +432,18 @@ mod tests {
         let minted_shares = deposit_log.shares;
 
         // Seed aggregate with the same balance as on-chain
-        seed_receipt(&cqrs, evm.vault_address, receipt_id, minted_shares).await;
+        seed_receipt(&store, evm.vault_address, receipt_id, minted_shares)
+            .await;
 
         let reconciler = ReceiptReconciler::new(
             bot_provider,
             receipt_contract,
             evm.wallet_address,
             evm.vault_address,
-            cqrs,
+            store,
         );
 
-        let result = reconciler.reconcile(store.as_ref()).await.unwrap();
+        let result = reconciler.reconcile().await.unwrap();
 
         assert_eq!(result.checked, 1, "Should have checked 1 receipt");
         assert_eq!(

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -1365,7 +1365,7 @@ mod tests {
         AggregateContext, EventStore,
         persist::{GenericQuery, PersistedEventStore},
     };
-    use event_sorcery::{Store, StoreBuilder};
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use fireblocks_sdk::models::TransactionStatus;
     use rust_decimal::Decimal;
     use sqlite_es::{
@@ -1476,7 +1476,7 @@ mod tests {
         cqrs: Arc<TestCqrs>,
         store: Arc<TestStore>,
         receipt_service: Arc<dyn ReceiptService>,
-        receipt_inventory_cqrs: Arc<SqliteCqrs<ReceiptInventory>>,
+        receipt_inventory_store: Arc<Store<ReceiptInventory>>,
         pool: sqlx::Pool<sqlx::Sqlite>,
         asset_store: Arc<Store<TokenizedAsset>>,
     }
@@ -1520,11 +1520,8 @@ mod tests {
             let repo = SqliteEventRepository::new(pool.clone());
             let store = Arc::new(PersistedEventStore::new_event_store(repo));
 
-            let receipt_inventory_repo =
-                SqliteEventRepository::new(pool.clone());
-            let receipt_inventory_store = Arc::new(
-                PersistedEventStore::new_event_store(receipt_inventory_repo),
-            );
+            let receipt_inventory_store =
+                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
             let (asset_store, _asset_projection) =
                 StoreBuilder::<TokenizedAsset>::new(pool.clone())
@@ -1532,19 +1529,15 @@ mod tests {
                     .await
                     .expect("Failed to build tokenized asset store");
 
-            let receipt_inventory_cqrs =
-                Arc::new(sqlite_cqrs(pool.clone(), vec![], ()));
-
             let receipt_service = Arc::new(CqrsReceiptService::new(
-                receipt_inventory_store,
-                receipt_inventory_cqrs.clone(),
+                receipt_inventory_store.clone(),
             ));
 
             Self {
                 cqrs,
                 store,
                 receipt_service,
-                receipt_inventory_cqrs,
+                receipt_inventory_store,
                 pool,
                 asset_store,
             }
@@ -1575,9 +1568,9 @@ mod tests {
             receipt_id: U256,
             balance: U256,
         ) {
-            self.receipt_inventory_cqrs
-                .execute(
-                    &vault.to_string(),
+            self.receipt_inventory_store
+                .send(
+                    &vault,
                     ReceiptInventoryCommand::DiscoverReceipt {
                         receipt_id: ReceiptId::from(receipt_id),
                         balance: Shares::from(balance),
@@ -2086,7 +2079,7 @@ mod tests {
             cqrs,
             store,
             receipt_service,
-            receipt_inventory_cqrs,
+            receipt_inventory_store,
             pool,
             ..
         } = &harness;
@@ -2115,9 +2108,9 @@ mod tests {
             None,
         );
 
-        receipt_inventory_cqrs
-            .execute(
-                &vault.to_string(),
+        receipt_inventory_store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(99_U256)),
                     balance: Shares::from(
@@ -2176,7 +2169,7 @@ mod tests {
             cqrs,
             store,
             receipt_service,
-            receipt_inventory_cqrs,
+            receipt_inventory_store,
             pool,
             ..
         } = &harness;
@@ -2207,9 +2200,9 @@ mod tests {
 
         let raw_bytes = Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]);
 
-        receipt_inventory_cqrs
-            .execute(
-                &vault.to_string(),
+        receipt_inventory_store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(99_U256)),
                     balance: Shares::from(
@@ -3797,9 +3790,9 @@ mod tests {
         shares: U256,
     ) {
         harness
-            .receipt_inventory_cqrs
-            .execute(
-                &vault.to_string(),
+            .receipt_inventory_store
+            .send(
+                &vault,
                 ReceiptInventoryCommand::ReserveBurn {
                     redemption_issuer_request_id: redemption.clone(),
                     burns: vec![crate::redemption::BurnRecord {

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -317,6 +317,7 @@ mod tests {
     use alloy::rpc::types::Log;
     use alloy::signers::local::PrivateKeySigner;
     use cqrs_es::{CqrsFramework, mem_store::MemStore};
+    use event_sorcery::test_store;
     use sqlx::SqlitePool;
     use std::sync::Arc;
     use tracing_test::traced_test;
@@ -337,12 +338,15 @@ mod tests {
     type TestRedemptionCqrs =
         Arc<CqrsFramework<Redemption, TestRedemptionStore>>;
 
-    fn setup_test_cqrs()
-    -> (TestRedemptionCqrs, Arc<TestRedemptionStore>, Arc<dyn ReceiptService>)
+    /// `pool` must already have migrations applied — the receipt store writes
+    /// to the `events` table on first command dispatch.
+    fn setup_test_cqrs(
+        pool: &SqlitePool,
+    ) -> (TestRedemptionCqrs, Arc<TestRedemptionStore>, Arc<dyn ReceiptService>)
     {
         let store = Arc::new(MemStore::default());
-        let receipt_inventory_store: Arc<MemStore<ReceiptInventory>> =
-            Arc::new(MemStore::default());
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         let vault_service: Arc<dyn crate::vault::VaultService> =
             Arc::new(MockVaultService::new_success());
         let cqrs = Arc::new(CqrsFramework::new(
@@ -350,16 +354,8 @@ mod tests {
             vec![],
             vault_service,
         ));
-        let receipt_inventory_cqrs = Arc::new(CqrsFramework::new(
-            (*receipt_inventory_store).clone(),
-            vec![],
-            (),
-        ));
         let receipt_service: Arc<dyn ReceiptService> =
-            Arc::new(CqrsReceiptService::new(
-                receipt_inventory_store,
-                receipt_inventory_cqrs,
-            ));
+            Arc::new(CqrsReceiptService::new(receipt_store));
 
         (cqrs, store, receipt_service)
     }
@@ -387,7 +383,7 @@ mod tests {
         backfill_start_block: u64,
         pool: SqlitePool,
     ) -> TestPollerSetup<impl alloy::providers::Provider + Clone> {
-        let (cqrs, store, receipt_service) = setup_test_cqrs();
+        let (cqrs, store, receipt_service) = setup_test_cqrs(&pool);
 
         let alpaca_service = Arc::new(MockAlpacaService::new_success())
             as Arc<dyn crate::alpaca::AlpacaService>;
@@ -630,7 +626,7 @@ mod tests {
 
         let pool = setup_test_db_with_asset(vault, None).await;
 
-        let (cqrs, store, receipt_service) = setup_test_cqrs();
+        let (cqrs, store, receipt_service) = setup_test_cqrs(&pool);
 
         let alpaca_service = Arc::new(MockAlpacaService::new_success())
             as Arc<dyn crate::alpaca::AlpacaService>;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -103,14 +103,8 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
         StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
 
     // Setup ReceiptInventory (needed by MintServices for receipt lookups and registration)
-    let receipt_inventory_event_store = Arc::new(PersistedEventStore::<
-        SqliteEventRepository,
-        ReceiptInventory,
-    >::new_event_store(
-        SqliteEventRepository::new(pool.clone()),
-    ));
-    let receipt_inventory_cqrs =
-        Arc::new(sqlite_cqrs(pool.clone(), vec![], ()));
+    let receipt_inventory_store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
 
     // Create mock services for Mint aggregate
     let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
@@ -119,10 +113,7 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
         alpaca: Arc::new(MockAlpacaService::new_success()),
         pool: pool.clone(),
         bot,
-        receipts: Arc::new(CqrsReceiptService::new(
-            receipt_inventory_event_store.clone(),
-            receipt_inventory_cqrs,
-        )),
+        receipts: Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
     };
 
     // Setup Mint CQRS


### PR DESCRIPTION
## Motivation

Part of migrating st0x.issuance off its in-repo `cqrs-es` / `sqlite-es` wiring
and onto the extracted
[`event-sorcery`](https://github.com/ST0x-Technology/event-sorcery) crate (epic
RAI-785). `ReceiptInventory` is the third aggregate to migrate, after `Account`
(#172) and `TokenizedAsset` (#173).

It is the first aggregate with no materialized view of its own and the first
consumed by other aggregates: `Mint` and `Redemption` reach it through
`CqrsReceiptService` (a `dyn ReceiptService`). Migrating it before those two
lets the service swap its internals to `event_sorcery::Store` while keeping the
un-migrated `Mint`/`Redemption` compiling against an unchanged trait + error
surface.

Stacked on #173. Closes RAI-555.

## Solution

`ReceiptInventory` now implements `event_sorcery::EventSourced` instead of
`cqrs_es::Aggregate`.

- **Aggregate** (`src/receipt_inventory/mod.rs`): the aggregate stays a struct —
  its empty `Default` (a vault with no receipts) is simultaneously the
  uninitialized seed and a valid live state, so there is no `NotInitialized`
  variant to lift into `Lifecycle`. `originate` builds state from the only
  genesis event (`Discovered`); `evolve` applies every event and always returns
  `Ok(Some(..))`, preserving the existing infallible-by-WARN `apply`;
  `initialize` / `transition` run the existing command logic (against
  `Self::default()` and `&self` respectively). `Id = Address` (keyed by vault),
  `Materialized = Nil` (no own view), `Services = ()`.
- **Service** (`src/receipt_inventory/mod.rs`): `CqrsReceiptService` now wraps a
  single `Arc<Store<ReceiptInventory>>`. Reads go through `Store::load`
  (`None` → empty inventory, matching the old default-construction); writes
  through `Store::send`. A `to_aggregate_error` translation maps the
  `event_sorcery` send error back into `AggregateError<ReceiptInventoryError>`,
  so the trait's error variants are unchanged and — critically —
  `AggregateConflict` still surfaces for `BurnManager`'s optimistic-concurrency
  retry. The `ReceiptService` trait and all seven method signatures are
  untouched, so `MintServices` / `BurnManager` need no changes.
- **Backfill / reconcile** (`backfill.rs`, `reconcile.rs`): drop the
  `EventStore` generic for a concrete `Arc<Store<ReceiptInventory>>`;
  `cqrs.execute` → `Store::send`; reconcile loads through the store (the
  separate `event_store` argument is gone).
- **Wiring** (`src/lib.rs`): built with
  `StoreBuilder::<ReceiptInventory>::new(pool).build(())`; the
  `ReceiptInventoryCqrs` / `ReceiptInventoryEventStore` aliases and the
  `ReceiptInventoryDeps` struct are removed and a single
  `Arc<Store<ReceiptInventory>>` is threaded through setup, backfill, and
  reconciliation.
- **Tests**: receipt `MemStore` / `CqrsFramework` construction moves to
  `event_sorcery::test_store` + `Store::send` / `Store::load`.

Existing `ReceiptInventory` events replay unchanged — `event_type` strings and
payloads are byte-identical; only the aggregate and service representations
change.

### Scope note

The `receipt_inventory` module owns two projections, `ReceiptInventoryView` and
`ReceiptBurnsView`, but neither is a view of the `ReceiptInventory` aggregate's
own stream — they are `View<Mint>` and `View<Redemption>` respectively, attached
to the Mint and Redemption CQRS frameworks. They (and `replay_receipt_burns_view`)
stay exactly where they are and migrate with their driving aggregates in
RAI-556 / RAI-557. The aggregate itself has no canonical table projection, hence
`Materialized = Nil`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Refactored internal receipt inventory persistence layer to improve system architecture and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->