### PR TITLE
fix: pin event-sorcery to version with sqlite-es bug fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,7 +217,7 @@ dependencies = [
  "either",
  "serde",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
 ]
 
@@ -775,7 +775,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1227,6 +1227,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "blst"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,10 +1389,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chrono"
-version = "0.4.44"
+name = "chacha20"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1461,6 +1481,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,7 +1525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "proptest",
  "serde_core",
 ]
@@ -1587,15 +1613,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "cqrs-es"
-version = "0.4.12"
+name = "cpufeatures"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5da025e9082adb74e8bb2b7e93feed51c711aa6c384cc18ad03b463ed776db64"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cqrs-es"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de58236a73fe80ff6cd1af71c5205ce5652033f0cb47b42f820d82481903fe12"
 dependencies = [
  "async-trait",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
 ]
 
@@ -1667,13 +1702,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
@@ -1852,10 +1905,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1921,7 +1985,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1959,7 +2023,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2011,18 +2075,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2049,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "event-sorcery"
 version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git#1557172049c8a43add209a86c7d809e89a5fbc82"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
 dependencies = [
  "async-trait",
  "cqrs-es",
@@ -2144,7 +2207,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2176,9 +2239,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2404,6 +2467,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -2556,11 +2620,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -2575,7 +2639,7 @@ dependencies = [
  "http 1.4.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.6",
 ]
 
 [[package]]
@@ -2620,7 +2684,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -2633,12 +2706,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.59.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2743,6 +2816,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2837,7 +2919,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3053,7 +3135,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3116,7 +3198,7 @@ dependencies = [
  "base64",
  "ed25519-dalek",
  "getrandom 0.2.17",
- "hmac",
+ "hmac 0.12.1",
  "js-sys",
  "p256",
  "p384",
@@ -3125,7 +3207,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "signature",
  "simple_asn1",
 ]
@@ -3141,7 +3223,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3150,7 +3232,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -3204,18 +3286,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3307,12 +3377,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3406,7 +3476,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3654,7 +3724,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3666,7 +3736,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3721,7 +3791,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3867,12 +3937,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -4083,7 +4147,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4120,7 +4184,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4176,6 +4240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4215,6 +4290,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4247,15 +4328,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -4386,7 +4458,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -4649,7 +4721,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4883,9 +4955,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4973,8 +5045,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -4984,8 +5067,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5105,7 +5199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5139,9 +5233,8 @@ dependencies = [
 [[package]]
 name = "sqlite-es"
 version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git#1557172049c8a43add209a86c7d809e89a5fbc82"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
 dependencies = [
- "async-trait",
  "chrono",
  "cqrs-es",
  "serde",
@@ -5154,9 +5247,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -5167,12 +5260,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -5182,31 +5276,30 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap 2.14.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "rustls",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5217,77 +5310,62 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.117",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -5301,18 +5379,16 @@ dependencies = [
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -5323,13 +5399,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -5339,7 +5416,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -5576,7 +5652,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6045,7 +6121,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -6259,12 +6335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6408,13 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "winapi"
@@ -6519,27 +6585,9 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,17 +4,18 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git" }
-sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git" }
-cqrs-es = "0.4.12"
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1" }
+sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1" }
+cqrs-es = "0.5.0"
 async-trait = "0.1.89"
 rocket = { version = "0.5.1", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
-sqlx = { version = "0.8.6", features = [
+serde_json = "1.0.150"
+sqlx = { version = "0.9.0", features = [
   "sqlite",
   "chrono",
-  "runtime-tokio-rustls",
+  "runtime-tokio",
+  "tls-rustls",
   "macros",
   "migrate",
 ] }
@@ -55,7 +56,7 @@ flate2 = "1.1.9"
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"
 alloy-sol-types = "1.4.1"
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", features = [
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1", features = [
   "test-support",
 ] }
 httpmock = "0.8.2"

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
-use sqlx::{Sqlite, encode::IsNull, sqlite::SqliteArgumentValue};
+use sqlx::Encode;
+use sqlx::sqlite::SqliteArgumentsBuffer;
+use sqlx::{Sqlite, encode::IsNull};
 use std::str::FromStr;
 use uuid::Uuid;
 
@@ -90,13 +92,12 @@ impl sqlx::Type<Sqlite> for ClientId {
     }
 }
 
-impl<'q> sqlx::Encode<'q, Sqlite> for ClientId {
+impl Encode<'_, Sqlite> for ClientId {
     fn encode_by_ref(
         &self,
-        args: &mut Vec<SqliteArgumentValue<'q>>,
+        args: &mut SqliteArgumentsBuffer,
     ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        args.push(SqliteArgumentValue::Text(self.0.to_string().into()));
-        Ok(IsNull::No)
+        <String as Encode<'_, Sqlite>>::encode_by_ref(&self.0.to_string(), args)
     }
 }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2212,7 +2212,7 @@ mod tests {
 
         result.expect("Expected Ok response");
 
-        let context = event_store
+        let mut context = event_store
             .load_aggregate(&metadata.issuer_request_id.to_string())
             .await
             .expect("Expected aggregate to load");
@@ -2274,7 +2274,7 @@ mod tests {
 
         result.expect("Expected Ok response");
 
-        let context = event_store
+        let mut context = event_store
             .load_aggregate(&metadata.issuer_request_id.to_string())
             .await
             .expect("Expected aggregate to load");

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -49,7 +49,7 @@ pub(crate) async fn confirm_journal(
         issuer_request_id, tokenization_request_id.0, status
     );
 
-    let mint_ctx = match event_store
+    let mut mint_ctx = match event_store
         .load_aggregate(&issuer_request_id.to_string())
         .await
     {
@@ -171,7 +171,7 @@ async fn process_journal_completion(
     }
 
     // Step 3: Load the fireblocks_tx_id from the aggregate and confirm
-    let context = match event_store.load_aggregate(&aggregate_id).await {
+    let mut context = match event_store.load_aggregate(&aggregate_id).await {
         Ok(ctx) => ctx,
         Err(err) => {
             error!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -231,7 +231,7 @@ async fn process_journal_completion(
         return;
     }
 
-    let context = match event_store.load_aggregate(&aggregate_id).await {
+    let mut context = match event_store.load_aggregate(&aggregate_id).await {
         Ok(ctx) => ctx,
         Err(err) => {
             error!(target: "mint", issuer_request_id = %issuer_request_id,

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -5,9 +5,9 @@ pub(crate) mod recovery;
 mod view;
 
 use alloy::primitives::{Address, B256, TxHash, U256};
-use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use cqrs_es::Aggregate;
+use cqrs_es::event_sink::EventSink;
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
@@ -242,7 +242,7 @@ pub(crate) enum Mint {
 
 /// Groups mint submission parameters to keep `execute_mint_submission` under
 /// the clippy argument limit.
-struct MintSubmissionInput<'a> {
+struct MintSubmissionParams<'a> {
     issuer_request_id: IssuerMintRequestId,
     tokenization_request_id: &'a TokenizationRequestId,
     quantity: &'a Quantity,
@@ -257,6 +257,75 @@ struct MintSubmissionInput<'a> {
 struct KnownMintTx {
     external_tx_id: String,
     fireblocks_tx_id: String,
+}
+
+struct IncompleteMintRecovery {
+    tokenization_request_id: TokenizationRequestId,
+    quantity: Quantity,
+    underlying: UnderlyingSymbol,
+    wallet: Address,
+    journal_confirmed_at: DateTime<Utc>,
+    is_minting_failed: bool,
+}
+
+struct KnownTxRecovery {
+    issuer_request_id: IssuerMintRequestId,
+    recovery: IncompleteMintRecovery,
+    vault: Address,
+    receipt_info: ReceiptInformation,
+    receipt_tx_hash: Option<TxHash>,
+    known_tx: KnownMintTx,
+    mode: MintRecoveryMode,
+}
+
+impl IncompleteMintRecovery {
+    fn from_mint(
+        mint: &Mint,
+    ) -> Result<(IssuerMintRequestId, Self), MintError> {
+        match mint {
+            Mint::Minting {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                wallet,
+                journal_confirmed_at,
+                ..
+            } => Ok((
+                issuer_request_id.clone(),
+                Self {
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    quantity: quantity.clone(),
+                    underlying: underlying.clone(),
+                    wallet: *wallet,
+                    journal_confirmed_at: *journal_confirmed_at,
+                    is_minting_failed: false,
+                },
+            )),
+            Mint::MintingFailed {
+                issuer_request_id,
+                tokenization_request_id,
+                quantity,
+                underlying,
+                wallet,
+                journal_confirmed_at,
+                ..
+            } => Ok((
+                issuer_request_id.clone(),
+                Self {
+                    tokenization_request_id: tokenization_request_id.clone(),
+                    quantity: quantity.clone(),
+                    underlying: underlying.clone(),
+                    wallet: *wallet,
+                    journal_confirmed_at: *journal_confirmed_at,
+                    is_minting_failed: true,
+                },
+            )),
+            _ => Err(MintError::NotInMintingOrMintingFailedState {
+                current_state: mint.state_name().to_string(),
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -418,10 +487,11 @@ impl Mint {
         }
     }
 
-    fn handle_confirm_journal(
-        &self,
+    async fn handle_confirm_journal(
+        &mut self,
+        sink: &EventSink<Self>,
         provided_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::Initiated { issuer_request_id: expected_id, .. } = self
         else {
             return Err(MintError::NotInInitiatedState {
@@ -431,19 +501,24 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &provided_id)?;
 
-        let now = Utc::now();
+        sink.write(
+            MintEvent::JournalConfirmed {
+                issuer_request_id: provided_id,
+                confirmed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
 
-        Ok(vec![MintEvent::JournalConfirmed {
-            issuer_request_id: provided_id,
-            confirmed_at: now,
-        }])
+        Ok(())
     }
 
-    fn handle_reject_journal(
-        &self,
+    async fn handle_reject_journal(
+        &mut self,
+        sink: &EventSink<Self>,
         provided_id: IssuerMintRequestId,
         reason: String,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::Initiated { issuer_request_id: expected_id, .. } = self
         else {
             return Err(MintError::NotInInitiatedState {
@@ -453,13 +528,17 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &provided_id)?;
 
-        let now = Utc::now();
+        sink.write(
+            MintEvent::JournalRejected {
+                issuer_request_id: provided_id,
+                reason,
+                rejected_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
 
-        Ok(vec![MintEvent::JournalRejected {
-            issuer_request_id: provided_id,
-            reason,
-            rejected_at: now,
-        }])
+        Ok(())
     }
 
     fn validate_issuer_request_id(
@@ -477,10 +556,11 @@ impl Mint {
 
     /// Records the intent to mint by transitioning from `JournalConfirmed`
     /// to `Minting` state. Pure state transition — no network call.
-    fn handle_deposit(
-        &self,
+    async fn handle_deposit(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::JournalConfirmed { issuer_request_id: expected_id, .. } =
             self
         else {
@@ -491,19 +571,26 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        Ok(vec![MintEvent::MintingStarted {
-            issuer_request_id,
-            started_at: Utc::now(),
-        }])
+        sink.write(
+            MintEvent::MintingStarted {
+                issuer_request_id,
+                started_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Submits the on-chain mint transaction to the signing backend.
     /// Requires `Minting` state (set by prior `Deposit` command).
     async fn handle_submit_mint(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::Minting {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -523,7 +610,7 @@ impl Mint {
 
         let event = Self::execute_mint_submission(
             services,
-            MintSubmissionInput {
+            MintSubmissionParams {
                 issuer_request_id,
                 tokenization_request_id,
                 quantity,
@@ -536,16 +623,18 @@ impl Mint {
         )
         .await?;
 
-        Ok(vec![event])
+        sink.write(event, self).await;
+
+        Ok(())
     }
 
     /// Shared submission logic: vault lookup, receipt info, submit_mint call.
     /// Returns a single `FireblocksSubmitted` or `MintingFailed` event.
     async fn execute_mint_submission(
         services: &MintServices,
-        input: MintSubmissionInput<'_>,
+        input: MintSubmissionParams<'_>,
     ) -> Result<MintEvent, MintError> {
-        let MintSubmissionInput {
+        let MintSubmissionParams {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -622,11 +711,12 @@ impl Mint {
     /// Confirms a previously submitted mint transaction by polling the backend.
     /// Produces `TokensMinted` on success, or `MintingFailed` on failure.
     async fn handle_confirm_mint(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         fireblocks_tx_id: String,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::FireblocksSubmitted {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -722,15 +812,21 @@ impl Mint {
                     }
                 }
 
-                Ok(vec![MintEvent::TokensMinted {
-                    issuer_request_id,
-                    tx_hash: result.tx_hash,
-                    receipt_id: result.receipt_id,
-                    shares_minted: result.shares_minted,
-                    gas_used: result.gas_used,
-                    block_number: result.block_number,
-                    minted_at: now,
-                }])
+                sink.write(
+                    MintEvent::TokensMinted {
+                        issuer_request_id,
+                        tx_hash: result.tx_hash,
+                        receipt_id: result.receipt_id,
+                        shares_minted: result.shares_minted,
+                        gas_used: result.gas_used,
+                        block_number: result.block_number,
+                        minted_at: now,
+                    },
+                    self,
+                )
+                .await;
+
+                Ok(())
             }
             Err(err) => {
                 warn!(
@@ -740,20 +836,27 @@ impl Mint {
                     "On-chain deposit confirmation failed"
                 );
 
-                Ok(vec![MintEvent::MintingFailed {
-                    issuer_request_id,
-                    error: err.to_string(),
-                    failed_at: now,
-                }])
+                sink.write(
+                    MintEvent::MintingFailed {
+                        issuer_request_id,
+                        error: err.to_string(),
+                        failed_at: now,
+                    },
+                    self,
+                )
+                .await;
+
+                Ok(())
             }
         }
     }
 
     async fn handle_send_callback(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let Self::CallbackPending {
             issuer_request_id: expected_id,
             tokenization_request_id,
@@ -787,25 +890,34 @@ impl Mint {
             "Alpaca callback succeeded"
         );
 
-        Ok(vec![MintEvent::MintCompleted {
-            issuer_request_id,
-            completed_at: Utc::now(),
-        }])
+        sink.write(
+            MintEvent::MintCompleted {
+                issuer_request_id,
+                completed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     async fn handle_recover(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        match self {
+    ) -> Result<(), MintError> {
+        match &*self {
             Self::JournalConfirmed { .. } => {
                 // Emit MintingStarted (intent). drive_recovery will call
                 // Recover again, which hits the Minting arm to submit.
-                self.handle_deposit(issuer_request_id)
+                self.handle_deposit(sink, issuer_request_id).await
             }
             Self::FireblocksSubmitted { fireblocks_tx_id, .. } => {
+                let fireblocks_tx_id = fireblocks_tx_id.clone();
+
                 // Non-blocking pre-check: a pending tx must pause recovery (so
                 // the scheduled loop backs off) instead of blocking in
                 // confirm_mint's long poll, which the bounded startup recovery
@@ -813,28 +925,24 @@ impl Mint {
                 if matches!(
                     services
                         .vault
-                        .check_fireblocks_tx(fireblocks_tx_id)
+                        .check_fireblocks_tx(&fireblocks_tx_id)
                         .await?,
                     Some(FireblocksTxStatus::Pending)
                 ) {
                     return Err(MintError::FireblocksTxStillPending {
-                        fireblocks_tx_id: fireblocks_tx_id.clone(),
+                        fireblocks_tx_id,
                     });
                 }
 
-                let deposit_events = self
-                    .handle_confirm_mint(
-                        services,
-                        issuer_request_id.clone(),
-                        fireblocks_tx_id.clone(),
-                    )
-                    .await?;
-                self.advance_through_callback(
+                self.handle_confirm_mint(
                     services,
-                    issuer_request_id,
-                    deposit_events,
+                    sink,
+                    issuer_request_id.clone(),
+                    fireblocks_tx_id,
                 )
-                .await
+                .await?;
+                self.advance_through_callback(services, sink, issuer_request_id)
+                    .await
             }
             Self::MintingFailed { .. } => {
                 // Preserve the previous Fireblocks tx so recovery can
@@ -842,41 +950,34 @@ impl Mint {
                 // failures that are safe to resubmit.
                 let known_tx = self.latest_known_mint_tx();
 
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        None,
-                        known_tx,
-                        mode,
-                    )
-                    .await?;
-                self.advance_through_callback(
+                self.handle_recover_incomplete(
                     services,
-                    issuer_request_id,
-                    deposit_events,
+                    sink,
+                    issuer_request_id.clone(),
+                    None,
+                    known_tx,
+                    mode,
                 )
-                .await
+                .await?;
+                self.advance_through_callback(services, sink, issuer_request_id)
+                    .await
             }
             Self::Minting { .. } => {
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        None,
-                        None,
-                        mode,
-                    )
-                    .await?;
-                self.advance_through_callback(
+                self.handle_recover_incomplete(
                     services,
-                    issuer_request_id,
-                    deposit_events,
+                    sink,
+                    issuer_request_id.clone(),
+                    None,
+                    None,
+                    mode,
                 )
-                .await
+                .await?;
+                self.advance_through_callback(services, sink, issuer_request_id)
+                    .await
             }
             Self::CallbackPending { .. } => {
-                self.handle_send_callback(services, issuer_request_id).await
+                self.handle_send_callback(services, sink, issuer_request_id)
+                    .await
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
@@ -894,12 +995,13 @@ impl Mint {
     /// `CallbackPending` here would race with the normal flow's
     /// `SendCallback` command, causing duplicate Alpaca callbacks.
     async fn handle_recover_from_receipt(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         tx_hash: TxHash,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        match self {
+    ) -> Result<(), MintError> {
+        match &*self {
             Self::MintingFailed { .. }
                 if matches!(
                     self.non_failed_predecessor(),
@@ -908,21 +1010,17 @@ impl Mint {
             {
                 let known_tx = self.latest_known_mint_tx();
 
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        Some(tx_hash),
-                        known_tx,
-                        MintRecoveryMode::Manual,
-                    )
-                    .await?;
-                self.advance_through_callback(
+                self.handle_recover_incomplete(
                     services,
-                    issuer_request_id,
-                    deposit_events,
+                    sink,
+                    issuer_request_id.clone(),
+                    Some(tx_hash),
+                    known_tx,
+                    MintRecoveryMode::Manual,
                 )
-                .await
+                .await?;
+                self.advance_through_callback(services, sink, issuer_request_id)
+                    .await
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
@@ -930,11 +1028,9 @@ impl Mint {
         }
     }
 
-    /// If `deposit_events` contain a successful deposit (`TokensMinted` or
-    /// `ExistingMintRecovered`), advance through `CallbackPending` by
-    /// sending the Alpaca callback in the same command execution and
-    /// return the combined event list. Otherwise return `deposit_events`
-    /// unchanged.
+    /// If the aggregate reached `CallbackPending` after deposit recovery,
+    /// advance through the Alpaca callback in the same command execution.
+    /// Otherwise return immediately.
     ///
     /// Keeps recovery atomic: a single `Recover` command takes the
     /// aggregate from a stuck pre-callback state straight to `Completed`,
@@ -943,252 +1039,91 @@ impl Mint {
     /// boot-time loop, or receipt-discovery handler) picks up the same
     /// advancing behavior.
     async fn advance_through_callback(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
-        deposit_events: Vec<MintEvent>,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let deposit_succeeded = deposit_events.iter().any(|event| {
-            matches!(
-                event,
-                MintEvent::TokensMinted { .. }
-                    | MintEvent::ExistingMintRecovered { .. }
-            )
-        });
-
-        if !deposit_succeeded {
-            return Ok(deposit_events);
-        }
-
-        let mut intermediate = self.clone();
-        for event in &deposit_events {
-            intermediate.apply(event.clone());
+    ) -> Result<(), MintError> {
+        if !matches!(self, Self::CallbackPending { .. }) {
+            return Ok(());
         }
 
         // If callback delivery fails after a successful on-chain deposit,
-        // preserve the deposit events so the aggregate advances to
-        // CallbackPending. The next recovery picks up from there instead
-        // of re-running the deposit path.
-        let callback_events = match intermediate
-            .handle_send_callback(services, issuer_request_id.clone())
+        // preserve CallbackPending. The next recovery picks up from there
+        // instead of re-running the deposit path.
+        if let Err(err) = self
+            .handle_send_callback(services, sink, issuer_request_id.clone())
             .await
         {
-            Ok(events) => events,
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Callback failed after successful deposit; \
-                     keeping mint in CallbackPending"
-                );
-                return Ok(deposit_events);
-            }
-        };
+            warn!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                error = %err,
+                "Callback failed after successful deposit; \
+                 keeping mint in CallbackPending"
+            );
+        }
 
-        Ok(deposit_events.into_iter().chain(callback_events).collect())
+        Ok(())
     }
 
     async fn handle_recover_incomplete(
-        &self,
+        &mut self,
         services: &MintServices,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         receipt_tx_hash: Option<TxHash>,
         known_mint_tx: Option<KnownMintTx>,
         mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let (Self::Minting {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            wallet,
-            journal_confirmed_at,
-            ..
-        }
-        | Self::MintingFailed {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            wallet,
-            journal_confirmed_at,
-            ..
-        }) = self
-        else {
-            return Err(MintError::NotInMintingOrMintingFailedState {
-                current_state: self.state_name().to_string(),
-            });
-        };
+    ) -> Result<(), MintError> {
+        let (expected_id, recovery) = IncompleteMintRecovery::from_mint(self)?;
 
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
+        Self::validate_issuer_request_id(&expected_id, &issuer_request_id)?;
 
-        let vault = find_vault_by_underlying(&services.pool, underlying)
-            .await?
-            .ok_or_else(|| MintError::AssetNotFound {
-                underlying: underlying.clone(),
-            })?;
+        let vault =
+            find_vault_by_underlying(&services.pool, &recovery.underlying)
+                .await?
+                .ok_or_else(|| MintError::AssetNotFound {
+                    underlying: recovery.underlying.clone(),
+                })?;
 
-        if let Some(events) = Self::recover_from_existing_receipt(
+        if Self::recover_from_existing_receipt(
             services,
             &vault,
             &issuer_request_id,
+            sink,
+            self,
         )
         .await?
         {
-            return Ok(events);
+            return Ok(());
         }
 
         let receipt_info = ReceiptInformation::new(
-            tokenization_request_id.clone(),
+            recovery.tokenization_request_id.clone(),
             issuer_request_id.clone(),
-            underlying.clone(),
-            quantity.clone(),
-            *journal_confirmed_at,
+            recovery.underlying.clone(),
+            recovery.quantity.clone(),
+            recovery.journal_confirmed_at,
             Some("Recovery mint".to_string()),
         );
 
-        let now = Utc::now();
-
         if let Some(known_tx) = known_mint_tx {
-            // Known tx_id from a prior submission: go straight to confirm.
-            info!(
-                target: "mint",
-                issuer_request_id = %issuer_request_id,
-                fireblocks_tx_id = %known_tx.fireblocks_tx_id,
-                "Resuming confirmation of previously submitted mint"
-            );
-
-            if let Some(status) = services
-                .vault
-                .check_fireblocks_tx(&known_tx.fireblocks_tx_id)
-                .await?
-            {
-                match status {
-                    FireblocksTxStatus::Completed { .. } => {}
-                    FireblocksTxStatus::Pending => {
-                        return Err(MintError::FireblocksTxStillPending {
-                            fireblocks_tx_id: known_tx.fireblocks_tx_id,
-                        });
-                    }
-                    FireblocksTxStatus::Failed {
-                        detail, sub_status, ..
-                    } => {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            fireblocks_tx_id = %known_tx.fireblocks_tx_id,
-                            external_tx_id = %known_tx.external_tx_id,
-                            sub_status = sub_status.as_deref().unwrap_or(""),
-                            detail = %detail,
-                            "Previous Fireblocks mint transaction failed; \
-                             submitting retry"
-                        );
-
-                        return self
-                            .submit_recovery_mint(
-                                services,
-                                MintSubmissionInput {
-                                    issuer_request_id,
-                                    tokenization_request_id,
-                                    quantity,
-                                    underlying,
-                                    wallet: *wallet,
-                                    journal_confirmed_at: *journal_confirmed_at,
-                                    receipt_note: Some("Recovery mint"),
-                                    external_tx_id: None,
-                                },
-                                receipt_tx_hash,
-                                mode,
-                            )
-                            .await;
-                    }
-                }
-            }
-
-            return match services
-                .vault
-                .confirm_mint(&known_tx.fireblocks_tx_id)
-                .await
-            {
-                Ok(result) => {
-                    info!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        tx_hash = %result.tx_hash,
-                        "Recovery mint succeeded"
-                    );
-
-                    // Best-effort receipt registration
-                    if let Err(err) = services
-                        .receipts
-                        .register_minted_receipt(MintedReceiptParams {
-                            vault,
-                            receipt_id: ReceiptId::from(result.receipt_id),
-                            shares: Shares::from(result.shares_minted),
-                            block_number: result.block_number,
-                            tx_hash: result.tx_hash,
-                            receipt_info: receipt_info.clone(),
-                            receipt_info_bytes: result
-                                .receipt_info_bytes
-                                .clone(),
-                        })
-                        .await
-                    {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            error = %err,
-                            "Failed to register recovered receipt \
-                             (monitor/backfill will discover it)"
-                        );
-                    }
-
-                    let retry_event =
-                        matches!(self, Self::MintingFailed { .. }).then(|| {
-                            MintEvent::MintRetryStarted {
-                                issuer_request_id: issuer_request_id.clone(),
-                                tx_hash: receipt_tx_hash,
-                                started_at: now,
-                            }
-                        });
-
-                    let minted = MintEvent::TokensMinted {
+            return self
+                .resume_incomplete_recovery_known_tx(
+                    services,
+                    sink,
+                    KnownTxRecovery {
                         issuer_request_id,
-                        tx_hash: result.tx_hash,
-                        receipt_id: result.receipt_id,
-                        shares_minted: result.shares_minted,
-                        gas_used: result.gas_used,
-                        block_number: result.block_number,
-                        minted_at: now,
-                    };
-
-                    Ok(retry_event
-                        .into_iter()
-                        .chain(std::iter::once(minted))
-                        .collect())
-                }
-                Err(err) => {
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        error = %err,
-                        "Recovery mint confirmation failed — \
-                         preserving fireblocks_tx_id for next retry"
-                    );
-
-                    // Do NOT emit MintRetryStarted here — that would
-                    // move the aggregate from MintingFailed to Minting,
-                    // losing the FireblocksSubmitted predecessor and its
-                    // fireblocks_tx_id. Instead, re-emit MintingFailed
-                    // which keeps the existing predecessor chain intact.
-                    Ok(vec![MintEvent::MintingFailed {
-                        issuer_request_id,
-                        error: err.to_string(),
-                        failed_at: now,
-                    }])
-                }
-            };
+                        recovery,
+                        vault,
+                        receipt_info,
+                        receipt_tx_hash,
+                        known_tx,
+                        mode,
+                    },
+                )
+                .await;
         }
 
         // No prior tx_id: submit and persist FireblocksSubmitted.
@@ -1196,13 +1131,14 @@ impl Mint {
         // ConfirmMint from the FireblocksSubmitted state.
         self.submit_recovery_mint(
             services,
-            MintSubmissionInput {
+            sink,
+            MintSubmissionParams {
                 issuer_request_id,
-                tokenization_request_id,
-                quantity,
-                underlying,
-                wallet: *wallet,
-                journal_confirmed_at: *journal_confirmed_at,
+                tokenization_request_id: &recovery.tokenization_request_id,
+                quantity: &recovery.quantity,
+                underlying: &recovery.underlying,
+                wallet: recovery.wallet,
+                journal_confirmed_at: recovery.journal_confirmed_at,
                 receipt_note: Some("Recovery mint"),
                 external_tx_id: None,
             },
@@ -1212,13 +1148,176 @@ impl Mint {
         .await
     }
 
-    async fn submit_recovery_mint(
-        &self,
+    async fn resume_incomplete_recovery_known_tx(
+        &mut self,
         services: &MintServices,
-        mut input: MintSubmissionInput<'_>,
+        sink: &EventSink<Self>,
+        recovery: KnownTxRecovery,
+    ) -> Result<(), MintError> {
+        let KnownTxRecovery {
+            issuer_request_id,
+            recovery,
+            vault,
+            receipt_info,
+            receipt_tx_hash,
+            known_tx,
+            mode,
+        } = recovery;
+
+        info!(
+            target: "mint",
+            issuer_request_id = %issuer_request_id,
+            fireblocks_tx_id = %known_tx.fireblocks_tx_id,
+            "Resuming confirmation of previously submitted mint"
+        );
+
+        if let Some(status) = services
+            .vault
+            .check_fireblocks_tx(&known_tx.fireblocks_tx_id)
+            .await?
+        {
+            match status {
+                FireblocksTxStatus::Completed { .. } => {}
+                FireblocksTxStatus::Pending => {
+                    return Err(MintError::FireblocksTxStillPending {
+                        fireblocks_tx_id: known_tx.fireblocks_tx_id,
+                    });
+                }
+                FireblocksTxStatus::Failed { detail, sub_status, .. } => {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        fireblocks_tx_id = %known_tx.fireblocks_tx_id,
+                        external_tx_id = %known_tx.external_tx_id,
+                        sub_status = sub_status.as_deref().unwrap_or(""),
+                        detail = %detail,
+                        "Previous Fireblocks mint transaction failed; \
+                         submitting retry"
+                    );
+
+                    return self
+                        .submit_recovery_mint(
+                            services,
+                            sink,
+                            MintSubmissionParams {
+                                issuer_request_id,
+                                tokenization_request_id: &recovery
+                                    .tokenization_request_id,
+                                quantity: &recovery.quantity,
+                                underlying: &recovery.underlying,
+                                wallet: recovery.wallet,
+                                journal_confirmed_at: recovery
+                                    .journal_confirmed_at,
+                                receipt_note: Some("Recovery mint"),
+                                external_tx_id: None,
+                            },
+                            receipt_tx_hash,
+                            mode,
+                        )
+                        .await;
+                }
+            }
+        }
+
+        let now = Utc::now();
+
+        match services.vault.confirm_mint(&known_tx.fireblocks_tx_id).await {
+            Ok(result) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %result.tx_hash,
+                    "Recovery mint succeeded"
+                );
+
+                // Best-effort receipt registration
+                if let Err(err) = services
+                    .receipts
+                    .register_minted_receipt(MintedReceiptParams {
+                        vault,
+                        receipt_id: ReceiptId::from(result.receipt_id),
+                        shares: Shares::from(result.shares_minted),
+                        block_number: result.block_number,
+                        tx_hash: result.tx_hash,
+                        receipt_info: receipt_info.clone(),
+                        receipt_info_bytes: result.receipt_info_bytes.clone(),
+                    })
+                    .await
+                {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Failed to register recovered receipt \
+                         (monitor/backfill will discover it)"
+                    );
+                }
+
+                if recovery.is_minting_failed {
+                    sink.write(
+                        MintEvent::MintRetryStarted {
+                            issuer_request_id: issuer_request_id.clone(),
+                            tx_hash: receipt_tx_hash,
+                            started_at: now,
+                        },
+                        self,
+                    )
+                    .await;
+                }
+
+                sink.write(
+                    MintEvent::TokensMinted {
+                        issuer_request_id,
+                        tx_hash: result.tx_hash,
+                        receipt_id: result.receipt_id,
+                        shares_minted: result.shares_minted,
+                        gas_used: result.gas_used,
+                        block_number: result.block_number,
+                        minted_at: now,
+                    },
+                    self,
+                )
+                .await;
+
+                Ok(())
+            }
+            Err(err) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Recovery mint confirmation failed — \
+                     preserving fireblocks_tx_id for next retry"
+                );
+
+                // Do NOT emit MintRetryStarted here — that would
+                // move the aggregate from MintingFailed to Minting,
+                // losing the FireblocksSubmitted predecessor and its
+                // fireblocks_tx_id. Instead, re-emit MintingFailed
+                // which keeps the existing predecessor chain intact.
+                sink.write(
+                    MintEvent::MintingFailed {
+                        issuer_request_id,
+                        error: err.to_string(),
+                        failed_at: now,
+                    },
+                    self,
+                )
+                .await;
+
+                Ok(())
+            }
+        }
+    }
+
+    async fn submit_recovery_mint(
+        &mut self,
+        services: &MintServices,
+        sink: &EventSink<Self>,
+        mut input: MintSubmissionParams<'_>,
         receipt_tx_hash: Option<TxHash>,
         mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         let retrying_failed_mint = matches!(self, Self::MintingFailed { .. });
         // The delay/cap gate uses the failure-count-based schedule
         // (`automatic_retry_decision`); the external_tx_id uses the
@@ -1274,24 +1373,29 @@ impl Mint {
             started_at: now,
         });
 
-        Ok(retry_event
-            .into_iter()
-            .chain(std::iter::once(submission_event))
-            .collect())
+        if let Some(retry_event) = retry_event {
+            sink.write(retry_event, self).await;
+        }
+
+        sink.write(submission_event, self).await;
+
+        Ok(())
     }
 
     async fn recover_from_existing_receipt(
         services: &MintServices,
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
-    ) -> Result<Option<Vec<MintEvent>>, MintError> {
+        sink: &EventSink<Self>,
+        aggregate: &mut Self,
+    ) -> Result<bool, MintError> {
         let Some(receipt) = services
             .receipts
             .find_by_issuer_request_id(vault, issuer_request_id)
             .await?
         else {
             debug!(target: "mint", issuer_request_id = %issuer_request_id, "No receipt found, retrying mint");
-            return Ok(None);
+            return Ok(false);
         };
 
         info!(
@@ -1301,14 +1405,20 @@ impl Mint {
             "Found existing receipt, recording recovery"
         );
 
-        Ok(Some(vec![MintEvent::ExistingMintRecovered {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash: receipt.tx_hash,
-            receipt_id: receipt.receipt_id,
-            shares_minted: receipt.shares,
-            block_number: receipt.block_number,
-            recovered_at: Utc::now(),
-        }]))
+        sink.write(
+            MintEvent::ExistingMintRecovered {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: receipt.tx_hash,
+                receipt_id: receipt.receipt_id,
+                shares_minted: receipt.shares,
+                block_number: receipt.block_number,
+                recovered_at: Utc::now(),
+            },
+            aggregate,
+        )
+        .await;
+
+        Ok(true)
     }
 
     fn apply_journal_confirmed(&mut self, confirmed_at: DateTime<Utc>) {
@@ -1739,11 +1849,12 @@ impl Mint {
             minting_started_at: started_at,
         };
     }
-    fn handle_close_mint(
-        &self,
+    async fn handle_close_mint(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerMintRequestId,
         reason: String,
-    ) -> Result<Vec<MintEvent>, MintError> {
+    ) -> Result<(), MintError> {
         match self {
             Self::Completed { .. } | Self::Closed { .. } => {
                 Err(MintError::NotRecoverable {
@@ -1753,31 +1864,37 @@ impl Mint {
             Self::Uninitialized => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
             }),
-            _ => Ok(vec![MintEvent::MintClosed {
-                issuer_request_id,
-                reason,
-                closed_at: Utc::now(),
-            }]),
+            _ => {
+                sink.write(
+                    MintEvent::MintClosed {
+                        issuer_request_id,
+                        reason,
+                        closed_at: Utc::now(),
+                    },
+                    self,
+                )
+                .await;
+
+                Ok(())
+            }
         }
     }
 }
 
-#[async_trait]
 impl Aggregate for Mint {
     type Command = MintCommand;
     type Event = MintEvent;
     type Error = MintError;
     type Services = MintServices;
 
-    fn aggregate_type() -> String {
-        "Mint".to_string()
-    }
+    const TYPE: &'static str = "Mint";
 
     async fn handle(
-        &self,
+        &mut self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error> {
+        sink: &EventSink<Self>,
+    ) -> Result<(), Self::Error> {
         match command {
             MintCommand::Initiate {
                 issuer_request_id,
@@ -1795,59 +1912,77 @@ impl Aggregate for Mint {
                     });
                 }
 
-                let now = Utc::now();
+                sink.write(
+                    MintEvent::Initiated {
+                        issuer_request_id,
+                        tokenization_request_id,
+                        quantity,
+                        underlying,
+                        token,
+                        network,
+                        client_id,
+                        wallet,
+                        initiated_at: Utc::now(),
+                    },
+                    self,
+                )
+                .await;
 
-                Ok(vec![MintEvent::Initiated {
-                    issuer_request_id,
-                    tokenization_request_id,
-                    quantity,
-                    underlying,
-                    token,
-                    network,
-                    client_id,
-                    wallet,
-                    initiated_at: now,
-                }])
+                Ok(())
             }
+
             MintCommand::ConfirmJournal { issuer_request_id } => {
-                self.handle_confirm_journal(issuer_request_id)
+                self.handle_confirm_journal(sink, issuer_request_id).await
             }
+
             MintCommand::RejectJournal { issuer_request_id, reason } => {
-                self.handle_reject_journal(issuer_request_id, reason)
+                self.handle_reject_journal(sink, issuer_request_id, reason)
+                    .await
             }
+
             MintCommand::Deposit { issuer_request_id } => {
-                self.handle_deposit(issuer_request_id)
+                self.handle_deposit(sink, issuer_request_id).await
             }
+
             MintCommand::SubmitMint { issuer_request_id } => {
-                self.handle_submit_mint(services, issuer_request_id).await
+                self.handle_submit_mint(services, sink, issuer_request_id).await
             }
+
             MintCommand::ConfirmMint {
                 issuer_request_id,
                 fireblocks_tx_id,
             } => {
                 self.handle_confirm_mint(
                     services,
+                    sink,
                     issuer_request_id,
                     fireblocks_tx_id,
                 )
                 .await
             }
+
             MintCommand::SendCallback { issuer_request_id } => {
-                self.handle_send_callback(services, issuer_request_id).await
+                self.handle_send_callback(services, sink, issuer_request_id)
+                    .await
             }
+
             MintCommand::Recover { issuer_request_id, mode } => {
-                self.handle_recover(services, issuer_request_id, mode).await
+                self.handle_recover(services, sink, issuer_request_id, mode)
+                    .await
             }
+
             MintCommand::RecoverFromReceipt { issuer_request_id, tx_hash } => {
                 self.handle_recover_from_receipt(
                     services,
+                    sink,
                     issuer_request_id,
                     tx_hash,
                 )
                 .await
             }
+
             MintCommand::CloseMint { issuer_request_id, reason } => {
-                self.handle_close_mint(issuer_request_id, reason)
+                self.handle_close_mint(sink, issuer_request_id, reason).await
             }
         }
     }
@@ -2026,7 +2161,8 @@ pub(crate) mod tests {
     use cqrs_es::View;
     use cqrs_es::{
         Aggregate, AggregateContext, CqrsFramework, EventStore,
-        mem_store::MemStore, persist::GenericQuery, test::TestFramework,
+        event_sink::EventSink, mem_store::MemStore, persist::GenericQuery,
+        test::TestFramework,
     };
     use proptest::prelude::*;
     use rust_decimal::Decimal;
@@ -3315,7 +3451,7 @@ pub(crate) mod tests {
         .unwrap();
 
         // Load the fireblocks_tx_id from the aggregate state
-        let ctx = store
+        let mut ctx = store
             .load_aggregate(&data.issuer_request_id.to_string())
             .await
             .unwrap();
@@ -3351,7 +3487,7 @@ pub(crate) mod tests {
         .await
         .unwrap();
 
-        let context = store
+        let mut context = store
             .load_aggregate(&data.issuer_request_id.to_string())
             .await
             .unwrap();
@@ -3468,7 +3604,7 @@ pub(crate) mod tests {
             Some(format!("mint-{issuer_request_id}-retry-1"))
         );
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -3598,7 +3734,7 @@ pub(crate) mod tests {
             Some(format!("mint-{issuer_request_id}-retry-5"))
         );
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -3665,14 +3801,14 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
             .unwrap();
-        let aggregate = context.aggregate();
+        let aggregate = context.aggregate().clone();
 
-        let Mint::MintingFailed { failed_at, failed_from, .. } = aggregate
+        let Mint::MintingFailed { failed_at, failed_from, .. } = &aggregate
         else {
             panic!(
                 "Expected MintingFailed after failed resubmission, got: {}",
@@ -3924,7 +4060,7 @@ pub(crate) mod tests {
             journal_confirmed_at: now,
         };
 
-        let mint = Mint::MintingFailed {
+        let mut mint = Mint::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("tok-123"),
             quantity: Quantity::new(Decimal::from(100)),
@@ -3970,9 +4106,12 @@ pub(crate) mod tests {
             bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
         };
 
+        let sink = EventSink::default();
+
         let result = mint
             .handle_recover_from_receipt(
                 &services,
+                &sink,
                 issuer_request_id,
                 b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
             )

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -136,7 +136,8 @@ async fn recover_mint_until_automatic_budget_exhausted<ES>(
     let mut polled_tx_id: Option<String> = None;
 
     loop {
-        let context = match event_store.load_aggregate(&aggregate_id).await {
+        let mut context = match event_store.load_aggregate(&aggregate_id).await
+        {
             Ok(context) => context,
             Err(err) => {
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -584,7 +585,7 @@ mod tests {
 
         recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -618,7 +619,7 @@ mod tests {
 
         recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -663,7 +664,7 @@ mod tests {
             .await
             .unwrap();
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -701,7 +702,7 @@ mod tests {
             .await
             .unwrap();
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -745,7 +746,7 @@ mod tests {
             .await
             .unwrap();
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -772,7 +773,7 @@ mod tests {
 
         recover_mint(&fixture.mint_cqrs, issuer_request_id.clone()).await;
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -841,7 +842,7 @@ mod tests {
              poll, elapsed={elapsed:?}"
         );
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -879,7 +880,7 @@ mod tests {
 
         assert_eq!(outcome, DriveOutcome::Pending);
 
-        let context = fixture
+        let mut context = fixture
             .mint_store
             .load_aggregate(&issuer_request_id.to_string())
             .await

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -886,7 +886,7 @@ mod tests {
 
         // After the first run the aggregate has exactly one Discovered event
         // and the SQL checkpoint matches the chain head.
-        let ctx_after_first =
+        let mut ctx_after_first =
             store.load_aggregate(&vault.to_string()).await.unwrap();
         assert_eq!(
             ctx_after_first.aggregate().receipts_with_balance().len(),
@@ -931,7 +931,7 @@ mod tests {
         // After the second run the aggregate still has exactly one receipt
         // (no duplicate Discovered event applied) and the checkpoint is
         // unchanged.
-        let ctx_after_second =
+        let mut ctx_after_second =
             store.load_aggregate(&vault.to_string()).await.unwrap();
         assert_eq!(
             ctx_after_second.aggregate().receipts_with_balance().len(),
@@ -1072,7 +1072,7 @@ mod tests {
 
         assert_eq!(result.processed_count, 1);
 
-        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = ctx.aggregate().receipts_with_balance();
 
         assert_eq!(receipts.len(), 1);
@@ -1446,7 +1446,7 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify the receipt was actually discovered with correct ID and balance
-        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = ctx.aggregate().receipts_with_balance();
         assert_eq!(receipts.len(), 1, "Should discover exactly one receipt");
         assert_eq!(
@@ -1533,7 +1533,7 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify: aggregate has no receipts at all
-        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
         assert!(
             ctx.aggregate().receipts_with_balance().is_empty(),
             "No receipts should be discovered from outbound/mint transfers"
@@ -1613,7 +1613,7 @@ mod tests {
         // Should only process once despite appearing in both Deposit and Transfer
         assert_eq!(result.processed_count, 1);
 
-        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = ctx.aggregate().receipts_with_balance();
         assert_eq!(
             receipts.len(),
@@ -1711,7 +1711,7 @@ mod tests {
         assert_eq!(result.processed_count, 1);
 
         // Verify balance was reconciled upward from 500 to 750
-        let ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut ctx = store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = ctx.aggregate().receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -9,6 +9,7 @@ use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
 use async_trait::async_trait;
 use cqrs_es::{
     Aggregate, AggregateContext, AggregateError, CqrsFramework, EventStore,
+    event_sink::EventSink,
 };
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -364,7 +365,7 @@ where
         shares_to_burn: Shares,
         dust: Shares,
     ) -> Result<BurnPlan, BurnTrackingError> {
-        let context = self.store.load_aggregate(&vault.to_string()).await?;
+        let mut context = self.store.load_aggregate(&vault.to_string()).await?;
 
         let receipts = context
             .aggregate()
@@ -429,7 +430,7 @@ where
         &self,
         vault: Address,
     ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError> {
-        let context = self.store.load_aggregate(&vault.to_string()).await?;
+        let mut context = self.store.load_aggregate(&vault.to_string()).await?;
         Ok(context.aggregate().reserved_redemptions())
     }
 
@@ -568,11 +569,11 @@ impl ReceiptInventory {
     /// also covers a receipt already at zero balance — preserved by the
     /// zero-drain reconcile guard — so it is depleted once its last reservation
     /// resolves rather than lingering empty forever.
-    fn depletions_after_clearing(
+    fn depletion_receipt_ids_after_clearing(
         &self,
         redemption: &IssuerRedemptionRequestId,
         consume_balance: bool,
-    ) -> Vec<ReceiptInventoryEvent> {
+    ) -> Vec<ReceiptId> {
         self.receipts
             .iter()
             .filter_map(|(receipt_id, metadata)| {
@@ -592,9 +593,7 @@ impl ReceiptInventory {
                     metadata.balance
                 };
 
-                post_balance.is_zero().then_some(
-                    ReceiptInventoryEvent::Depleted { receipt_id: *receipt_id },
-                )
+                post_balance.is_zero().then_some(*receipt_id)
             })
             .collect()
     }
@@ -664,22 +663,20 @@ pub(crate) enum ReceiptInventoryError {
     },
 }
 
-#[async_trait]
 impl Aggregate for ReceiptInventory {
     type Command = ReceiptInventoryCommand;
     type Event = ReceiptInventoryEvent;
     type Error = ReceiptInventoryError;
     type Services = ();
 
-    fn aggregate_type() -> String {
-        "ReceiptInventory".to_string()
-    }
+    const TYPE: &'static str = "ReceiptInventory";
 
     async fn handle(
-        &self,
+        &mut self,
         command: Self::Command,
         _services: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error> {
+        sink: &EventSink<Self>,
+    ) -> Result<(), Self::Error> {
         match command {
             ReceiptInventoryCommand::DiscoverReceipt {
                 receipt_id,
@@ -691,18 +688,22 @@ impl Aggregate for ReceiptInventory {
                 receipt_info_bytes,
             } => {
                 if self.receipts.contains_key(&receipt_id) {
-                    return Ok(vec![]);
+                    return Ok(());
                 }
 
-                Ok(vec![ReceiptInventoryEvent::Discovered {
-                    receipt_id,
-                    balance,
-                    block_number,
-                    tx_hash,
-                    source,
-                    receipt_info,
-                    receipt_info_bytes,
-                }])
+                sink.write(
+                    ReceiptInventoryEvent::Discovered {
+                        receipt_id,
+                        balance,
+                        block_number,
+                        tx_hash,
+                        source,
+                        receipt_info,
+                        receipt_info_bytes,
+                    },
+                    self,
+                )
+                .await;
             }
 
             ReceiptInventoryCommand::ReconcileBalance {
@@ -710,11 +711,12 @@ impl Aggregate for ReceiptInventory {
                 on_chain_balance,
             } => {
                 let Some(metadata) = self.receipts.get(&receipt_id) else {
-                    return Ok(vec![]);
+                    return Ok(());
                 };
 
                 let mirror = metadata.balance;
                 let available = metadata.available();
+                let reserved_empty = metadata.reserved.is_empty();
 
                 // While a submitted burn is pending, on-chain legitimately
                 // sits between `available` (all reservations settled) and
@@ -722,26 +724,38 @@ impl Aggregate for ReceiptInventory {
                 // "no external change" so reconciliation never clobbers a
                 // reservation — settlement, not reconciliation, consumes it.
                 if (available..=mirror).contains(&on_chain_balance) {
-                    return Ok(if mirror.is_zero() {
-                        depletion_events(receipt_id, metadata)
-                    } else {
-                        vec![]
-                    });
+                    if mirror.is_zero() {
+                        write_depletion_if_unreserved(
+                            sink,
+                            self,
+                            receipt_id,
+                            reserved_empty,
+                        )
+                        .await;
+                    }
+
+                    return Ok(());
                 }
 
-                let reconciled = ReceiptInventoryEvent::BalanceReconciled {
-                    receipt_id,
-                    previous_balance: mirror,
-                    on_chain_balance,
-                };
+                sink.write(
+                    ReceiptInventoryEvent::BalanceReconciled {
+                        receipt_id,
+                        previous_balance: mirror,
+                        on_chain_balance,
+                    },
+                    self,
+                )
+                .await;
 
-                let depletion = if on_chain_balance.is_zero() {
-                    depletion_events(receipt_id, metadata)
-                } else {
-                    vec![]
-                };
-
-                Ok(std::iter::once(reconciled).chain(depletion).collect())
+                if on_chain_balance.is_zero() {
+                    write_depletion_if_unreserved(
+                        sink,
+                        self,
+                        receipt_id,
+                        reserved_empty,
+                    )
+                    .await;
+                }
             }
 
             ReceiptInventoryCommand::ReserveBurn {
@@ -776,10 +790,14 @@ impl Aggregate for ReceiptInventory {
                     }
                 }
 
-                Ok(vec![ReceiptInventoryEvent::BurnReserved {
-                    redemption_issuer_request_id,
-                    burns,
-                }])
+                sink.write(
+                    ReceiptInventoryEvent::BurnReserved {
+                        redemption_issuer_request_id,
+                        burns,
+                    },
+                    self,
+                )
+                .await;
             }
 
             // Release restores a reservation without touching the mirror
@@ -792,19 +810,29 @@ impl Aggregate for ReceiptInventory {
                 redemption_issuer_request_id,
             } => {
                 if !self.holds_reservation(&redemption_issuer_request_id) {
-                    return Ok(vec![]);
+                    return Ok(());
                 }
 
-                let depletions = self.depletions_after_clearing(
+                let depleted = self.depletion_receipt_ids_after_clearing(
                     &redemption_issuer_request_id,
                     false,
                 );
 
-                Ok(std::iter::once(ReceiptInventoryEvent::BurnReleased {
-                    redemption_issuer_request_id,
-                })
-                .chain(depletions)
-                .collect())
+                sink.write(
+                    ReceiptInventoryEvent::BurnReleased {
+                        redemption_issuer_request_id,
+                    },
+                    self,
+                )
+                .await;
+
+                for receipt_id in depleted {
+                    sink.write(
+                        ReceiptInventoryEvent::Depleted { receipt_id },
+                        self,
+                    )
+                    .await;
+                }
             }
 
             // Settle consumes a reservation after its burn confirmed on-chain:
@@ -814,21 +842,33 @@ impl Aggregate for ReceiptInventory {
                 redemption_issuer_request_id,
             } => {
                 if !self.holds_reservation(&redemption_issuer_request_id) {
-                    return Ok(vec![]);
+                    return Ok(());
                 }
 
-                let depletions = self.depletions_after_clearing(
+                let depleted = self.depletion_receipt_ids_after_clearing(
                     &redemption_issuer_request_id,
                     true,
                 );
 
-                Ok(std::iter::once(ReceiptInventoryEvent::BurnSettled {
-                    redemption_issuer_request_id,
-                })
-                .chain(depletions)
-                .collect())
+                sink.write(
+                    ReceiptInventoryEvent::BurnSettled {
+                        redemption_issuer_request_id,
+                    },
+                    self,
+                )
+                .await;
+
+                for receipt_id in depleted {
+                    sink.write(
+                        ReceiptInventoryEvent::Depleted { receipt_id },
+                        self,
+                    )
+                    .await;
+                }
             }
         }
+
+        Ok(())
     }
 
     fn apply(&mut self, event: Self::Event) {
@@ -981,25 +1021,28 @@ impl Aggregate for ReceiptInventory {
     }
 }
 
-/// Decides whether a receipt that has reached zero balance should be depleted.
+/// Writes `Depleted` when a zero-balance receipt has no outstanding reservations.
 ///
 /// A receipt that still holds a reservation is preserved (with a WARN) instead
 /// of depleted: removing it would silently discard the reservation and turn a
 /// later settle/release into a no-op. A pending settle/release or the startup
 /// reservation recovery resolves it instead.
-fn depletion_events(
+async fn write_depletion_if_unreserved(
+    sink: &EventSink<ReceiptInventory>,
+    aggregate: &mut ReceiptInventory,
     receipt_id: ReceiptId,
-    metadata: &ReceiptMetadata,
-) -> Vec<ReceiptInventoryEvent> {
-    if metadata.reserved.is_empty() {
-        return vec![ReceiptInventoryEvent::Depleted { receipt_id }];
+    reserved_empty: bool,
+) {
+    if reserved_empty {
+        sink.write(ReceiptInventoryEvent::Depleted { receipt_id }, aggregate)
+            .await;
+        return;
     }
 
     warn!(target: "receipt", receipt_id = %receipt_id,
         "Receipt reached zero balance while still holding reservations; \
          preserving it so the reservation can resolve"
     );
-    vec![]
 }
 
 fn required_burns_by_receipt(
@@ -1093,25 +1136,33 @@ mod tests {
         }
     }
 
+    async fn handle_command(
+        aggregate: &mut ReceiptInventory,
+        command: ReceiptInventoryCommand,
+    ) -> Result<Vec<ReceiptInventoryEvent>, ReceiptInventoryError> {
+        let sink = EventSink::default();
+        aggregate.handle(command, &(), &sink).await?;
+        Ok(sink.collect().await)
+    }
+
     #[tokio::test]
     async fn test_discover_receipt_emits_discovered_event() {
-        let aggregate = ReceiptInventory::default();
+        let mut aggregate = ReceiptInventory::default();
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(100),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -1133,18 +1184,17 @@ mod tests {
         );
 
         // First discovery succeeds
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(100),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 1);
         for event in events {
@@ -1152,18 +1202,17 @@ mod tests {
         }
 
         // Second discovery is idempotent - returns Ok with no events
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(200),
-                    2000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(200),
+                2000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         assert!(events.is_empty());
     }
@@ -1257,7 +1306,8 @@ mod tests {
         .await
         .unwrap();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = context.aggregate().receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
@@ -1330,7 +1380,8 @@ mod tests {
         .await
         .unwrap();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let found =
             context.aggregate().find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, Some(make_receipt_id(42)));
@@ -1342,7 +1393,8 @@ mod tests {
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let found =
             context.aggregate().find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, None);
@@ -1371,7 +1423,8 @@ mod tests {
         .await
         .unwrap();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let aggregate = context.aggregate();
 
         // External receipts should not be indexed by issuer_request_id
@@ -1405,7 +1458,8 @@ mod tests {
         .await
         .unwrap();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let aggregate = context.aggregate();
 
         // Verify the receipt is in both maps
@@ -1438,7 +1492,8 @@ mod tests {
         .await
         .unwrap();
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let aggregate = context.aggregate();
 
         // Receipt exists but not in itn_receipts
@@ -1865,16 +1920,15 @@ mod tests {
             "fully reserved receipt must be unavailable"
         );
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(100),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(100),
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.is_empty(),
@@ -1914,16 +1968,15 @@ mod tests {
         });
 
         // available = 40, mirror = 100; the burn of 60 lands -> on-chain 40.
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(40),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(40),
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.is_empty(),
@@ -1952,16 +2005,15 @@ mod tests {
         });
 
         // available = 70; on-chain 50 < 70 -> external drain.
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(50),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(50),
+            },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -1995,16 +2047,15 @@ mod tests {
             .reserved
             .insert("red-00000001".parse().unwrap(), make_shares(50));
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(0),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(0),
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2041,16 +2092,15 @@ mod tests {
             .insert("red-00000001".parse().unwrap(), make_shares(70));
 
         // available = 30; an external drain to 0 is below it (out of band).
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(0),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(0),
+            },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             events.len(),
@@ -2101,7 +2151,7 @@ mod tests {
         // must be cleared. Checking internals distinguishes a real settlement
         // from merely leaving the reservation in place (which would leave the
         // same 40 available but a stale 100 mirror).
-        let context =
+        let mut context =
             service.store.load_aggregate(&vault.to_string()).await.unwrap();
         let metadata = context
             .aggregate()
@@ -2139,7 +2189,7 @@ mod tests {
             .unwrap();
         service.settle_burn(vault, redemption_id).await.unwrap();
 
-        let context =
+        let mut context =
             service.store.load_aggregate(&vault.to_string()).await.unwrap();
         assert!(
             context.aggregate().receipts_with_balance().is_empty(),
@@ -2171,15 +2221,14 @@ mod tests {
             .reserved
             .insert(redemption_id.clone(), make_shares(100));
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReleaseBurn {
-                    redemption_issuer_request_id: redemption_id,
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReleaseBurn {
+                redemption_issuer_request_id: redemption_id,
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.iter().any(|event| matches!(
@@ -2342,7 +2391,7 @@ mod tests {
 
         service.settle_burn(vault, redemption_id).await.unwrap();
 
-        let context =
+        let mut context =
             service.store.load_aggregate(&vault.to_string()).await.unwrap();
         let aggregate = context.aggregate();
 
@@ -2519,33 +2568,31 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(100),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         for event in events {
             aggregate.apply(event);
         }
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(100),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(100),
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2560,33 +2607,31 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(100),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         for event in events {
             aggregate.apply(event);
         }
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(50),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(50),
+            },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -2609,33 +2654,31 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(100),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(100),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         for event in events {
             aggregate.apply(event);
         }
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(0),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(0),
+            },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 2);
         assert!(matches!(
@@ -2653,18 +2696,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_reconcile_unknown_receipt_emits_no_events() {
-        let aggregate = ReceiptInventory::default();
+        let mut aggregate = ReceiptInventory::default();
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(99),
-                    on_chain_balance: make_shares(0),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(99),
+                on_chain_balance: make_shares(0),
+            },
+        )
+        .await
+        .unwrap();
 
         assert!(
             events.is_empty(),
@@ -2679,33 +2721,31 @@ mod tests {
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
 
-        let events = aggregate
-            .handle(
-                discover_receipt_cmd(
-                    make_receipt_id(42),
-                    make_shares(50),
-                    1000,
-                    tx_hash,
-                ),
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            discover_receipt_cmd(
+                make_receipt_id(42),
+                make_shares(50),
+                1000,
+                tx_hash,
+            ),
+        )
+        .await
+        .unwrap();
 
         for event in events {
             aggregate.apply(event);
         }
 
-        let events = aggregate
-            .handle(
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: make_receipt_id(42),
-                    on_chain_balance: make_shares(100),
-                },
-                &(),
-            )
-            .await
-            .unwrap();
+        let events = handle_command(
+            &mut aggregate,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: make_receipt_id(42),
+                on_chain_balance: make_shares(100),
+            },
+        )
+        .await
+        .unwrap();
 
         assert_eq!(events.len(), 1);
         assert!(matches!(
@@ -2835,7 +2875,8 @@ mod tests {
                 .expect("Registration should succeed (idempotent)");
         }
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = context.aggregate().receipts_with_balance();
 
         assert_eq!(
@@ -2871,7 +2912,8 @@ mod tests {
             .await
             .expect("Registration should succeed");
 
-        let context = store.load_aggregate(&vault.to_string()).await.unwrap();
+        let mut context =
+            store.load_aggregate(&vault.to_string()).await.unwrap();
         let receipts = context.aggregate().receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -70,7 +70,7 @@ where
         &self,
         event_store: &ReceiptInventoryStore,
     ) -> Result<ReconcileResult, ReconcileError> {
-        let aggregate_context =
+        let mut aggregate_context =
             event_store.load_aggregate(&self.vault.to_string()).await?;
 
         let receipts: Vec<_> = aggregate_context
@@ -357,7 +357,7 @@ mod tests {
         assert_eq!(result.mismatches, 1, "Should have detected 1 mismatch");
 
         // Verify the aggregate was updated — receipt should be depleted
-        let context =
+        let mut context =
             store.load_aggregate(&evm.vault_address.to_string()).await.unwrap();
         let receipts = context.aggregate().receipts_with_balance();
         assert!(

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -195,7 +195,7 @@ where
         burn_tx_hash: B256,
         reason: String,
     ) -> Result<BurnVerification, BurnManagerError> {
-        let context =
+        let mut context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
         let underlying = match context.aggregate() {
@@ -305,7 +305,7 @@ where
     ) -> Result<(), BurnManagerError> {
         use Redemption::{Completed, Uninitialized};
 
-        let context =
+        let mut context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
         match context.aggregate() {
@@ -510,7 +510,7 @@ where
 
         // Step 2: Load the updated aggregate (now in Burning) and use
         // the standard submit → persist tx ID → confirm flow.
-        let context =
+        let mut context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
         self.handle_burning_started(issuer_request_id, context.aggregate())
@@ -619,7 +619,7 @@ where
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
-        let context =
+        let mut context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
         let aggregate = context.aggregate();
@@ -1130,7 +1130,7 @@ where
         }
 
         // Step 2: Load aggregate to get the fireblocks_tx_id from BurnSubmitted state
-        let context =
+        let mut context =
             self.store.load_aggregate(&issuer_request_id.to_string()).await?;
 
         let Redemption::BurnSubmitted { fireblocks_tx_id, .. } =
@@ -1663,7 +1663,7 @@ mod tests {
         store: &TestStore,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Redemption {
-        let context =
+        let mut context =
             store.load_aggregate(&issuer_request_id.to_string()).await.unwrap();
         context.aggregate().clone()
     }

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -13,9 +13,9 @@ pub(crate) mod transfer;
 
 use alloy::hex;
 use alloy::primitives::{Address, B256, FixedBytes, TxHash, U256};
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::Aggregate;
+use cqrs_es::event_sink::EventSink;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::warn;
@@ -226,11 +226,11 @@ pub(crate) enum Redemption {
     },
 }
 
-/// Input parameters for the BurnTokens command handler.
+/// Burn-related parameters for the BurnTokens command handler.
 ///
 /// Groups burn-related parameters to reduce argument count. The `user` field
 /// is derived from aggregate state, not passed in the command.
-struct BurnInput {
+struct BurnTokensParams {
     vault: Address,
     burns: Vec<MultiBurnEntry>,
     dust_shares: U256,
@@ -238,7 +238,7 @@ struct BurnInput {
     external_tx_id: Option<BurnExternalTxId>,
 }
 
-struct DetectInput {
+struct RedemptionDetection {
     issuer_request_id: IssuerRedemptionRequestId,
     underlying: UnderlyingSymbol,
     token: TokenSymbol,
@@ -248,7 +248,7 @@ struct DetectInput {
     block_number: u64,
 }
 
-struct ResumeBurnInput {
+struct BurnRecovery {
     issuer_request_id: IssuerRedemptionRequestId,
     metadata: RedemptionMetadata,
     tokenization_request_id: TokenizationRequestId,
@@ -325,35 +325,43 @@ impl Redemption {
         }
     }
 
-    fn handle_detect(
-        &self,
-        input: DetectInput,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    async fn handle_detect(
+        &mut self,
+        sink: &EventSink<Self>,
+        input: RedemptionDetection,
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::Uninitialized) {
             return Err(RedemptionError::AlreadyDetected {
                 issuer_request_id: input.issuer_request_id,
             });
         }
 
-        Ok(vec![RedemptionEvent::Detected {
-            issuer_request_id: input.issuer_request_id,
-            underlying: input.underlying,
-            token: input.token,
-            wallet: input.wallet,
-            quantity: input.quantity,
-            tx_hash: input.tx_hash,
-            block_number: input.block_number,
-            detected_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::Detected {
+                issuer_request_id: input.issuer_request_id,
+                underlying: input.underlying,
+                token: input.token,
+                wallet: input.wallet,
+                quantity: input.quantity,
+                tx_hash: input.tx_hash,
+                block_number: input.block_number,
+                detected_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_record_alpaca_call(
-        &self,
+    async fn handle_record_alpaca_call(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         tokenization_request_id: TokenizationRequestId,
         alpaca_quantity: Quantity,
         dust_quantity: Quantity,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::Detected { .. }) {
             return Err(RedemptionError::InvalidState {
                 expected: "Detected".to_string(),
@@ -361,20 +369,27 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::AlpacaCalled {
-            issuer_request_id,
-            tokenization_request_id,
-            alpaca_quantity,
-            dust_quantity,
-            called_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_record_alpaca_failure(
-        &self,
+    async fn handle_record_alpaca_failure(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         error: String,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::Detected { .. }) {
             return Err(RedemptionError::InvalidState {
                 expected: "Detected".to_string(),
@@ -382,18 +397,25 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::AlpacaCallFailed {
-            issuer_request_id,
-            error,
-            failed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::AlpacaCallFailed {
+                issuer_request_id,
+                error,
+                failed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_mark_failed(
-        &self,
+    async fn handle_mark_failed(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(
             self,
             Self::Detected { .. }
@@ -409,21 +431,28 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::RedemptionFailed {
-            issuer_request_id,
-            reason,
-            failed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::RedemptionFailed {
+                issuer_request_id,
+                reason,
+                failed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Submits the burn transaction to the signing backend.
     /// Produces `BurnFireblocksSubmitted` on success; failure is propagated to caller.
     async fn handle_burn_tokens(
-        &self,
+        &mut self,
         services: &Arc<dyn VaultService>,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
-        input: BurnInput,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        input: BurnTokensParams,
+    ) -> Result<(), RedemptionError> {
         let Self::Burning { metadata, .. } = self else {
             return Err(RedemptionError::InvalidState {
                 expected: "Burning".to_string(),
@@ -455,25 +484,32 @@ impl Redemption {
             })
             .await?;
 
-        Ok(vec![RedemptionEvent::BurnFireblocksSubmitted {
-            issuer_request_id,
-            external_tx_id: BurnExternalTxId::from_string(
-                submitted.external_tx_id,
-            ),
-            fireblocks_tx_id: submitted.fireblocks_tx_id,
-            planned_burns,
-            submitted_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::BurnFireblocksSubmitted {
+                issuer_request_id,
+                external_tx_id: BurnExternalTxId::from_string(
+                    submitted.external_tx_id,
+                ),
+                fireblocks_tx_id: submitted.fireblocks_tx_id,
+                planned_burns,
+                submitted_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Confirms a previously submitted burn transaction.
     async fn handle_confirm_burn(
-        &self,
+        &mut self,
         services: &Arc<dyn VaultService>,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         fireblocks_tx_id: String,
         dust_shares: U256,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         let Self::BurnSubmitted { fireblocks_tx_id: stored_tx_id, .. } = self
         else {
             return Err(RedemptionError::InvalidState {
@@ -501,24 +537,31 @@ impl Redemption {
             })
             .collect();
 
-        Ok(vec![RedemptionEvent::TokensBurned {
-            issuer_request_id,
-            tx_hash: result.tx_hash,
-            burns,
-            dust_returned: result.dust_returned,
-            gas_used: result.gas_used,
-            block_number: result.block_number,
-            burned_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::TokensBurned {
+                issuer_request_id,
+                tx_hash: result.tx_hash,
+                burns,
+                dust_returned: result.dust_returned,
+                gas_used: result.gas_used,
+                block_number: result.block_number,
+                burned_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_record_burn_failure(
-        &self,
+    async fn handle_record_burn_failure(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         error: String,
         fireblocks_tx_id: Option<String>,
         planned_burns: Vec<BurnRecord>,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
             return Err(RedemptionError::InvalidState {
                 expected: "Burning or BurnSubmitted".to_string(),
@@ -526,24 +569,31 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::BurningFailed {
-            issuer_request_id,
-            error,
-            failed_at: Utc::now(),
-            fireblocks_tx_id,
-            planned_burns,
-        }])
+        sink.write(
+            RedemptionEvent::BurningFailed {
+                issuer_request_id,
+                error,
+                failed_at: Utc::now(),
+                fireblocks_tx_id,
+                planned_burns,
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Reprocessing is only valid from `Failed` state. Post-Alpaca states
     /// (`AlpacaCalled`, `Burning`) have dedicated recovery paths in the
     /// burn/journal managers and resetting them to `Detected` would cause
     /// a duplicate Alpaca redeem call.
-    fn handle_reprocess(
-        &self,
+    async fn handle_reprocess(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         metadata: RedemptionMetadata,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         let Self::Failed { .. } = self else {
             return Err(match self {
                 Self::Completed { .. } => {
@@ -556,27 +606,34 @@ impl Redemption {
             });
         };
 
-        Ok(vec![RedemptionEvent::Reprocessed {
-            issuer_request_id,
-            underlying: metadata.underlying,
-            token: metadata.token,
-            wallet: metadata.wallet,
-            quantity: metadata.quantity,
-            tx_hash: metadata.detected_tx_hash,
-            block_number: metadata.block_number,
-            detected_at: metadata.detected_at,
-            previous_state: self.state_name().to_string(),
-            reprocessed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::Reprocessed {
+                issuer_request_id,
+                underlying: metadata.underlying,
+                token: metadata.token,
+                wallet: metadata.wallet,
+                quantity: metadata.quantity,
+                tx_hash: metadata.detected_tx_hash,
+                block_number: metadata.block_number,
+                detected_at: metadata.detected_at,
+                previous_state: self.state_name().to_string(),
+                reprocessed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Resumes a post-Alpaca failed redemption directly to Burning state.
     /// Only valid from `Failed` state. The API layer validates that Alpaca
     /// was already called before issuing this command.
-    fn handle_resume_burn(
-        &self,
-        input: ResumeBurnInput,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    async fn handle_resume_burn(
+        &mut self,
+        sink: &EventSink<Self>,
+        input: BurnRecovery,
+    ) -> Result<(), RedemptionError> {
         let Self::Failed { .. } = self else {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
@@ -591,33 +648,40 @@ impl Redemption {
             });
         };
 
-        Ok(vec![RedemptionEvent::BurnResumed {
-            issuer_request_id: input.issuer_request_id,
-            underlying: input.metadata.underlying,
-            token: input.metadata.token,
-            wallet: input.metadata.wallet,
-            quantity: input.metadata.quantity,
-            tx_hash: input.metadata.detected_tx_hash,
-            block_number: input.metadata.block_number,
-            detected_at: input.metadata.detected_at,
-            tokenization_request_id: input.tokenization_request_id,
-            alpaca_quantity: input.alpaca_quantity,
-            dust_quantity: input.dust_quantity,
-            called_at: input.called_at,
-            alpaca_journal_completed_at: input.alpaca_journal_completed_at,
-            external_tx_id: input.external_tx_id,
-            resumed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::BurnResumed {
+                issuer_request_id: input.issuer_request_id,
+                underlying: input.metadata.underlying,
+                token: input.metadata.token,
+                wallet: input.metadata.wallet,
+                quantity: input.metadata.quantity,
+                tx_hash: input.metadata.detected_tx_hash,
+                block_number: input.metadata.block_number,
+                detected_at: input.metadata.detected_at,
+                tokenization_request_id: input.tokenization_request_id,
+                alpaca_quantity: input.alpaca_quantity,
+                dust_quantity: input.dust_quantity,
+                called_at: input.called_at,
+                alpaca_journal_completed_at: input.alpaca_journal_completed_at,
+                external_tx_id: input.external_tx_id,
+                resumed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_record_existing_burn(
-        &self,
+    async fn handle_record_existing_burn(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         fireblocks_tx_id: String,
         tx_hash: B256,
         planned_burns: Vec<BurnRecord>,
         block_number: u64,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         let Self::Failed { .. } = self else {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
@@ -630,14 +694,20 @@ impl Redemption {
             });
         };
 
-        Ok(vec![RedemptionEvent::ExistingBurnRecovered {
-            issuer_request_id,
-            fireblocks_tx_id,
-            tx_hash,
-            burns: planned_burns,
-            block_number,
-            recovered_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::ExistingBurnRecovered {
+                issuer_request_id,
+                fireblocks_tx_id,
+                tx_hash,
+                burns: planned_burns,
+                block_number,
+                recovered_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Admin-closes a redemption that cannot be auto-recovered. Valid from
@@ -646,11 +716,12 @@ impl Redemption {
     /// verifiable on-chain. Widening beyond `Failed` covers redemptions stuck in
     /// `Burning` (including the `Failed -> Burning` recovery regression, which
     /// would otherwise strand a previously-closeable redemption).
-    fn handle_close_redemption(
-        &self,
+    async fn handle_close_redemption(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(
             self,
             Self::Failed { .. }
@@ -668,11 +739,17 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::RedemptionClosed {
-            issuer_request_id,
-            reason,
-            closed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::RedemptionClosed {
+                issuer_request_id,
+                reason,
+                closed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
@@ -680,13 +757,14 @@ impl Redemption {
     /// verifies `burn_tx_hash` on-chain before issuing this command, so the
     /// aggregate trusts the supplied tx hash and block number and records the
     /// proving terminal event, transitioning to `Completed`.
-    fn handle_force_complete_burn(
-        &self,
+    async fn handle_force_complete_burn(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         block_number: u64,
         reason: String,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
@@ -699,19 +777,26 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::BurnForceCompleted {
-            issuer_request_id,
-            burn_tx_hash,
-            block_number,
-            reason,
-            completed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::BurnForceCompleted {
+                issuer_request_id,
+                burn_tx_hash,
+                block_number,
+                reason,
+                completed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
-    fn handle_confirm_alpaca_complete(
-        &self,
+    async fn handle_confirm_alpaca_complete(
+        &mut self,
+        sink: &EventSink<Self>,
         issuer_request_id: IssuerRedemptionRequestId,
-    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+    ) -> Result<(), RedemptionError> {
         if !matches!(self, Self::AlpacaCalled { .. }) {
             return Err(RedemptionError::InvalidState {
                 expected: "AlpacaCalled".to_string(),
@@ -719,10 +804,16 @@ impl Redemption {
             });
         }
 
-        Ok(vec![RedemptionEvent::AlpacaJournalCompleted {
-            issuer_request_id,
-            alpaca_journal_completed_at: Utc::now(),
-        }])
+        sink.write(
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id,
+                alpaca_journal_completed_at: Utc::now(),
+            },
+            self,
+        )
+        .await;
+
+        Ok(())
     }
 
     fn apply_alpaca_called(
@@ -857,22 +948,20 @@ impl PartialEq for RedemptionError {
     }
 }
 
-#[async_trait]
 impl Aggregate for Redemption {
     type Command = RedemptionCommand;
     type Event = RedemptionEvent;
     type Error = RedemptionError;
     type Services = Arc<dyn VaultService>;
 
-    fn aggregate_type() -> String {
-        "Redemption".to_string()
-    }
+    const TYPE: &'static str = "Redemption";
 
     async fn handle(
-        &self,
+        &mut self,
         command: Self::Command,
         services: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error> {
+        sink: &EventSink<Self>,
+    ) -> Result<(), Self::Error> {
         match command {
             RedemptionCommand::Detect {
                 issuer_request_id,
@@ -882,36 +971,59 @@ impl Aggregate for Redemption {
                 quantity,
                 tx_hash,
                 block_number,
-            } => self.handle_detect(DetectInput {
-                issuer_request_id,
-                underlying,
-                token,
-                wallet,
-                quantity,
-                tx_hash,
-                block_number,
-            }),
+            } => {
+                self.handle_detect(
+                    sink,
+                    RedemptionDetection {
+                        issuer_request_id,
+                        underlying,
+                        token,
+                        wallet,
+                        quantity,
+                        tx_hash,
+                        block_number,
+                    },
+                )
+                .await
+            }
+
             RedemptionCommand::RecordAlpacaCall {
                 issuer_request_id,
                 tokenization_request_id,
                 alpaca_quantity,
                 dust_quantity,
-            } => self.handle_record_alpaca_call(
-                issuer_request_id,
-                tokenization_request_id,
-                alpaca_quantity,
-                dust_quantity,
-            ),
+            } => {
+                self.handle_record_alpaca_call(
+                    sink,
+                    issuer_request_id,
+                    tokenization_request_id,
+                    alpaca_quantity,
+                    dust_quantity,
+                )
+                .await
+            }
+
             RedemptionCommand::RecordAlpacaFailure {
                 issuer_request_id,
                 error,
-            } => self.handle_record_alpaca_failure(issuer_request_id, error),
+            } => {
+                self.handle_record_alpaca_failure(
+                    sink,
+                    issuer_request_id,
+                    error,
+                )
+                .await
+            }
+
             RedemptionCommand::ConfirmAlpacaComplete { issuer_request_id } => {
-                self.handle_confirm_alpaca_complete(issuer_request_id)
+                self.handle_confirm_alpaca_complete(sink, issuer_request_id)
+                    .await
             }
+
             RedemptionCommand::MarkFailed { issuer_request_id, reason } => {
-                self.handle_mark_failed(issuer_request_id, reason)
+                self.handle_mark_failed(sink, issuer_request_id, reason).await
             }
+
             RedemptionCommand::BurnTokens {
                 issuer_request_id,
                 vault,
@@ -922,8 +1034,9 @@ impl Aggregate for Redemption {
             } => {
                 self.handle_burn_tokens(
                     services,
+                    sink,
                     issuer_request_id,
-                    BurnInput {
+                    BurnTokensParams {
                         vault,
                         burns,
                         dust_shares,
@@ -933,6 +1046,7 @@ impl Aggregate for Redemption {
                 )
                 .await
             }
+
             RedemptionCommand::ConfirmBurn {
                 issuer_request_id,
                 fireblocks_tx_id,
@@ -940,54 +1054,76 @@ impl Aggregate for Redemption {
             } => {
                 self.handle_confirm_burn(
                     services,
+                    sink,
                     issuer_request_id,
                     fireblocks_tx_id,
                     dust_shares,
                 )
                 .await
             }
+
             RedemptionCommand::RecordBurnFailure {
                 issuer_request_id,
                 error,
                 fireblocks_tx_id,
                 planned_burns,
-            } => self.handle_record_burn_failure(
-                issuer_request_id,
-                error,
-                fireblocks_tx_id,
-                planned_burns,
-            ),
+            } => {
+                self.handle_record_burn_failure(
+                    sink,
+                    issuer_request_id,
+                    error,
+                    fireblocks_tx_id,
+                    planned_burns,
+                )
+                .await
+            }
+
             RedemptionCommand::RecordExistingBurn {
                 issuer_request_id,
                 fireblocks_tx_id,
                 tx_hash,
                 planned_burns,
                 block_number,
-            } => self.handle_record_existing_burn(
-                issuer_request_id,
-                fireblocks_tx_id,
-                tx_hash,
-                planned_burns,
-                block_number,
-            ),
+            } => {
+                self.handle_record_existing_burn(
+                    sink,
+                    issuer_request_id,
+                    fireblocks_tx_id,
+                    tx_hash,
+                    planned_burns,
+                    block_number,
+                )
+                .await
+            }
+
             RedemptionCommand::CloseRedemption {
                 issuer_request_id,
                 reason,
-            } => self.handle_close_redemption(issuer_request_id, reason),
+            } => {
+                self.handle_close_redemption(sink, issuer_request_id, reason)
+                    .await
+            }
+
             RedemptionCommand::ForceCompleteBurn {
                 issuer_request_id,
                 burn_tx_hash,
                 block_number,
                 reason,
-            } => self.handle_force_complete_burn(
-                issuer_request_id,
-                burn_tx_hash,
-                block_number,
-                reason,
-            ),
-            RedemptionCommand::Reprocess { issuer_request_id, metadata } => {
-                self.handle_reprocess(issuer_request_id, metadata)
+            } => {
+                self.handle_force_complete_burn(
+                    sink,
+                    issuer_request_id,
+                    burn_tx_hash,
+                    block_number,
+                    reason,
+                )
+                .await
             }
+
+            RedemptionCommand::Reprocess { issuer_request_id, metadata } => {
+                self.handle_reprocess(sink, issuer_request_id, metadata).await
+            }
+
             RedemptionCommand::ResumeBurn {
                 issuer_request_id,
                 metadata,
@@ -997,16 +1133,22 @@ impl Aggregate for Redemption {
                 called_at,
                 alpaca_journal_completed_at,
                 external_tx_id,
-            } => self.handle_resume_burn(ResumeBurnInput {
-                issuer_request_id,
-                metadata,
-                tokenization_request_id,
-                alpaca_quantity,
-                dust_quantity,
-                called_at,
-                alpaca_journal_completed_at,
-                external_tx_id,
-            }),
+            } => {
+                self.handle_resume_burn(
+                    sink,
+                    BurnRecovery {
+                        issuer_request_id,
+                        metadata,
+                        tokenization_request_id,
+                        alpaca_quantity,
+                        dust_quantity,
+                        called_at,
+                        alpaca_journal_completed_at,
+                        external_tx_id,
+                    },
+                )
+                .await
+            }
         }
     }
 

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -110,7 +110,7 @@ impl<ES: EventStore<Redemption>> RedeemCallManager<ES> {
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<(), RedeemCallManagerError> {
-        let aggregate_ctx = self
+        let mut aggregate_ctx = self
             .event_store
             .load_aggregate(&issuer_request_id.to_string())
             .await?;
@@ -576,7 +576,7 @@ mod tests {
         store: &TestStore,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Redemption {
-        let context =
+        let mut context =
             store.load_aggregate(&issuer_request_id.to_string()).await.unwrap();
         context.aggregate().clone()
     }
@@ -853,7 +853,7 @@ mod tests {
             "Should call Alpaca once for the detected redemption"
         );
 
-        let context = harness
+        let mut context = harness
             .redemption_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -917,7 +917,7 @@ mod tests {
         // No account registered for this wallet — recovery should auto-fail
         manager.recover_detected_redemptions().await;
 
-        let context = harness
+        let mut context = harness
             .redemption_store
             .load_aggregate(&issuer_request_id.to_string())
             .await

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -174,7 +174,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
     RedemptionStore: EventStore<Redemption> + 'static,
     RedemptionStore::AC: Send,
 {
-    let aggregate_ctx = match deps
+    let mut aggregate_ctx = match deps
         .event_store
         .load_aggregate(&issuer_request_id.to_string())
         .await
@@ -207,7 +207,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
         return;
     }
 
-    let aggregate_ctx = match deps
+    let mut aggregate_ctx = match deps
         .event_store
         .load_aggregate(&issuer_request_id.to_string())
         .await
@@ -251,7 +251,7 @@ pub(crate) async fn drive_redemption_flow<RedemptionStore>(
             return;
         }
 
-        let aggregate_ctx = match deps
+        let mut aggregate_ctx = match deps
             .event_store
             .load_aggregate(&issuer_request_id.to_string())
             .await
@@ -370,7 +370,7 @@ mod tests {
         );
 
         if let TransferOutcome::Detected { issuer_request_id, .. } = outcome {
-            let context = store
+            let mut context = store
                 .load_aggregate(&issuer_request_id.to_string())
                 .await
                 .unwrap();

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -4,9 +4,9 @@ mod event;
 pub(crate) mod view;
 
 use alloy::primitives::Address;
-use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::Aggregate;
+use cqrs_es::event_sink::EventSink;
 use serde::{Deserialize, Serialize};
 
 pub(crate) use api::{
@@ -75,22 +75,20 @@ pub(crate) enum TokenizedAsset {
     },
 }
 
-#[async_trait]
 impl Aggregate for TokenizedAsset {
     type Command = TokenizedAssetCommand;
     type Event = TokenizedAssetEvent;
     type Error = TokenizedAssetError;
     type Services = ();
 
-    fn aggregate_type() -> String {
-        "TokenizedAsset".to_string()
-    }
+    const TYPE: &'static str = "TokenizedAsset";
 
     async fn handle(
-        &self,
+        &mut self,
         command: Self::Command,
         _services: &Self::Services,
-    ) -> Result<Vec<Self::Event>, Self::Error> {
+        sink: &EventSink<Self>,
+    ) -> Result<(), Self::Error> {
         match command {
             TokenizedAssetCommand::Add {
                 underlying,
@@ -104,32 +102,44 @@ impl Aggregate for TokenizedAsset {
                     tracing::debug!(target: "asset", underlying = %underlying.0,
                         "Asset already added with same vault, skipping"
                     );
-                    Ok(vec![])
+                    Ok(())
                 }
+
                 Self::Added { vault: current_vault, .. } => {
                     tracing::info!(target: "asset", underlying = %underlying.0,
                         previous_vault = %current_vault,
                         new_vault = %vault,
                         "Updating vault address for asset"
                     );
-                    Ok(vec![TokenizedAssetEvent::VaultAddressUpdated {
-                        vault,
-                        previous_vault: *current_vault,
-                        updated_at: Utc::now(),
-                    }])
+                    sink.write(
+                        TokenizedAssetEvent::VaultAddressUpdated {
+                            vault,
+                            previous_vault: *current_vault,
+                            updated_at: Utc::now(),
+                        },
+                        self,
+                    )
+                    .await;
+                    Ok(())
                 }
+
                 Self::NotAdded => {
                     tracing::info!(target: "asset", underlying = %underlying.0,
                         vault = %vault,
                         "Adding new tokenized asset"
                     );
-                    Ok(vec![TokenizedAssetEvent::Added {
-                        underlying,
-                        token,
-                        network,
-                        vault,
-                        added_at: Utc::now(),
-                    }])
+                    sink.write(
+                        TokenizedAssetEvent::Added {
+                            underlying,
+                            token,
+                            network,
+                            vault,
+                            added_at: Utc::now(),
+                        },
+                        self,
+                    )
+                    .await;
+                    Ok(())
                 }
             },
         }
@@ -172,6 +182,7 @@ pub(crate) enum TokenizedAssetError {}
 mod tests {
     use alloy::primitives::address;
     use cqrs_es::{Aggregate, test::TestFramework};
+    use tracing::Level;
     use tracing_test::traced_test;
 
     use super::{
@@ -190,43 +201,38 @@ mod tests {
         let network = Network::new("base");
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let validator = TokenizedAssetTestFramework::with(())
+        let events = TokenizedAssetTestFramework::with(())
             .given_no_previous_events()
             .when(TokenizedAssetCommand::Add {
                 underlying: underlying.clone(),
                 token: token.clone(),
                 network: network.clone(),
                 vault,
-            });
+            })
+            .inspect_result()
+            .unwrap();
 
-        let result = validator.inspect_result();
+        assert_eq!(events.len(), 1);
 
-        match result {
-            Ok(events) => {
-                assert_eq!(events.len(), 1);
+        let TokenizedAssetEvent::Added {
+            underlying: event_underlying,
+            token: event_token,
+            network: event_network,
+            vault: event_vault,
+            added_at,
+        } = &events[0]
+        else {
+            panic!("Expected Added event, got: {:?}", events[0])
+        };
 
-                let TokenizedAssetEvent::Added {
-                    underlying: event_underlying,
-                    token: event_token,
-                    network: event_network,
-                    vault: event_vault,
-                    added_at,
-                } = &events[0]
-                else {
-                    panic!("Expected Added event, got: {:?}", events[0])
-                };
-
-                assert_eq!(event_underlying, &underlying);
-                assert_eq!(event_token, &token);
-                assert_eq!(event_network, &network);
-                assert_eq!(event_vault, &vault);
-                assert!(added_at.timestamp() > 0);
-            }
-            Err(e) => panic!("Expected success, got error: {e}"),
-        }
+        assert_eq!(event_underlying, &underlying);
+        assert_eq!(event_token, &token);
+        assert_eq!(event_network, &network);
+        assert_eq!(event_vault, &vault);
+        assert!(added_at.timestamp() > 0);
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            Level::INFO,
             &["Adding new tokenized asset", "AAPL"]
         ));
     }
@@ -253,7 +259,7 @@ mod tests {
             .then_expect_events(vec![]);
 
         assert!(logs_contain_at!(
-            tracing::Level::DEBUG,
+            Level::DEBUG,
             &["Asset already added with same vault, skipping"]
         ));
     }
@@ -264,7 +270,7 @@ mod tests {
         let vault_a = address!("0x1234567890abcdef1234567890abcdef12345678");
         let vault_b = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
 
-        let validator = TokenizedAssetTestFramework::with(())
+        let events = TokenizedAssetTestFramework::with(())
             .given(vec![TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
@@ -277,49 +283,41 @@ mod tests {
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::new("base"),
                 vault: vault_b,
-            });
+            })
+            .inspect_result()
+            .unwrap();
 
-        let result = validator.inspect_result();
+        assert_eq!(events.len(), 1, "Expected exactly one event");
 
-        match result {
-            Ok(events) => {
-                assert_eq!(events.len(), 1, "Expected exactly one event");
-
-                match &events[0] {
-                    TokenizedAssetEvent::VaultAddressUpdated {
-                        vault,
-                        previous_vault,
-                        ..
-                    } => {
-                        assert_eq!(*vault, vault_b);
-                        assert_eq!(*previous_vault, vault_a);
-                    }
-                    other @ TokenizedAssetEvent::Added { .. } => {
-                        panic!("Expected VaultAddressUpdated, got: {other:?}")
-                    }
-                }
+        match &events[0] {
+            TokenizedAssetEvent::VaultAddressUpdated {
+                vault,
+                previous_vault,
+                ..
+            } => {
+                assert_eq!(*vault, vault_b);
+                assert_eq!(*previous_vault, vault_a);
             }
-            Err(err) => panic!("Expected success, got error: {err}"),
+            other @ TokenizedAssetEvent::Added { .. } => {
+                panic!("Expected VaultAddressUpdated, got: {other:?}")
+            }
         }
 
         assert!(logs_contain_at!(
-            tracing::Level::INFO,
+            Level::INFO,
             &["Updating vault address for asset", "AAPL"]
         ));
     }
 
     #[test]
     fn test_apply_asset_added_updates_state() {
-        let mut asset = TokenizedAsset::default();
-
-        assert!(matches!(asset, TokenizedAsset::NotAdded));
-
         let underlying = UnderlyingSymbol::new("TSLA");
         let token = TokenSymbol::new("tTSLA");
         let network = Network::new("base");
         let vault = address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc");
         let added_at = chrono::Utc::now();
 
+        let mut asset = TokenizedAsset::default();
         asset.apply(TokenizedAssetEvent::Added {
             underlying: underlying.clone(),
             token: token.clone(),
@@ -328,24 +326,79 @@ mod tests {
             added_at,
         });
 
-        match asset {
-            TokenizedAsset::Added {
-                underlying: added_underlying,
-                token: added_token,
-                network: added_network,
-                vault: added_vault,
-                enabled,
-                added_at: added_at_timestamp,
-            } => {
-                assert_eq!(added_underlying, underlying);
-                assert_eq!(added_token, token);
-                assert_eq!(added_network, network);
-                assert_eq!(added_vault, vault);
-                assert!(enabled);
-                assert_eq!(added_at_timestamp, added_at);
-            }
-            TokenizedAsset::NotAdded => panic!("Expected asset to be added"),
-        }
+        let TokenizedAsset::Added {
+            underlying: added_underlying,
+            token: added_token,
+            network: added_network,
+            vault: added_vault,
+            enabled,
+            added_at: added_at_timestamp,
+        } = asset
+        else {
+            panic!("Expected Added state after apply");
+        };
+
+        assert_eq!(added_underlying, underlying);
+        assert_eq!(added_token, token);
+        assert_eq!(added_network, network);
+        assert_eq!(added_vault, vault);
+        assert!(enabled);
+        assert_eq!(added_at_timestamp, added_at);
+    }
+
+    #[test]
+    fn test_apply_vault_address_updated_changes_vault() {
+        let vault_a = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let vault_b = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let mut asset = TokenizedAsset::default();
+        asset.apply(TokenizedAssetEvent::Added {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::new("base"),
+            vault: vault_a,
+            added_at: chrono::Utc::now(),
+        });
+        asset.apply(TokenizedAssetEvent::VaultAddressUpdated {
+            vault: vault_b,
+            previous_vault: vault_a,
+            updated_at: chrono::Utc::now(),
+        });
+
+        let TokenizedAsset::Added { vault, .. } = asset else {
+            panic!("Expected Added state after vault update");
+        };
+
+        assert_eq!(vault, vault_b);
+    }
+
+    #[test]
+    fn test_apply_duplicate_added_overwrites_state() {
+        let vault_a = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let vault_b = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let mut asset = TokenizedAsset::default();
+        asset.apply(TokenizedAssetEvent::Added {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::new("base"),
+            vault: vault_a,
+            added_at: chrono::Utc::now(),
+        });
+        asset.apply(TokenizedAssetEvent::Added {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL2"),
+            network: Network::new("base"),
+            vault: vault_b,
+            added_at: chrono::Utc::now(),
+        });
+
+        let TokenizedAsset::Added { vault, token, .. } = asset else {
+            panic!("Expected Added state after duplicate Added");
+        };
+
+        assert_eq!(vault, vault_b);
+        assert_eq!(token, TokenSymbol::new("tAAPL2"));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`event-sorcery` and `sqlite-es` were pinned to an untagged git commit. Tag `0.1.1` includes a sqlite-es snapshot-sequence bug fix we need before the event-sorcery migration stack lands.

That tag also requires `cqrs-es` 0.5 and `sqlx` 0.9, so the remaining cqrs-es aggregates (Mint, Redemption, TokenizedAsset, ReceiptInventory) had to be migrated off the 0.4 `handle` API before this branch compiles.

## Solution

- Pin `event-sorcery` and `sqlite-es` to git tag `0.1.1`.
- Upgrade `cqrs-es` to `0.5.0`, `sqlx` to `0.9.0` (`runtime-tokio` / `tls-rustls`), and `serde_json` to `1.0.150`.
- Migrate the four cqrs-es aggregates to the 0.5 API: `const TYPE`, `EventSink`-based `handle`, and `mut` aggregate contexts from `load_aggregate`.
- Update `ClientId`'s sqlx `Encode` impl for the 0.9 argument buffer type.

Account already uses event-sorcery's `EventSourced` adapter (merged in #172); this PR unblocks the stack above it.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs