### PR TITLE
refactor: migrate mint aggregate to event-sorcery

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2,6 +2,7 @@ use alloy::primitives::B256;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::{Aggregate, AggregateError, EventStore};
+use event_sorcery::Store;
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use rocket::{get, post};
@@ -14,7 +15,7 @@ use crate::Quantity;
 use crate::alpaca::{AlpacaService, RedeemRequestStatus, TokenizationRequest};
 use crate::auth::InternalAuth;
 use crate::mint::{
-    IssuerMintRequestId, MintCommand, MintEvent, MintView,
+    IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
     TokenizationRequestId, find_by_issuer_request_id,
     find_stuck as find_stuck_mints, recovery::spawn_scheduled_mint_recovery,
 };
@@ -32,10 +33,7 @@ use crate::tokenized_asset::UnderlyingSymbol;
 use crate::vault::{
     BurnVerification, FireblocksTxStatus, VaultError, VaultService,
 };
-use crate::{
-    MintCqrs, MintEventStore, RedemptionCqrs, RedemptionEventStore,
-    SqliteEventStore,
-};
+use crate::{RedemptionCqrs, RedemptionEventStore, SqliteEventStore};
 
 #[async_trait]
 pub(crate) trait RedemptionBurnRecovery: Send + Sync {
@@ -876,12 +874,11 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
     }
 }
 
-#[tracing::instrument(skip(_auth, cqrs, event_store, pool))]
+#[tracing::instrument(skip(_auth, store, pool))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
     _auth: InternalAuth,
-    cqrs: &rocket::State<MintCqrs>,
-    event_store: &rocket::State<MintEventStore>,
+    store: &rocket::State<Arc<Store<Mint>>>,
     pool: &rocket::State<Pool<Sqlite>>,
     aggregate_id: &str,
 ) -> Result<Json<ReprocessResponse>, Status> {
@@ -907,6 +904,7 @@ pub(crate) async fn reprocess_mint(
                 MintView::JournalConfirmed { .. } => "JournalConfirmed",
                 MintView::JournalRejected { .. } => "JournalRejected",
                 MintView::Minting { .. } => "Minting",
+                MintView::FireblocksSubmitted { .. } => "FireblocksSubmitted",
                 MintView::CallbackPending { .. } => "CallbackPending",
                 MintView::MintingFailed { .. } => "MintingFailed",
             };
@@ -919,24 +917,25 @@ pub(crate) async fn reprocess_mint(
         }
     };
 
-    cqrs.execute(
-        aggregate_id,
-        MintCommand::Recover {
-            issuer_request_id: issuer_request_id.clone(),
-            mode: crate::mint::MintRecoveryMode::Manual,
-        },
-    )
-    .await
-    .map_err(|err| {
-        error!(target: "admin", aggregate_id = aggregate_id,
-            error = %err,
-            "Failed to reprocess mint"
-        );
-        match err {
-            AggregateError::UserError(_) => Status::UnprocessableEntity,
-            _ => Status::InternalServerError,
-        }
-    })?;
+    store
+        .send(
+            &issuer_request_id,
+            MintCommand::Recover {
+                issuer_request_id: issuer_request_id.clone(),
+                mode: crate::mint::MintRecoveryMode::Manual,
+            },
+        )
+        .await
+        .map_err(|err| {
+            error!(target: "admin", aggregate_id = aggregate_id,
+                error = %err,
+                "Failed to reprocess mint"
+            );
+            match err {
+                AggregateError::UserError(_) => Status::UnprocessableEntity,
+                _ => Status::InternalServerError,
+            }
+        })?;
 
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
@@ -947,11 +946,7 @@ pub(crate) async fn reprocess_mint(
     // next retry, leaving it in FireblocksSubmitted). Hand it to a background
     // scheduled-recovery task so it is driven to completion instead of
     // stalling until the next restart or another manual reprocess.
-    spawn_scheduled_mint_recovery(
-        cqrs.inner().clone(),
-        event_store.inner().clone(),
-        issuer_request_id,
-    );
+    spawn_scheduled_mint_recovery(store.inner().clone(), issuer_request_id);
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Mint,
@@ -969,11 +964,11 @@ pub(crate) struct CloseMintRequest {
 /// Admin endpoint to close a mint that cannot be automatically recovered.
 ///
 /// Valid from any non-terminal state. Closed mints do not appear in stuck queries.
-#[tracing::instrument(skip(_auth, cqrs))]
+#[tracing::instrument(skip(_auth, store))]
 #[post("/admin/close/mint/<aggregate_id>", format = "json", data = "<body>")]
 pub(crate) async fn close_mint(
     _auth: InternalAuth,
-    cqrs: &rocket::State<MintCqrs>,
+    store: &rocket::State<Arc<Store<Mint>>>,
     aggregate_id: &str,
     body: Json<CloseMintRequest>,
 ) -> Result<Json<ReprocessResponse>, Status> {
@@ -982,24 +977,25 @@ pub(crate) async fn close_mint(
         .map(IssuerMintRequestId::new)
         .map_err(|_| Status::BadRequest)?;
 
-    cqrs.execute(
-        aggregate_id,
-        MintCommand::CloseMint {
-            issuer_request_id: issuer_request_id.clone(),
-            reason: body.into_inner().reason,
-        },
-    )
-    .await
-    .map_err(|err| {
-        error!(target: "admin", aggregate_id = %aggregate_id,
-            error = %err,
-            "Failed to close mint"
-        );
-        match err {
-            AggregateError::UserError(_) => Status::UnprocessableEntity,
-            _ => Status::InternalServerError,
-        }
-    })?;
+    store
+        .send(
+            &issuer_request_id,
+            MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: body.into_inner().reason,
+            },
+        )
+        .await
+        .map_err(|err| {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                error = %err,
+                "Failed to close mint"
+            );
+            match err {
+                AggregateError::UserError(_) => Status::UnprocessableEntity,
+                _ => Status::InternalServerError,
+            }
+        })?;
 
     info!(target: "admin", aggregate_id = %aggregate_id, "Mint closed");
 
@@ -1021,7 +1017,6 @@ const STUCK_THRESHOLD: chrono::Duration = chrono::Duration::hours(1);
 #[tracing::instrument(skip(
     _auth,
     pool,
-    mint_event_store,
     redemption_event_store,
     vault_service
 ))]
@@ -1029,7 +1024,6 @@ const STUCK_THRESHOLD: chrono::Duration = chrono::Duration::hours(1);
 pub(crate) async fn list_stuck(
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
-    mint_event_store: &rocket::State<MintEventStore>,
     redemption_event_store: &rocket::State<RedemptionEventStore>,
     vault_service: &rocket::State<Arc<dyn VaultService>>,
 ) -> Result<Json<StuckResponse>, Status> {
@@ -1077,11 +1071,8 @@ pub(crate) async fn list_stuck(
         }
 
         let (underlying, quantity) = mint_view_asset(&view);
-        let mint_history = mint_history_summary(
-            mint_event_store.inner(),
-            &issuer_mint_request_id.to_string(),
-        )
-        .await;
+        let mint_history =
+            mint_history_summary(pool.inner(), &issuer_mint_request_id).await;
 
         stuck.push(StuckAggregate {
             aggregate_type: AggregateKind::Mint,
@@ -1473,6 +1464,17 @@ fn mint_view_summary(view: &MintView) -> Option<MintStuckSummary> {
             detail: "Deposit in progress".to_string(),
             timestamp: *minting_started_at,
         }),
+        MintView::FireblocksSubmitted {
+            tokenization_request_id,
+            minting_started_at,
+            ..
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "FireblocksSubmitted".to_string(),
+            detail: "Awaiting on-chain confirmation".to_string(),
+            timestamp: *minting_started_at,
+        }),
         MintView::MintingFailed {
             tokenization_request_id,
             error,
@@ -1510,6 +1512,7 @@ fn mint_view_asset(
         | MintView::JournalConfirmed { underlying, quantity, .. }
         | MintView::JournalRejected { underlying, quantity, .. }
         | MintView::Minting { underlying, quantity, .. }
+        | MintView::FireblocksSubmitted { underlying, quantity, .. }
         | MintView::MintingFailed { underlying, quantity, .. }
         | MintView::CallbackPending { underlying, quantity, .. } => {
             (Some(underlying.clone()), Some(quantity.clone()))
@@ -1527,16 +1530,32 @@ struct MintHistorySummary {
 }
 
 /// Returns the latest useful transaction hints from this mint's history.
+///
+/// Reads the raw `MintEvent` payloads straight from the `events` table.
+/// `event_sorcery::Store` exposes no event-log read, so the history is loaded
+/// with a direct query rather than through the aggregate store.
 async fn mint_history_summary(
-    event_store: &crate::SqliteEventStore<crate::mint::Mint>,
-    aggregate_id: &str,
+    pool: &Pool<Sqlite>,
+    issuer_request_id: &IssuerMintRequestId,
 ) -> MintHistorySummary {
-    let events = match event_store.load_events(aggregate_id).await {
-        Ok(events) => events,
+    let aggregate_id = issuer_request_id.to_string();
+    let rows = match sqlx::query!(
+        r#"
+        SELECT payload as "payload!: String"
+        FROM events
+        WHERE aggregate_type = 'Mint' AND aggregate_id = ?
+        ORDER BY sequence
+        "#,
+        aggregate_id
+    )
+    .fetch_all(pool)
+    .await
+    {
+        Ok(rows) => rows,
         Err(err) => {
             warn!(
                 target: "admin",
-                aggregate_id = aggregate_id,
+                aggregate_id = %aggregate_id,
                 error = %err,
                 "Failed to load mint events for fireblocks_tx_id lookup"
             );
@@ -1544,9 +1563,35 @@ async fn mint_history_summary(
         }
     };
 
+    let events = match rows
+        .into_iter()
+        .map(|row| serde_json::from_str::<MintEvent>(&row.payload))
+        .collect::<Result<Vec<_>, _>>()
+    {
+        Ok(events) => events,
+        Err(err) => {
+            warn!(
+                target: "admin",
+                aggregate_id = %aggregate_id,
+                error = %err,
+                "Failed to deserialize mint events for fireblocks_tx_id lookup"
+            );
+            return MintHistorySummary::default();
+        }
+    };
+
+    mint_history_summary_from_events(events)
+}
+
+/// Pure reduce: builds a [`MintHistorySummary`] from an ordered sequence of
+/// `MintEvent`s. Split out from `mint_history_summary` so the fold is
+/// unit-testable without an event store or database.
+fn mint_history_summary_from_events(
+    events: impl IntoIterator<Item = MintEvent>,
+) -> MintHistorySummary {
     let mut summary = MintHistorySummary::default();
     for event in events {
-        match event.payload {
+        match event {
             MintEvent::TokensMinted { tx_hash, .. }
             | MintEvent::ExistingMintRecovered { tx_hash, .. }
             | MintEvent::MintRetryStarted { tx_hash: Some(tx_hash), .. } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,19 +18,18 @@ use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
 use crate::mint::{
-    Mint, MintServices, MintView, find_all_recoverable_mints,
+    Mint, MintServices, find_all_recoverable_mints,
     recovery::{
         DriveOutcome, MintRecoveryHandler, recover_mint,
         spawn_scheduled_mint_recovery,
     },
-    replay_mint_view,
 };
 use crate::receipt_inventory::backfill::{NoOpItnHandler, ReceiptBackfiller};
 use crate::receipt_inventory::reconcile::run_startup_reconciliation;
 use crate::receipt_inventory::{
     CqrsReceiptService, ItnReceiptHandler, ReceiptBurnsView, ReceiptInventory,
-    ReceiptInventoryView, burn_tracking::replay_receipt_burns_view,
-    replay_receipt_inventory_view,
+    burn_tracking::replay_receipt_burns_view,
+    view::{ReceiptInventoryViewReactor, rebuild_receipt_inventory_view},
 };
 use crate::redemption::{
     Redemption, RedemptionView,
@@ -72,10 +71,6 @@ pub use fireblocks::SignerConfig;
 pub use telemetry::TelemetryGuard;
 pub use test_utils::ANVIL_CHAIN_ID;
 
-pub(crate) type MintCqrs = Arc<SqliteCqrs<Mint>>;
-pub(crate) type MintEventStore =
-    Arc<PersistedEventStore<SqliteEventRepository, Mint>>;
-
 pub(crate) type RedemptionCqrs = Arc<SqliteCqrs<Redemption>>;
 pub(crate) type RedemptionEventStore =
     Arc<PersistedEventStore<SqliteEventRepository, Redemption>>;
@@ -84,14 +79,9 @@ pub(crate) type SqliteEventStore<A> =
     PersistedEventStore<SqliteEventRepository, A>;
 
 struct AggregateCqrsSetup {
-    mint: MintDeps,
+    mint_store: Arc<Store<Mint>>,
     redemption_cqrs: RedemptionCqrs,
     redemption_event_store: RedemptionEventStore,
-}
-
-struct MintDeps {
-    cqrs: MintCqrs,
-    event_store: MintEventStore,
 }
 
 struct RedemptionManagers {
@@ -262,14 +252,18 @@ pub async fn initialize_rocket(
 
     let vault_service_for_rocket = blockchain_setup.vault_service.clone();
 
-    let AggregateCqrsSetup { mint, redemption_cqrs, redemption_event_store } =
-        setup_aggregate_cqrs(
-            &pool,
-            &receipt_inventory_store,
-            blockchain_setup.vault_service.clone(),
-            alpaca_service.clone(),
-            bot_wallet,
-        );
+    let AggregateCqrsSetup {
+        mint_store,
+        redemption_cqrs,
+        redemption_event_store,
+    } = setup_aggregate_cqrs(
+        &pool,
+        &receipt_inventory_store,
+        blockchain_setup.vault_service.clone(),
+        alpaca_service.clone(),
+        bot_wallet,
+    )
+    .await?;
 
     let managers = setup_redemption_managers(
         &config,
@@ -285,8 +279,7 @@ pub async fn initialize_rocket(
     // up-to-date views. Each replay clears its view table first to remove
     // stale/corrupt data, then rebuilds from the event store.
     debug!(target: "startup", "Rebuilding all views from events");
-    replay_mint_view(pool.clone()).await?;
-    replay_receipt_inventory_view(pool.clone()).await?;
+    rebuild_receipt_inventory_view(&pool).await?;
     replay_redemption_view(pool.clone()).await?;
     replay_receipt_burns_view(pool.clone()).await?;
 
@@ -335,14 +328,7 @@ pub async fn initialize_rocket(
     let vaults: Vec<Address> =
         vault_configs.iter().map(|config| config.vault).collect();
 
-    run_recovery_with_timeout(
-        &pool,
-        &mint.cqrs,
-        &mint.event_store,
-        &managers,
-        &vaults,
-    )
-    .await;
+    run_recovery_with_timeout(&pool, &mint_store, &managers, &vaults).await;
 
     spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
         pool: pool.clone(),
@@ -352,7 +338,7 @@ pub async fn initialize_rocket(
         bot_wallet,
         backfill_start_block: config.backfill_start_block,
         receipt_poll_interval: config.receipt_poll_interval,
-        handler: MintRecoveryHandler::new(mint.cqrs.clone()),
+        handler: MintRecoveryHandler::new(mint_store.clone()),
     });
 
     {
@@ -386,7 +372,7 @@ pub async fn initialize_rocket(
         pool,
         account_store,
         tokenized_asset_store,
-        mint,
+        mint_store,
         redemption_cqrs,
         redemption_event_store,
         alpaca_service,
@@ -402,7 +388,7 @@ struct RocketState {
     pool: Pool<Sqlite>,
     account_store: Arc<Store<Account>>,
     tokenized_asset_store: Arc<Store<TokenizedAsset>>,
-    mint: MintDeps,
+    mint_store: Arc<Store<Mint>>,
     redemption_cqrs: RedemptionCqrs,
     redemption_event_store: RedemptionEventStore,
     alpaca_service: Arc<dyn AlpacaService>,
@@ -425,8 +411,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .manage(state.rate_limiter)
         .manage(state.account_store)
         .manage(state.tokenized_asset_store)
-        .manage(state.mint.cqrs)
-        .manage(state.mint.event_store)
+        .manage(state.mint_store)
         .manage(state.redemption_cqrs)
         .manage(state.redemption_event_store)
         .manage(state.alpaca_service)
@@ -457,13 +442,13 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .register("/", catchers::json_catchers())
 }
 
-fn setup_aggregate_cqrs(
+async fn setup_aggregate_cqrs(
     pool: &Pool<Sqlite>,
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     vault_service: Arc<dyn vault::VaultService>,
     alpaca_service: Arc<dyn AlpacaService>,
     bot_wallet: Address,
-) -> AggregateCqrsSetup {
+) -> Result<AggregateCqrsSetup, anyhow::Error> {
     // Create MintServices with all dependencies
     let receipt_service =
         Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
@@ -475,28 +460,20 @@ fn setup_aggregate_cqrs(
         receipts: receipt_service,
     };
 
-    let mint_view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-        pool.clone(),
-        "mint_view".to_string(),
-    ));
-    let mint_query = GenericQuery::new(mint_view_repo);
+    // Mint's canonical `mint_view` projection is auto-wired by StoreBuilder; the
+    // secondary `receipt_inventory_view` (formerly a View<Mint> GenericQuery) is
+    // maintained by the registered reactor.
+    let (mint_store, mint_projection) = StoreBuilder::<Mint>::new(pool.clone())
+        .with(Arc::new(ReceiptInventoryViewReactor::new(pool.clone())))
+        .build(mint_services)
+        .await?;
 
-    let receipt_inventory_mint_repo =
-        Arc::new(SqliteViewRepository::<ReceiptInventoryView, Mint>::new(
-            pool.clone(),
-            "receipt_inventory_view".to_string(),
-        ));
-    let receipt_inventory_mint_query =
-        GenericQuery::new(receipt_inventory_mint_repo);
-
-    let mint_cqrs = Arc::new(sqlite_cqrs(
-        pool.clone(),
-        vec![Box::new(mint_query), Box::new(receipt_inventory_mint_query)],
-        mint_services,
-    ));
-    let mint_event_store = Arc::new(PersistedEventStore::new_event_store(
-        SqliteEventRepository::new(pool.clone()),
-    ));
+    // Rebuild `mint_view` from scratch so it reflects the current event log even
+    // when events were rolled back below the existing view version. StoreBuilder's
+    // `catch_up` is incremental — it cannot detect a truncated log (max event
+    // sequence < view version), so it would leave a stale view that recovery
+    // reads. Preserves the prior `replay_mint_view` startup behavior.
+    mint_projection.rebuild_all().await?;
 
     let redemption_view_repo =
         Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
@@ -527,11 +504,11 @@ fn setup_aggregate_cqrs(
         .with_upcasters(vec![create_tokens_burned_upcaster()]),
     );
 
-    AggregateCqrsSetup {
-        mint: MintDeps { cqrs: mint_cqrs, event_store: mint_event_store },
+    Ok(AggregateCqrsSetup {
+        mint_store,
         redemption_cqrs,
         redemption_event_store,
-    }
+    })
 }
 
 fn setup_redemption_managers(
@@ -572,11 +549,7 @@ fn setup_redemption_managers(
     Ok(RedemptionManagers { redeem_call, journal, burn })
 }
 
-async fn run_mint_recovery(
-    pool: &Pool<Sqlite>,
-    mint_cqrs: &MintCqrs,
-    mint_event_store: &MintEventStore,
-) {
+async fn run_mint_recovery(pool: &Pool<Sqlite>, mint_store: &Arc<Store<Mint>>) {
     info!(target: "mint", "Running mint recovery");
 
     let recoverable_mints = match find_all_recoverable_mints(pool).await {
@@ -603,13 +576,12 @@ async fn run_mint_recovery(
         // failure — hand the mint to a background scheduled-recovery task so it
         // keeps progressing while the service runs instead of waiting for the
         // next restart.
-        match recover_mint(mint_cqrs, issuer_request_id.clone()).await {
+        match recover_mint(mint_store, issuer_request_id.clone()).await {
             DriveOutcome::RetryNotDue
             | DriveOutcome::Pending
             | DriveOutcome::Failed => {
                 spawn_scheduled_mint_recovery(
-                    mint_cqrs.clone(),
-                    mint_event_store.clone(),
+                    mint_store.clone(),
                     issuer_request_id,
                 );
             }
@@ -660,13 +632,12 @@ const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 /// cancelled to prevent concurrent side effects.
 async fn run_recovery_with_timeout(
     pool: &Pool<Sqlite>,
-    mint_cqrs: &MintCqrs,
-    mint_event_store: &MintEventStore,
+    mint_store: &Arc<Store<Mint>>,
     managers: &RedemptionManagers,
     vaults: &[Address],
 ) {
     let recovery = async {
-        run_mint_recovery(pool, mint_cqrs, mint_event_store).await;
+        run_mint_recovery(pool, mint_store).await;
         run_redemption_recovery(
             &managers.redeem_call,
             &managers.journal,

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -1,6 +1,7 @@
-use cqrs_es::{AggregateContext, EventStore};
-use rocket::{State, post, serde::json::Json};
+use event_sorcery::Store;
+use rocket::{post, serde::json::Json};
 use serde::Deserialize;
+use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::auth::IssuerAuth;
@@ -8,7 +9,6 @@ use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, TokenizationRequestId,
     recovery::spawn_scheduled_mint_recovery,
 };
-use crate::{MintCqrs, MintEventStore};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JournalConfirmationRequest {
@@ -25,7 +25,7 @@ pub(crate) enum JournalStatus {
     Rejected,
 }
 
-#[tracing::instrument(skip(_auth, cqrs, event_store), fields(
+#[tracing::instrument(skip(_auth, mint_store), fields(
     tokenization_request_id = %request.tokenization_request_id.0,
     issuer_request_id = %request.issuer_request_id,
     status = ?request.status
@@ -33,8 +33,7 @@ pub(crate) enum JournalStatus {
 #[post("/inkind/issuance/confirm", format = "json", data = "<request>")]
 pub(crate) async fn confirm_journal(
     _auth: IssuerAuth,
-    cqrs: &State<MintCqrs>,
-    event_store: &State<MintEventStore>,
+    mint_store: &rocket::State<Arc<Store<Mint>>>,
     request: Json<JournalConfirmationRequest>,
 ) -> rocket::http::Status {
     let JournalConfirmationRequest {
@@ -49,11 +48,14 @@ pub(crate) async fn confirm_journal(
         issuer_request_id, tokenization_request_id.0, status
     );
 
-    let mut mint_ctx = match event_store
-        .load_aggregate(&issuer_request_id.to_string())
-        .await
-    {
-        Ok(ctx) => ctx,
+    let mint = match mint_store.load(&issuer_request_id).await {
+        Ok(Some(mint)) => mint,
+        Ok(None) => {
+            error!(target: "mint", "Mint aggregate not found for issuer_request_id={}",
+                issuer_request_id
+            );
+            return rocket::http::Status::InternalServerError;
+        }
         Err(err) => {
             error!(target: "mint", "Failed to load mint aggregate for issuer_request_id={}: {}",
                 issuer_request_id, err
@@ -62,8 +64,7 @@ pub(crate) async fn confirm_journal(
         }
     };
 
-    if let Some(expected_tokenization_id) =
-        mint_ctx.aggregate().tokenization_request_id()
+    if let Some(expected_tokenization_id) = mint.tokenization_request_id()
         && &tokenization_request_id != expected_tokenization_id
     {
         error!(target: "mint", "Tokenization request ID mismatch for issuer_request_id={}. \
@@ -84,8 +85,7 @@ pub(crate) async fn confirm_journal(
                 }),
             };
 
-            if let Err(err) =
-                cqrs.execute(&issuer_request_id.to_string(), command).await
+            if let Err(err) = mint_store.send(&issuer_request_id, command).await
             {
                 error!(target: "mint", "Failed to execute journal rejection command for \
                      issuer_request_id={}: {}",
@@ -100,8 +100,7 @@ pub(crate) async fn confirm_journal(
                 issuer_request_id: issuer_request_id.clone(),
             };
 
-            if let Err(err) =
-                cqrs.execute(&issuer_request_id.to_string(), command).await
+            if let Err(err) = mint_store.send(&issuer_request_id, command).await
             {
                 error!(target: "mint", "Failed to execute journal confirmation command for \
                      issuer_request_id={}: {}",
@@ -110,11 +109,9 @@ pub(crate) async fn confirm_journal(
                 return rocket::http::Status::InternalServerError;
             }
 
-            let cqrs = cqrs.inner().clone();
-            let store = event_store.inner().clone();
+            let mint_store = mint_store.inner().clone();
             rocket::tokio::spawn(process_journal_completion(
-                cqrs,
-                store,
+                mint_store,
                 issuer_request_id,
             ));
         }
@@ -123,23 +120,20 @@ pub(crate) async fn confirm_journal(
     rocket::http::Status::Ok
 }
 
-#[tracing::instrument(skip(cqrs, event_store), fields(
+#[tracing::instrument(skip(mint_store), fields(
     issuer_request_id = %issuer_request_id
 ))]
 async fn process_journal_completion(
-    cqrs: MintCqrs,
-    event_store: MintEventStore,
+    mint_store: Arc<Store<Mint>>,
     issuer_request_id: IssuerMintRequestId,
 ) {
-    let aggregate_id = issuer_request_id.to_string();
-
     // Step 1: Record mint intent (Deposit → MintingStarted).
     // Persisted BEFORE the network call so a crash between here and
     // Step 2 leaves the aggregate in Minting (recoverable) rather
     // than JournalConfirmed (which would lose track of the submission).
-    if let Err(err) = cqrs
-        .execute(
-            &aggregate_id,
+    if let Err(err) = mint_store
+        .send(
+            &issuer_request_id,
             MintCommand::Deposit {
                 issuer_request_id: issuer_request_id.clone(),
             },
@@ -154,9 +148,9 @@ async fn process_journal_completion(
     }
 
     // Step 2: Submit mint transaction (SubmitMint → FireblocksSubmitted).
-    if let Err(err) = cqrs
-        .execute(
-            &aggregate_id,
+    if let Err(err) = mint_store
+        .send(
+            &issuer_request_id,
             MintCommand::SubmitMint {
                 issuer_request_id: issuer_request_id.clone(),
             },
@@ -171,8 +165,14 @@ async fn process_journal_completion(
     }
 
     // Step 3: Load the fireblocks_tx_id from the aggregate and confirm
-    let mut context = match event_store.load_aggregate(&aggregate_id).await {
-        Ok(ctx) => ctx,
+    let mint = match mint_store.load(&issuer_request_id).await {
+        Ok(Some(mint)) => mint,
+        Ok(None) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint aggregate not found after SubmitMint"
+            );
+            return;
+        }
         Err(err) => {
             error!(target: "mint", issuer_request_id = %issuer_request_id,
                 error = ?err,
@@ -182,12 +182,10 @@ async fn process_journal_completion(
         }
     };
 
-    if let Mint::FireblocksSubmitted { fireblocks_tx_id, .. } =
-        context.aggregate()
-    {
-        if let Err(err) = cqrs
-            .execute(
-                &aggregate_id,
+    if let Mint::FireblocksSubmitted { fireblocks_tx_id, .. } = &mint {
+        if let Err(err) = mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::ConfirmMint {
                     issuer_request_id: issuer_request_id.clone(),
                     fireblocks_tx_id: fireblocks_tx_id.clone(),
@@ -202,18 +200,14 @@ async fn process_journal_completion(
             return;
         }
     } else {
-        let state = context.aggregate().state_name();
-        match context.aggregate() {
+        let state = mint.state_name();
+        match &mint {
             Mint::MintingFailed { .. } => {
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     %state,
                     "Mint submission failed — scheduling automatic recovery"
                 );
-                spawn_scheduled_mint_recovery(
-                    cqrs,
-                    event_store,
-                    issuer_request_id,
-                );
+                spawn_scheduled_mint_recovery(mint_store, issuer_request_id);
             }
             Mint::CallbackPending { .. } | Mint::Completed { .. } => {
                 info!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -231,8 +225,14 @@ async fn process_journal_completion(
         return;
     }
 
-    let mut context = match event_store.load_aggregate(&aggregate_id).await {
-        Ok(ctx) => ctx,
+    let mint = match mint_store.load(&issuer_request_id).await {
+        Ok(Some(mint)) => mint,
+        Ok(None) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint aggregate not found after ConfirmMint"
+            );
+            return;
+        }
         Err(err) => {
             error!(target: "mint", issuer_request_id = %issuer_request_id,
                 error = ?err,
@@ -242,12 +242,12 @@ async fn process_journal_completion(
         }
     };
 
-    match context.aggregate() {
+    match &mint {
         Mint::MintingFailed { .. } => {
             warn!(target: "mint", issuer_request_id = %issuer_request_id,
                 "Mint confirmation failed — scheduling automatic recovery"
             );
-            spawn_scheduled_mint_recovery(cqrs, event_store, issuer_request_id);
+            spawn_scheduled_mint_recovery(mint_store, issuer_request_id);
             return;
         }
         Mint::CallbackPending { .. } => {}
@@ -267,9 +267,9 @@ async fn process_journal_completion(
     }
 
     // Step 4: Send callback to Alpaca.
-    if let Err(err) = cqrs
-        .execute(
-            &issuer_request_id.to_string(),
+    if let Err(err) = mint_store
+        .send(
+            &issuer_request_id,
             MintCommand::SendCallback {
                 issuer_request_id: issuer_request_id.clone(),
             },
@@ -293,7 +293,7 @@ mod tests {
     use super::confirm_journal;
     use crate::auth::FailedAuthRateLimiter;
     use crate::mint::api::test_utils::{
-        TestAccountAndAsset, TestHarness, create_test_event_store, test_config,
+        TestAccountAndAsset, TestHarness, test_config,
     };
     use crate::mint::{
         IssuerMintRequestId, MintCommand, MintView, Quantity,
@@ -307,7 +307,7 @@ mod tests {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
 
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-ok-test");
@@ -323,18 +323,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![confirm_journal]);
 
@@ -369,7 +366,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -386,18 +383,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![confirm_journal]);
 
@@ -433,7 +427,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -450,18 +444,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool.clone())
             .mount("/", routes![confirm_journal]);
 
@@ -514,7 +505,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -531,18 +522,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool.clone())
             .mount("/", routes![confirm_journal]);
 
@@ -597,7 +585,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -614,18 +602,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool.clone())
             .mount("/", routes![confirm_journal]);
 
@@ -678,7 +663,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -695,18 +680,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool.clone())
             .mount("/", routes![confirm_journal]);
 
@@ -763,7 +745,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, mint_cqrs, .. } = harness;
+        let TestHarness { pool, mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let correct_tokenization_request_id =
@@ -782,18 +764,15 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&issuer_request_id.to_string(), initiate_cmd)
+        mint_store
+            .send(&issuer_request_id, initiate_cmd)
             .await
             .expect("Failed to initiate mint");
-
-        let event_store = create_test_event_store(&pool);
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![confirm_journal]);
 
@@ -825,15 +804,12 @@ mod tests {
     #[tokio::test]
     async fn test_confirm_journal_for_nonexistent_mint_returns_internal_server_error()
      {
-        let TestHarness { pool, mint_cqrs, .. } = TestHarness::new().await;
-
-        let event_store = create_test_event_store(&pool);
+        let TestHarness { pool, mint_store, .. } = TestHarness::new().await;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![confirm_journal]);
 
@@ -864,15 +840,12 @@ mod tests {
 
     #[tokio::test]
     async fn test_confirm_journal_without_auth_returns_401() {
-        let TestHarness { pool, mint_cqrs, .. } = TestHarness::new().await;
-
-        let event_store = create_test_event_store(&pool);
+        let TestHarness { pool, mint_store, .. } = TestHarness::new().await;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
-            .manage(event_store)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![confirm_journal]);
 

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -1,8 +1,10 @@
 use alloy::primitives::Address;
+use event_sorcery::Store;
 use rocket::post;
 use rocket::serde::json::Json;
 use rust_decimal::Decimal;
 use serde::Deserialize;
+use std::sync::Arc;
 use tracing::error;
 
 use super::{
@@ -10,8 +12,8 @@ use super::{
 };
 use crate::auth::IssuerAuth;
 use crate::mint::{
-    ClientId, IssuerMintRequestId, MintCommand, MintView, Network, Quantity,
-    TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+    ClientId, IssuerMintRequestId, Mint, MintCommand, MintView, Network,
+    Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     view::find_by_issuer_request_id,
 };
 
@@ -30,7 +32,7 @@ pub(crate) struct MintRequest {
     pub(crate) wallet: Address,
 }
 
-#[tracing::instrument(skip(_auth, cqrs, pool), fields(
+#[tracing::instrument(skip(_auth, mint_store, pool), fields(
     tokenization_request_id = %request.tokenization_request_id.0,
     underlying = %request.underlying.0,
     client_id = %request.client_id,
@@ -39,7 +41,7 @@ pub(crate) struct MintRequest {
 #[post("/inkind/issuance", format = "json", data = "<request>")]
 pub(crate) async fn initiate_mint(
     _auth: IssuerAuth,
-    cqrs: &rocket::State<crate::MintCqrs>,
+    mint_store: &rocket::State<Arc<Store<Mint>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
     request: Json<MintRequest>,
 ) -> Result<Json<MintResponse>, MintApiError> {
@@ -73,17 +75,17 @@ pub(crate) async fn initiate_mint(
         wallet: request.wallet,
     };
 
-    cqrs.execute(&issuer_request_id.to_string(), command).await.map_err(
-        |error| {
-            error!(target: "mint", "Failed to execute mint command: {error}");
-            MintApiError::CommandExecutionFailed(Box::new(error))
-        },
-    )?;
+    mint_store.send(&issuer_request_id, command).await.map_err(|error| {
+        error!(target: "mint", error = %error, "Failed to execute mint command");
+        MintApiError::CommandExecutionFailed(error)
+    })?;
 
     let mint_view = find_by_issuer_request_id(pool.inner(), &issuer_request_id)
         .await
         .map_err(|error| {
-            error!(target: "mint", "Failed to find mint by issuer_request_id: {error}");
+            error!(target: "mint", error = %error,
+                "Failed to find mint by issuer_request_id"
+            );
             MintApiError::MintViewQueryFailed(error)
         })?
         .ok_or(MintApiError::MintViewNotFound)?;
@@ -123,7 +125,7 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = TestHarness::new().await;
 
@@ -175,7 +177,7 @@ mod tests {
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -224,7 +226,7 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = TestHarness::new().await;
 
@@ -251,7 +253,7 @@ mod tests {
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -302,7 +304,7 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = TestHarness::new().await;
 
@@ -311,7 +313,7 @@ mod tests {
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -362,7 +364,7 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = TestHarness::new().await;
 
@@ -387,7 +389,7 @@ mod tests {
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -442,14 +444,14 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = harness;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool.clone())
@@ -519,14 +521,14 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = harness;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool.clone())
@@ -611,14 +613,14 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = harness;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -662,14 +664,14 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = harness;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)
@@ -720,13 +722,12 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { mint_cqrs, .. } = harness;
+        let TestHarness { mint_store, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
-        let aggregate_id = issuer_request_id.to_string();
 
         let command = MintCommand::Initiate {
-            issuer_request_id,
+            issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("alp-123"),
             quantity: Quantity::new(Decimal::from(100)),
             underlying: underlying.clone(),
@@ -736,24 +737,24 @@ mod tests {
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
         };
 
-        mint_cqrs
-            .execute(&aggregate_id, command.clone())
+        mint_store
+            .send(&issuer_request_id, command.clone())
             .await
             .expect("First execution should succeed");
 
-        let result = mint_cqrs.execute(&aggregate_id, command).await;
+        let result = mint_store.send(&issuer_request_id, command).await;
 
         assert!(result.is_err());
     }
 
     #[tokio::test]
     async fn test_initiate_mint_without_auth_returns_401() {
-        let TestHarness { pool, mint_cqrs, .. } = TestHarness::new().await;
+        let TestHarness { pool, mint_store, .. } = TestHarness::new().await;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(pool)
             .mount("/", routes![initiate_mint]);
 
@@ -795,14 +796,14 @@ mod tests {
             pool,
             account_store,
             asset_store: tokenized_asset_store,
-            mint_cqrs,
+            mint_store,
             ..
         } = harness;
 
         let rocket = rocket::build()
             .manage(test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_cqrs)
+            .manage(mint_store)
             .manage(account_store)
             .manage(tokenized_asset_store)
             .manage(pool)

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -1,4 +1,6 @@
 use alloy::primitives::Address;
+use cqrs_es::AggregateError;
+use event_sorcery::LifecycleError;
 use rocket::http::{ContentType, Status};
 use rocket::response::{self, Responder};
 use rocket::serde::json::Json;
@@ -6,7 +8,8 @@ use serde::{Deserialize, Serialize};
 use tracing::{error, warn};
 
 use super::{
-    ClientId, IssuerMintRequestId, Network, TokenSymbol, UnderlyingSymbol,
+    ClientId, IssuerMintRequestId, Mint, MintError, Network, TokenSymbol,
+    UnderlyingSymbol,
 };
 use crate::account::{AccountView, view::find_by_client_id};
 
@@ -53,7 +56,7 @@ pub(crate) enum MintApiError {
     AccountQueryFailed(#[source] crate::account::view::AccountViewError),
 
     #[error("Failed to execute mint command")]
-    CommandExecutionFailed(#[source] Box<dyn std::error::Error + Send>),
+    CommandExecutionFailed(#[source] AggregateError<LifecycleError<Mint>>),
 
     #[error("Failed to query mint view")]
     MintViewQueryFailed(#[source] super::view::MintViewError),
@@ -84,7 +87,7 @@ impl<'r> Responder<'r, 'static> for MintApiError {
                 "Insufficient Eligibility: Wallet not whitelisted for client",
             ),
             Self::CommandExecutionFailed(e) => {
-                Self::handle_command_execution_error(e.as_ref())
+                Self::handle_command_execution_error(&e)
             }
             Self::AssetQueryFailed(e) => {
                 Self::handle_query_error(&e, "Failed to query enabled assets")
@@ -115,17 +118,18 @@ impl<'r> Responder<'r, 'static> for MintApiError {
 
 impl MintApiError {
     fn handle_command_execution_error(
-        e: &(dyn std::error::Error + Send),
+        error: &AggregateError<LifecycleError<Mint>>,
     ) -> MintErrorResponse {
-        error!(target: "mint", error = %e, "Failed to execute mint command");
+        error!(target: "mint", error = %error, "Failed to execute mint command");
 
-        let error_msg = e.to_string().to_lowercase();
-        if error_msg.contains("already") || error_msg.contains("duplicate") {
-            MintErrorResponse::conflict("Mint already initiated")
-        } else {
-            MintErrorResponse::internal_server_error(
+        match error {
+            AggregateError::AggregateConflict
+            | AggregateError::UserError(LifecycleError::Apply(
+                MintError::AlreadyInitiated { .. },
+            )) => MintErrorResponse::conflict("Mint already initiated"),
+            _ => MintErrorResponse::internal_server_error(
                 "Failed to execute mint command",
-            )
+            ),
         }
     }
 

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -1,12 +1,9 @@
 use alloy::primitives::{Address, B256, address};
-use cqrs_es::persist::{GenericQuery, PersistedEventStore};
 use event_sorcery::{Store, StoreBuilder, test_store};
-use sqlite_es::{SqliteEventRepository, SqliteViewRepository, sqlite_cqrs};
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 use url::Url;
 
-use crate::MintCqrs;
 use crate::account::{
     Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
 };
@@ -15,9 +12,7 @@ use crate::alpaca::service::AlpacaConfig;
 use crate::auth::test_auth_config;
 use crate::config::{Config, LogLevel};
 use crate::fireblocks::SignerConfig;
-use crate::mint::{
-    Mint, MintServices, MintView, Network, TokenSymbol, UnderlyingSymbol,
-};
+use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
 use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
 use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
 use crate::vault::mock::MockVaultService;
@@ -40,18 +35,11 @@ pub(crate) fn test_config() -> Config {
     }
 }
 
-pub(crate) fn create_test_event_store(
-    pool: &sqlx::Pool<sqlx::Sqlite>,
-) -> Arc<PersistedEventStore<SqliteEventRepository, Mint>> {
-    let event_repo = SqliteEventRepository::new(pool.clone());
-    Arc::new(PersistedEventStore::new_event_store(event_repo))
-}
-
 pub(crate) struct TestHarness {
     pub(crate) pool: sqlx::Pool<sqlx::Sqlite>,
     pub(crate) account_store: Arc<Store<Account>>,
     pub(crate) asset_store: Arc<Store<TokenizedAsset>>,
-    pub(crate) mint_cqrs: MintCqrs,
+    pub(crate) mint_store: Arc<Store<Mint>>,
 }
 
 impl TestHarness {
@@ -93,19 +81,13 @@ impl TestHarness {
             )),
         };
 
-        let mint_view_repo =
-            Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-                pool.clone(),
-                "mint_view".to_string(),
-            ));
-        let mint_query = GenericQuery::new(mint_view_repo);
-        let mint_cqrs = Arc::new(sqlite_cqrs(
-            pool.clone(),
-            vec![Box::new(mint_query)],
-            mint_services,
-        ));
+        let (mint_store, _mint_projection) =
+            StoreBuilder::<Mint>::new(pool.clone())
+                .build(mint_services)
+                .await
+                .expect("Failed to build mint store");
 
-        Self { pool, account_store, asset_store, mint_cqrs }
+        Self { pool, account_store, asset_store, mint_store }
     }
 }
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -5,27 +5,21 @@ pub(crate) mod recovery;
 mod view;
 
 use alloy::primitives::{Address, B256, TxHash, U256};
+use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
-use cqrs_es::Aggregate;
-use cqrs_es::event_sink::EventSink;
+use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::account::view::AccountViewError;
-use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
+use crate::alpaca::{AlpacaService, MintCallbackRequest};
 use crate::receipt_inventory::{
-    MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
-    view::ReceiptInventoryViewError,
+    MintedReceiptParams, ReceiptId, ReceiptService, Shares,
 };
-use crate::tokenized_asset::view::{
-    TokenizedAssetViewError, find_vault_by_underlying,
-};
-use crate::vault::{
-    FireblocksTxStatus, ReceiptInformation, VaultError, VaultService,
-};
+use crate::tokenized_asset::view::find_vault_by_underlying;
+use crate::vault::{FireblocksTxStatus, ReceiptInformation, VaultService};
 
 pub use api::MintResponse;
 
@@ -33,8 +27,7 @@ pub(crate) use api::{confirm_journal, initiate_mint};
 pub(crate) use cmd::{MintCommand, MintRecoveryMode};
 pub(crate) use event::MintEvent;
 pub(crate) use view::{
-    MintView, find_all_recoverable_mints, find_by_issuer_request_id,
-    find_stuck, replay_mint_view,
+    MintView, find_all_recoverable_mints, find_by_issuer_request_id, find_stuck,
 };
 
 /// Services required by the Mint aggregate for command handling.
@@ -89,10 +82,16 @@ impl std::fmt::Display for IssuerMintRequestId {
     }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+impl std::str::FromStr for IssuerMintRequestId {
+    type Err = uuid::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(value).map(Self)
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum Mint {
-    #[default]
-    Uninitialized,
     Initiated {
         issuer_request_id: IssuerMintRequestId,
         tokenization_request_id: TokenizationRequestId,
@@ -242,7 +241,7 @@ pub(crate) enum Mint {
 
 /// Groups mint submission parameters to keep `execute_mint_submission` under
 /// the clippy argument limit.
-struct MintSubmissionParams<'a> {
+struct MintSubmissionInput<'a> {
     issuer_request_id: IssuerMintRequestId,
     tokenization_request_id: &'a TokenizationRequestId,
     quantity: &'a Quantity,
@@ -259,75 +258,6 @@ struct KnownMintTx {
     fireblocks_tx_id: String,
 }
 
-struct IncompleteMintRecovery {
-    tokenization_request_id: TokenizationRequestId,
-    quantity: Quantity,
-    underlying: UnderlyingSymbol,
-    wallet: Address,
-    journal_confirmed_at: DateTime<Utc>,
-    is_minting_failed: bool,
-}
-
-struct KnownTxRecovery {
-    issuer_request_id: IssuerMintRequestId,
-    recovery: IncompleteMintRecovery,
-    vault: Address,
-    receipt_info: ReceiptInformation,
-    receipt_tx_hash: Option<TxHash>,
-    known_tx: KnownMintTx,
-    mode: MintRecoveryMode,
-}
-
-impl IncompleteMintRecovery {
-    fn from_mint(
-        mint: &Mint,
-    ) -> Result<(IssuerMintRequestId, Self), MintError> {
-        match mint {
-            Mint::Minting {
-                issuer_request_id,
-                tokenization_request_id,
-                quantity,
-                underlying,
-                wallet,
-                journal_confirmed_at,
-                ..
-            } => Ok((
-                issuer_request_id.clone(),
-                Self {
-                    tokenization_request_id: tokenization_request_id.clone(),
-                    quantity: quantity.clone(),
-                    underlying: underlying.clone(),
-                    wallet: *wallet,
-                    journal_confirmed_at: *journal_confirmed_at,
-                    is_minting_failed: false,
-                },
-            )),
-            Mint::MintingFailed {
-                issuer_request_id,
-                tokenization_request_id,
-                quantity,
-                underlying,
-                wallet,
-                journal_confirmed_at,
-                ..
-            } => Ok((
-                issuer_request_id.clone(),
-                Self {
-                    tokenization_request_id: tokenization_request_id.clone(),
-                    quantity: quantity.clone(),
-                    underlying: underlying.clone(),
-                    wallet: *wallet,
-                    journal_confirmed_at: *journal_confirmed_at,
-                    is_minting_failed: true,
-                },
-            )),
-            _ => Err(MintError::NotInMintingOrMintingFailedState {
-                current_state: mint.state_name().to_string(),
-            }),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum AutomaticRetryDecision {
     Ready,
@@ -342,7 +272,6 @@ impl Mint {
 
     const fn state_name(&self) -> &'static str {
         match self {
-            Self::Uninitialized => "Uninitialized",
             Self::Initiated { .. } => "Initiated",
             Self::JournalConfirmed { .. } => "JournalConfirmed",
             Self::JournalRejected { .. } => "JournalRejected",
@@ -483,15 +412,14 @@ impl Mint {
             | Self::Completed { tokenization_request_id, .. } => {
                 Some(tokenization_request_id)
             }
-            Self::Uninitialized | Self::Closed { .. } => None,
+            Self::Closed { .. } => None,
         }
     }
 
-    async fn handle_confirm_journal(
-        &mut self,
-        sink: &EventSink<Self>,
+    fn handle_confirm_journal(
+        &self,
         provided_id: IssuerMintRequestId,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::Initiated { issuer_request_id: expected_id, .. } = self
         else {
             return Err(MintError::NotInInitiatedState {
@@ -501,24 +429,19 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &provided_id)?;
 
-        sink.write(
-            MintEvent::JournalConfirmed {
-                issuer_request_id: provided_id,
-                confirmed_at: Utc::now(),
-            },
-            self,
-        )
-        .await;
+        let now = Utc::now();
 
-        Ok(())
+        Ok(vec![MintEvent::JournalConfirmed {
+            issuer_request_id: provided_id,
+            confirmed_at: now,
+        }])
     }
 
-    async fn handle_reject_journal(
-        &mut self,
-        sink: &EventSink<Self>,
+    fn handle_reject_journal(
+        &self,
         provided_id: IssuerMintRequestId,
         reason: String,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::Initiated { issuer_request_id: expected_id, .. } = self
         else {
             return Err(MintError::NotInInitiatedState {
@@ -528,17 +451,13 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &provided_id)?;
 
-        sink.write(
-            MintEvent::JournalRejected {
-                issuer_request_id: provided_id,
-                reason,
-                rejected_at: Utc::now(),
-            },
-            self,
-        )
-        .await;
+        let now = Utc::now();
 
-        Ok(())
+        Ok(vec![MintEvent::JournalRejected {
+            issuer_request_id: provided_id,
+            reason,
+            rejected_at: now,
+        }])
     }
 
     fn validate_issuer_request_id(
@@ -556,11 +475,10 @@ impl Mint {
 
     /// Records the intent to mint by transitioning from `JournalConfirmed`
     /// to `Minting` state. Pure state transition — no network call.
-    async fn handle_deposit(
-        &mut self,
-        sink: &EventSink<Self>,
+    fn handle_deposit(
+        &self,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::JournalConfirmed { issuer_request_id: expected_id, .. } =
             self
         else {
@@ -571,26 +489,19 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        sink.write(
-            MintEvent::MintingStarted {
-                issuer_request_id,
-                started_at: Utc::now(),
-            },
-            self,
-        )
-        .await;
-
-        Ok(())
+        Ok(vec![MintEvent::MintingStarted {
+            issuer_request_id,
+            started_at: Utc::now(),
+        }])
     }
 
     /// Submits the on-chain mint transaction to the signing backend.
     /// Requires `Minting` state (set by prior `Deposit` command).
     async fn handle_submit_mint(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::Minting {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -610,7 +521,7 @@ impl Mint {
 
         let event = Self::execute_mint_submission(
             services,
-            MintSubmissionParams {
+            MintSubmissionInput {
                 issuer_request_id,
                 tokenization_request_id,
                 quantity,
@@ -623,18 +534,16 @@ impl Mint {
         )
         .await?;
 
-        sink.write(event, self).await;
-
-        Ok(())
+        Ok(vec![event])
     }
 
     /// Shared submission logic: vault lookup, receipt info, submit_mint call.
     /// Returns a single `FireblocksSubmitted` or `MintingFailed` event.
     async fn execute_mint_submission(
         services: &MintServices,
-        input: MintSubmissionParams<'_>,
+        input: MintSubmissionInput<'_>,
     ) -> Result<MintEvent, MintError> {
-        let MintSubmissionParams {
+        let MintSubmissionInput {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -645,12 +554,15 @@ impl Mint {
             external_tx_id,
         } = input;
         let vault = find_vault_by_underlying(&services.pool, underlying)
-            .await?
+            .await
+            .map_err(|e| MintError::AssetView { message: e.to_string() })?
             .ok_or_else(|| MintError::AssetNotFound {
                 underlying: underlying.clone(),
             })?;
 
-        let assets = quantity.to_u256_with_18_decimals()?;
+        let assets = quantity.to_u256_with_18_decimals().map_err(|e| {
+            MintError::QuantityConversion { message: e.to_string() }
+        })?;
 
         let receipt_info = ReceiptInformation::new(
             tokenization_request_id.clone(),
@@ -711,12 +623,11 @@ impl Mint {
     /// Confirms a previously submitted mint transaction by polling the backend.
     /// Produces `TokensMinted` on success, or `MintingFailed` on failure.
     async fn handle_confirm_mint(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         fireblocks_tx_id: String,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::FireblocksSubmitted {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -812,21 +723,15 @@ impl Mint {
                     }
                 }
 
-                sink.write(
-                    MintEvent::TokensMinted {
-                        issuer_request_id,
-                        tx_hash: result.tx_hash,
-                        receipt_id: result.receipt_id,
-                        shares_minted: result.shares_minted,
-                        gas_used: result.gas_used,
-                        block_number: result.block_number,
-                        minted_at: now,
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
+                Ok(vec![MintEvent::TokensMinted {
+                    issuer_request_id,
+                    tx_hash: result.tx_hash,
+                    receipt_id: result.receipt_id,
+                    shares_minted: result.shares_minted,
+                    gas_used: result.gas_used,
+                    block_number: result.block_number,
+                    minted_at: now,
+                }])
             }
             Err(err) => {
                 warn!(
@@ -836,27 +741,20 @@ impl Mint {
                     "On-chain deposit confirmation failed"
                 );
 
-                sink.write(
-                    MintEvent::MintingFailed {
-                        issuer_request_id,
-                        error: err.to_string(),
-                        failed_at: now,
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
+                Ok(vec![MintEvent::MintingFailed {
+                    issuer_request_id,
+                    error: err.to_string(),
+                    failed_at: now,
+                }])
             }
         }
     }
 
     async fn handle_send_callback(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let Self::CallbackPending {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -882,7 +780,11 @@ impl Mint {
             network: network.clone(),
         };
 
-        services.alpaca.send_mint_callback(callback_request).await?;
+        services
+            .alpaca
+            .send_mint_callback(callback_request)
+            .await
+            .map_err(|e| MintError::Alpaca { message: e.to_string() })?;
 
         info!(
             target: "mint",
@@ -890,34 +792,25 @@ impl Mint {
             "Alpaca callback succeeded"
         );
 
-        sink.write(
-            MintEvent::MintCompleted {
-                issuer_request_id,
-                completed_at: Utc::now(),
-            },
-            self,
-        )
-        .await;
-
-        Ok(())
+        Ok(vec![MintEvent::MintCompleted {
+            issuer_request_id,
+            completed_at: Utc::now(),
+        }])
     }
 
     async fn handle_recover(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         mode: MintRecoveryMode,
-    ) -> Result<(), MintError> {
-        match &*self {
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
             Self::JournalConfirmed { .. } => {
                 // Emit MintingStarted (intent). drive_recovery will call
                 // Recover again, which hits the Minting arm to submit.
-                self.handle_deposit(sink, issuer_request_id).await
+                self.handle_deposit(issuer_request_id)
             }
             Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
-                let fireblocks_tx_id = fireblocks_tx_id.clone();
-
                 // Non-blocking pre-check: a pending tx must pause recovery (so
                 // the scheduled loop backs off) instead of blocking in
                 // confirm_mint's long poll, which the bounded startup recovery
@@ -925,24 +818,31 @@ impl Mint {
                 if matches!(
                     services
                         .vault
-                        .check_fireblocks_tx(&fireblocks_tx_id)
-                        .await?,
+                        .check_fireblocks_tx(fireblocks_tx_id)
+                        .await
+                        .map_err(|e| MintError::Vault {
+                            message: e.to_string(),
+                        })?,
                     Some(FireblocksTxStatus::Pending)
                 ) {
                     return Err(MintError::FireblocksTxStillPending {
-                        fireblocks_tx_id,
+                        fireblocks_tx_id: fireblocks_tx_id.clone(),
                     });
                 }
 
-                self.handle_confirm_mint(
+                let deposit_events = self
+                    .handle_confirm_mint(
+                        services,
+                        issuer_request_id.clone(),
+                        fireblocks_tx_id.clone(),
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
-                    sink,
-                    issuer_request_id.clone(),
-                    fireblocks_tx_id,
+                    issuer_request_id,
+                    deposit_events,
                 )
-                .await?;
-                self.advance_through_callback(services, sink, issuer_request_id)
-                    .await
+                .await
             }
             Self::MintingFailed { .. } => {
                 // Preserve the previous Fireblocks tx so recovery can
@@ -950,34 +850,41 @@ impl Mint {
                 // failures that are safe to resubmit.
                 let known_tx = self.latest_known_mint_tx();
 
-                self.handle_recover_incomplete(
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        None,
+                        known_tx,
+                        mode,
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
-                    sink,
-                    issuer_request_id.clone(),
-                    None,
-                    known_tx,
-                    mode,
+                    issuer_request_id,
+                    deposit_events,
                 )
-                .await?;
-                self.advance_through_callback(services, sink, issuer_request_id)
-                    .await
+                .await
             }
             Self::Minting { .. } => {
-                self.handle_recover_incomplete(
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        None,
+                        None,
+                        mode,
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
-                    sink,
-                    issuer_request_id.clone(),
-                    None,
-                    None,
-                    mode,
+                    issuer_request_id,
+                    deposit_events,
                 )
-                .await?;
-                self.advance_through_callback(services, sink, issuer_request_id)
-                    .await
+                .await
             }
             Self::CallbackPending { .. } => {
-                self.handle_send_callback(services, sink, issuer_request_id)
-                    .await
+                self.handle_send_callback(services, issuer_request_id).await
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
@@ -995,13 +902,12 @@ impl Mint {
     /// `CallbackPending` here would race with the normal flow's
     /// `SendCallback` command, causing duplicate Alpaca callbacks.
     async fn handle_recover_from_receipt(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         tx_hash: TxHash,
-    ) -> Result<(), MintError> {
-        match &*self {
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
             Self::MintingFailed { .. }
                 if matches!(
                     self.non_failed_predecessor(),
@@ -1010,17 +916,21 @@ impl Mint {
             {
                 let known_tx = self.latest_known_mint_tx();
 
-                self.handle_recover_incomplete(
+                let deposit_events = self
+                    .handle_recover_incomplete(
+                        services,
+                        issuer_request_id.clone(),
+                        Some(tx_hash),
+                        known_tx,
+                        MintRecoveryMode::Manual,
+                    )
+                    .await?;
+                self.advance_through_callback(
                     services,
-                    sink,
-                    issuer_request_id.clone(),
-                    Some(tx_hash),
-                    known_tx,
-                    MintRecoveryMode::Manual,
+                    issuer_request_id,
+                    deposit_events,
                 )
-                .await?;
-                self.advance_through_callback(services, sink, issuer_request_id)
-                    .await
+                .await
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
@@ -1028,9 +938,11 @@ impl Mint {
         }
     }
 
-    /// If the aggregate reached `CallbackPending` after deposit recovery,
-    /// advance through the Alpaca callback in the same command execution.
-    /// Otherwise return immediately.
+    /// If `deposit_events` contain a successful deposit (`TokensMinted` or
+    /// `ExistingMintRecovered`), advance through `CallbackPending` by
+    /// sending the Alpaca callback in the same command execution and
+    /// return the combined event list. Otherwise return `deposit_events`
+    /// unchanged.
     ///
     /// Keeps recovery atomic: a single `Recover` command takes the
     /// aggregate from a stuck pre-callback state straight to `Completed`,
@@ -1039,91 +951,254 @@ impl Mint {
     /// boot-time loop, or receipt-discovery handler) picks up the same
     /// advancing behavior.
     async fn advance_through_callback(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<(), MintError> {
-        if !matches!(self, Self::CallbackPending { .. }) {
-            return Ok(());
+        deposit_events: Vec<MintEvent>,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let deposit_succeeded = deposit_events.iter().any(|event| {
+            matches!(
+                event,
+                MintEvent::TokensMinted { .. }
+                    | MintEvent::ExistingMintRecovered { .. }
+            )
+        });
+
+        if !deposit_succeeded {
+            return Ok(deposit_events);
+        }
+
+        let mut intermediate = self.clone();
+        for event in &deposit_events {
+            intermediate.apply_event(event.clone());
         }
 
         // If callback delivery fails after a successful on-chain deposit,
-        // preserve CallbackPending. The next recovery picks up from there
-        // instead of re-running the deposit path.
-        if let Err(err) = self
-            .handle_send_callback(services, sink, issuer_request_id.clone())
+        // preserve the deposit events so the aggregate advances to
+        // CallbackPending. The next recovery picks up from there instead
+        // of re-running the deposit path.
+        let callback_events = match intermediate
+            .handle_send_callback(services, issuer_request_id.clone())
             .await
         {
-            warn!(
-                target: "mint",
-                issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Callback failed after successful deposit; \
-                 keeping mint in CallbackPending"
-            );
-        }
+            Ok(events) => events,
+            Err(err) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Callback failed after successful deposit; \
+                     keeping mint in CallbackPending"
+                );
+                return Ok(deposit_events);
+            }
+        };
 
-        Ok(())
+        Ok(deposit_events.into_iter().chain(callback_events).collect())
     }
 
     async fn handle_recover_incomplete(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         receipt_tx_hash: Option<TxHash>,
         known_mint_tx: Option<KnownMintTx>,
         mode: MintRecoveryMode,
-    ) -> Result<(), MintError> {
-        let (expected_id, recovery) = IncompleteMintRecovery::from_mint(self)?;
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let (Self::Minting {
+            issuer_request_id: expected_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            wallet,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::MintingFailed {
+            issuer_request_id: expected_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            wallet,
+            journal_confirmed_at,
+            ..
+        }) = self
+        else {
+            return Err(MintError::NotInMintingOrMintingFailedState {
+                current_state: self.state_name().to_string(),
+            });
+        };
 
-        Self::validate_issuer_request_id(&expected_id, &issuer_request_id)?;
+        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        let vault =
-            find_vault_by_underlying(&services.pool, &recovery.underlying)
-                .await?
-                .ok_or_else(|| MintError::AssetNotFound {
-                    underlying: recovery.underlying.clone(),
-                })?;
+        let vault = find_vault_by_underlying(&services.pool, underlying)
+            .await
+            .map_err(|e| MintError::AssetView { message: e.to_string() })?
+            .ok_or_else(|| MintError::AssetNotFound {
+                underlying: underlying.clone(),
+            })?;
 
-        if Self::recover_from_existing_receipt(
+        if let Some(events) = Self::recover_from_existing_receipt(
             services,
             &vault,
             &issuer_request_id,
-            sink,
-            self,
         )
         .await?
         {
-            return Ok(());
+            return Ok(events);
         }
 
         let receipt_info = ReceiptInformation::new(
-            recovery.tokenization_request_id.clone(),
+            tokenization_request_id.clone(),
             issuer_request_id.clone(),
-            recovery.underlying.clone(),
-            recovery.quantity.clone(),
-            recovery.journal_confirmed_at,
+            underlying.clone(),
+            quantity.clone(),
+            *journal_confirmed_at,
             Some("Recovery mint".to_string()),
         );
 
+        let now = Utc::now();
+
         if let Some(known_tx) = known_mint_tx {
-            return self
-                .resume_incomplete_recovery_known_tx(
-                    services,
-                    sink,
-                    KnownTxRecovery {
+            // Known tx_id from a prior submission: go straight to confirm.
+            info!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                fireblocks_tx_id = %known_tx.fireblocks_tx_id,
+                "Resuming confirmation of previously submitted mint"
+            );
+
+            if let Some(status) = services
+                .vault
+                .check_fireblocks_tx(&known_tx.fireblocks_tx_id)
+                .await
+                .map_err(|e| MintError::Vault { message: e.to_string() })?
+            {
+                match status {
+                    FireblocksTxStatus::Completed { .. } => {}
+                    FireblocksTxStatus::Pending => {
+                        return Err(MintError::FireblocksTxStillPending {
+                            fireblocks_tx_id: known_tx.fireblocks_tx_id,
+                        });
+                    }
+                    FireblocksTxStatus::Failed {
+                        detail, sub_status, ..
+                    } => {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            fireblocks_tx_id = %known_tx.fireblocks_tx_id,
+                            external_tx_id = %known_tx.external_tx_id,
+                            sub_status = sub_status.as_deref().unwrap_or(""),
+                            detail = %detail,
+                            "Previous Fireblocks mint transaction failed; \
+                             submitting retry"
+                        );
+
+                        return self
+                            .submit_recovery_mint(
+                                services,
+                                MintSubmissionInput {
+                                    issuer_request_id,
+                                    tokenization_request_id,
+                                    quantity,
+                                    underlying,
+                                    wallet: *wallet,
+                                    journal_confirmed_at: *journal_confirmed_at,
+                                    receipt_note: Some("Recovery mint"),
+                                    external_tx_id: None,
+                                },
+                                receipt_tx_hash,
+                                mode,
+                            )
+                            .await;
+                    }
+                }
+            }
+
+            return match services
+                .vault
+                .confirm_mint(&known_tx.fireblocks_tx_id)
+                .await
+            {
+                Ok(result) => {
+                    info!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        tx_hash = %result.tx_hash,
+                        "Recovery mint succeeded"
+                    );
+
+                    // Best-effort receipt registration
+                    if let Err(err) = services
+                        .receipts
+                        .register_minted_receipt(MintedReceiptParams {
+                            vault,
+                            receipt_id: ReceiptId::from(result.receipt_id),
+                            shares: Shares::from(result.shares_minted),
+                            block_number: result.block_number,
+                            tx_hash: result.tx_hash,
+                            receipt_info: receipt_info.clone(),
+                            receipt_info_bytes: result
+                                .receipt_info_bytes
+                                .clone(),
+                        })
+                        .await
+                    {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            error = %err,
+                            "Failed to register recovered receipt \
+                             (monitor/backfill will discover it)"
+                        );
+                    }
+
+                    let retry_event =
+                        matches!(self, Self::MintingFailed { .. }).then(|| {
+                            MintEvent::MintRetryStarted {
+                                issuer_request_id: issuer_request_id.clone(),
+                                tx_hash: receipt_tx_hash,
+                                started_at: now,
+                            }
+                        });
+
+                    let minted = MintEvent::TokensMinted {
                         issuer_request_id,
-                        recovery,
-                        vault,
-                        receipt_info,
-                        receipt_tx_hash,
-                        known_tx,
-                        mode,
-                    },
-                )
-                .await;
+                        tx_hash: result.tx_hash,
+                        receipt_id: result.receipt_id,
+                        shares_minted: result.shares_minted,
+                        gas_used: result.gas_used,
+                        block_number: result.block_number,
+                        minted_at: now,
+                    };
+
+                    Ok(retry_event
+                        .into_iter()
+                        .chain(std::iter::once(minted))
+                        .collect())
+                }
+                Err(err) => {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Recovery mint confirmation failed — \
+                         preserving fireblocks_tx_id for next retry"
+                    );
+
+                    // Do NOT emit MintRetryStarted here — that would
+                    // move the aggregate from MintingFailed to Minting,
+                    // losing the FireblocksSubmitted predecessor and its
+                    // fireblocks_tx_id. Instead, re-emit MintingFailed
+                    // which keeps the existing predecessor chain intact.
+                    Ok(vec![MintEvent::MintingFailed {
+                        issuer_request_id,
+                        error: err.to_string(),
+                        failed_at: now,
+                    }])
+                }
+            };
         }
 
         // No prior tx_id: submit and persist FireblocksSubmitted.
@@ -1131,14 +1206,13 @@ impl Mint {
         // ConfirmMint from the FireblocksSubmitted state.
         self.submit_recovery_mint(
             services,
-            sink,
-            MintSubmissionParams {
+            MintSubmissionInput {
                 issuer_request_id,
-                tokenization_request_id: &recovery.tokenization_request_id,
-                quantity: &recovery.quantity,
-                underlying: &recovery.underlying,
-                wallet: recovery.wallet,
-                journal_confirmed_at: recovery.journal_confirmed_at,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                wallet: *wallet,
+                journal_confirmed_at: *journal_confirmed_at,
                 receipt_note: Some("Recovery mint"),
                 external_tx_id: None,
             },
@@ -1148,176 +1222,13 @@ impl Mint {
         .await
     }
 
-    async fn resume_incomplete_recovery_known_tx(
-        &mut self,
-        services: &MintServices,
-        sink: &EventSink<Self>,
-        recovery: KnownTxRecovery,
-    ) -> Result<(), MintError> {
-        let KnownTxRecovery {
-            issuer_request_id,
-            recovery,
-            vault,
-            receipt_info,
-            receipt_tx_hash,
-            known_tx,
-            mode,
-        } = recovery;
-
-        info!(
-            target: "mint",
-            issuer_request_id = %issuer_request_id,
-            fireblocks_tx_id = %known_tx.fireblocks_tx_id,
-            "Resuming confirmation of previously submitted mint"
-        );
-
-        if let Some(status) = services
-            .vault
-            .check_fireblocks_tx(&known_tx.fireblocks_tx_id)
-            .await?
-        {
-            match status {
-                FireblocksTxStatus::Completed { .. } => {}
-                FireblocksTxStatus::Pending => {
-                    return Err(MintError::FireblocksTxStillPending {
-                        fireblocks_tx_id: known_tx.fireblocks_tx_id,
-                    });
-                }
-                FireblocksTxStatus::Failed { detail, sub_status, .. } => {
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        fireblocks_tx_id = %known_tx.fireblocks_tx_id,
-                        external_tx_id = %known_tx.external_tx_id,
-                        sub_status = sub_status.as_deref().unwrap_or(""),
-                        detail = %detail,
-                        "Previous Fireblocks mint transaction failed; \
-                         submitting retry"
-                    );
-
-                    return self
-                        .submit_recovery_mint(
-                            services,
-                            sink,
-                            MintSubmissionParams {
-                                issuer_request_id,
-                                tokenization_request_id: &recovery
-                                    .tokenization_request_id,
-                                quantity: &recovery.quantity,
-                                underlying: &recovery.underlying,
-                                wallet: recovery.wallet,
-                                journal_confirmed_at: recovery
-                                    .journal_confirmed_at,
-                                receipt_note: Some("Recovery mint"),
-                                external_tx_id: None,
-                            },
-                            receipt_tx_hash,
-                            mode,
-                        )
-                        .await;
-                }
-            }
-        }
-
-        let now = Utc::now();
-
-        match services.vault.confirm_mint(&known_tx.fireblocks_tx_id).await {
-            Ok(result) => {
-                info!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    tx_hash = %result.tx_hash,
-                    "Recovery mint succeeded"
-                );
-
-                // Best-effort receipt registration
-                if let Err(err) = services
-                    .receipts
-                    .register_minted_receipt(MintedReceiptParams {
-                        vault,
-                        receipt_id: ReceiptId::from(result.receipt_id),
-                        shares: Shares::from(result.shares_minted),
-                        block_number: result.block_number,
-                        tx_hash: result.tx_hash,
-                        receipt_info: receipt_info.clone(),
-                        receipt_info_bytes: result.receipt_info_bytes.clone(),
-                    })
-                    .await
-                {
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        error = %err,
-                        "Failed to register recovered receipt \
-                         (monitor/backfill will discover it)"
-                    );
-                }
-
-                if recovery.is_minting_failed {
-                    sink.write(
-                        MintEvent::MintRetryStarted {
-                            issuer_request_id: issuer_request_id.clone(),
-                            tx_hash: receipt_tx_hash,
-                            started_at: now,
-                        },
-                        self,
-                    )
-                    .await;
-                }
-
-                sink.write(
-                    MintEvent::TokensMinted {
-                        issuer_request_id,
-                        tx_hash: result.tx_hash,
-                        receipt_id: result.receipt_id,
-                        shares_minted: result.shares_minted,
-                        gas_used: result.gas_used,
-                        block_number: result.block_number,
-                        minted_at: now,
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
-            }
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Recovery mint confirmation failed — \
-                     preserving fireblocks_tx_id for next retry"
-                );
-
-                // Do NOT emit MintRetryStarted here — that would
-                // move the aggregate from MintingFailed to Minting,
-                // losing the FireblocksSubmitted predecessor and its
-                // fireblocks_tx_id. Instead, re-emit MintingFailed
-                // which keeps the existing predecessor chain intact.
-                sink.write(
-                    MintEvent::MintingFailed {
-                        issuer_request_id,
-                        error: err.to_string(),
-                        failed_at: now,
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
-            }
-        }
-    }
-
     async fn submit_recovery_mint(
-        &mut self,
+        &self,
         services: &MintServices,
-        sink: &EventSink<Self>,
-        mut input: MintSubmissionParams<'_>,
+        mut input: MintSubmissionInput<'_>,
         receipt_tx_hash: Option<TxHash>,
         mode: MintRecoveryMode,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         let retrying_failed_mint = matches!(self, Self::MintingFailed { .. });
         // The delay/cap gate uses the failure-count-based schedule
         // (`automatic_retry_decision`); the external_tx_id uses the
@@ -1373,29 +1284,25 @@ impl Mint {
             started_at: now,
         });
 
-        if let Some(retry_event) = retry_event {
-            sink.write(retry_event, self).await;
-        }
-
-        sink.write(submission_event, self).await;
-
-        Ok(())
+        Ok(retry_event
+            .into_iter()
+            .chain(std::iter::once(submission_event))
+            .collect())
     }
 
     async fn recover_from_existing_receipt(
         services: &MintServices,
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
-        sink: &EventSink<Self>,
-        aggregate: &mut Self,
-    ) -> Result<bool, MintError> {
+    ) -> Result<Option<Vec<MintEvent>>, MintError> {
         let Some(receipt) = services
             .receipts
             .find_by_issuer_request_id(vault, issuer_request_id)
-            .await?
+            .await
+            .map_err(|e| MintError::ReceiptLookup { message: e.to_string() })?
         else {
             debug!(target: "mint", issuer_request_id = %issuer_request_id, "No receipt found, retrying mint");
-            return Ok(false);
+            return Ok(None);
         };
 
         info!(
@@ -1405,20 +1312,14 @@ impl Mint {
             "Found existing receipt, recording recovery"
         );
 
-        sink.write(
-            MintEvent::ExistingMintRecovered {
-                issuer_request_id: issuer_request_id.clone(),
-                tx_hash: receipt.tx_hash,
-                receipt_id: receipt.receipt_id,
-                shares_minted: receipt.shares,
-                block_number: receipt.block_number,
-                recovered_at: Utc::now(),
-            },
-            aggregate,
-        )
-        .await;
-
-        Ok(true)
+        Ok(Some(vec![MintEvent::ExistingMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: receipt.tx_hash,
+            receipt_id: receipt.receipt_id,
+            shares_minted: receipt.shares,
+            block_number: receipt.block_number,
+            recovered_at: Utc::now(),
+        }]))
     }
 
     fn apply_journal_confirmed(&mut self, confirmed_at: DateTime<Utc>) {
@@ -1849,52 +1750,146 @@ impl Mint {
             minting_started_at: started_at,
         };
     }
-    async fn handle_close_mint(
-        &mut self,
-        sink: &EventSink<Self>,
+    fn handle_close_mint(
+        &self,
         issuer_request_id: IssuerMintRequestId,
         reason: String,
-    ) -> Result<(), MintError> {
+    ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::Completed { .. } | Self::Closed { .. } => {
                 Err(MintError::NotRecoverable {
                     current_state: self.state_name().to_string(),
                 })
             }
-            Self::Uninitialized => Err(MintError::NotRecoverable {
-                current_state: self.state_name().to_string(),
-            }),
-            _ => {
-                sink.write(
-                    MintEvent::MintClosed {
-                        issuer_request_id,
-                        reason,
-                        closed_at: Utc::now(),
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
-            }
+            _ => Ok(vec![MintEvent::MintClosed {
+                issuer_request_id,
+                reason,
+                closed_at: Utc::now(),
+            }]),
         }
     }
 }
 
-impl Aggregate for Mint {
-    type Command = MintCommand;
+#[async_trait]
+impl EventSourced for Mint {
+    type Id = IssuerMintRequestId;
     type Event = MintEvent;
+    type Command = MintCommand;
     type Error = MintError;
     type Services = MintServices;
+    type Materialized = Table;
 
-    const TYPE: &'static str = "Mint";
+    const AGGREGATE_TYPE: &'static str = "Mint";
+    const PROJECTION: Table = Table("mint_view");
+    const SCHEMA_VERSION: u64 = 1;
 
-    async fn handle(
-        &mut self,
+    // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
+    // and event-sorcery hardwires snapshot-every-N with no off switch, so
+    // usize::MAX makes the next-snapshot threshold unreachable. The proper
+    // fix is for event-sorcery to take the snapshot policy explicitly from
+    // the consumer, including the option to disable snapshotting entirely.
+    const SNAPSHOT_SIZE: usize = usize::MAX;
+
+    fn originate(event: &Self::Event) -> Option<Self> {
+        match event {
+            MintEvent::Initiated {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                token,
+                network,
+                client_id,
+                wallet,
+                initiated_at,
+            } => Some(Self::Initiated {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: tokenization_request_id.clone(),
+                quantity: quantity.clone(),
+                underlying: underlying.clone(),
+                token: token.clone(),
+                network: network.clone(),
+                client_id: *client_id,
+                wallet: *wallet,
+                initiated_at: *initiated_at,
+            }),
+            _ => None,
+        }
+    }
+
+    fn evolve(
+        entity: &Self,
+        event: &Self::Event,
+    ) -> Result<Option<Self>, Self::Error> {
+        let mut next = entity.clone();
+        next.apply_event(event.clone());
+        Ok(Some(next))
+    }
+
+    async fn initialize(
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            MintCommand::Initiate {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                token,
+                network,
+                client_id,
+                wallet,
+            } => Ok(vec![MintEvent::Initiated {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                token,
+                network,
+                client_id,
+                wallet,
+                initiated_at: Utc::now(),
+            }]),
+            MintCommand::ConfirmJournal { .. }
+            | MintCommand::RejectJournal { .. } => {
+                Err(MintError::NotInInitiatedState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::Deposit { .. } => {
+                Err(MintError::NotInJournalConfirmedState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::SubmitMint { .. } => {
+                Err(MintError::NotInMintingState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::ConfirmMint { .. } => {
+                Err(MintError::NotInFireblocksSubmittedState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::SendCallback { .. } => {
+                Err(MintError::NotInCallbackPendingState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::Recover { .. }
+            | MintCommand::RecoverFromReceipt { .. }
+            | MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
+                current_state: "Uninitialized".to_string(),
+            }),
+        }
+    }
+
+    async fn transition(
+        &self,
         command: Self::Command,
         services: &Self::Services,
-        sink: &EventSink<Self>,
-    ) -> Result<(), Self::Error> {
+    ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             MintCommand::Initiate {
                 issuer_request_id,
@@ -1907,13 +1902,11 @@ impl Aggregate for Mint {
                 wallet,
             } => {
                 if matches!(self, Self::Initiated { .. }) {
-                    return Err(MintError::AlreadyInitiated {
+                    Err(MintError::AlreadyInitiated {
                         tokenization_request_id: tokenization_request_id.0,
-                    });
-                }
-
-                sink.write(
-                    MintEvent::Initiated {
+                    })
+                } else {
+                    Ok(vec![MintEvent::Initiated {
                         issuer_request_id,
                         tokenization_request_id,
                         quantity,
@@ -1923,71 +1916,55 @@ impl Aggregate for Mint {
                         client_id,
                         wallet,
                         initiated_at: Utc::now(),
-                    },
-                    self,
-                )
-                .await;
-
-                Ok(())
+                    }])
+                }
             }
-
             MintCommand::ConfirmJournal { issuer_request_id } => {
-                self.handle_confirm_journal(sink, issuer_request_id).await
+                self.handle_confirm_journal(issuer_request_id)
             }
-
             MintCommand::RejectJournal { issuer_request_id, reason } => {
-                self.handle_reject_journal(sink, issuer_request_id, reason)
-                    .await
+                self.handle_reject_journal(issuer_request_id, reason)
             }
-
             MintCommand::Deposit { issuer_request_id } => {
-                self.handle_deposit(sink, issuer_request_id).await
+                self.handle_deposit(issuer_request_id)
             }
-
             MintCommand::SubmitMint { issuer_request_id } => {
-                self.handle_submit_mint(services, sink, issuer_request_id).await
+                self.handle_submit_mint(services, issuer_request_id).await
             }
-
             MintCommand::ConfirmMint {
                 issuer_request_id,
                 fireblocks_tx_id,
             } => {
                 self.handle_confirm_mint(
                     services,
-                    sink,
                     issuer_request_id,
                     fireblocks_tx_id,
                 )
                 .await
             }
-
             MintCommand::SendCallback { issuer_request_id } => {
-                self.handle_send_callback(services, sink, issuer_request_id)
-                    .await
+                self.handle_send_callback(services, issuer_request_id).await
             }
-
             MintCommand::Recover { issuer_request_id, mode } => {
-                self.handle_recover(services, sink, issuer_request_id, mode)
-                    .await
+                self.handle_recover(services, issuer_request_id, mode).await
             }
-
             MintCommand::RecoverFromReceipt { issuer_request_id, tx_hash } => {
                 self.handle_recover_from_receipt(
                     services,
-                    sink,
                     issuer_request_id,
                     tx_hash,
                 )
                 .await
             }
-
             MintCommand::CloseMint { issuer_request_id, reason } => {
-                self.handle_close_mint(sink, issuer_request_id, reason).await
+                self.handle_close_mint(issuer_request_id, reason)
             }
         }
     }
+}
 
-    fn apply(&mut self, event: Self::Event) {
+impl Mint {
+    fn apply_event(&mut self, event: MintEvent) {
         match event {
             MintEvent::Initiated {
                 issuer_request_id,
@@ -2088,7 +2065,7 @@ impl Aggregate for Mint {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
 pub(crate) enum MintError {
     #[error(
         "Mint already initiated for tokenization request: {tokenization_request_id}"
@@ -2137,20 +2114,16 @@ pub(crate) enum MintError {
     FireblocksTxIdMismatch { expected: String, provided: String },
     #[error("Asset not found for underlying: {underlying}")]
     AssetNotFound { underlying: UnderlyingSymbol },
-    #[error("Quantity conversion: {0}")]
-    QuantityConversion(#[from] QuantityConversionError),
-    #[error("View: {0}")]
-    View(#[from] TokenizedAssetViewError),
-    #[error("Alpaca: {0}")]
-    Alpaca(#[from] AlpacaError),
-    #[error("Account view: {0}")]
-    AccountView(#[from] AccountViewError),
-    #[error("Receipt inventory view: {0}")]
-    ReceiptInventoryView(#[from] ReceiptInventoryViewError),
-    #[error(transparent)]
-    ReceiptLookup(#[from] ReceiptLookupError),
-    #[error("Vault: {0}")]
-    Vault(#[from] VaultError),
+    #[error("Quantity conversion: {message}")]
+    QuantityConversion { message: String },
+    #[error("Asset view: {message}")]
+    AssetView { message: String },
+    #[error("Alpaca: {message}")]
+    Alpaca { message: String },
+    #[error("Receipt lookup: {message}")]
+    ReceiptLookup { message: String },
+    #[error("Vault: {message}")]
+    Vault { message: String },
 }
 
 #[cfg(test)]
@@ -2158,16 +2131,14 @@ pub(crate) mod tests {
     use alloy::primitives::{Address, B256, U256, address, b256, uint};
     use async_trait::async_trait;
     use chrono::{DateTime, Duration as ChronoDuration, Utc};
-    use cqrs_es::View;
-    use cqrs_es::{
-        Aggregate, AggregateContext, CqrsFramework, EventStore,
-        event_sink::EventSink, mem_store::MemStore, test::TestFramework,
+    use cqrs_es::DomainEvent;
+    use event_sorcery::{
+        LifecycleError, Store, StoreBuilder, TestHarness, replay, test_store,
     };
-    use event_sorcery::{Store, StoreBuilder, test_store};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
-    use std::collections::HashMap;
+    use sqlx::{Pool, Sqlite};
     use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
@@ -2177,7 +2148,7 @@ pub(crate) mod tests {
         AutomaticRetryDecision, ClientId, IssuerMintRequestId, Mint,
         MintCommand, MintError, MintEvent, MintRecoveryMode, MintServices,
         MintView, Network, Quantity, TokenSymbol, TokenizationRequestId,
-        UnderlyingSymbol,
+        UnderlyingSymbol, find_by_issuer_request_id,
     };
     use crate::alpaca::mock::MockAlpacaService;
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
@@ -2354,21 +2325,13 @@ pub(crate) mod tests {
         }
     }
 
-    pub(super) struct MintTestFixture {
-        pub(super) mint_cqrs: Arc<CqrsFramework<Mint, MemStore<Mint>>>,
-        pub(super) mint_store: Arc<MemStore<Mint>>,
-        pub(super) receipt_store: Arc<Store<ReceiptInventory>>,
+    struct MintTestFixture {
+        mint_store: Arc<Store<Mint>>,
+        pool: Pool<Sqlite>,
     }
 
     impl MintTestFixture {
-        pub(super) async fn new() -> Self {
-            Self::new_with_vault(Arc::new(MockVaultService::new_success()))
-                .await
-        }
-
-        pub(super) async fn new_with_vault(
-            vault: Arc<dyn VaultService>,
-        ) -> Self {
+        async fn new_with_vault(vault: Arc<dyn VaultService>) -> Self {
             let pool = SqlitePoolOptions::new()
                 .max_connections(1)
                 .connect(":memory:")
@@ -2403,35 +2366,56 @@ pub(crate) mod tests {
             let services = MintServices {
                 vault,
                 alpaca: Arc::new(MockAlpacaService::new_success()),
-                receipts: Arc::new(CqrsReceiptService::new(
-                    receipt_store.clone(),
-                )),
+                receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
                 pool: pool.clone(),
                 bot: BOT,
             };
 
-            let mint_store = Arc::new(MemStore::<Mint>::default());
-            let mint_cqrs = Arc::new(CqrsFramework::new(
-                (*mint_store).clone(),
-                vec![],
-                services,
-            ));
+            let mint_store =
+                Arc::new(test_store::<Mint>(pool.clone(), services));
 
-            Self { mint_cqrs, mint_store, receipt_store }
+            Self { mint_store, pool }
         }
 
-        pub(super) async fn seed_mint_events(
+        /// Seeds a pre-existing `MintEvent` history directly into the event
+        /// store so command tests can start from any lifecycle state.
+        ///
+        /// Inserts raw `MintEvent` rows — `Lifecycle<Mint>` persists the inner
+        /// `MintEvent` verbatim (`event_type = "MintEvent::<Variant>"`, payload
+        /// `{"<Variant>": {...}}`), so `mint_store.load`/`send` replay them
+        /// exactly as if they had been produced by commands.
+        async fn seed_mint_events(
             &self,
             aggregate_id: &str,
             events: Vec<MintEvent>,
         ) {
-            let context =
-                self.mint_store.load_aggregate(aggregate_id).await.unwrap();
+            for (index, event) in events.into_iter().enumerate() {
+                let sequence = i64::try_from(index).unwrap() + 1;
+                let event_type = event.event_type();
+                let payload = serde_json::to_string(&event).unwrap();
 
-            self.mint_store
-                .commit(events, context, HashMap::default())
+                sqlx::query(
+                    "
+                    INSERT INTO events (
+                        aggregate_type,
+                        aggregate_id,
+                        sequence,
+                        event_type,
+                        event_version,
+                        payload,
+                        metadata
+                    )
+                    VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
+                    ",
+                )
+                .bind(aggregate_id)
+                .bind(sequence)
+                .bind(event_type)
+                .bind(payload)
+                .execute(&self.pool)
                 .await
                 .unwrap();
+            }
         }
     }
 
@@ -2480,28 +2464,37 @@ pub(crate) mod tests {
         }
     }
 
-    type MintTestFramework = TestFramework<Mint>;
+    /// Counts persisted `Mint` events of a given `event_type` for one mint,
+    /// reading the event store directly (recovery's audit-trail assertions
+    /// inspect emitted events, which `Store::load` collapses into state).
+    async fn count_events_of_type(
+        pool: &Pool<Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        event_type: &str,
+    ) -> i64 {
+        sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+              AND event_type = ?
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .bind(event_type)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
 
-    fn test_mint_services() -> MintServices {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("Failed to create runtime");
-
-        let pool = rt.block_on(async {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect(":memory:")
-                .await
-                .expect("Failed to create in-memory database");
-
-            sqlx::migrate!()
-                .run(&pool)
-                .await
-                .expect("Failed to run migrations");
-
-            pool
-        });
+    async fn test_mint_services() -> MintServices {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+        sqlx::migrate!().run(&pool).await.expect("Failed to run migrations");
 
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
@@ -2516,8 +2509,8 @@ pub(crate) mod tests {
         }
     }
 
-    #[test]
-    fn test_initiate_mint_creates_event() {
+    #[tokio::test]
+    async fn test_initiate_mint_creates_event() {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-123");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2527,7 +2520,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let events = TestHarness::<Mint>::with(test_mint_services().await)
             .given_no_previous_events()
             .when(MintCommand::Initiate {
                 issuer_request_id: issuer_request_id.clone(),
@@ -2538,62 +2531,51 @@ pub(crate) mod tests {
                 network: network.clone(),
                 client_id,
                 wallet,
-            });
+            })
+            .await
+            .events();
 
-        let result = validator.inspect_result();
+        assert_eq!(events.len(), 1);
 
-        match result {
-            Ok(events) => {
-                assert_eq!(events.len(), 1);
-
-                match &events[0] {
-                    MintEvent::Initiated {
-                        issuer_request_id: event_issuer_id,
-                        tokenization_request_id: event_tokenization_id,
-                        quantity: event_quantity,
-                        underlying: event_underlying,
-                        token: event_token,
-                        network: event_network,
-                        client_id: event_client_id,
-                        wallet: event_wallet,
-                        initiated_at,
-                    } => {
-                        assert_eq!(event_issuer_id, &issuer_request_id);
-                        assert_eq!(
-                            event_tokenization_id,
-                            &tokenization_request_id
-                        );
-                        assert_eq!(event_quantity, &quantity);
-                        assert_eq!(event_underlying, &underlying);
-                        assert_eq!(event_token, &token);
-                        assert_eq!(event_network, &network);
-                        assert_eq!(event_client_id, &client_id);
-                        assert_eq!(event_wallet, &wallet);
-                        assert!(initiated_at.timestamp() > 0);
-                    }
-                    MintEvent::JournalConfirmed { .. }
-                    | MintEvent::JournalRejected { .. }
-                    | MintEvent::MintingStarted { .. }
-                    | MintEvent::FireblocksSubmitted { .. }
-                    | MintEvent::TokensMinted { .. }
-                    | MintEvent::MintingFailed { .. }
-                    | MintEvent::MintCompleted { .. }
-                    | MintEvent::ExistingMintRecovered { .. }
-                    | MintEvent::MintRetryStarted { .. }
-                    | MintEvent::MintClosed { .. } => {
-                        panic!(
-                            "Expected MintInitiated event, got {:?}",
-                            &events[0]
-                        )
-                    }
-                }
+        match &events[0] {
+            MintEvent::Initiated {
+                issuer_request_id: event_issuer_id,
+                tokenization_request_id: event_tokenization_id,
+                quantity: event_quantity,
+                underlying: event_underlying,
+                token: event_token,
+                network: event_network,
+                client_id: event_client_id,
+                wallet: event_wallet,
+                initiated_at,
+            } => {
+                assert_eq!(event_issuer_id, &issuer_request_id);
+                assert_eq!(event_tokenization_id, &tokenization_request_id);
+                assert_eq!(event_quantity, &quantity);
+                assert_eq!(event_underlying, &underlying);
+                assert_eq!(event_token, &token);
+                assert_eq!(event_network, &network);
+                assert_eq!(event_client_id, &client_id);
+                assert_eq!(event_wallet, &wallet);
+                assert!(initiated_at.timestamp() > 0);
             }
-            Err(e) => panic!("Expected success, got error: {e}"),
+            MintEvent::JournalConfirmed { .. }
+            | MintEvent::JournalRejected { .. }
+            | MintEvent::MintingStarted { .. }
+            | MintEvent::FireblocksSubmitted { .. }
+            | MintEvent::TokensMinted { .. }
+            | MintEvent::MintingFailed { .. }
+            | MintEvent::MintCompleted { .. }
+            | MintEvent::ExistingMintRecovered { .. }
+            | MintEvent::MintRetryStarted { .. }
+            | MintEvent::MintClosed { .. } => {
+                panic!("Expected MintInitiated event, got {:?}", &events[0])
+            }
         }
     }
 
-    #[test]
-    fn test_initiate_mint_when_already_initiated_returns_error() {
+    #[tokio::test]
+    async fn test_initiate_mint_when_already_initiated_returns_error() {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-123");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2603,7 +2585,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let result = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: tokenization_request_id.clone(),
@@ -2625,20 +2607,20 @@ pub(crate) mod tests {
                 client_id,
                 wallet,
             })
-            .inspect_result();
+            .await
+            .then_expect_error();
 
         assert!(
-            matches!(result, Err(MintError::AlreadyInitiated { .. })),
-            "Expected AlreadyInitiated error, got {result:?}"
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::AlreadyInitiated { .. })
+            ),
+            "Expected AlreadyInitiated error, got {error:?}"
         );
     }
 
     #[test]
     fn test_apply_initiated_event_updates_state() {
-        let mut mint = Mint::default();
-
-        assert!(matches!(mint, Mint::Uninitialized));
-
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(50));
@@ -2649,7 +2631,7 @@ pub(crate) mod tests {
         let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
         let initiated_at = chrono::Utc::now();
 
-        mint.apply(MintEvent::Initiated {
+        let mint = replay::<Mint>(vec![MintEvent::Initiated {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: quantity.clone(),
@@ -2659,7 +2641,9 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
-        });
+        }])
+        .unwrap()
+        .unwrap();
 
         let Mint::Initiated {
             issuer_request_id: applied_issuer_id,
@@ -2713,7 +2697,7 @@ pub(crate) mod tests {
 
         let confirmed_at = Utc::now();
 
-        mint.apply(MintEvent::JournalConfirmed {
+        mint.apply_event(MintEvent::JournalConfirmed {
             issuer_request_id: issuer_request_id.clone(),
             confirmed_at,
         });
@@ -2758,7 +2742,7 @@ pub(crate) mod tests {
         let rejected_at = Utc::now();
         let reason = "Insufficient funds".to_string();
 
-        mint.apply(MintEvent::JournalRejected {
+        mint.apply_event(MintEvent::JournalRejected {
             issuer_request_id: issuer_request_id.clone(),
             reason: reason.clone(),
             rejected_at,
@@ -2779,8 +2763,8 @@ pub(crate) mod tests {
         assert_eq!(state_rejected_at, rejected_at);
     }
 
-    #[test]
-    fn test_confirm_journal_produces_event() {
+    #[tokio::test]
+    async fn test_confirm_journal_produces_event() {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2790,7 +2774,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let events = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
@@ -2802,29 +2786,32 @@ pub(crate) mod tests {
                 wallet,
                 initiated_at: Utc::now(),
             }])
-            .when(MintCommand::ConfirmJournal { issuer_request_id });
-
-        let events = validator.inspect_result().unwrap();
+            .when(MintCommand::ConfirmJournal { issuer_request_id })
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(&events[0], MintEvent::JournalConfirmed { .. }));
     }
 
-    #[test]
-    fn test_confirm_journal_for_uninitialized_mint_fails() {
+    #[tokio::test]
+    async fn test_confirm_journal_for_uninitialized_mint_fails() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given_no_previous_events()
-            .when(MintCommand::ConfirmJournal { issuer_request_id });
+            .when(MintCommand::ConfirmJournal { issuer_request_id })
+            .await
+            .then_expect_error();
 
-        let result = validator.inspect_result();
-
-        assert!(matches!(result, Err(MintError::NotInInitiatedState { .. })));
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(MintError::NotInInitiatedState { .. })
+        ));
     }
 
-    #[test]
-    fn test_confirm_journal_for_already_confirmed_mint_fails() {
+    #[tokio::test]
+    async fn test_confirm_journal_for_already_confirmed_mint_fails() {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2834,7 +2821,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![
                 MintEvent::Initiated {
                     issuer_request_id: issuer_request_id.clone(),
@@ -2852,15 +2839,18 @@ pub(crate) mod tests {
                     confirmed_at: Utc::now(),
                 },
             ])
-            .when(MintCommand::ConfirmJournal { issuer_request_id });
+            .when(MintCommand::ConfirmJournal { issuer_request_id })
+            .await
+            .then_expect_error();
 
-        let result = validator.inspect_result();
-
-        assert!(matches!(result, Err(MintError::NotInInitiatedState { .. })));
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(MintError::NotInInitiatedState { .. })
+        ));
     }
 
-    #[test]
-    fn test_reject_journal_produces_event() {
+    #[tokio::test]
+    async fn test_reject_journal_produces_event() {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2871,7 +2861,7 @@ pub(crate) mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let reason = "Insufficient funds";
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let events = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
@@ -2886,9 +2876,9 @@ pub(crate) mod tests {
             .when(MintCommand::RejectJournal {
                 issuer_request_id,
                 reason: reason.to_string(),
-            });
-
-        let events = validator.inspect_result().unwrap();
+            })
+            .await
+            .events();
 
         assert_eq!(events.len(), 1);
 
@@ -2901,24 +2891,27 @@ pub(crate) mod tests {
         assert_eq!(event_reason, reason);
     }
 
-    #[test]
-    fn test_reject_journal_for_uninitialized_mint_fails() {
+    #[tokio::test]
+    async fn test_reject_journal_for_uninitialized_mint_fails() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given_no_previous_events()
             .when(MintCommand::RejectJournal {
                 issuer_request_id,
                 reason: "Test reason".to_string(),
-            });
+            })
+            .await
+            .then_expect_error();
 
-        let result = validator.inspect_result();
-
-        assert!(matches!(result, Err(MintError::NotInInitiatedState { .. })));
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(MintError::NotInInitiatedState { .. })
+        ));
     }
 
-    #[test]
-    fn test_confirm_journal_with_mismatched_issuer_request_id_fails() {
+    #[tokio::test]
+    async fn test_confirm_journal_with_mismatched_issuer_request_id_fails() {
         let correct_issuer_request_id = IssuerMintRequestId::random();
         let wrong_issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
@@ -2929,7 +2922,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let result = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
@@ -2944,19 +2937,22 @@ pub(crate) mod tests {
             .when(MintCommand::ConfirmJournal {
                 issuer_request_id: wrong_issuer_request_id,
             })
-            .inspect_result();
+            .await
+            .then_expect_error();
 
         assert!(
             matches!(
-                result,
-                Err(MintError::IssuerMintRequestIdMismatch { .. })
+                error,
+                LifecycleError::Apply(
+                    MintError::IssuerMintRequestIdMismatch { .. }
+                )
             ),
-            "Expected IssuerMintRequestIdMismatch error, got {result:?}"
+            "Expected IssuerMintRequestIdMismatch error, got {error:?}"
         );
     }
 
-    #[test]
-    fn test_reject_journal_with_mismatched_issuer_request_id_fails() {
+    #[tokio::test]
+    async fn test_reject_journal_with_mismatched_issuer_request_id_fails() {
         let correct_issuer_request_id = IssuerMintRequestId::random();
         let wrong_issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
@@ -2967,7 +2963,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let result = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
@@ -2983,13 +2979,16 @@ pub(crate) mod tests {
                 issuer_request_id: wrong_issuer_request_id,
                 reason: "Test reason".to_string(),
             })
-            .inspect_result();
+            .await
+            .then_expect_error();
         assert!(
             matches!(
-                result,
-                Err(MintError::IssuerMintRequestIdMismatch { .. })
+                error,
+                LifecycleError::Apply(
+                    MintError::IssuerMintRequestIdMismatch { .. }
+                )
             ),
-            "Expected IssuerMintRequestIdMismatch error, got {result:?}"
+            "Expected IssuerMintRequestIdMismatch error, got {error:?}"
         );
     }
 
@@ -3020,7 +3019,7 @@ pub(crate) mod tests {
         };
 
         let minting_started_at = Utc::now();
-        mint.apply(MintEvent::MintingStarted {
+        mint.apply_event(MintEvent::MintingStarted {
             issuer_request_id: issuer_request_id.clone(),
             started_at: minting_started_at,
         });
@@ -3092,7 +3091,7 @@ pub(crate) mod tests {
         let block_number = 1000;
         let minted_at = Utc::now();
 
-        mint.apply(MintEvent::TokensMinted {
+        mint.apply_event(MintEvent::TokensMinted {
             issuer_request_id: issuer_request_id.clone(),
             tx_hash,
             receipt_id,
@@ -3156,7 +3155,7 @@ pub(crate) mod tests {
         let error_message = "Transaction failed: insufficient gas";
         let failed_at = Utc::now();
 
-        mint.apply(MintEvent::MintingFailed {
+        mint.apply_event(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: error_message.to_string(),
             failed_at,
@@ -3229,7 +3228,7 @@ pub(crate) mod tests {
 
         let completed_at = Utc::now();
 
-        mint.apply(MintEvent::MintCompleted {
+        mint.apply_event(MintEvent::MintCompleted {
             issuer_request_id: issuer_request_id.clone(),
             completed_at,
         });
@@ -3282,9 +3281,7 @@ pub(crate) mod tests {
         let minted_at = Utc::now();
         let completed_at = Utc::now();
 
-        let mut mint = Mint::default();
-
-        mint.apply(MintEvent::Initiated {
+        let mut mint = replay::<Mint>(vec![MintEvent::Initiated {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -3294,14 +3291,16 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
-        });
+        }])
+        .unwrap()
+        .unwrap();
 
         assert!(
             matches!(mint, Mint::Initiated { .. }),
             "Expected Initiated state, got {mint:?}"
         );
 
-        mint.apply(MintEvent::JournalConfirmed {
+        mint.apply_event(MintEvent::JournalConfirmed {
             issuer_request_id: issuer_request_id.clone(),
             confirmed_at,
         });
@@ -3312,7 +3311,7 @@ pub(crate) mod tests {
         );
 
         let minting_started_at = Utc::now();
-        mint.apply(MintEvent::MintingStarted {
+        mint.apply_event(MintEvent::MintingStarted {
             issuer_request_id: issuer_request_id.clone(),
             started_at: minting_started_at,
         });
@@ -3322,7 +3321,7 @@ pub(crate) mod tests {
             "Expected Minting state, got {mint:?}"
         );
 
-        mint.apply(MintEvent::TokensMinted {
+        mint.apply_event(MintEvent::TokensMinted {
             issuer_request_id: issuer_request_id.clone(),
             tx_hash,
             receipt_id,
@@ -3337,7 +3336,7 @@ pub(crate) mod tests {
             "Expected CallbackPending state, got {mint:?}"
         );
 
-        mint.apply(MintEvent::MintCompleted {
+        mint.apply_event(MintEvent::MintCompleted {
             issuer_request_id: issuer_request_id.clone(),
             completed_at,
         });
@@ -3383,146 +3382,184 @@ pub(crate) mod tests {
         }
     }
 
-    async fn setup_cqrs_integration_test()
-    -> (Arc<MemStore<Mint>>, Arc<CqrsFramework<Mint, MemStore<Mint>>>) {
-        let fixture = MintTestFixture::new().await;
-        (fixture.mint_store, fixture.mint_cqrs)
+    /// Builds a projected `Store<Mint>` (with the `mint_view` projection wired)
+    /// plus its pool, seeded with the AAPL tokenized asset, so the split mint
+    /// flow can be driven end to end and the resulting `MintView` inspected via
+    /// the view query helpers.
+    async fn setup_projected_mint_store() -> (Arc<Store<Mint>>, Pool<Sqlite>) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let (asset_store, _asset_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        asset_store
+            .send(
+                &UnderlyingSymbol::new("AAPL"),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL"),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::new("base"),
+                    vault: VAULT,
+                },
+            )
+            .await
+            .unwrap();
+
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+
+        let services = MintServices {
+            vault: Arc::new(MockVaultService::new_success()),
+            alpaca: Arc::new(MockAlpacaService::new_success()),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool: pool.clone(),
+            bot: BOT,
+        };
+
+        let (mint_store, _mint_projection) =
+            StoreBuilder::<Mint>::new(pool.clone())
+                .build(services)
+                .await
+                .unwrap();
+
+        (mint_store, pool)
     }
 
     #[tokio::test]
     async fn test_complete_mint_flow_via_cqrs() {
-        let (store, cqrs) = setup_cqrs_integration_test().await;
+        let (store, pool) = setup_projected_mint_store().await;
         let data = TestMintData::new();
 
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::Initiate {
-                issuer_request_id: data.issuer_request_id.clone(),
-                tokenization_request_id: data.tokenization_request_id.clone(),
-                quantity: data.quantity.clone(),
-                underlying: data.underlying.clone(),
-                token: data.token.clone(),
-                network: data.network.clone(),
-                client_id: data.client_id,
-                wallet: data.wallet,
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::Initiate {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                    tokenization_request_id: data
+                        .tokenization_request_id
+                        .clone(),
+                    quantity: data.quantity.clone(),
+                    underlying: data.underlying.clone(),
+                    token: data.token.clone(),
+                    network: data.network.clone(),
+                    client_id: data.client_id,
+                    wallet: data.wallet,
+                },
+            )
+            .await
+            .unwrap();
 
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::ConfirmJournal {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::ConfirmJournal {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
 
         // Deposit records intent (emits MintingStarted)
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::Deposit {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::Deposit {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
 
         // SubmitMint does the network call (emits FireblocksSubmitted)
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::SubmitMint {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::SubmitMint {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
 
         // Load the fireblocks_tx_id from the aggregate state
-        let mut ctx = store
-            .load_aggregate(&data.issuer_request_id.to_string())
-            .await
-            .unwrap();
-
-        let Mint::FireblocksSubmitted { fireblocks_tx_id, .. } =
-            ctx.aggregate()
+        let Some(Mint::FireblocksSubmitted { fireblocks_tx_id, .. }) =
+            store.load(&data.issuer_request_id).await.unwrap()
         else {
-            panic!(
-                "Expected FireblocksSubmitted state after SubmitMint, got {:?}",
-                ctx.aggregate()
-            );
+            panic!("Expected FireblocksSubmitted state after SubmitMint");
         };
 
-        let fb_tx_id = fireblocks_tx_id.clone();
-
         // ConfirmMint polls the backend (emits TokensMinted)
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::ConfirmMint {
-                issuer_request_id: data.issuer_request_id.clone(),
-                fireblocks_tx_id: fb_tx_id,
-            },
-        )
-        .await
-        .unwrap();
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::ConfirmMint {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                    fireblocks_tx_id,
+                },
+            )
+            .await
+            .unwrap();
 
-        cqrs.execute(
-            &data.issuer_request_id.to_string(),
-            MintCommand::SendCallback {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-        )
-        .await
-        .unwrap();
-
-        let mut context = store
-            .load_aggregate(&data.issuer_request_id.to_string())
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::SendCallback {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                },
+            )
             .await
             .unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
-            "Expected Completed state, got {:?}",
-            context.aggregate()
+            matches!(
+                store.load(&data.issuer_request_id).await.unwrap(),
+                Some(Mint::Completed { .. })
+            ),
+            "Expected Completed state"
         );
 
-        let events = store
-            .load_events(&data.issuer_request_id.to_string())
+        // The split flow must emit exactly these six events in order.
+        let event_types: Vec<String> = sqlx::query_scalar(
+            "
+            SELECT event_type
+            FROM events
+            WHERE aggregate_type = 'Mint' AND aggregate_id = ?
+            ORDER BY sequence
+            ",
+        )
+        .bind(data.issuer_request_id.to_string())
+        .fetch_all(&pool)
+        .await
+        .unwrap();
+
+        let event_types: Vec<&str> =
+            event_types.iter().map(String::as_str).collect();
+        assert_eq!(
+            event_types,
+            vec![
+                "MintEvent::Initiated",
+                "MintEvent::JournalConfirmed",
+                "MintEvent::MintingStarted",
+                "MintEvent::FireblocksSubmitted",
+                "MintEvent::TokensMinted",
+                "MintEvent::MintCompleted",
+            ],
+            "Expected 6 events in the split flow, in order"
+        );
+
+        let view = find_by_issuer_request_id(&pool, &data.issuer_request_id)
             .await
-            .unwrap();
-
-        assert_eq!(events.len(), 6, "Expected 6 events in the split flow");
-
-        assert!(
-            matches!(&events[0].payload, MintEvent::Initiated { .. }),
-            "First event should be Initiated"
-        );
-        assert!(
-            matches!(&events[1].payload, MintEvent::JournalConfirmed { .. }),
-            "Second event should be JournalConfirmed"
-        );
-        assert!(
-            matches!(&events[2].payload, MintEvent::MintingStarted { .. }),
-            "Third event should be MintingStarted"
-        );
-        assert!(
-            matches!(&events[3].payload, MintEvent::FireblocksSubmitted { .. }),
-            "Fourth event should be FireblocksSubmitted"
-        );
-        assert!(
-            matches!(&events[4].payload, MintEvent::TokensMinted { .. }),
-            "Fifth event should be TokensMinted"
-        );
-        assert!(
-            matches!(&events[5].payload, MintEvent::MintCompleted { .. }),
-            "Sixth event should be MintCompleted"
-        );
-
-        let mut view = MintView::default();
-        for event in &events {
-            view.update(event);
-        }
+            .unwrap()
+            .expect("MintView should exist after the flow completes");
 
         let MintView::Completed {
             issuer_request_id: view_issuer_id,
@@ -3577,9 +3614,9 @@ pub(crate) mod tests {
         fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -3593,35 +3630,21 @@ pub(crate) mod tests {
             Some(format!("mint-{issuer_request_id}-retry-1"))
         );
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
-
-        let Mint::FireblocksSubmitted { external_tx_id, .. } =
-            context.aggregate()
+        let Some(Mint::FireblocksSubmitted { external_tx_id, .. }) =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap()
         else {
             panic!("Expected FireblocksSubmitted after retry");
         };
-        assert_eq!(
-            external_tx_id,
-            &format!("mint-{issuer_request_id}-retry-1")
-        );
+        assert_eq!(external_tx_id, format!("mint-{issuer_request_id}-retry-1"));
 
         // A successful retry must record MintRetryStarted as the permanent
         // audit-trail fact that recovery resubmitted the mint.
-        let stored = fixture
-            .mint_store
-            .load_events(&issuer_request_id.to_string())
-            .await
-            .unwrap();
-        let retry_started = stored
-            .iter()
-            .filter(|event| {
-                matches!(event.payload, MintEvent::MintRetryStarted { .. })
-            })
-            .count();
+        let retry_started = count_events_of_type(
+            &fixture.pool,
+            &issuer_request_id,
+            "MintEvent::MintRetryStarted",
+        )
+        .await;
         assert_eq!(
             retry_started, 1,
             "Expected exactly one MintRetryStarted event after a retry"
@@ -3650,9 +3673,9 @@ pub(crate) mod tests {
         fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
 
         let result = fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -3663,9 +3686,9 @@ pub(crate) mod tests {
         assert!(
             matches!(
                 result,
-                Err(cqrs_es::AggregateError::UserError(
+                Err(cqrs_es::AggregateError::UserError(LifecycleError::Apply(
                     MintError::RetryNotDue { .. }
-                ))
+                )))
             ),
             "Expected RetryNotDue, got {result:?}"
         );
@@ -3687,9 +3710,9 @@ pub(crate) mod tests {
         fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
 
         let automatic_result = fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -3699,17 +3722,17 @@ pub(crate) mod tests {
         assert!(
             matches!(
                 automatic_result,
-                Err(cqrs_es::AggregateError::UserError(
+                Err(cqrs_es::AggregateError::UserError(LifecycleError::Apply(
                     MintError::AutomaticRetriesExhausted { attempts: 4 }
-                ))
+                )))
             ),
             "Expected AutomaticRetriesExhausted, got {automatic_result:?}"
         );
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Manual,
@@ -3723,17 +3746,16 @@ pub(crate) mod tests {
             Some(format!("mint-{issuer_request_id}-retry-5"))
         );
 
-        let mut context = fixture
+        let mint = fixture
             .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
+            .load(&issuer_request_id)
             .await
-            .unwrap();
-        let Mint::FireblocksSubmitted { external_tx_id, .. } =
-            context.aggregate()
-        else {
+            .unwrap()
+            .expect("Expected a live mint after manual retry");
+        let Mint::FireblocksSubmitted { external_tx_id, .. } = &mint else {
             panic!(
                 "Expected FireblocksSubmitted after manual retry, got: {}",
-                context.aggregate().state_name()
+                mint.state_name()
             );
         };
         assert_eq!(
@@ -3779,9 +3801,9 @@ pub(crate) mod tests {
         fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -3790,18 +3812,17 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let mut context = fixture
+        let mint = fixture
             .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
+            .load(&issuer_request_id)
             .await
-            .unwrap();
-        let aggregate = context.aggregate().clone();
+            .unwrap()
+            .expect("Expected a live mint after failed resubmission");
 
-        let Mint::MintingFailed { failed_at, failed_from, .. } = &aggregate
-        else {
+        let Mint::MintingFailed { failed_at, failed_from, .. } = &mint else {
             panic!(
                 "Expected MintingFailed after failed resubmission, got: {}",
-                aggregate.state_name()
+                mint.state_name()
             );
         };
         assert!(
@@ -3809,7 +3830,7 @@ pub(crate) mod tests {
             "Predecessor chain must be preserved on submission failure"
         );
         assert_eq!(
-            aggregate.next_retry_attempt(),
+            mint.next_retry_attempt(),
             2,
             "Retry counter must not reset after a failed retry submission"
         );
@@ -3818,17 +3839,12 @@ pub(crate) mod tests {
             "failed_at must advance so the backoff anchor moves forward"
         );
 
-        let stored = fixture
-            .mint_store
-            .load_events(&issuer_request_id.to_string())
-            .await
-            .unwrap();
-        let retry_started = stored
-            .iter()
-            .filter(|event| {
-                matches!(event.payload, MintEvent::MintRetryStarted { .. })
-            })
-            .count();
+        let retry_started = count_events_of_type(
+            &fixture.pool,
+            &issuer_request_id,
+            "MintEvent::MintRetryStarted",
+        )
+        .await;
         assert_eq!(
             retry_started, 0,
             "A failed submission must not emit MintRetryStarted"
@@ -3852,9 +3868,9 @@ pub(crate) mod tests {
         fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Manual,
@@ -3879,33 +3895,36 @@ pub(crate) mod tests {
     fn pre_acceptance_failures_escalate_attempts_but_reuse_external_id() {
         let issuer_request_id = IssuerMintRequestId::random();
         let now = Utc::now();
-        let mut mint = Mint::default();
-        mint.apply(MintEvent::Initiated {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: TokenizationRequestId::new("tok-123"),
-            quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL"),
-            token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            initiated_at: now,
-        });
-        mint.apply(MintEvent::JournalConfirmed {
-            issuer_request_id: issuer_request_id.clone(),
-            confirmed_at: now,
-        });
-        mint.apply(MintEvent::MintingStarted {
-            issuer_request_id: issuer_request_id.clone(),
-            started_at: now,
-        });
+        let mut mint = replay::<Mint>(vec![
+            MintEvent::Initiated {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("tok-123"),
+                quantity: Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::new("base"),
+                client_id: ClientId::new(),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                initiated_at: now,
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: now,
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: now,
+            },
+        ])
+        .unwrap()
+        .unwrap();
 
         // failed_at far in the past so every retry window has elapsed; the
         // decision then turns only on the escalating attempt counter.
         let failed_at = now - ChronoDuration::hours(3);
 
         // First submission failure from Minting: attempts = 1, retryable.
-        mint.apply(MintEvent::MintingFailed {
+        mint.apply_event(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "submission rejected".to_string(),
             failed_at,
@@ -3919,7 +3938,7 @@ pub(crate) mod tests {
         // retryable attempt), then a fifth exhausts the automatic schedule —
         // proving the counter escalates without a FireblocksSubmitted record.
         for _ in 0..3 {
-            mint.apply(MintEvent::MintingFailed {
+            mint.apply_event(MintEvent::MintingFailed {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
@@ -3930,7 +3949,7 @@ pub(crate) mod tests {
             AutomaticRetryDecision::Ready
         );
 
-        mint.apply(MintEvent::MintingFailed {
+        mint.apply_event(MintEvent::MintingFailed {
             issuer_request_id,
             error: "submission rejected".to_string(),
             failed_at,
@@ -3944,12 +3963,12 @@ pub(crate) mod tests {
         assert_eq!(mint.next_retry_attempt(), 1);
     }
 
-    #[test]
-    fn test_recover_from_receipt_rejects_journal_confirmed() {
+    #[tokio::test]
+    async fn test_recover_from_receipt_rejects_journal_confirmed() {
         let issuer_request_id = IssuerMintRequestId::random();
         let now = Utc::now();
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![
                 MintEvent::Initiated {
                     issuer_request_id: issuer_request_id.clone(),
@@ -3974,23 +3993,25 @@ pub(crate) mod tests {
             .when(MintCommand::RecoverFromReceipt {
                 issuer_request_id,
                 tx_hash: b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            });
+            })
+            .await
+            .then_expect_error();
 
         assert!(
             matches!(
-                validator.inspect_result(),
-                Err(MintError::NotRecoverable { .. })
+                error,
+                LifecycleError::Apply(MintError::NotRecoverable { .. })
             ),
             "RecoverFromReceipt should reject JournalConfirmed state"
         );
     }
 
-    #[test]
-    fn test_recover_from_receipt_rejects_minting() {
+    #[tokio::test]
+    async fn test_recover_from_receipt_rejects_minting() {
         let issuer_request_id = IssuerMintRequestId::random();
         let now = Utc::now();
 
-        let validator = MintTestFramework::with(test_mint_services())
+        let error = TestHarness::<Mint>::with(test_mint_services().await)
             .given(vec![
                 MintEvent::Initiated {
                     issuer_request_id: issuer_request_id.clone(),
@@ -4019,12 +4040,14 @@ pub(crate) mod tests {
             .when(MintCommand::RecoverFromReceipt {
                 issuer_request_id,
                 tx_hash: b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            });
+            })
+            .await
+            .then_expect_error();
 
         assert!(
             matches!(
-                validator.inspect_result(),
-                Err(MintError::NotRecoverable { .. })
+                error,
+                LifecycleError::Apply(MintError::NotRecoverable { .. })
             ),
             "RecoverFromReceipt should reject Minting state"
         );
@@ -4049,7 +4072,7 @@ pub(crate) mod tests {
             journal_confirmed_at: now,
         };
 
-        let mut mint = Mint::MintingFailed {
+        let mint = Mint::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("tok-123"),
             quantity: Quantity::new(Decimal::from(100)),
@@ -4080,6 +4103,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
+        sqlx::migrate!().run(&pool).await.unwrap();
+
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
@@ -4091,12 +4116,9 @@ pub(crate) mod tests {
             bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
         };
 
-        let sink = EventSink::default();
-
         let result = mint
             .handle_recover_from_receipt(
                 &services,
-                &sink,
                 issuer_request_id,
                 b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
             )

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1,8 +1,8 @@
 use alloy::primitives::TxHash;
 use async_trait::async_trait;
 use chrono::Utc;
-use cqrs_es::{AggregateContext, AggregateError, CqrsFramework, EventStore};
-use sqlite_es::SqliteCqrs;
+use cqrs_es::AggregateError;
+use event_sorcery::{LifecycleError, Store};
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, error, info, warn};
@@ -12,18 +12,17 @@ use super::{
     MintRecoveryMode,
 };
 use crate::receipt_inventory::ItnReceiptHandler;
-use crate::{MintCqrs, MintEventStore};
 
 /// Production handler that triggers mint recovery when an ITN receipt is
 /// discovered by the receipt monitor.
 #[derive(Clone)]
 pub(crate) struct MintRecoveryHandler {
-    mint_cqrs: Arc<SqliteCqrs<Mint>>,
+    mint_store: Arc<Store<Mint>>,
 }
 
 impl MintRecoveryHandler {
-    pub(crate) const fn new(mint_cqrs: Arc<SqliteCqrs<Mint>>) -> Self {
-        Self { mint_cqrs }
+    pub(crate) const fn new(mint_store: Arc<Store<Mint>>) -> Self {
+        Self { mint_store }
     }
 }
 
@@ -34,9 +33,9 @@ impl ItnReceiptHandler for MintRecoveryHandler {
         issuer_request_id: IssuerMintRequestId,
         tx_hash: TxHash,
     ) {
-        let mint_cqrs = self.mint_cqrs.clone();
+        let mint_store = self.mint_store.clone();
         tokio::spawn(async move {
-            drive_recovery(&mint_cqrs, issuer_request_id, |id| {
+            drive_recovery(&mint_store, issuer_request_id, |id| {
                 MintCommand::RecoverFromReceipt {
                     issuer_request_id: id,
                     tx_hash,
@@ -64,14 +63,11 @@ pub(crate) enum DriveOutcome {
 }
 
 /// Drives a mint through recovery to completion using `MintCommand::Recover`.
-pub(crate) async fn recover_mint<ES>(
-    mint_cqrs: &CqrsFramework<Mint, ES>,
+pub(crate) async fn recover_mint(
+    mint_store: &Store<Mint>,
     issuer_request_id: IssuerMintRequestId,
-) -> DriveOutcome
-where
-    ES: EventStore<Mint>,
-{
-    drive_recovery(mint_cqrs, issuer_request_id, |id| MintCommand::Recover {
+) -> DriveOutcome {
+    drive_recovery(mint_store, issuer_request_id, |id| MintCommand::Recover {
         issuer_request_id: id,
         mode: MintRecoveryMode::Automatic,
     })
@@ -104,14 +100,12 @@ const MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS: usize = 8;
 const MAX_SCHEDULED_RECOVERY_PENDING_POLLS: usize = 360;
 
 pub(crate) fn spawn_scheduled_mint_recovery(
-    mint_cqrs: MintCqrs,
-    event_store: MintEventStore,
+    mint_store: Arc<Store<Mint>>,
     issuer_request_id: IssuerMintRequestId,
 ) {
     tokio::spawn(async move {
         recover_mint_until_automatic_budget_exhausted(
-            mint_cqrs.as_ref(),
-            event_store.as_ref(),
+            mint_store.as_ref(),
             issuer_request_id,
             SCHEDULED_RECOVERY_BACKOFF,
             MAX_SCHEDULED_RECOVERY_PENDING_POLLS,
@@ -120,25 +114,29 @@ pub(crate) fn spawn_scheduled_mint_recovery(
     });
 }
 
-async fn recover_mint_until_automatic_budget_exhausted<ES>(
-    mint_cqrs: &CqrsFramework<Mint, ES>,
-    event_store: &ES,
+async fn recover_mint_until_automatic_budget_exhausted(
+    mint_store: &Store<Mint>,
     issuer_request_id: IssuerMintRequestId,
     backoff: Duration,
     max_pending_polls: usize,
-) where
-    ES: EventStore<Mint>,
-{
-    let aggregate_id = issuer_request_id.to_string();
+) {
     let mut retry_wakeups = 0;
     let mut failure_backoffs = 0;
     let mut pending_polls = 0;
     let mut polled_tx_id: Option<String> = None;
 
     loop {
-        let mut context = match event_store.load_aggregate(&aggregate_id).await
-        {
-            Ok(context) => context,
+        let mint = match mint_store.load(&issuer_request_id).await {
+            Ok(Some(mint)) => mint,
+            // A missing mint cannot be recovered — the same outcome the old
+            // default (`Uninitialized`) aggregate produced via
+            // `AutomaticRetryDecision::NotRecoverable`.
+            Ok(None) => {
+                debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                    "Mint not found for scheduled recovery"
+                );
+                return;
+            }
             Err(err) => {
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     error = %err,
@@ -152,15 +150,16 @@ async fn recover_mint_until_automatic_budget_exhausted<ES>(
         // budget: when recovery advances to a new submitted tx, reset the
         // counter so a healthy retry is not abandoned because a prior tx
         // already spent the budget.
-        let current_tx_id = context.aggregate().pending_fireblocks_tx_id();
+        let current_tx_id = mint.pending_fireblocks_tx_id();
         if current_tx_id != polled_tx_id {
             pending_polls = 0;
             polled_tx_id = current_tx_id;
         }
 
-        match context.aggregate().automatic_retry_decision(Utc::now()) {
+        match mint.automatic_retry_decision(Utc::now()) {
             AutomaticRetryDecision::Ready => {
-                match recover_mint(mint_cqrs, issuer_request_id.clone()).await {
+                match recover_mint(mint_store, issuer_request_id.clone()).await
+                {
                     DriveOutcome::Done | DriveOutcome::Exhausted => return,
                     // A still-pending Fireblocks tx is healthy; poll it on a
                     // generous budget separate from transient failures.
@@ -252,19 +251,14 @@ const MAX_RECOVERY_ATTEMPTS: usize = 10;
 ///
 /// Bounded to [`MAX_RECOVERY_ATTEMPTS`] iterations to prevent infinite
 /// spinning if a command returns `Ok(())` without advancing state.
-async fn drive_recovery<ES>(
-    mint_cqrs: &CqrsFramework<Mint, ES>,
+async fn drive_recovery(
+    mint_store: &Store<Mint>,
     issuer_request_id: IssuerMintRequestId,
     make_command: impl Fn(IssuerMintRequestId) -> MintCommand,
-) -> DriveOutcome
-where
-    ES: EventStore<Mint>,
-{
-    let aggregate_id = issuer_request_id.to_string();
-
+) -> DriveOutcome {
     for attempt in 1..=MAX_RECOVERY_ATTEMPTS {
-        let result = mint_cqrs
-            .execute(&aggregate_id, make_command(issuer_request_id.clone()))
+        let result = mint_store
+            .send(&issuer_request_id, make_command(issuer_request_id.clone()))
             .await;
 
         match result {
@@ -274,36 +268,36 @@ where
                     "Recovery step succeeded, continuing"
                 );
             }
-            Err(AggregateError::UserError(MintError::NotRecoverable {
-                current_state,
-            })) => {
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                MintError::NotRecoverable { current_state },
+            ))) => {
                 info!(target: "mint", issuer_request_id = %issuer_request_id,
                     current_state,
                     "Mint recovery complete"
                 );
                 return DriveOutcome::Done;
             }
-            Err(AggregateError::UserError(MintError::RetryNotDue {
-                retry_at,
-            })) => {
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                MintError::RetryNotDue { retry_at },
+            ))) => {
                 info!(target: "mint", issuer_request_id = %issuer_request_id,
                     %retry_at,
                     "Mint recovery paused until retry window"
                 );
                 return DriveOutcome::RetryNotDue;
             }
-            Err(AggregateError::UserError(
+            Err(AggregateError::UserError(LifecycleError::Apply(
                 MintError::AutomaticRetriesExhausted { attempts },
-            )) => {
+            ))) => {
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     attempts,
                     "Automatic mint retries exhausted"
                 );
                 return DriveOutcome::Exhausted;
             }
-            Err(AggregateError::UserError(
+            Err(AggregateError::UserError(LifecycleError::Apply(
                 MintError::FireblocksTxStillPending { fireblocks_tx_id },
-            )) => {
+            ))) => {
                 info!(target: "mint", issuer_request_id = %issuer_request_id,
                     fireblocks_tx_id,
                     "Mint recovery paused while Fireblocks transaction is pending"
@@ -321,7 +315,7 @@ where
     }
 
     error!(target: "mint", issuer_request_id = %issuer_request_id,
-        aggregate_id,
+        aggregate_id = %issuer_request_id,
         max_attempts = MAX_RECOVERY_ATTEMPTS,
         "Mint recovery exceeded maximum attempts without reaching terminal state"
     );
@@ -333,26 +327,142 @@ where
 mod tests {
     use alloy::primitives::{Address, B256, U256, address, b256, uint};
     use chrono::Utc;
-    use cqrs_es::AggregateContext;
+    use event_sorcery::{StoreBuilder, test_store};
     use rust_decimal::Decimal;
+    use sqlx::sqlite::SqlitePoolOptions;
     use tracing::Level;
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::mint::tests::{MintTestFixture, VAULT};
+    use crate::alpaca::mock::MockAlpacaService;
+    use crate::mint::tests::{BOT, VAULT};
     use crate::mint::{
-        ClientId, IssuerMintRequestId, MintEvent, Network, Quantity,
-        TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        ClientId, IssuerMintRequestId, MintEvent, MintServices, Network,
+        Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::receipt_inventory::{
-        ReceiptId, ReceiptInventoryCommand, ReceiptSource, Shares,
+        CqrsReceiptService, ReceiptId, ReceiptInventory,
+        ReceiptInventoryCommand, ReceiptSource, Shares,
     };
     use crate::test_utils::log_count_at;
+    use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
+    use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
         MultiBurnResult, ReceiptInformation, SubmittedTx, VaultError,
         VaultService,
     };
+
+    /// Builds a real event-sorcery [`Store<Mint>`] backed by an in-memory
+    /// SQLite pool, wired with the same services the production recovery flow
+    /// uses (vault, Alpaca, receipt inventory). The [`TokenizedAsset`]
+    /// projection is populated with the AAPL -> [`VAULT`] mapping so the
+    /// recovery vault lookup (`find_vault_by_underlying`) resolves.
+    struct MintRecoveryFixture {
+        mint_store: Arc<Store<Mint>>,
+        receipt_store: Arc<Store<ReceiptInventory>>,
+        pool: sqlx::SqlitePool,
+    }
+
+    impl MintRecoveryFixture {
+        async fn new() -> Self {
+            Self::new_with_vault(Arc::new(MockVaultService::new_success()))
+                .await
+        }
+
+        async fn new_with_vault(vault: Arc<dyn VaultService>) -> Self {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect(":memory:")
+                .await
+                .unwrap();
+
+            sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+            let (asset_store, _asset_projection) =
+                StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                    .build(())
+                    .await
+                    .unwrap();
+
+            asset_store
+                .send(
+                    &UnderlyingSymbol::new("AAPL"),
+                    TokenizedAssetCommand::Add {
+                        underlying: UnderlyingSymbol::new("AAPL"),
+                        token: TokenSymbol::new("tAAPL"),
+                        network: Network::new("base"),
+                        vault: VAULT,
+                    },
+                )
+                .await
+                .unwrap();
+
+            let receipt_store =
+                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+
+            let services = MintServices {
+                vault,
+                alpaca: Arc::new(MockAlpacaService::new_success()),
+                receipts: Arc::new(CqrsReceiptService::new(
+                    receipt_store.clone(),
+                )),
+                pool: pool.clone(),
+                bot: BOT,
+            };
+
+            let mint_store =
+                Arc::new(test_store::<Mint>(pool.clone(), services));
+
+            Self { mint_store, receipt_store, pool }
+        }
+
+        /// Seeds the event store with raw `Mint` events, putting the aggregate
+        /// directly into the desired lifecycle state. Mirrors the e2e
+        /// setup-phase pattern of writing rows to the `events` table; the
+        /// running service then reacts to them during the scenario.
+        async fn seed_mint_events(
+            &self,
+            issuer_request_id: &IssuerMintRequestId,
+            events: Vec<MintEvent>,
+        ) {
+            let aggregate_id = issuer_request_id.to_string();
+
+            for (offset, event) in events.into_iter().enumerate() {
+                let sequence = i64::try_from(offset).unwrap() + 1;
+                let payload = serde_json::to_value(&event).unwrap();
+                let variant = payload
+                    .as_object()
+                    .and_then(|map| map.keys().next())
+                    .expect("MintEvent serializes as an externally-tagged enum")
+                    .clone();
+                let event_type = format!("MintEvent::{variant}");
+                let payload_str = payload.to_string();
+
+                sqlx::query(
+                    "
+                    INSERT INTO events (
+                        aggregate_type,
+                        aggregate_id,
+                        sequence,
+                        event_type,
+                        event_version,
+                        payload,
+                        metadata
+                    )
+                    VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
+                    ",
+                )
+                .bind(&aggregate_id)
+                .bind(sequence)
+                .bind(&event_type)
+                .bind(&payload_str)
+                .execute(&self.pool)
+                .await
+                .unwrap();
+            }
+        }
+    }
 
     /// Vault whose Fireblocks transaction never finalizes — every status check
     /// returns `Pending`. Used to exercise the scheduled-recovery backoff.
@@ -535,9 +645,9 @@ mod tests {
 
     async fn setup_with_receipt_and_events(
         events: Vec<MintEvent>,
-    ) -> MintTestFixture {
+    ) -> MintRecoveryFixture {
         let issuer_request_id = test_issuer_request_id();
-        let fixture = MintTestFixture::new().await;
+        let fixture = MintRecoveryFixture::new().await;
 
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
@@ -571,7 +681,7 @@ mod tests {
             .await
             .unwrap();
 
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
 
         fixture
     }
@@ -583,18 +693,16 @@ mod tests {
         let events = minting_failed_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
 
-        recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
+        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
+            .await;
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
         let test = "minting_failed_with_receipt_recovers_to_completed";
         assert_eq!(
@@ -617,18 +725,16 @@ mod tests {
         let events = callback_pending_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
 
-        recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
+        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
+            .await;
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
         let test = "callback_pending_recovers_to_completed";
         assert_eq!(
@@ -653,9 +759,9 @@ mod tests {
         let fixture = setup_with_receipt_and_events(events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -664,16 +770,13 @@ mod tests {
             .await
             .unwrap();
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state after one Recover, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
         let test = "single_recover_command_from_minting_reaches_completed";
         assert_eq!(
@@ -691,9 +794,9 @@ mod tests {
         let fixture = setup_with_receipt_and_events(events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -702,16 +805,13 @@ mod tests {
             .await
             .unwrap();
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state after one Recover, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
         let test =
             "single_recover_command_from_minting_failed_reaches_completed";
@@ -731,13 +831,13 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
         let events = fireblocks_submitted_events(&issuer_request_id);
         // No pre-existing receipt — the mock confirm path produces TokensMinted.
-        let fixture = MintTestFixture::new().await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
 
         fixture
-            .mint_cqrs
-            .execute(
-                &issuer_request_id.to_string(),
+            .mint_store
+            .send(
+                &issuer_request_id,
                 MintCommand::Recover {
                     issuer_request_id: issuer_request_id.clone(),
                     mode: MintRecoveryMode::Automatic,
@@ -746,16 +846,13 @@ mod tests {
             .await
             .unwrap();
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state after one Recover, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
         let test = "single_recover_command_from_fireblocks_submitted_reaches_completed";
         assert_eq!(
@@ -771,18 +868,16 @@ mod tests {
         let events = completed_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
 
-        recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
+        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
+            .await;
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(context.aggregate(), Mint::Completed { .. }),
+            matches!(mint, Mint::Completed { .. }),
             "Expected Completed state, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
 
         let test = "completed_mint_returns_cleanly";
@@ -798,11 +893,12 @@ mod tests {
         let failed_at = Utc::now() - chrono::Duration::minutes(2);
         let events = fireblocks_failed_events(&issuer_request_id, failed_at);
         let fixture =
-            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+            MintRecoveryFixture::new_with_vault(Arc::new(PendingMintVault))
+                .await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let outcome =
-            recover_mint(fixture.mint_cqrs.as_ref(), issuer_request_id).await;
+            recover_mint(fixture.mint_store.as_ref(), issuer_request_id).await;
 
         assert_eq!(outcome, DriveOutcome::Pending);
     }
@@ -819,14 +915,14 @@ mod tests {
         let failed_at = Utc::now() - chrono::Duration::minutes(2);
         let events = fireblocks_failed_events(&issuer_request_id, failed_at);
         let fixture =
-            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
+            MintRecoveryFixture::new_with_vault(Arc::new(PendingMintVault))
+                .await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let backoff = Duration::from_millis(5);
         let max_pending_polls = 8;
         let start = tokio::time::Instant::now();
         recover_mint_until_automatic_budget_exhausted(
-            fixture.mint_cqrs.as_ref(),
             fixture.mint_store.as_ref(),
             issuer_request_id.clone(),
             backoff,
@@ -842,15 +938,12 @@ mod tests {
              poll, elapsed={elapsed:?}"
         );
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
         assert!(
-            matches!(context.aggregate(), Mint::MintingFailed { .. }),
+            matches!(mint, Mint::MintingFailed { .. }),
             "Mint stays MintingFailed while the tx remains pending, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
 
         let test = "scheduled_recovery_backs_off_while_fireblocks_tx_pending";
@@ -871,24 +964,24 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
         let events = fireblocks_submitted_events(&issuer_request_id);
         let fixture =
-            MintTestFixture::new_with_vault(Arc::new(PendingMintVault)).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        let outcome =
-            recover_mint(fixture.mint_cqrs.as_ref(), issuer_request_id.clone())
+            MintRecoveryFixture::new_with_vault(Arc::new(PendingMintVault))
                 .await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let outcome = recover_mint(
+            fixture.mint_store.as_ref(),
+            issuer_request_id.clone(),
+        )
+        .await;
 
         assert_eq!(outcome, DriveOutcome::Pending);
 
-        let mut context = fixture
-            .mint_store
-            .load_aggregate(&issuer_request_id.to_string())
-            .await
-            .unwrap();
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
         assert!(
-            matches!(context.aggregate(), Mint::FireblocksSubmitted { .. }),
+            matches!(mint, Mint::FireblocksSubmitted { .. }),
             "A pending tx must leave the mint in FireblocksSubmitted, got: {}",
-            context.aggregate().state_name()
+            mint.state_name()
         );
     }
 }

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -1,18 +1,13 @@
 use alloy::primitives::{Address, B256, U256};
 use chrono::{DateTime, Utc};
-use cqrs_es::{EventEnvelope, View};
 use serde::{Deserialize, Serialize};
-use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
 use sqlx::{Pool, Sqlite};
-use std::sync::Arc;
-use tracing::debug;
 use uuid::Uuid;
 
 use super::{
-    ClientId, IssuerMintRequestId, Mint, MintError, MintEvent, Network,
-    Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+    ClientId, IssuerMintRequestId, Network, Quantity, TokenSymbol,
+    TokenizationRequestId, UnderlyingSymbol,
 };
-use crate::replay::{ReplayError, replay_all_or_fail};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MintViewError {
@@ -20,34 +15,17 @@ pub(crate) enum MintViewError {
     Database(#[from] sqlx::Error),
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
-    #[error("Replay error: {0}")]
-    Replay(#[from] ReplayError<MintError>),
     #[error("UUID parse error: {0}")]
     Uuid(#[from] uuid::Error),
 }
 
-/// Replays all `Mint` events through the `mint_view`.
+/// Read model for a mint, projected from the `mint_view` table.
 ///
-/// Re-projects the view from existing events in the event store. This is used at
-/// startup to ensure the view is in sync with events after manual event store
-/// modifications or schema changes.
-pub async fn replay_mint_view(pool: Pool<Sqlite>) -> Result<(), MintViewError> {
-    debug!(target: "mint", "Rebuilding mint view from events");
-
-    sqlx::query!("DELETE FROM mint_view").execute(&pool).await?;
-
-    let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-        pool.clone(),
-        "mint_view".to_string(),
-    ));
-    let event_repo = SqliteEventRepository::new(pool);
-    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
-
-    debug!(target: "mint", "Mint view rebuild complete");
-
-    Ok(())
-}
-
+/// `mint_view` stores the event-sorcery `Lifecycle<Mint>` payload
+/// (`{"Live": {...}}`). The `find_*` queries extract the `$.Live` sub-object —
+/// which is one of the live `Mint` variants — and deserialize it into this
+/// enum, which mirrors those variants field-for-field. `NotFound` is the
+/// query-miss sentinel and is never a deserialize target.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub(crate) enum MintView {
     #[default]
@@ -100,6 +78,21 @@ pub(crate) enum MintView {
         initiated_at: DateTime<Utc>,
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
+    },
+    FireblocksSubmitted {
+        issuer_request_id: IssuerMintRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        quantity: Quantity,
+        underlying: UnderlyingSymbol,
+        token: TokenSymbol,
+        network: Network,
+        client_id: ClientId,
+        wallet: Address,
+        initiated_at: DateTime<Utc>,
+        journal_confirmed_at: DateTime<Utc>,
+        minting_started_at: DateTime<Utc>,
+        external_tx_id: String,
+        fireblocks_tx_id: String,
     },
     CallbackPending {
         issuer_request_id: IssuerMintRequestId,
@@ -168,384 +161,11 @@ impl MintView {
             Self::JournalConfirmed { .. } => "JournalConfirmed",
             Self::JournalRejected { .. } => "JournalRejected",
             Self::Minting { .. } => "Minting",
+            Self::FireblocksSubmitted { .. } => "FireblocksSubmitted",
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
             Self::Completed { .. } => "Completed",
             Self::Closed { .. } => "Closed",
-        }
-    }
-
-    fn handle_initiated(&mut self, event: &MintEvent) {
-        let MintEvent::Initiated {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        } = event
-        else {
-            return;
-        };
-
-        *self = Self::Initiated {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: tokenization_request_id.clone(),
-            quantity: quantity.clone(),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: network.clone(),
-            client_id: *client_id,
-            wallet: *wallet,
-            initiated_at: *initiated_at,
-        };
-    }
-
-    fn handle_journal_confirmed(&mut self, confirmed_at: DateTime<Utc>) {
-        let Self::Initiated {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::JournalConfirmed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at: confirmed_at,
-        };
-    }
-
-    fn handle_journal_rejected(
-        &mut self,
-        reason: String,
-        rejected_at: DateTime<Utc>,
-    ) {
-        let Self::Initiated {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::JournalRejected {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            reason,
-            rejected_at,
-        };
-    }
-
-    fn handle_minting_started(&mut self, started_at: DateTime<Utc>) {
-        let Self::JournalConfirmed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::Minting {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            minting_started_at: started_at,
-        };
-    }
-
-    fn handle_tokens_minted(
-        &mut self,
-        tx_hash: B256,
-        receipt_id: U256,
-        shares_minted: U256,
-        gas_used: Option<u64>,
-        block_number: u64,
-        minted_at: DateTime<Utc>,
-    ) {
-        let (Self::Minting {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            ..
-        }
-        | Self::MintingFailed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            ..
-        }) = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::CallbackPending {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used,
-            block_number,
-            minted_at,
-        };
-    }
-
-    fn handle_minting_failed(
-        &mut self,
-        error: String,
-        failed_at: DateTime<Utc>,
-    ) {
-        let Self::Minting {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            ..
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::MintingFailed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            error,
-            failed_at,
-        };
-    }
-
-    fn handle_mint_completed(&mut self, completed_at: DateTime<Utc>) {
-        let Self::CallbackPending {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used,
-            block_number,
-            minted_at,
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::Completed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used,
-            block_number,
-            minted_at,
-            completed_at,
-        };
-    }
-
-    fn handle_mint_retry_started(&mut self, started_at: DateTime<Utc>) {
-        let Self::MintingFailed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            ..
-        } = self.clone()
-        else {
-            return;
-        };
-
-        *self = Self::Minting {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            minting_started_at: started_at,
-        };
-    }
-}
-
-impl View<Mint> for MintView {
-    fn update(&mut self, event: &EventEnvelope<Mint>) {
-        match &event.payload {
-            MintEvent::Initiated { .. } => {
-                self.handle_initiated(&event.payload);
-            }
-            MintEvent::JournalConfirmed { confirmed_at, .. } => {
-                self.handle_journal_confirmed(*confirmed_at);
-            }
-            MintEvent::JournalRejected { reason, rejected_at, .. } => {
-                self.handle_journal_rejected(reason.clone(), *rejected_at);
-            }
-            MintEvent::MintingStarted { started_at, .. } => {
-                self.handle_minting_started(*started_at);
-            }
-            MintEvent::TokensMinted {
-                tx_hash,
-                receipt_id,
-                shares_minted,
-                gas_used,
-                block_number,
-                minted_at,
-                ..
-            } => {
-                self.handle_tokens_minted(
-                    *tx_hash,
-                    *receipt_id,
-                    *shares_minted,
-                    Some(*gas_used),
-                    *block_number,
-                    *minted_at,
-                );
-            }
-            MintEvent::MintingFailed { error, failed_at, .. } => {
-                self.handle_minting_failed(error.clone(), *failed_at);
-            }
-            MintEvent::MintCompleted { completed_at, .. } => {
-                self.handle_mint_completed(*completed_at);
-            }
-            MintEvent::ExistingMintRecovered {
-                tx_hash,
-                receipt_id,
-                shares_minted,
-                block_number,
-                recovered_at,
-                ..
-            } => {
-                self.handle_tokens_minted(
-                    *tx_hash,
-                    *receipt_id,
-                    *shares_minted,
-                    None,
-                    *block_number,
-                    *recovered_at,
-                );
-            }
-            MintEvent::FireblocksSubmitted { .. } => {
-                // View stays in Minting — FireblocksSubmitted is an internal
-                // detail that doesn't change the query-facing state.
-            }
-            MintEvent::MintRetryStarted { started_at, .. } => {
-                self.handle_mint_retry_started(*started_at);
-            }
-            MintEvent::MintClosed { issuer_request_id, reason, closed_at } => {
-                *self = Self::Closed {
-                    issuer_request_id: issuer_request_id.clone(),
-                    reason: reason.clone(),
-                    closed_at: *closed_at,
-                };
-            }
         }
     }
 }
@@ -557,7 +177,7 @@ pub(crate) async fn find_by_issuer_request_id(
     let issuer_request_id_str = issuer_request_id.to_string();
     let row = sqlx::query!(
         r#"
-        SELECT payload as "payload!: String"
+        SELECT json_extract(payload, '$.Live') as "live: String"
         FROM mint_view
         WHERE view_id = ?
         "#,
@@ -566,11 +186,11 @@ pub(crate) async fn find_by_issuer_request_id(
     .fetch_optional(pool)
     .await?;
 
-    let Some(row) = row else {
+    let Some(live) = row.and_then(|row| row.live) else {
         return Ok(None);
     };
 
-    let view: MintView = serde_json::from_str(&row.payload)?;
+    let view: MintView = serde_json::from_str(&live)?;
 
     Ok(Some(view))
 }
@@ -583,21 +203,25 @@ pub(crate) async fn find_all_recoverable_mints(
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
     let rows = sqlx::query!(
         r#"
-        SELECT view_id as "view_id!: String", payload as "payload!: String"
+        SELECT
+            view_id as "view_id!: String",
+            json_extract(payload, '$.Live') as "live: String"
         FROM mint_view
-        WHERE json_extract(payload, '$.JournalConfirmed') IS NOT NULL
-           OR json_extract(payload, '$.Minting') IS NOT NULL
-           OR json_extract(payload, '$.MintingFailed') IS NOT NULL
-           OR json_extract(payload, '$.CallbackPending') IS NOT NULL
+        WHERE json_extract(payload, '$.Live.JournalConfirmed') IS NOT NULL
+           OR json_extract(payload, '$.Live.Minting') IS NOT NULL
+           OR json_extract(payload, '$.Live.FireblocksSubmitted') IS NOT NULL
+           OR json_extract(payload, '$.Live.MintingFailed') IS NOT NULL
+           OR json_extract(payload, '$.Live.CallbackPending') IS NOT NULL
         "#
     )
     .fetch_all(pool)
     .await?;
 
     rows.into_iter()
-        .map(|row| {
-            let view: MintView = serde_json::from_str(&row.payload)?;
-            let id = Uuid::parse_str(&row.view_id)?;
+        .filter_map(|row| row.live.map(|live| (row.view_id, live)))
+        .map(|(view_id, live)| {
+            let view: MintView = serde_json::from_str(&live)?;
+            let id = Uuid::parse_str(&view_id)?;
             Ok((IssuerMintRequestId::new(id), view))
         })
         .collect()
@@ -616,23 +240,27 @@ pub(crate) async fn find_stuck(
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
     let rows = sqlx::query!(
         r#"
-        SELECT view_id as "view_id!: String", payload as "payload!: String"
+        SELECT
+            view_id as "view_id!: String",
+            json_extract(payload, '$.Live') as "live: String"
         FROM mint_view
-        WHERE json_extract(payload, '$.Initiated')        IS NOT NULL
-           OR json_extract(payload, '$.JournalConfirmed') IS NOT NULL
-           OR json_extract(payload, '$.JournalRejected')  IS NOT NULL
-           OR json_extract(payload, '$.Minting')          IS NOT NULL
-           OR json_extract(payload, '$.CallbackPending')  IS NOT NULL
-           OR json_extract(payload, '$.MintingFailed')    IS NOT NULL
+        WHERE json_extract(payload, '$.Live.Initiated')           IS NOT NULL
+           OR json_extract(payload, '$.Live.JournalConfirmed')    IS NOT NULL
+           OR json_extract(payload, '$.Live.JournalRejected')     IS NOT NULL
+           OR json_extract(payload, '$.Live.Minting')             IS NOT NULL
+           OR json_extract(payload, '$.Live.FireblocksSubmitted') IS NOT NULL
+           OR json_extract(payload, '$.Live.CallbackPending')     IS NOT NULL
+           OR json_extract(payload, '$.Live.MintingFailed')       IS NOT NULL
         "#
     )
     .fetch_all(pool)
     .await?;
 
     rows.into_iter()
-        .map(|row| {
-            let view: MintView = serde_json::from_str(&row.payload)?;
-            let id = Uuid::parse_str(&row.view_id)?;
+        .filter_map(|row| row.live.map(|live| (row.view_id, live)))
+        .map(|(view_id, live)| {
+            let view: MintView = serde_json::from_str(&live)?;
+            let id = Uuid::parse_str(&view_id)?;
             Ok((IssuerMintRequestId::new(id), view))
         })
         .collect()
@@ -641,100 +269,53 @@ pub(crate) async fn find_stuck(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, b256, uint};
-    use cqrs_es::EventEnvelope;
-    use cqrs_es::persist::GenericQuery;
-    use event_sorcery::test_store;
+    use event_sorcery::{StoreBuilder, test_store};
     use rust_decimal::Decimal;
-    use sqlite_es::{SqliteCqrs, SqliteViewRepository, sqlite_cqrs};
     use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
-    use std::collections::HashMap;
     use std::sync::Arc;
 
     use super::*;
     use crate::alpaca::mock::MockAlpacaService;
-    use crate::mint::{Mint, MintCommand, MintEvent, MintServices};
+    use crate::mint::{Mint, MintCommand, MintServices};
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
     use crate::vault::mock::MockVaultService;
 
-    struct TestHarness {
-        pool: Pool<Sqlite>,
-        cqrs: SqliteCqrs<Mint>,
+    /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given live
+    /// `Mint` variant. The projection stores `{"Live": {"<Variant>": {...}}}`,
+    /// which the `find_*` query helpers read via `$.Live`; serializing a
+    /// `MintView` (which mirrors the live `Mint` variants field-for-field)
+    /// produces the `{"<Variant>": {...}}` body, so wrapping it under `Live`
+    /// reproduces exactly what the running projection would write.
+    async fn insert_mint_view(
+        pool: &Pool<Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        view: &MintView,
+    ) {
+        let view_id = issuer_request_id.to_string();
+        let live = serde_json::to_value(view).unwrap();
+        let payload =
+            serde_json::to_string(&serde_json::json!({ "Live": live }))
+                .unwrap();
+        sqlx::query!(
+            "INSERT INTO mint_view (view_id, version, payload) VALUES (?, 1, ?)",
+            view_id,
+            payload,
+        )
+        .execute(pool)
+        .await
+        .unwrap();
     }
 
-    impl TestHarness {
-        async fn new() -> Self {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect(":memory:")
-                .await
-                .expect("Failed to create in-memory database");
+    fn mint_services(pool: Pool<Sqlite>) -> MintServices {
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-            sqlx::migrate!("./migrations")
-                .run(&pool)
-                .await
-                .expect("Failed to run migrations");
-
-            let receipt_store =
-                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-            let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-            let mint_services = MintServices {
-                vault: Arc::new(MockVaultService::new_success()),
-                alpaca: Arc::new(MockAlpacaService::new_success()),
-                pool: pool.clone(),
-                bot,
-                receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-            };
-
-            let view_repo =
-                Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-                    pool.clone(),
-                    "mint_view".to_string(),
-                ));
-            let query = GenericQuery::new(view_repo);
-            let cqrs =
-                sqlite_cqrs(pool.clone(), vec![Box::new(query)], mint_services);
-
-            Self { pool, cqrs }
-        }
-
-        async fn initiate_mint(&self, issuer_request_id: &IssuerMintRequestId) {
-            self.cqrs
-                .execute(
-                    &issuer_request_id.to_string(),
-                    MintCommand::Initiate {
-                        issuer_request_id: issuer_request_id.clone(),
-                        tokenization_request_id: TokenizationRequestId::new(
-                            "alp-888",
-                        ),
-                        quantity: Quantity::new(Decimal::from(50)),
-                        underlying: UnderlyingSymbol::new("TSLA"),
-                        token: TokenSymbol::new("tTSLA"),
-                        network: Network::new("base"),
-                        client_id: ClientId::new(),
-                        wallet: address!(
-                            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
-                        ),
-                    },
-                )
-                .await
-                .expect("Failed to initiate mint");
-        }
-
-        async fn insert_view(
-            &self,
-            issuer_request_id: &IssuerMintRequestId,
-            view: &MintView,
-        ) {
-            let view_id = issuer_request_id.to_string();
-            let payload = serde_json::to_string(view).unwrap();
-            sqlx::query!(
-                "INSERT INTO mint_view (view_id, version, payload) VALUES (?, 1, ?)",
-                view_id,
-                payload,
-            )
-            .execute(&self.pool)
-            .await
-            .unwrap();
+        MintServices {
+            vault: Arc::new(MockVaultService::new_success()),
+            alpaca: Arc::new(MockAlpacaService::new_success()),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool,
+            bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
         }
     }
 
@@ -765,79 +346,39 @@ mod tests {
         pool
     }
 
-    #[test]
-    fn test_view_update_from_mint_initiated_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-
-        let event = MintEvent::Initiated {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: tokenization_request_id.clone(),
-            quantity: quantity.clone(),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: network.clone(),
-            client_id,
-            wallet,
-            initiated_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 1,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        let mut view = MintView::default();
-
-        assert!(matches!(view, MintView::NotFound));
-
-        view.update(&envelope);
-
-        let MintView::Initiated {
-            issuer_request_id: view_issuer_id,
-            tokenization_request_id: view_tokenization_id,
-            quantity: view_quantity,
-            underlying: view_underlying,
-            token: view_token,
-            network: view_network,
-            client_id: view_client_id,
-            wallet: view_wallet,
-            initiated_at: view_initiated_at,
-        } = view
-        else {
-            panic!("Expected Initiated variant")
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(view_tokenization_id, tokenization_request_id);
-        assert_eq!(view_quantity, quantity);
-        assert_eq!(view_underlying, underlying);
-        assert_eq!(view_token, token);
-        assert_eq!(view_network, network);
-        assert_eq!(view_client_id, client_id);
-        assert_eq!(view_wallet, wallet);
-        assert_eq!(view_initiated_at, initiated_at);
-    }
-
     #[tokio::test]
     async fn test_find_by_issuer_request_id_returns_view() {
-        let harness = TestHarness::new().await;
-        let TestHarness { pool, .. } = &harness;
+        let pool = setup_test_db().await;
+
+        let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
+            .build(mint_services(pool.clone()))
+            .await
+            .expect("Failed to build mint store");
 
         let issuer_request_id = IssuerMintRequestId::random();
 
-        harness.initiate_mint(&issuer_request_id).await;
+        store
+            .send(
+                &issuer_request_id,
+                MintCommand::Initiate {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: TokenizationRequestId::new(
+                        "alp-888",
+                    ),
+                    quantity: Quantity::new(Decimal::from(50)),
+                    underlying: UnderlyingSymbol::new("TSLA"),
+                    token: TokenSymbol::new("tTSLA"),
+                    network: Network::new("base"),
+                    client_id: ClientId::new(),
+                    wallet: address!(
+                        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    ),
+                },
+            )
+            .await
+            .expect("Failed to initiate mint");
 
-        let result = find_by_issuer_request_id(pool, &issuer_request_id)
+        let result = find_by_issuer_request_id(&pool, &issuer_request_id)
             .await
             .expect("Query should succeed");
 
@@ -880,900 +421,6 @@ mod tests {
         assert!(result.is_none());
     }
 
-    #[test]
-    fn test_view_update_from_journal_confirmed_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-
-        let mut view = MintView::Initiated {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        };
-
-        let confirmed_at = Utc::now();
-
-        let event = MintEvent::JournalConfirmed {
-            issuer_request_id: issuer_request_id.clone(),
-            confirmed_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 2,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::JournalConfirmed {
-            issuer_request_id: view_issuer_id,
-            journal_confirmed_at,
-            ..
-        } = view
-        else {
-            panic!("Expected JournalConfirmed variant")
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(journal_confirmed_at, confirmed_at);
-    }
-
-    #[test]
-    fn test_view_update_from_journal_rejected_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-
-        let mut view = MintView::Initiated {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        };
-
-        let rejected_at = Utc::now();
-        let reason = "Insufficient funds".to_string();
-
-        let event = MintEvent::JournalRejected {
-            issuer_request_id: issuer_request_id.clone(),
-            reason: reason.clone(),
-            rejected_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 2,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::JournalRejected {
-            issuer_request_id: view_issuer_id,
-            reason: view_reason,
-            rejected_at: view_rejected_at,
-            ..
-        } = view
-        else {
-            panic!("Expected JournalRejected variant")
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(view_reason, reason);
-        assert_eq!(view_rejected_at, rejected_at);
-    }
-
-    #[test]
-    fn test_view_update_from_tokens_minted_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let minting_started_at = Utc::now();
-
-        let mut view = MintView::Minting {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            minting_started_at,
-        };
-
-        let tx_hash = b256!(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-        );
-        let receipt_id = uint!(1_U256);
-        let shares_minted = uint!(100_000000000000000000_U256);
-        let gas_used = 50000;
-        let block_number = 1000;
-        let minted_at = Utc::now();
-
-        let event = MintEvent::TokensMinted {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used,
-            block_number,
-            minted_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 3,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::CallbackPending {
-            issuer_request_id: view_issuer_id,
-            tx_hash: view_tx_hash,
-            receipt_id: view_receipt_id,
-            shares_minted: view_shares_minted,
-            gas_used: view_gas_used,
-            block_number: view_block_number,
-            minted_at: view_minted_at,
-            ..
-        } = view
-        else {
-            panic!("Expected CallbackPending variant, got {view:?}");
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(view_tx_hash, tx_hash);
-        assert_eq!(view_receipt_id, receipt_id);
-        assert_eq!(view_shares_minted, shares_minted);
-        assert_eq!(view_gas_used, Some(gas_used));
-        assert_eq!(view_block_number, block_number);
-        assert_eq!(view_minted_at, minted_at);
-    }
-
-    #[test]
-    fn test_view_update_from_minting_failed_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let minting_started_at = Utc::now();
-
-        let mut view = MintView::Minting {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            minting_started_at,
-        };
-
-        let error_message = "Transaction failed: insufficient gas";
-        let failed_at = Utc::now();
-
-        let event = MintEvent::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            error: error_message.to_string(),
-            failed_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 3,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::MintingFailed {
-            issuer_request_id: view_issuer_id,
-            error: view_error,
-            failed_at: view_failed_at,
-            ..
-        } = view
-        else {
-            panic!("Expected MintingFailed variant, got {view:?}");
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(view_error, error_message);
-        assert_eq!(view_failed_at, failed_at);
-    }
-
-    #[test]
-    fn test_handle_initiated_with_wrong_event_type_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        let wrong_event = MintEvent::JournalConfirmed {
-            issuer_request_id: IssuerMintRequestId::random(),
-            confirmed_at: Utc::now(),
-        };
-
-        view.handle_initiated(&wrong_event);
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_journal_confirmed_from_wrong_state_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        view.handle_journal_confirmed(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_journal_confirmed_from_journal_confirmed_state_does_not_change()
-     {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-
-        let mut view = MintView::JournalConfirmed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_journal_confirmed(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_journal_rejected_from_wrong_state_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        view.handle_journal_rejected("some error".to_string(), Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_journal_rejected_from_journal_confirmed_state_does_not_change()
-     {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-
-        let mut view = MintView::JournalConfirmed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_journal_rejected("some error".to_string(), Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_tokens_minted_from_wrong_state_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        let tx_hash = b256!(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-        );
-        let receipt_id = uint!(1_U256);
-        let shares_minted = uint!(100_000000000000000000_U256);
-
-        view.handle_tokens_minted(
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            Some(50000),
-            1000,
-            Utc::now(),
-        );
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_tokens_minted_from_initiated_state_does_not_change() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-
-        let mut view = MintView::Initiated {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        };
-        let original_view = view.clone();
-
-        let tx_hash = b256!(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-        );
-        let receipt_id = uint!(1_U256);
-        let shares_minted = uint!(100_000000000000000000_U256);
-
-        view.handle_tokens_minted(
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            Some(50000),
-            1000,
-            Utc::now(),
-        );
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_minting_failed_from_wrong_state_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        view.handle_minting_failed("error".to_string(), Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_minting_failed_from_initiated_state_does_not_change() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-
-        let mut view = MintView::Initiated {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_minting_failed("error".to_string(), Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_view_update_from_mint_completed_event() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let tx_hash = b256!(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
-        );
-        let receipt_id = uint!(1_U256);
-        let shares_minted = uint!(100_000000000000000000_U256);
-        let gas_used = 50000;
-        let block_number = 1000;
-        let minted_at = Utc::now();
-
-        let mut view = MintView::CallbackPending {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used: Some(gas_used),
-            block_number,
-            minted_at,
-        };
-
-        let completed_at = Utc::now();
-
-        let event = MintEvent::MintCompleted {
-            issuer_request_id: issuer_request_id.clone(),
-            completed_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 4,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::Completed {
-            issuer_request_id: view_issuer_id,
-            tx_hash: view_tx_hash,
-            receipt_id: view_receipt_id,
-            shares_minted: view_shares_minted,
-            gas_used: view_gas_used,
-            block_number: view_block_number,
-            minted_at: view_minted_at,
-            completed_at: view_completed_at,
-            ..
-        } = view
-        else {
-            panic!("Expected Completed variant, got {view:?}");
-        };
-
-        assert_eq!(view_issuer_id, issuer_request_id);
-        assert_eq!(view_tx_hash, tx_hash);
-        assert_eq!(view_receipt_id, receipt_id);
-        assert_eq!(view_shares_minted, shares_minted);
-        assert_eq!(view_gas_used, Some(gas_used));
-        assert_eq!(view_block_number, block_number);
-        assert_eq!(view_minted_at, minted_at);
-        assert_eq!(view_completed_at, completed_at);
-    }
-
-    #[test]
-    fn test_handle_mint_completed_from_wrong_state_does_not_change_state() {
-        let mut view = MintView::NotFound;
-        let original_view = view.clone();
-
-        view.handle_mint_completed(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_mint_completed_from_journal_confirmed_state_does_not_change()
-    {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-
-        let mut view = MintView::JournalConfirmed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_mint_completed(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_mint_completed_from_minting_failed_state_does_not_change() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-456");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let error = "Transaction failed: insufficient gas".to_string();
-        let failed_at = Utc::now();
-
-        let mut view = MintView::MintingFailed {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            error,
-            failed_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_mint_completed(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_mint_retry_started_transitions_minting_failed_to_minting() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-retry-1");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let failed_at = Utc::now();
-
-        let mut view = MintView::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: tokenization_request_id.clone(),
-            quantity: quantity.clone(),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: network.clone(),
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            error: "Previous failure".to_string(),
-            failed_at,
-        };
-
-        let retry_started_at = Utc::now();
-        view.handle_mint_retry_started(retry_started_at);
-
-        let MintView::Minting {
-            issuer_request_id: view_iss,
-            tokenization_request_id: view_tok,
-            quantity: view_qty,
-            underlying: view_und,
-            token: view_tok_sym,
-            network: view_net,
-            client_id: view_client,
-            wallet: view_wallet,
-            initiated_at: view_init,
-            journal_confirmed_at: view_jc,
-            minting_started_at,
-        } = view
-        else {
-            panic!("Expected Minting state, got {view:?}");
-        };
-
-        assert_eq!(view_iss, issuer_request_id);
-        assert_eq!(view_tok, tokenization_request_id);
-        assert_eq!(view_qty, quantity);
-        assert_eq!(view_und, underlying);
-        assert_eq!(view_tok_sym, token);
-        assert_eq!(view_net, network);
-        assert_eq!(view_client, client_id);
-        assert_eq!(view_wallet, wallet);
-        assert_eq!(view_init, initiated_at);
-        assert_eq!(view_jc, journal_confirmed_at);
-        assert_eq!(minting_started_at, retry_started_at);
-    }
-
-    #[test]
-    fn test_handle_mint_retry_started_from_minting_state_does_not_change() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id = TokenizationRequestId::new("alp-retry-2");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-        let minting_started_at = Utc::now();
-
-        let mut view = MintView::Minting {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            minting_started_at,
-        };
-        let original_view = view.clone();
-
-        view.handle_mint_retry_started(Utc::now());
-
-        assert_eq!(view, original_view);
-    }
-
-    #[test]
-    fn test_handle_tokens_minted_from_minting_failed_transitions_to_callback_pending()
-     {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id =
-            TokenizationRequestId::new("alp-recover-1");
-        let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-
-        let mut view = MintView::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: tokenization_request_id.clone(),
-            quantity: quantity.clone(),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: network.clone(),
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            error: "Transaction reverted".to_string(),
-            failed_at: Utc::now(),
-        };
-
-        let tx_hash = b256!(
-            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        );
-        let receipt_id = uint!(42_U256);
-        let shares_minted = uint!(100_000000000000000000_U256);
-        let block_number = 2000;
-        let recovered_at = Utc::now();
-
-        let event = MintEvent::ExistingMintRecovered {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            block_number,
-            recovered_at,
-        };
-
-        let envelope = EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 4,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let MintView::CallbackPending {
-            issuer_request_id: view_iss,
-            tokenization_request_id: view_tok,
-            quantity: view_qty,
-            underlying: view_und,
-            token: view_tok_sym,
-            network: view_net,
-            client_id: view_client,
-            wallet: view_wallet,
-            initiated_at: view_init,
-            journal_confirmed_at: view_jc,
-            tx_hash: view_tx,
-            receipt_id: view_receipt,
-            shares_minted: view_shares,
-            gas_used: view_gas,
-            block_number: view_block,
-            minted_at: view_minted,
-        } = view
-        else {
-            panic!("Expected CallbackPending variant, got {view:?}");
-        };
-
-        assert_eq!(view_iss, issuer_request_id);
-        assert_eq!(view_tok, tokenization_request_id);
-        assert_eq!(view_qty, quantity);
-        assert_eq!(view_und, underlying);
-        assert_eq!(view_tok_sym, token);
-        assert_eq!(view_net, network);
-        assert_eq!(view_client, client_id);
-        assert_eq!(view_wallet, wallet);
-        assert_eq!(view_init, initiated_at);
-        assert_eq!(view_jc, journal_confirmed_at);
-        assert_eq!(view_tx, tx_hash);
-        assert_eq!(view_receipt, receipt_id);
-        assert_eq!(view_shares, shares_minted);
-        assert_eq!(view_gas, None);
-        assert_eq!(view_block, block_number);
-        assert_eq!(view_minted, recovered_at);
-    }
-
-    #[test]
-    fn test_recovery_from_minting_failed_reaches_completed() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let tokenization_request_id =
-            TokenizationRequestId::new("alp-recover-2");
-        let quantity = Quantity::new(Decimal::from(50));
-        let underlying = UnderlyingSymbol::new("TSLA");
-        let token = TokenSymbol::new("tTSLA");
-        let network = Network::new("base");
-        let client_id = ClientId::new();
-        let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
-        let initiated_at = Utc::now();
-        let journal_confirmed_at = Utc::now();
-
-        let tx_hash = b256!(
-            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-        );
-        let receipt_id = uint!(99_U256);
-        let shares_minted = uint!(50_000000000000000000_U256);
-        let block_number = 3000;
-        let recovered_at = Utc::now();
-
-        let mut view = MintView::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id,
-            quantity,
-            underlying,
-            token,
-            network,
-            client_id,
-            wallet,
-            initiated_at,
-            journal_confirmed_at,
-            error: "Gas estimation failed".to_string(),
-            failed_at: Utc::now(),
-        };
-
-        let recover_event = MintEvent::ExistingMintRecovered {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            block_number,
-            recovered_at,
-        };
-
-        view.update(&EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 4,
-            payload: recover_event,
-            metadata: HashMap::new(),
-        });
-
-        let completed_at = Utc::now();
-        let complete_event = MintEvent::MintCompleted {
-            issuer_request_id: issuer_request_id.clone(),
-            completed_at,
-        };
-
-        view.update(&EventEnvelope {
-            aggregate_id: issuer_request_id.to_string(),
-            sequence: 5,
-            payload: complete_event,
-            metadata: HashMap::new(),
-        });
-
-        let MintView::Completed {
-            issuer_request_id: view_iss,
-            tx_hash: view_tx,
-            receipt_id: view_receipt,
-            shares_minted: view_shares,
-            completed_at: view_completed,
-            ..
-        } = view
-        else {
-            panic!("Expected Completed variant, got {view:?}");
-        };
-
-        assert_eq!(view_iss, issuer_request_id);
-        assert_eq!(view_tx, tx_hash);
-        assert_eq!(view_receipt, receipt_id);
-        assert_eq!(view_shares, shares_minted);
-        assert_eq!(view_completed, completed_at);
-    }
-
     fn test_mint_fields() -> TestMintFields {
         TestMintFields {
             issuer_request_id: IssuerMintRequestId::random(),
@@ -1788,11 +435,14 @@ mod tests {
         }
     }
 
+    /// Seeds one view per recoverable state. `find_all_recoverable_mints` and
+    /// `find_stuck` both match `FireblocksSubmitted`, so it is seeded here
+    /// alongside the other recoverable states.
     async fn seed_recoverable_mint_views(
-        harness: &TestHarness,
+        pool: &Pool<Sqlite>,
     ) -> Vec<IssuerMintRequestId> {
         let now = Utc::now();
-        let fields: Vec<_> = (0..4).map(|_| test_mint_fields()).collect();
+        let fields: Vec<_> = (0..5).map(|_| test_mint_fields()).collect();
 
         let views: Vec<MintView> = vec![
             MintView::JournalConfirmed {
@@ -1824,7 +474,7 @@ mod tests {
                 journal_confirmed_at: now,
                 minting_started_at: now,
             },
-            MintView::MintingFailed {
+            MintView::FireblocksSubmitted {
                 issuer_request_id: fields[2].issuer_request_id.clone(),
                 tokenization_request_id: fields[2]
                     .tokenization_request_id
@@ -1837,10 +487,11 @@ mod tests {
                 wallet: fields[2].wallet,
                 initiated_at: fields[2].initiated_at,
                 journal_confirmed_at: now,
-                error: "Transaction reverted".to_string(),
-                failed_at: now,
+                minting_started_at: now,
+                external_tx_id: "mint-base".to_string(),
+                fireblocks_tx_id: "fb-1".to_string(),
             },
-            MintView::CallbackPending {
+            MintView::MintingFailed {
                 issuer_request_id: fields[3].issuer_request_id.clone(),
                 tokenization_request_id: fields[3]
                     .tokenization_request_id
@@ -1853,6 +504,22 @@ mod tests {
                 wallet: fields[3].wallet,
                 initiated_at: fields[3].initiated_at,
                 journal_confirmed_at: now,
+                error: "Transaction reverted".to_string(),
+                failed_at: now,
+            },
+            MintView::CallbackPending {
+                issuer_request_id: fields[4].issuer_request_id.clone(),
+                tokenization_request_id: fields[4]
+                    .tokenization_request_id
+                    .clone(),
+                quantity: fields[4].quantity.clone(),
+                underlying: fields[4].underlying.clone(),
+                token: fields[4].token.clone(),
+                network: fields[4].network.clone(),
+                client_id: fields[4].client_id,
+                wallet: fields[4].wallet,
+                initiated_at: fields[4].initiated_at,
+                journal_confirmed_at: now,
                 tx_hash: b256!(
                     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 ),
@@ -1864,36 +531,36 @@ mod tests {
             },
         ];
 
-        for (f, view) in fields.iter().zip(&views) {
-            harness.insert_view(&f.issuer_request_id, view).await;
+        for (mint_fields, view) in fields.iter().zip(&views) {
+            insert_mint_view(pool, &mint_fields.issuer_request_id, view).await;
         }
 
         fields.into_iter().map(|f| f.issuer_request_id).collect()
     }
 
-    async fn seed_non_recoverable_mint_views(harness: &TestHarness) {
+    async fn seed_non_recoverable_mint_views(pool: &Pool<Sqlite>) {
         let now = Utc::now();
 
         let fields = test_mint_fields();
-        harness
-            .insert_view(
-                &fields.issuer_request_id,
-                &MintView::Initiated {
-                    issuer_request_id: fields.issuer_request_id.clone(),
-                    tokenization_request_id: fields.tokenization_request_id,
-                    quantity: fields.quantity,
-                    underlying: fields.underlying,
-                    token: fields.token,
-                    network: fields.network,
-                    client_id: fields.client_id,
-                    wallet: fields.wallet,
-                    initiated_at: fields.initiated_at,
-                },
-            )
-            .await;
+        insert_mint_view(
+            pool,
+            &fields.issuer_request_id,
+            &MintView::Initiated {
+                issuer_request_id: fields.issuer_request_id.clone(),
+                tokenization_request_id: fields.tokenization_request_id,
+                quantity: fields.quantity,
+                underlying: fields.underlying,
+                token: fields.token,
+                network: fields.network,
+                client_id: fields.client_id,
+                wallet: fields.wallet,
+                initiated_at: fields.initiated_at,
+            },
+        )
+        .await;
 
         let fields = test_mint_fields();
-        harness.insert_view(&fields.issuer_request_id, &MintView::Completed {
+        insert_mint_view(pool, &fields.issuer_request_id, &MintView::Completed {
             issuer_request_id: fields.issuer_request_id.clone(),
             tokenization_request_id: fields.tokenization_request_id,
             quantity: fields.quantity,
@@ -1916,13 +583,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_all_recoverable_mints_returns_all_recoverable_states() {
-        let harness = TestHarness::new().await;
-        let recoverable_ids = seed_recoverable_mint_views(&harness).await;
-        seed_non_recoverable_mint_views(&harness).await;
+        let pool = setup_test_db().await;
+        let recoverable_ids = seed_recoverable_mint_views(&pool).await;
+        seed_non_recoverable_mint_views(&pool).await;
 
-        let results = find_all_recoverable_mints(&harness.pool).await.unwrap();
+        let results = find_all_recoverable_mints(&pool).await.unwrap();
 
-        assert_eq!(results.len(), 4, "Expected 4 recoverable mints");
+        assert_eq!(results.len(), 5, "Expected 5 recoverable mints");
 
         let result_ids: Vec<_> =
             results.iter().map(|(id, _)| id.clone()).collect();
@@ -1937,6 +604,7 @@ mod tests {
             results.iter().map(|(_, view)| view.state_name()).collect();
         assert!(state_names.contains(&"JournalConfirmed"));
         assert!(state_names.contains(&"Minting"));
+        assert!(state_names.contains(&"FireblocksSubmitted"));
         assert!(state_names.contains(&"MintingFailed"));
         assert!(state_names.contains(&"CallbackPending"));
     }
@@ -1950,60 +618,60 @@ mod tests {
 
     #[tokio::test]
     async fn test_find_stuck_returns_all_non_terminal_variants() {
-        let harness = TestHarness::new().await;
+        let pool = setup_test_db().await;
         let now = Utc::now();
 
-        // Seed the 4 recoverable variants (JournalConfirmed, Minting,
-        // MintingFailed, CallbackPending).
-        let recoverable_ids = seed_recoverable_mint_views(&harness).await;
+        // Seed the 5 recoverable variants (JournalConfirmed, Minting,
+        // FireblocksSubmitted, MintingFailed, CallbackPending).
+        let recoverable_ids = seed_recoverable_mint_views(&pool).await;
 
         // Seed Initiated and JournalRejected (non-terminal-but-not-recoverable).
         let initiated_fields = test_mint_fields();
         let initiated_id = initiated_fields.issuer_request_id.clone();
-        harness
-            .insert_view(
-                &initiated_id,
-                &MintView::Initiated {
-                    issuer_request_id: initiated_fields.issuer_request_id,
-                    tokenization_request_id: initiated_fields
-                        .tokenization_request_id,
-                    quantity: initiated_fields.quantity,
-                    underlying: initiated_fields.underlying,
-                    token: initiated_fields.token,
-                    network: initiated_fields.network,
-                    client_id: initiated_fields.client_id,
-                    wallet: initiated_fields.wallet,
-                    initiated_at: initiated_fields.initiated_at,
-                },
-            )
-            .await;
+        insert_mint_view(
+            &pool,
+            &initiated_id,
+            &MintView::Initiated {
+                issuer_request_id: initiated_fields.issuer_request_id,
+                tokenization_request_id: initiated_fields
+                    .tokenization_request_id,
+                quantity: initiated_fields.quantity,
+                underlying: initiated_fields.underlying,
+                token: initiated_fields.token,
+                network: initiated_fields.network,
+                client_id: initiated_fields.client_id,
+                wallet: initiated_fields.wallet,
+                initiated_at: initiated_fields.initiated_at,
+            },
+        )
+        .await;
 
         let rejected_fields = test_mint_fields();
         let rejected_id = rejected_fields.issuer_request_id.clone();
-        harness
-            .insert_view(
-                &rejected_id,
-                &MintView::JournalRejected {
-                    issuer_request_id: rejected_fields.issuer_request_id,
-                    tokenization_request_id: rejected_fields
-                        .tokenization_request_id,
-                    quantity: rejected_fields.quantity,
-                    underlying: rejected_fields.underlying,
-                    token: rejected_fields.token,
-                    network: rejected_fields.network,
-                    client_id: rejected_fields.client_id,
-                    wallet: rejected_fields.wallet,
-                    initiated_at: rejected_fields.initiated_at,
-                    reason: "Alpaca rejected the journal".to_string(),
-                    rejected_at: now,
-                },
-            )
-            .await;
+        insert_mint_view(
+            &pool,
+            &rejected_id,
+            &MintView::JournalRejected {
+                issuer_request_id: rejected_fields.issuer_request_id,
+                tokenization_request_id: rejected_fields
+                    .tokenization_request_id,
+                quantity: rejected_fields.quantity,
+                underlying: rejected_fields.underlying,
+                token: rejected_fields.token,
+                network: rejected_fields.network,
+                client_id: rejected_fields.client_id,
+                wallet: rejected_fields.wallet,
+                initiated_at: rejected_fields.initiated_at,
+                reason: "Alpaca rejected the journal".to_string(),
+                rejected_at: now,
+            },
+        )
+        .await;
 
         // Seed a Completed mint that must NOT appear.
         let completed_fields = test_mint_fields();
         let completed_id = completed_fields.issuer_request_id.clone();
-        harness.insert_view(&completed_id, &MintView::Completed {
+        insert_mint_view(&pool, &completed_id, &MintView::Completed {
             issuer_request_id: completed_fields.issuer_request_id,
             tokenization_request_id: completed_fields.tokenization_request_id,
             quantity: completed_fields.quantity,
@@ -2026,25 +694,25 @@ mod tests {
         // Seed a Closed mint that must NOT appear.
         let closed_fields = test_mint_fields();
         let closed_id = closed_fields.issuer_request_id.clone();
-        harness
-            .insert_view(
-                &closed_id,
-                &MintView::Closed {
-                    issuer_request_id: closed_fields.issuer_request_id,
-                    reason: "closed by admin".to_string(),
-                    closed_at: now,
-                },
-            )
-            .await;
+        insert_mint_view(
+            &pool,
+            &closed_id,
+            &MintView::Closed {
+                issuer_request_id: closed_fields.issuer_request_id,
+                reason: "closed by admin".to_string(),
+                closed_at: now,
+            },
+        )
+        .await;
 
-        let results = find_stuck(&harness.pool).await.unwrap();
+        let results = find_stuck(&pool).await.unwrap();
         let result_ids: Vec<_> =
             results.iter().map(|(id, _)| id.clone()).collect();
 
         assert_eq!(
             results.len(),
-            6,
-            "Expected 6 non-terminal mints, got ids: {result_ids:?}"
+            7,
+            "Expected 7 non-terminal mints, got ids: {result_ids:?}"
         );
         for id in &recoverable_ids {
             assert!(result_ids.contains(id), "Should include {id}");
@@ -2069,6 +737,7 @@ mod tests {
         assert!(state_names.contains(&"JournalConfirmed"));
         assert!(state_names.contains(&"JournalRejected"));
         assert!(state_names.contains(&"Minting"));
+        assert!(state_names.contains(&"FireblocksSubmitted"));
         assert!(state_names.contains(&"MintingFailed"));
         assert!(state_names.contains(&"CallbackPending"));
     }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -29,7 +29,6 @@ pub(crate) use burn_tracking::{
 pub(crate) use cmd::ReceiptInventoryCommand;
 pub(crate) use event::{ReceiptInventoryEvent, ReceiptSource};
 use reconcile::ReconcileError;
-pub(crate) use view::{ReceiptInventoryView, replay_receipt_inventory_view};
 
 /// Receipt data recovered from the inventory for mint recovery.
 #[derive(Debug, Clone)]

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -1,14 +1,12 @@
 use alloy::primitives::U256;
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use cqrs_es::{EventEnvelope, View};
+use event_sorcery::{EntityList, Never, Reactor, deps};
 use serde::{Deserialize, Serialize};
-use sqlite_es::{SqliteEventRepository, SqliteViewRepository};
-use sqlx::{Pool, Sqlite};
-use std::sync::Arc;
-use tracing::debug;
+use sqlx::{Pool, Sqlite, SqlitePool};
+use tracing::{debug, warn};
 
-use crate::mint::{Mint, MintError, MintEvent};
-use crate::replay::{ReplayError, replay_all_or_fail};
+use crate::mint::{IssuerMintRequestId, Mint, MintEvent};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
 
 #[derive(Debug, thiserror::Error)]
@@ -18,42 +16,44 @@ pub(crate) enum ReceiptInventoryViewError {
 
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
+
+    #[error("Issuer request id parse error: {0}")]
+    IssuerRequestIdParse(#[from] uuid::Error),
 }
 
-/// Errors raised while rebuilding the `receipt_inventory_view` from events.
+/// Rebuilds the `receipt_inventory_view` from the `Mint` event log.
 ///
-/// Kept separate from [`ReceiptInventoryViewError`] because `MintError` already
-/// embeds that type; holding `AggregateError<MintError>` here instead avoids a
-/// recursive type cycle through the replay path.
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ReceiptInventoryReplayError {
-    #[error("Database error: {0}")]
-    Database(#[from] sqlx::Error),
-
-    #[error("Replay error: {0}")]
-    Replay(#[from] ReplayError<MintError>),
-}
-
-/// Replays all `Mint` events through the `receipt_inventory_view`.
-///
-/// Re-projects the view from existing events in the event store. This runs at
-/// startup so receipts activated through historical
-/// `MintEvent::ExistingMintRecovered` events — which earlier code ignored —
-/// are rebuilt as `Active` instead of left stale in `Pending`.
-pub(crate) async fn replay_receipt_inventory_view(
-    pool: Pool<Sqlite>,
-) -> Result<(), ReceiptInventoryReplayError> {
+/// event-sorcery reactors only observe newly committed events, so the historical
+/// `Mint` streams are replayed through the reactor at startup. Preserves #167:
+/// receipts activated through historical `MintEvent::ExistingMintRecovered`
+/// events are rebuilt as `Active` rather than left stale in `Pending`.
+pub(crate) async fn rebuild_receipt_inventory_view(
+    pool: &Pool<Sqlite>,
+) -> Result<(), ReceiptInventoryViewError> {
     debug!(target: "receipt", "Rebuilding receipt inventory view from events");
 
-    sqlx::query!("DELETE FROM receipt_inventory_view").execute(&pool).await?;
+    sqlx::query!("DELETE FROM receipt_inventory_view").execute(pool).await?;
 
-    let view_repo =
-        Arc::new(SqliteViewRepository::<ReceiptInventoryView, Mint>::new(
-            pool.clone(),
-            "receipt_inventory_view".to_string(),
-        ));
-    let event_repo = SqliteEventRepository::new(pool);
-    replay_all_or_fail(event_repo, view_repo, vec![]).await?;
+    let reactor = ReceiptInventoryViewReactor::new(pool.clone());
+
+    let rows = sqlx::query!(
+        r#"
+        SELECT
+            aggregate_id as "aggregate_id!: String",
+            payload as "payload!: String"
+        FROM events
+        WHERE aggregate_type = 'Mint'
+        ORDER BY aggregate_id, sequence
+        "#
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for row in rows {
+        let mint_id: IssuerMintRequestId = row.aggregate_id.parse()?;
+        let event: MintEvent = serde_json::from_str(&row.payload)?;
+        reactor.project(&mint_id, &event).await;
+    }
 
     debug!(target: "receipt", "Receipt inventory view rebuild complete");
 
@@ -68,10 +68,9 @@ pub(crate) async fn replay_receipt_inventory_view(
 /// - `Active`: Tokens minted, receipt exists with available balance
 /// - `Depleted`: Receipt fully burned (balance = 0)
 ///
-/// The view uses cross-aggregate listening, implementing both `View<Mint>` and
-/// `View<Redemption>` to track receipts through their complete lifecycle. Currently
-/// only Mint events are fully implemented; Redemption burn events will be added in
-/// issue #25.
+/// `ReceiptInventoryViewReactor` projects this from the `Mint` event stream.
+/// Currently only Mint events are handled; Redemption burn events will be added
+/// in issue #25.
 ///
 /// View ID: `issuer_request_id` (the Mint aggregate's aggregate_id)
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -131,160 +130,305 @@ impl ReceiptInventoryView {
     }
 }
 
-impl View<Mint> for ReceiptInventoryView {
-    fn update(&mut self, event: &EventEnvelope<Mint>) {
-        match &event.payload {
+deps!(ReceiptInventoryViewReactor, [Mint]);
+
+/// Maintains the `receipt_inventory_view` table from the `Mint` event stream.
+///
+/// event-sorcery allows only one canonical `Table` projection per aggregate
+/// (that is `mint_view`), so this secondary view of the Mint stream is kept up
+/// to date by an explicit reactor rather than a second projection. It is
+/// write-only today — nothing reads `receipt_inventory_view` in production; it
+/// is retained for the planned dual-listening receipt lifecycle (issue #25).
+pub(crate) struct ReceiptInventoryViewReactor {
+    pool: SqlitePool,
+}
+
+impl ReceiptInventoryViewReactor {
+    pub(crate) const fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    async fn project(&self, mint_id: &IssuerMintRequestId, event: &MintEvent) {
+        // Only these events transition the view; skip the rest to avoid a
+        // pointless read-write cycle.
+        if !matches!(
+            event,
+            MintEvent::Initiated { .. }
+                | MintEvent::TokensMinted { .. }
+                | MintEvent::ExistingMintRecovered { .. }
+        ) {
+            return;
+        }
+
+        let view_id = mint_id.to_string();
+
+        let current = match self.load(&view_id).await {
+            Ok(view) => view,
+            Err(error) => {
+                warn!(target: "receipt", view_id, error = %error,
+                    "Failed to load receipt inventory view; skipping update"
+                );
+                return;
+            }
+        };
+
+        let updated = match event {
             MintEvent::Initiated { underlying, token, .. } => {
-                *self = self
-                    .clone()
-                    .with_initiated_data(underlying.clone(), token.clone());
+                current.with_initiated_data(underlying.clone(), token.clone())
             }
             MintEvent::TokensMinted {
                 receipt_id,
                 shares_minted,
                 minted_at,
                 ..
-            } => {
-                *self = self.clone().with_tokens_minted(
-                    *receipt_id,
-                    *shares_minted,
-                    *minted_at,
-                );
-            }
+            } => current.with_tokens_minted(
+                *receipt_id,
+                *shares_minted,
+                *minted_at,
+            ),
+            // Recovered mints (#167) must activate their receipt in inventory
+            // too, otherwise recovery would leave the receipt inactive and
+            // unspendable for redemption burn planning.
             MintEvent::ExistingMintRecovered {
                 receipt_id,
                 shares_minted,
                 recovered_at,
                 ..
-            } => {
-                *self = self.clone().with_tokens_minted(
-                    *receipt_id,
-                    *shares_minted,
-                    *recovered_at,
-                );
-            }
-            MintEvent::JournalConfirmed { .. }
-            | MintEvent::JournalRejected { .. }
-            | MintEvent::MintingStarted { .. }
-            | MintEvent::MintingFailed { .. }
-            | MintEvent::MintCompleted { .. }
-            | MintEvent::MintRetryStarted { .. }
-            | MintEvent::MintClosed { .. }
-            | MintEvent::FireblocksSubmitted { .. } => {}
+            } => current.with_tokens_minted(
+                *receipt_id,
+                *shares_minted,
+                *recovered_at,
+            ),
+            _ => return,
+        };
+
+        if let Err(error) = self.upsert(&view_id, &updated).await {
+            warn!(target: "receipt", view_id, error = %error,
+                "Failed to write receipt inventory view"
+            );
         }
+    }
+
+    async fn load(
+        &self,
+        view_id: &str,
+    ) -> Result<ReceiptInventoryView, ReceiptInventoryViewError> {
+        let row = sqlx::query!(
+            r#"
+            SELECT payload as "payload!: String"
+            FROM receipt_inventory_view
+            WHERE view_id = ?
+            "#,
+            view_id
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+
+        match row {
+            Some(row) => Ok(serde_json::from_str(&row.payload)?),
+            None => Ok(ReceiptInventoryView::Unavailable),
+        }
+    }
+
+    async fn upsert(
+        &self,
+        view_id: &str,
+        view: &ReceiptInventoryView,
+    ) -> Result<(), ReceiptInventoryViewError> {
+        let payload = serde_json::to_string(view)?;
+
+        sqlx::query!(
+            "
+            INSERT INTO receipt_inventory_view (view_id, version, payload)
+            VALUES (?, 1, ?)
+            ON CONFLICT(view_id) DO UPDATE SET
+                version = version + 1,
+                payload = ?
+            ",
+            view_id,
+            payload,
+            payload
+        )
+        .execute(&self.pool)
+        .await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Reactor for ReceiptInventoryViewReactor {
+    type Error = Never;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        let (mint_id, mint_event) = event.into_inner();
+        self.project(&mint_id, &mint_event).await;
+        Ok(())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, b256, uint};
+    use alloy::primitives::{Address, address, b256, uint};
     use chrono::Utc;
-    use cqrs_es::EventEnvelope;
-    use cqrs_es::persist::GenericQuery;
+    use event_sorcery::ReactorHarness;
     use rust_decimal::Decimal;
-    use sqlite_es::SqliteViewRepository;
-    use sqlx::sqlite::SqlitePoolOptions;
-    use std::collections::HashMap;
-    use std::sync::Arc;
-    use tracing_test::traced_test;
+    use sqlx::SqlitePool;
 
     use super::*;
-    use crate::mint::{
-        ClientId, IssuerMintRequestId, Mint, MintEvent, Network, Quantity,
-        TokenizationRequestId,
-    };
-    use crate::test_utils::logs_contain_at;
+    use crate::mint::{ClientId, Network, Quantity, TokenizationRequestId};
 
-    async fn setup_test_db() -> Pool<Sqlite> {
-        let pool = SqlitePoolOptions::new()
+    async fn migrated_pool() -> SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
             .max_connections(1)
             .connect(":memory:")
             .await
             .expect("Failed to create in-memory database");
-
         sqlx::migrate!("./migrations")
             .run(&pool)
             .await
             .expect("Failed to run migrations");
-
         pool
     }
 
-    #[test]
-    fn test_unavailable_to_pending_on_mint_initiated() {
-        let underlying = UnderlyingSymbol::new("AAPL");
-        let token = TokenSymbol::new("tAAPL");
+    /// Reads back the projected view for `mint_id`, deserializing the row the
+    /// reactor wrote. Returns `Unavailable` when no row exists yet.
+    async fn load_view(
+        pool: &SqlitePool,
+        mint_id: &IssuerMintRequestId,
+    ) -> ReceiptInventoryView {
+        let view_id = mint_id.to_string();
+        let row = sqlx::query!(
+            r#"
+            SELECT payload as "payload!: String"
+            FROM receipt_inventory_view
+            WHERE view_id = ?
+            "#,
+            view_id
+        )
+        .fetch_optional(pool)
+        .await
+        .expect("Failed to query receipt inventory view");
 
-        let event = MintEvent::Initiated {
+        match row {
+            Some(row) => serde_json::from_str(&row.payload)
+                .expect("Failed to deserialize receipt inventory view"),
+            None => ReceiptInventoryView::Unavailable,
+        }
+    }
+
+    fn initiated_event(
+        underlying: UnderlyingSymbol,
+        token: TokenSymbol,
+        tokenization_request_id: &str,
+        wallet: Address,
+    ) -> MintEvent {
+        MintEvent::Initiated {
             issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new("alp-456"),
+            tokenization_request_id: TokenizationRequestId::new(
+                tokenization_request_id,
+            ),
             quantity: Quantity::new(Decimal::from(100)),
-            underlying: underlying.clone(),
-            token: token.clone(),
+            underlying,
+            token,
             network: Network::new("base"),
             client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            wallet,
             initiated_at: Utc::now(),
-        };
+        }
+    }
 
-        let envelope: EventEnvelope<Mint> = EventEnvelope {
-            aggregate_id: "iss-123".to_string(),
-            sequence: 1,
-            payload: event,
-            metadata: HashMap::new(),
-        };
+    #[tokio::test]
+    async fn test_unavailable_to_pending_on_mint_initiated() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let mut view = ReceiptInventoryView::default();
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let mint_id = IssuerMintRequestId::random();
 
-        assert!(matches!(view, ReceiptInventoryView::Unavailable));
+        assert!(matches!(
+            load_view(&pool, &mint_id).await,
+            ReceiptInventoryView::Unavailable
+        ));
 
-        view.update(&envelope);
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    underlying.clone(),
+                    token.clone(),
+                    "alp-456",
+                    address!("0x1234567890abcdef1234567890abcdef12345678"),
+                ),
+            )
+            .await
+            .unwrap();
 
         let ReceiptInventoryView::Pending {
             underlying: view_underlying,
             token: view_token,
-        } = view
+        } = load_view(&pool, &mint_id).await
         else {
-            panic!("Expected Pending variant, got {view:?}");
+            panic!("Expected Pending variant");
         };
 
         assert_eq!(view_underlying, underlying);
         assert_eq!(view_token, token);
     }
 
-    #[test]
-    fn test_pending_to_active_on_tokens_minted() {
+    #[tokio::test]
+    async fn test_pending_to_active_on_tokens_minted() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
+
         let underlying = UnderlyingSymbol::new("TSLA");
         let token = TokenSymbol::new("tTSLA");
         let receipt_id = uint!(42_U256);
         let shares_minted = uint!(100_000000000000000000_U256);
         let minted_at = Utc::now();
+        let mint_id = IssuerMintRequestId::random();
 
-        let mut view = ReceiptInventoryView::Pending {
-            underlying: underlying.clone(),
-            token: token.clone(),
-        };
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    underlying.clone(),
+                    token.clone(),
+                    "alp-456",
+                    address!("0x1234567890abcdef1234567890abcdef12345678"),
+                ),
+            )
+            .await
+            .unwrap();
 
-        let event = MintEvent::TokensMinted {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tx_hash: b256!(
-                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
-            ),
-            receipt_id,
-            shares_minted,
-            gas_used: 50000,
-            block_number: 1000,
-            minted_at,
-        };
+        assert!(matches!(
+            load_view(&pool, &mint_id).await,
+            ReceiptInventoryView::Pending { .. }
+        ));
 
-        let envelope: EventEnvelope<Mint> = EventEnvelope {
-            aggregate_id: "iss-456".to_string(),
-            sequence: 2,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                MintEvent::TokensMinted {
+                    issuer_request_id: IssuerMintRequestId::random(),
+                    tx_hash: b256!(
+                        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    ),
+                    receipt_id,
+                    shares_minted,
+                    gas_used: 50000,
+                    block_number: 1000,
+                    minted_at,
+                },
+            )
+            .await
+            .unwrap();
 
         let ReceiptInventoryView::Active {
             receipt_id: view_receipt_id,
@@ -293,9 +437,9 @@ mod tests {
             initial_amount,
             current_balance,
             minted_at: view_minted_at,
-        } = view
+        } = load_view(&pool, &mint_id).await
         else {
-            panic!("Expected Active variant, got {view:?}");
+            panic!("Expected Active variant");
         };
 
         assert_eq!(view_receipt_id, receipt_id);
@@ -306,79 +450,84 @@ mod tests {
         assert_eq!(view_minted_at, minted_at);
     }
 
-    #[test]
-    fn test_view_stores_underlying_and_token_from_initiated() {
+    #[tokio::test]
+    async fn test_view_stores_underlying_and_token_from_initiated() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
+
         let underlying = UnderlyingSymbol::new("NVDA");
         let token = TokenSymbol::new("tNVDA");
+        let mint_id = IssuerMintRequestId::random();
 
-        let event = MintEvent::Initiated {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new("alp-999"),
-            quantity: Quantity::new(Decimal::from(50)),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc"),
-            initiated_at: Utc::now(),
-        };
-
-        let envelope: EventEnvelope<Mint> = EventEnvelope {
-            aggregate_id: "iss-789".to_string(),
-            sequence: 1,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        let mut view = ReceiptInventoryView::default();
-        view.update(&envelope);
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    underlying.clone(),
+                    token.clone(),
+                    "alp-999",
+                    address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc"),
+                ),
+            )
+            .await
+            .unwrap();
 
         let ReceiptInventoryView::Pending {
             underlying: stored_underlying,
             token: stored_token,
-        } = view
+        } = load_view(&pool, &mint_id).await
         else {
-            panic!("Expected Pending variant, got {view:?}");
+            panic!("Expected Pending variant");
         };
 
         assert_eq!(stored_underlying, underlying);
         assert_eq!(stored_token, token);
     }
 
-    #[test]
-    fn test_view_combines_initiated_data_with_tokens_minted() {
+    #[tokio::test]
+    async fn test_view_combines_initiated_data_with_tokens_minted() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
+
         let underlying = UnderlyingSymbol::new("AMD");
         let token = TokenSymbol::new("tAMD");
-
-        let mut view = ReceiptInventoryView::Pending {
-            underlying: underlying.clone(),
-            token: token.clone(),
-        };
-
         let receipt_id = uint!(7_U256);
         let shares_minted = uint!(250_500000000000000000_U256);
         let minted_at = Utc::now();
+        let mint_id = IssuerMintRequestId::random();
 
-        let event = MintEvent::TokensMinted {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tx_hash: b256!(
-                "0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
-            ),
-            receipt_id,
-            shares_minted,
-            gas_used: 75000,
-            block_number: 2000,
-            minted_at,
-        };
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    underlying.clone(),
+                    token.clone(),
+                    "alp-combo",
+                    address!("0x3333333333333333333333333333333333333333"),
+                ),
+            )
+            .await
+            .unwrap();
 
-        let envelope: EventEnvelope<Mint> = EventEnvelope {
-            aggregate_id: "iss-combo".to_string(),
-            sequence: 2,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                MintEvent::TokensMinted {
+                    issuer_request_id: IssuerMintRequestId::random(),
+                    tx_hash: b256!(
+                        "0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+                    ),
+                    receipt_id,
+                    shares_minted,
+                    gas_used: 75000,
+                    block_number: 2000,
+                    minted_at,
+                },
+            )
+            .await
+            .unwrap();
 
         let ReceiptInventoryView::Active {
             underlying: view_underlying,
@@ -387,9 +536,9 @@ mod tests {
             initial_amount,
             current_balance,
             minted_at: view_minted_at,
-        } = view
+        } = load_view(&pool, &mint_id).await
         else {
-            panic!("Expected Active variant, got {view:?}");
+            panic!("Expected Active variant");
         };
 
         assert_eq!(view_underlying, underlying);
@@ -400,253 +549,53 @@ mod tests {
         assert_eq!(view_minted_at, minted_at);
     }
 
-    #[test]
-    fn test_view_activates_receipt_on_existing_mint_recovered() {
-        let underlying = UnderlyingSymbol::new("MSTR");
-        let token = TokenSymbol::new("tMSTR");
-        let receipt_id = uint!(136_U256);
-        let shares_minted = uint!(4_028802626000000000_U256);
-        let recovered_at = Utc::now();
-
-        let mut view = ReceiptInventoryView::Pending {
-            underlying: underlying.clone(),
-            token: token.clone(),
-        };
-
-        let event = MintEvent::ExistingMintRecovered {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tx_hash: b256!(
-                "0xaff33e27ec0a4232eb2c172fac9a86f794d6551d969b301d734b9ca8511f1e07"
-            ),
-            receipt_id,
-            shares_minted,
-            block_number: 46_337_116,
-            recovered_at,
-        };
-
-        let envelope: EventEnvelope<Mint> = EventEnvelope {
-            aggregate_id: "iss-recovered".to_string(),
-            sequence: 6,
-            payload: event,
-            metadata: HashMap::new(),
-        };
-
-        view.update(&envelope);
-
-        let ReceiptInventoryView::Active {
-            receipt_id: view_receipt_id,
-            underlying: view_underlying,
-            token: view_token,
-            initial_amount,
-            current_balance,
-            minted_at,
-        } = view
-        else {
-            panic!("Expected Active variant, got {view:?}");
-        };
-
-        assert_eq!(view_receipt_id, receipt_id);
-        assert_eq!(view_underlying, underlying);
-        assert_eq!(view_token, token);
-        assert_eq!(initial_amount, shares_minted);
-        assert_eq!(current_balance, shares_minted);
-        assert_eq!(minted_at, recovered_at);
-    }
-
-    #[test]
-    fn test_view_recovers_through_full_initiated_then_recovered_sequence() {
-        let underlying = UnderlyingSymbol::new("MSTR");
-        let token = TokenSymbol::new("tMSTR");
-        let receipt_id = uint!(136_U256);
-        let shares_minted = uint!(4_028802626000000000_U256);
-        let recovered_at = Utc::now();
-
-        let mut view = ReceiptInventoryView::default();
-        assert!(matches!(view, ReceiptInventoryView::Unavailable));
-
-        let initiated = MintEvent::Initiated {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new(
-                "alp-recovered",
-            ),
-            quantity: Quantity::new(Decimal::from(4)),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            initiated_at: Utc::now(),
-        };
-
-        view.update(&EventEnvelope::<Mint> {
-            aggregate_id: "iss-recovered".to_string(),
-            sequence: 1,
-            payload: initiated,
-            metadata: HashMap::new(),
-        });
-
-        assert!(matches!(view, ReceiptInventoryView::Pending { .. }));
-
-        let recovered = MintEvent::ExistingMintRecovered {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tx_hash: b256!(
-                "0xaff33e27ec0a4232eb2c172fac9a86f794d6551d969b301d734b9ca8511f1e07"
-            ),
-            receipt_id,
-            shares_minted,
-            block_number: 46_337_116,
-            recovered_at,
-        };
-
-        view.update(&EventEnvelope::<Mint> {
-            aggregate_id: "iss-recovered".to_string(),
-            sequence: 2,
-            payload: recovered,
-            metadata: HashMap::new(),
-        });
-
-        let ReceiptInventoryView::Active {
-            receipt_id: view_receipt_id,
-            underlying: view_underlying,
-            token: view_token,
-            initial_amount,
-            current_balance,
-            minted_at,
-        } = view
-        else {
-            panic!("Expected Active variant, got {view:?}");
-        };
-
-        assert_eq!(view_receipt_id, receipt_id);
-        assert_eq!(view_underlying, underlying);
-        assert_eq!(view_token, token);
-        assert_eq!(initial_amount, shares_minted);
-        assert_eq!(current_balance, shares_minted);
-        assert_eq!(minted_at, recovered_at);
-    }
-
-    #[traced_test]
     #[tokio::test]
-    async fn test_replay_activates_recovered_receipt() {
-        let pool = setup_test_db().await;
+    async fn test_view_activates_receipt_on_existing_mint_recovered() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let aggregate_id = "iss-replay-recovered";
         let underlying = UnderlyingSymbol::new("MSTR");
         let token = TokenSymbol::new("tMSTR");
         let receipt_id = uint!(136_U256);
         let shares_minted = uint!(4_028802626000000000_U256);
-
-        let initiated = MintEvent::Initiated {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new("alp-replay"),
-            quantity: Quantity::new(Decimal::from(4)),
-            underlying: underlying.clone(),
-            token: token.clone(),
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            initiated_at: Utc::now(),
-        };
-        let initiated_payload = serde_json::to_string(&initiated).unwrap();
-
         let recovered_at = Utc::now();
-        let recovered = MintEvent::ExistingMintRecovered {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tx_hash: b256!(
-                "0xaff33e27ec0a4232eb2c172fac9a86f794d6551d969b301d734b9ca8511f1e07"
-            ),
-            receipt_id,
-            shares_minted,
-            block_number: 46_337_116,
-            recovered_at,
-        };
-        let recovered_payload = serde_json::to_string(&recovered).unwrap();
+        let mint_id = IssuerMintRequestId::random();
 
-        sqlx::query!(
-            r#"
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    underlying.clone(),
+                    token.clone(),
+                    "alp-recovered",
+                    address!("0x1234567890abcdef1234567890abcdef12345678"),
+                ),
             )
-            VALUES ('Mint', ?, 1, 'MintEvent::Initiated', '1.0', ?, '{}')
-            "#,
-            aggregate_id,
-            initiated_payload
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        sqlx::query!(
-            r#"
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES ('Mint', ?, 2, 'MintEvent::ExistingMintRecovered', '1.0', ?, '{}')
-            "#,
-            aggregate_id,
-            recovered_payload
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        // Seed a stale `Pending` row to reproduce the production bug: a recovered
-        // mint whose receipt was left in `Pending` because earlier code ignored
-        // `ExistingMintRecovered`. The replay must overwrite it with `Active`.
-        let stale_payload =
-            serde_json::to_string(&ReceiptInventoryView::Pending {
-                underlying: underlying.clone(),
-                token: token.clone(),
-            })
+            .await
             .unwrap();
-        sqlx::query!(
-            "
-            INSERT INTO receipt_inventory_view (view_id, version, payload)
-            VALUES (?, 2, ?)
-            ",
-            aggregate_id,
-            stale_payload
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
 
-        let view_repo =
-            Arc::new(SqliteViewRepository::<ReceiptInventoryView, Mint>::new(
-                pool.clone(),
-                "receipt_inventory_view".to_string(),
-            ));
-        let query = GenericQuery::new(view_repo);
+        assert!(matches!(
+            load_view(&pool, &mint_id).await,
+            ReceiptInventoryView::Pending { .. }
+        ));
 
-        let stale_view = query
-            .load(aggregate_id)
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                MintEvent::ExistingMintRecovered {
+                    issuer_request_id: IssuerMintRequestId::random(),
+                    tx_hash: b256!(
+                        "0xaff33e27ec0a4232eb2c172fac9a86f794d6551d969b301d734b9ca8511f1e07"
+                    ),
+                    receipt_id,
+                    shares_minted,
+                    block_number: 46_337_116,
+                    recovered_at,
+                },
+            )
             .await
-            .expect("Stale view row should load before replay");
-        assert!(
-            matches!(stale_view, ReceiptInventoryView::Pending { .. }),
-            "View should be stale Pending before replay, got {stale_view:?}"
-        );
-
-        replay_receipt_inventory_view(pool.clone())
-            .await
-            .expect("Replay should succeed");
-
-        let view = query
-            .load(aggregate_id)
-            .await
-            .expect("View should be populated after replay");
+            .unwrap();
 
         let ReceiptInventoryView::Active {
             receipt_id: view_receipt_id,
@@ -655,9 +604,9 @@ mod tests {
             initial_amount,
             current_balance,
             minted_at,
-        } = view
+        } = load_view(&pool, &mint_id).await
         else {
-            panic!("Expected Active variant after replay, got {view:?}");
+            panic!("Expected Active variant");
         };
 
         assert_eq!(view_receipt_id, receipt_id);
@@ -666,71 +615,47 @@ mod tests {
         assert_eq!(initial_amount, shares_minted);
         assert_eq!(current_balance, shares_minted);
         assert_eq!(minted_at, recovered_at);
-
-        assert!(
-            logs_contain_at!(
-                tracing::Level::DEBUG,
-                &["Rebuilding receipt inventory view from events"]
-            ),
-            "Expected DEBUG log on replay start"
-        );
-        assert!(
-            logs_contain_at!(
-                tracing::Level::DEBUG,
-                &["Receipt inventory view rebuild complete"]
-            ),
-            "Expected DEBUG log on replay completion"
-        );
     }
 
-    #[test]
-    fn test_multiple_mints_for_different_symbols() {
+    #[tokio::test]
+    async fn test_multiple_mints_for_different_symbols() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
+
         let aapl_underlying = UnderlyingSymbol::new("AAPL");
-        let aapl_token = TokenSymbol::new("tAAPL");
-
         let tsla_underlying = UnderlyingSymbol::new("TSLA");
-        let tsla_token = TokenSymbol::new("tTSLA");
+        let aapl_mint_id = IssuerMintRequestId::random();
+        let tsla_mint_id = IssuerMintRequestId::random();
 
-        let mut aapl_view = ReceiptInventoryView::default();
-        let mut tsla_view = ReceiptInventoryView::default();
+        harness
+            .receive::<Mint>(
+                aapl_mint_id.clone(),
+                initiated_event(
+                    aapl_underlying.clone(),
+                    TokenSymbol::new("tAAPL"),
+                    "alp-aapl",
+                    address!("0x1111111111111111111111111111111111111111"),
+                ),
+            )
+            .await
+            .unwrap();
 
-        let aapl_initiated = MintEvent::Initiated {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new("alp-aapl"),
-            quantity: Quantity::new(Decimal::from(100)),
-            underlying: aapl_underlying.clone(),
-            token: aapl_token,
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0x1111111111111111111111111111111111111111"),
-            initiated_at: Utc::now(),
-        };
+        harness
+            .receive::<Mint>(
+                tsla_mint_id.clone(),
+                initiated_event(
+                    tsla_underlying.clone(),
+                    TokenSymbol::new("tTSLA"),
+                    "alp-tsla",
+                    address!("0x2222222222222222222222222222222222222222"),
+                ),
+            )
+            .await
+            .unwrap();
 
-        let tsla_initiated = MintEvent::Initiated {
-            issuer_request_id: IssuerMintRequestId::random(),
-            tokenization_request_id: TokenizationRequestId::new("alp-tsla"),
-            quantity: Quantity::new(Decimal::from(50)),
-            underlying: tsla_underlying.clone(),
-            token: tsla_token,
-            network: Network::new("base"),
-            client_id: ClientId::new(),
-            wallet: address!("0x2222222222222222222222222222222222222222"),
-            initiated_at: Utc::now(),
-        };
-
-        aapl_view.update(&EventEnvelope::<Mint> {
-            aggregate_id: "iss-aapl".to_string(),
-            sequence: 1,
-            payload: aapl_initiated,
-            metadata: HashMap::new(),
-        });
-
-        tsla_view.update(&EventEnvelope::<Mint> {
-            aggregate_id: "iss-tsla".to_string(),
-            sequence: 1,
-            payload: tsla_initiated,
-            metadata: HashMap::new(),
-        });
+        let aapl_view = load_view(&pool, &aapl_mint_id).await;
+        let tsla_view = load_view(&pool, &tsla_mint_id).await;
 
         assert!(matches!(aapl_view, ReceiptInventoryView::Pending { .. }));
         assert!(matches!(tsla_view, ReceiptInventoryView::Pending { .. }));
@@ -744,13 +669,29 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_other_mint_events_do_not_change_state() {
-        let mut view = ReceiptInventoryView::Pending {
-            underlying: UnderlyingSymbol::new("AAPL"),
-            token: TokenSymbol::new("tAAPL"),
-        };
-        let original_view = view.clone();
+    #[tokio::test]
+    async fn test_other_mint_events_do_not_change_state() {
+        let pool = migrated_pool().await;
+        let harness =
+            ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
+
+        let mint_id = IssuerMintRequestId::random();
+
+        harness
+            .receive::<Mint>(
+                mint_id.clone(),
+                initiated_event(
+                    UnderlyingSymbol::new("AAPL"),
+                    TokenSymbol::new("tAAPL"),
+                    "alp-other",
+                    address!("0x4444444444444444444444444444444444444444"),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let original_view = load_view(&pool, &mint_id).await;
+        assert!(matches!(original_view, ReceiptInventoryView::Pending { .. }));
 
         let events = vec![
             MintEvent::JournalConfirmed {
@@ -774,16 +715,9 @@ mod tests {
         ];
 
         for event in events {
-            let envelope: EventEnvelope<Mint> = EventEnvelope {
-                aggregate_id: "iss-123".to_string(),
-                sequence: 2,
-                payload: event,
-                metadata: HashMap::new(),
-            };
+            harness.receive::<Mint>(mint_id.clone(), event).await.unwrap();
 
-            view.update(&envelope);
-
-            assert_eq!(view, original_view);
+            assert_eq!(load_view(&pool, &mint_id).await, original_view);
         }
     }
 }

--- a/src/replay.rs
+++ b/src/replay.rs
@@ -126,7 +126,6 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::mint::{Mint, MintView};
     use crate::redemption::upcaster::create_tokens_burned_upcaster;
     use crate::redemption::{Redemption, RedemptionView};
     use crate::test_utils::logs_contain_at;
@@ -220,21 +219,23 @@ mod tests {
     async fn replay_fails_fast_on_malformed_event() {
         let pool = migrated_pool().await;
 
-        // A Mint event whose payload cannot deserialize into MintEvent, so the
-        // stream delivers a per-event error the handler must surface.
+        // A Redemption event whose payload cannot deserialize into
+        // RedemptionEvent, so the stream delivers a per-event error the handler
+        // must surface.
         seed_event(
             &pool,
-            "Mint",
-            "MintEvent::Garbage",
+            "Redemption",
+            "RedemptionEvent::Garbage",
             "1.0",
             r#"{"NonexistentVariant":{}}"#,
         )
         .await;
 
-        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-            pool.clone(),
-            "mint_view".to_string(),
-        ));
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
         let event_repo = SqliteEventRepository::new(pool);
 
         let error = replay_all_or_fail(event_repo, view_repo, vec![])
@@ -360,20 +361,22 @@ mod tests {
     async fn replay_succeeds_on_empty_store() {
         let pool = migrated_pool().await;
 
-        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-            pool.clone(),
-            "mint_view".to_string(),
-        ));
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
         let event_repo = SqliteEventRepository::new(pool.clone());
 
         replay_all_or_fail(event_repo, view_repo, vec![])
             .await
             .expect("an empty event store is not a replay failure");
 
-        let rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM mint_view")
-            .fetch_one(&pool)
-            .await
-            .expect("mint_view should be queryable");
+        let rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM redemption_view")
+                .fetch_one(&pool)
+                .await
+                .expect("redemption_view should be queryable");
         assert_eq!(
             rows, 0,
             "a replay over no events must leave the view empty"
@@ -497,10 +500,11 @@ mod tests {
             .await
             .expect("Failed to drop events");
 
-        let view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-            pool.clone(),
-            "mint_view".to_string(),
-        ));
+        let view_repo =
+            Arc::new(SqliteViewRepository::<RedemptionView, Redemption>::new(
+                pool.clone(),
+                "redemption_view".to_string(),
+            ));
         let event_repo = SqliteEventRepository::new(pool);
 
         let error = replay_all_or_fail(event_repo, view_repo, vec![])

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -11,10 +11,8 @@ use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolValue;
 use alloy::transports::{RpcError, TransportErrorKind};
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
-use cqrs_es::persist::{GenericQuery, PersistedEventStore};
 use event_sorcery::{Store, StoreBuilder};
 use rocket::routes;
-use sqlite_es::{SqliteEventRepository, SqliteViewRepository, sqlite_cqrs};
 use sqlx::sqlite::SqlitePoolOptions;
 use std::sync::Arc;
 use url::Url;
@@ -29,8 +27,10 @@ use crate::bindings::{
 };
 use crate::config::{Config, LogLevel};
 use crate::fireblocks::SignerConfig;
-use crate::mint::{Mint, MintServices, MintView};
-use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+use crate::mint::{Mint, MintServices};
+use crate::receipt_inventory::{
+    CqrsReceiptService, ReceiptInventory, view::ReceiptInventoryViewReactor,
+};
 use crate::tokenized_asset::{
     Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol,
@@ -116,24 +116,13 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
         receipts: Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
     };
 
-    // Setup Mint CQRS
-    let mint_view_repo = Arc::new(SqliteViewRepository::<MintView, Mint>::new(
-        pool.clone(),
-        "mint_view".to_string(),
-    ));
-
-    let mint_query = GenericQuery::new(mint_view_repo);
-    let mint_cqrs = Arc::new(sqlite_cqrs(
-        pool.clone(),
-        vec![Box::new(mint_query)],
-        mint_services,
-    ));
-
-    let mint_event_repo = SqliteEventRepository::new(pool.clone());
-    let mint_event_store = Arc::new(PersistedEventStore::<
-        SqliteEventRepository,
-        Mint,
-    >::new_event_store(mint_event_repo));
+    // Setup Mint store (event-sorcery), mirroring the production wiring: the
+    // reactor keeps receipt_inventory_view in sync with Mint events.
+    let (mint_store, _mint_projection) =
+        StoreBuilder::<Mint>::new(pool.clone())
+            .with(Arc::new(ReceiptInventoryViewReactor::new(pool.clone())))
+            .build(mint_services)
+            .await?;
 
     // Seed initial assets
     seed_test_assets(&tokenized_asset_store).await?;
@@ -145,8 +134,7 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
         .manage(test_config()?)
         .manage(account_store)
         .manage(tokenized_asset_store)
-        .manage(mint_cqrs)
-        .manage(mint_event_store)
+        .manage(mint_store)
         .manage(rate_limiter)
         .manage(pool)
         .mount(


### PR DESCRIPTION
## Motivation

Part of migrating st0x.issuance off its in-repo `cqrs-es` / `sqlite-es` wiring
and onto the extracted
[`event-sorcery`](https://github.com/ST0x-Technology/event-sorcery) crate (epic
RAI-785). `Mint` is the fourth and most complex aggregate to migrate — it is the
first with real injected `Services`, the first whose stream has a second view,
and it drives the recovery flow and the mint HTTP endpoints. Migrating it
establishes the `Services` and `Reactor` patterns the remaining work builds on.

Stacked on #174. Closes RAI-556.

## Solution

`Mint` now implements `event_sorcery::EventSourced`.

- **Aggregate** (`src/mint/mod.rs`): the lifecycle enum drops `Uninitialized`
  (lifted into event-sorcery's `Lifecycle`); `handle`/`apply` split into
  `initialize`/`transition` (commands) and `originate`/`evolve`/`apply_event`
  (events), preserving the exact state machine including the multi-event
  recovery paths. `Id = IssuerMintRequestId` (given a `FromStr`),
  `Services = MintServices`, `Materialized = Table("mint_view")`.
- **MintError → pure domain** (settled design decision): the aggregate error is
  now `Clone + Serialize + Deserialize`. The two genuinely-unreachable service
  variants (`AccountView`, `ReceiptInventoryView`) were dropped; the five
  reachable ones (`Vault`, `Alpaca`, `AssetView`, `ReceiptLookup`,
  `QuantityConversion`) are stringified at the `MintError` boundary
  (`{ message: String }`). The underlying `VaultError` / `AlpacaError` / view /
  fireblocks error types are left completely untouched — no cascade into the
  Fireblocks SDK, and `is_retryable` etc. keep their typed errors.
- **ReceiptInventoryView → Reactor** (settled design decision): event-sorcery
  allows one `Table` projection per aggregate (that is `mint_view`), so the
  second `View<Mint>` is kept up to date by `ReceiptInventoryViewReactor`
  registered via `StoreBuilder::with()` — the first reactor in this repo.
- **MintView → canonical Table projection**: `impl View<Mint>` and
  `replay_mint_view` are removed; the query helpers read the `$.Live.*` payload.
  A `FireblocksSubmitted` variant was added so the projection deserializes every
  live `Mint` state (it was previously collapsed into `Minting`), and the
  recoverable / stuck queries now also match `$.Live.FireblocksSubmitted`.
- **Recovery / HTTP / admin** (`recovery.rs`, `mint/api/*`, `admin.rs`):
  `cqrs.execute` → `Store::send` with the typed id, `load_aggregate` →
  `Store::load`, and the error matching re-targets
  `AggregateError<LifecycleError<Mint>>` (the API maps `AggregateConflict` /
  `AlreadyInitiated` → 409). `admin`'s event-history read swaps to a direct sqlx
  query (`Store` has no `load_events`).
- **Wiring** (`src/lib.rs`): built with
  `StoreBuilder::<Mint>::new(pool).with(reactor).build(mint_services)`; the
  `MintCqrs` / `MintEventStore` aliases and `MintDeps` are gone, replaced by a
  single `Arc<Store<Mint>>`. `mint_view` is rebuilt from scratch at startup
  (`Projection::rebuild_all`) so it stays correct even when the event log is
  rolled back below the existing view version — `catch_up` is incremental and
  cannot detect a truncated log; this preserves the prior `replay_mint_view`
  startup behaviour that recovery depends on.
- **Tests**: aggregate tests move to `event_sorcery::TestHarness` / `replay`;
  the projection/recovery/api harnesses to `test_store` / `StoreBuilder`; the
  reactor is tested via `ReactorHarness`.

Existing `Mint` events replay unchanged — `event_type` strings and payloads are
byte-identical; only the aggregate, error, view and service representations
change.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added FireblocksSubmitted state to track Fireblocks-submitted transactions in mint operations
  * Enhanced mint stuck classification and history handling for improved visibility

* **Improvements**
  * Updated error handling with typed error structures for better diagnostics
  * Refined admin endpoints for mint management (reprocess, close, list stuck)
  * Improved mint recovery mechanism and handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->