### PR TITLE
fix: poll Alpaca journal status via keyed per-request GET endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,9 +36,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e84ab07ca0c3210734019e4d0e5392952ed574196ab0f904ab9c7ba0ae15595"
+checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abecb92ba478a285fbf5689100dbafe4003ded4a09bf4b5ef62cca87cd4f79e"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -84,13 +84,14 @@ dependencies = [
  "alloy-trie",
  "alloy-tx-macros",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
  "k256",
  "once_cell",
  "rand 0.8.6",
- "secp256k1",
+ "secp256k1 0.30.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -99,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e864d4f11d1fb8d3ac2fd8f3a15f1ee46d55ec6d116b342ed1b2cb737f25894"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -113,9 +114,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c98d21aeef3e0783046c207abd3eb6cb41f6e77e0c0fc8077ebecd6df4f9d171"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -132,13 +133,14 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
 name = "alloy-core"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e8604b0c092fabc80d075ede181c9b9e596249c70b99253082d7e689836529"
+checksum = "62ddde5968de6044d67af107ad835bc0069a7ca245870b94c5958a7d8712b184"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -149,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2db5c583aaef0255aa63a4fe827f826090142528bba48d1bf4119b62780cad"
+checksum = "a475bb02d9cef2dbb99065c1664ab3fe1f9352e21d6d5ed3f02cdbfc06ed1abc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -160,7 +162,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow 0.7.15",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -178,59 +180,77 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b82752a889170df67bbb36d42ca63c531eb16274f0d7299ae2a680facba17bd"
+checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
  "serde",
 ]
 
 [[package]]
 name = "alloy-eip7702"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
+checksum = "2919c5a56a1007492da313e7a3b6d45ef5edc5d33416fdec63c0d7a2702a0d20"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "borsh",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-eip7928"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b827a6d7784fe3eb3489d40699407a4cdcce74271421a01bdffe60cf573bb16"
+dependencies = [
+ "alloy-primitives",
+ "alloy-rlp",
+ "borsh",
+ "once_cell",
  "serde",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d9a64522a0db6ebcc4ff9c904e329e77dd737c2c25d30f1bdc32ca6c6ce334"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
  "alloy-eip7702",
+ "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
  "auto_impl",
+ "borsh",
  "c-kzg",
  "derive_more",
  "either",
  "serde",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675b163946b343ed2ddde4416114ad61fabc8b2a50d08423f38aa0ac2319e800"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
  "alloy-serde",
  "alloy-trie",
+ "borsh",
  "serde",
  "serde_with",
 ]
@@ -250,9 +270,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dbe713da0c737d9e5e387b0ba790eb98b14dd207fe53eef50e19a5a8ec3dac"
+checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -262,13 +282,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f87b774478fcc616993e97659697f3e3c7988fdad598e46ee0ed11209cd0d8ee"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http 1.4.0",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -277,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d6ed73d440bae8f27771b7cd507fa8f10f19ddf0b8f67e7622a52e0dbf798e"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -303,9 +323,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219dccd2cf753a43bd9b0fbb7771a16927ffdb56e43e3a15755bef1a74d614aa"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -316,9 +336,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1141f259c5e79cd0c97d08ad1090f9d5d87cfb50029889e2acf403f3e125367a"
+checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -327,6 +347,7 @@ dependencies = [
  "alloy-signer",
  "alloy-signer-local",
  "k256",
+ "libc",
  "rand 0.8.6",
  "serde_json",
  "tempfile",
@@ -337,18 +358,18 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3b431b4e72cd8bd0ec7a50b4be18e73dab74de0dba180eef171055e5d5926e"
+checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
- "foldhash 0.2.0",
- "getrandom 0.4.2",
- "hashbrown 0.16.1",
+ "foldhash",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
  "k256",
@@ -359,15 +380,16 @@ dependencies = [
  "rapidhash",
  "ruint",
  "rustc-hash",
+ "secp256k1 0.31.1",
  "serde",
  "sha3",
 ]
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0ef8cbc2b68e2512acf04b2d296c05c98a661bc460462add6414528f4ff3d9b"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -396,7 +418,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -408,9 +430,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be028fb1c6c173f5765d0baa3580a11d69826ea89fe00ee5c9d7eddb2c3509cd"
+checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -447,14 +469,14 @@ checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0f67d1e655ed93efca217213340d21cce982333cc44a1d918af9150952ef66"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -464,7 +486,7 @@ dependencies = [
  "alloy-transport-ws",
  "futures",
  "pin-project",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "tokio",
@@ -477,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe106e50522980bc9e7cc9016f445531edf1a53e0fdba904c833b98c6fdff3f0"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -489,9 +511,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cf94d581b3aa13ebacb90ea52e0179985b7c20d8a522319e7d40768d56667a"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -501,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "425e14ee32eb8b7edd6a2247fe0ed640785e6eba75af27db27f1e6220c15ef0d"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -512,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0185f68a0f8391ab996d335a887087d7ccdbc97952efab3516f6307d456ba2cd"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -533,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "596cfa360922ba9af901cc7370c68640e4f72adb6df0ab064de32f21fec498d7"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -544,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f06333680d04370c8ed3a6b0eccff384e422c3d8e6b19e61fedc3a9f0ab7743"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -559,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "590dcaeb290cdce23155e68af4791d093afc3754b1a331198a25d2d44c5456e8"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -575,23 +597,23 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab81bab693da9bb79f7a95b64b394718259fdd7e41dceeced4cad57cb71c4f6a"
+checksum = "840128ed2b2971d6d4668a553fe403a82683d3acc646c73e75887e7157408033"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "489f1620bb7e2483fb5819ed01ab6edc1d2f93939dce35a5695085a1afd1d699"
+checksum = "63ec265e5d65d725175f6ca7711c970824c90ef9c0d1f1973711d4150ee612dd"
 dependencies = [
  "alloy-json-abi",
  "alloy-sol-macro-input",
@@ -602,15 +624,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56cef806ad22d4392c5fc83cf8f2089f988eb99c7067b4e0c6f1971fc1cca318"
+checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -620,25 +642,25 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.118",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
+checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
 dependencies = [
  "serde",
- "winnow 0.7.15",
+ "winnow 1.0.3",
 ]
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64612d29379782a5dde6f4b6570d9c756d734d760c0c94c254d361e678a6591f"
+checksum = "384cf252de0db2dec52821eac037a7f57e2aa33fe5b900ce6fe39973402341f1"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -648,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55bbdcee53e4e3857b5ddbc2986ebe9c2ab5f352ec285cb0da04c1e8f2ca9c18"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -671,13 +693,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793967215109b4a334047c810ed6db5e873ad3ea07f65cc02202bd4b810d9615"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "itertools 0.14.0",
+ "reqwest 0.13.4",
  "serde_json",
  "tower",
  "tracing",
@@ -686,19 +709,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e9dc891c80d6216003d4b04f0a7463015d0873d36e4ac2ec0bcc9196aa4ea7"
+checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "rustls",
  "serde_json",
  "tokio",
  "tokio-tungstenite",
  "tracing",
+ "url",
  "ws_stream_wasm",
 ]
 
@@ -720,14 +744,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.42"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab54221eccefa254ce9f65b079c097b1796e48c21c7ce358230f8988d75392fb"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -880,7 +904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -918,7 +942,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1052,7 +1076,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1063,7 +1087,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1115,14 +1139,36 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "backon"
@@ -1182,15 +1228,15 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
  "bitcoin-io",
  "hex-conservative",
@@ -1198,9 +1244,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -1249,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1259,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.9.1"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling",
  "ident_case",
@@ -1269,7 +1315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1293,14 +1339,23 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1368,11 +1423,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1471,7 +1528,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1479,6 +1536,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -1491,6 +1557,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "compression-codecs"
@@ -1520,9 +1596,9 @@ dependencies = [
 
 [[package]]
 name = "const-hex"
-version = "1.19.0"
+version = "1.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20d9a563d167a9cce0f94153382b33cb6eded6dfabff03c69ad65a28ea1514e0"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -1743,14 +1819,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1758,35 +1834,34 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "serde",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1819,7 +1894,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1853,7 +1927,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
 ]
 
@@ -1887,7 +1961,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1924,13 +1998,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1999,14 +2073,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -2059,7 +2133,7 @@ checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2111,8 +2185,8 @@ dependencies = [
 
 [[package]]
 name = "event-sorcery"
-version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
+version = "0.1.2"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.2#8f5c81f3472ac4ca84bbcebbddaa0b3b01f2cfea"
 dependencies = [
  "async-trait",
  "cqrs-es",
@@ -2199,10 +2273,10 @@ dependencies = [
  "bon",
  "chrono",
  "futures",
- "http 1.4.0",
+ "http 1.4.2",
  "jsonwebtoken",
  "rand 0.9.4",
- "reqwest",
+ "reqwest 0.12.28",
  "reqwest-middleware",
  "serde",
  "serde_json",
@@ -2256,12 +2330,6 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
@@ -2289,6 +2357,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2363,7 +2437,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2380,9 +2454,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
@@ -2460,16 +2534,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -2545,16 +2617,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -2590,26 +2662,13 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
- "serde",
- "serde_core",
+ "foldhash",
 ]
 
 [[package]]
@@ -2617,6 +2676,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -2636,7 +2700,7 @@ dependencies = [
  "base64",
  "bytes",
  "headers-core",
- "http 1.4.0",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1 0.10.6",
@@ -2648,7 +2712,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2727,9 +2791,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2753,7 +2817,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2764,7 +2828,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2783,9 +2847,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511f510e9b1888d67f10bab4397f8b019d2a9b249a2c10acbce2d705b1b32e26"
+checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -2797,9 +2861,9 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "headers",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "path-tree",
  "regex",
@@ -2850,16 +2914,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2876,14 +2940,13 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2894,7 +2957,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2912,14 +2975,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3034,12 +3097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3083,7 +3140,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3178,22 +3235,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.98"
+name = "jni"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
+ "simd_cesu8",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.3.0"
+version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -3210,6 +3325,7 @@ dependencies = [
  "sha2 0.10.9",
  "signature",
  "simple_asn1",
+ "zeroize",
 ]
 
 [[package]]
@@ -3228,18 +3344,19 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cfg-if",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -3270,12 +3387,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3289,9 +3400,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.30.1"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+checksum = "b1f111c8c41e7c61a49cd34e44c7619462967221a6443b0ec299e0ac30cfb9b1"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3321,9 +3432,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -3342,11 +3453,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.13.0"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -3357,13 +3468,13 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "macro-string"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
+checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3387,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "mime"
@@ -3419,9 +3530,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3437,7 +3548,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "memchr",
  "mime",
@@ -3507,9 +3618,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3569,14 +3680,14 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "nybbles"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5676b5c379cf5b03da1df2b3061c4a4e2aa691086a56ac923e08c143f53f59"
+checksum = "0d49ff0c0d00d4a502b39df9af3a525e1efeb14b9dabb5bb83335284c1309210"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -3600,9 +3711,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3620,7 +3731,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3631,9 +3742,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",
@@ -3663,9 +3774,9 @@ checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry",
- "reqwest",
+ "reqwest 0.12.28",
 ]
 
 [[package]]
@@ -3674,13 +3785,13 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.2",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest",
+ "reqwest 0.12.28",
  "thiserror 2.0.18",
  "tracing",
 ]
@@ -3764,7 +3875,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3831,7 +3942,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3881,22 +3992,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.12"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3975,7 +4086,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4004,7 +4115,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -4026,7 +4137,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4046,7 +4157,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "version_check",
  "yansi",
 ]
@@ -4090,7 +4201,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4147,7 +4258,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4160,6 +4271,7 @@ version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
+ "aws-lc-rs",
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
@@ -4184,7 +4296,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -4246,7 +4358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -4349,14 +4461,14 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4377,9 +4489,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -4402,11 +4514,11 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
- "http 1.4.0",
+ "h2 0.4.15",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
@@ -4417,8 +4529,6 @@ dependencies = [
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
- "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -4426,6 +4536,42 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-core",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.10.1",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "serde",
+ "serde_json",
+ "sync_wrapper",
+ "tokio",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -4434,7 +4580,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -4445,8 +4590,8 @@ checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
 dependencies = [
  "anyhow",
  "async-trait",
- "http 1.4.0",
- "reqwest",
+ "http 1.4.2",
+ "reqwest 0.12.28",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -4565,7 +4710,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.117",
+ "syn 2.0.118",
  "unicode-xid",
  "version_check",
 ]
@@ -4619,9 +4764,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.17.2"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c141e807189ad38a07276942c6623032d3753c8859c146104ac2e4d68865945a"
+checksum = "0298da754d1395046b0afdc2f20ee76d29a8ae310cd30ffa84ed42acba9cb12a"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -4653,9 +4798,9 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
 name = "rust_decimal"
-version = "1.42.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4675,7 +4820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74a5a6f027e892c7a035c6fddb50435a1fbf5a734ffc0c2a9fed4d0221440519"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4730,12 +4875,25 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -4749,11 +4907,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
 name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -4782,6 +4968,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -4857,8 +5052,19 @@ checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
  "rand 0.8.6",
- "secp256k1-sys",
+ "secp256k1-sys 0.10.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
+dependencies = [
+ "bitcoin_hashes",
+ "rand 0.9.4",
+ "secp256k1-sys 0.11.0",
 ]
 
 [[package]]
@@ -4866,6 +5072,15 @@ name = "secp256k1-sys"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb913707158fadaf0d8702c2db0e857de66eb003ccfdda5924b5f5ac98efb38"
 dependencies = [
  "cc",
 ]
@@ -4950,7 +5165,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4968,9 +5183,9 @@ dependencies = [
 
 [[package]]
 name = "serde_regex"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
 dependencies = [
  "regex",
  "serde",
@@ -4999,11 +5214,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.17.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381b283ce7bc6b476d903296fb59d0d36633652b633b27f64db4fb46dcbfc3b9"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5018,14 +5234,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.17.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6d4e30573c8cb306ed6ab1dca8423eec9a463ea0e155f45399455e0368b27e0"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5084,19 +5300,19 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
- "digest 0.10.7",
+ "digest 0.11.3",
  "keccak",
 ]
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
 dependencies = [
  "cc",
  "cfg-if",
@@ -5113,9 +5329,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -5144,6 +5360,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version 0.4.1",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5157,9 +5383,9 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
 dependencies = [
  "num-bigint",
  "num-traits",
@@ -5175,9 +5401,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
@@ -5194,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -5232,8 +5458,8 @@ dependencies = [
 
 [[package]]
 name = "sqlite-es"
-version = "0.1.0"
-source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6"
+version = "0.1.2"
+source = "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.2#8f5c81f3472ac4ca84bbcebbddaa0b3b01f2cfea"
 dependencies = [
  "chrono",
  "cqrs-es",
@@ -5292,7 +5518,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
@@ -5305,7 +5531,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5328,7 +5554,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.117",
+ "syn 2.0.118",
  "thiserror 2.0.18",
  "tokio",
  "url",
@@ -5451,7 +5677,7 @@ dependencies = [
  "opentelemetry_sdk",
  "proptest",
  "rand 0.8.6",
- "reqwest",
+ "reqwest 0.12.28",
  "rocket",
  "rsa",
  "rust_decimal",
@@ -5543,7 +5769,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5565,9 +5791,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5576,14 +5802,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.5.7"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f425ae0b12e2f5ae65542e00898d500d4d318b4baf09f40fd0d410454e9947"
+checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5603,7 +5829,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5649,7 +5875,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -5681,7 +5907,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5692,7 +5918,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5715,12 +5941,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5730,15 +5955,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5781,7 +6006,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -5794,7 +6019,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -5831,9 +6056,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -5904,14 +6129,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5920,7 +6145,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5938,7 +6163,7 @@ dependencies = [
  "async-trait",
  "base64",
  "bytes",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -5967,16 +6192,16 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "pin-project-lite",
@@ -6020,7 +6245,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6098,7 +6323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad06847b7afb65c7866a36664b75c40b895e318cea4f71299f013fb22965329d"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6109,13 +6334,13 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.0",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
@@ -6128,9 +6353,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ubyte"
@@ -6210,9 +6435,9 @@ checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -6242,6 +6467,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -6264,11 +6490,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -6302,6 +6528,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6318,27 +6554,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6350,9 +6577,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.71"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6360,9 +6587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6370,58 +6597,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.121"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -6440,9 +6633,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.98"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6459,19 +6652,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webpki-roots"
 version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.8",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6497,6 +6699,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -6534,7 +6745,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6545,7 +6756,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -6807,20 +7018,11 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -6828,85 +7030,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -6953,9 +7076,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6970,28 +7093,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7011,28 +7134,28 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -7065,7 +7188,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1" }
-sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1" }
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2" }
+sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2" }
 cqrs-es = "0.5.0"
 async-trait = "0.1.89"
 rocket = { version = "0.5.1", features = ["json"] }
@@ -56,7 +56,7 @@ flate2 = "1.1.9"
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"
 alloy-sol-types = "1.4.1"
-event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.1", features = [
+event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2", features = [
   "test-support",
 ] }
 httpmock = "0.8.2"

--- a/README.md
+++ b/README.md
@@ -199,7 +199,8 @@ endpoints.
   completed
 - `POST /v1/accounts/{account_id}/tokenization/callback/redeem` - Initiate
   redemption
-- `GET /v1/accounts/{account_id}/tokenization/requests` - Poll request status
+- `GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}` -
+  Poll request status
 
 ## Mint Flow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -327,6 +327,10 @@ Bug fixes and improvements that don't fit into the original phases.
 
 #### API & Integration
 
+- [x] [RAI-912](https://linear.app/makeitrain/issue/RAI-912) - Switch Alpaca
+      journal polling to per-request GET endpoints (fixes aged-request recovery
+      502s; admin recovery now returns 404 for a definitive Alpaca not-found)
+  - **PR:** [#178](https://github.com/ST0x-Technology/st0x.issuance/pull/178)
 - [x] [#76](https://github.com/ST0x-Technology/st0x.issuance/issues/76) - Split
       account creation into Registration and Alpaca Linking
   - **PR:** [#75](https://github.com/ST0x-Technology/st0x.issuance/pull/75)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1346,7 +1346,7 @@ sequenceDiagram
     Alpaca->>Alpaca: Journal 10 AAPL shares<br/>From: Issuer account -> To: AP
 
     loop Poll for completion
-        Us->>Alpaca: GET /tokenization/requests
+        Us->>Alpaca: GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}
         Alpaca->>Us: {status: "pending" | "completed"}
     end
 
@@ -1547,9 +1547,14 @@ struct AlpacaRedeemResponse {
 **Alpaca's Action:** Automatically journals the underlying shares from our
 tokenization account to the AP's account.
 
-**Our Action:** Poll Alpaca's list endpoint to check status.
+**Our Action:** Poll Alpaca's per-request endpoint to check status.
 
-**Endpoint:** `GET /v1/accounts/{account_id}/tokenization/requests`
+**Endpoint:**
+`GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}`
+— returns a single request object. A real HTTP `404` maps to `RequestNotFound`
+(the journal loop keeps polling it until timeout rather than aborting, since a
+freshly-created request may briefly be invisible — empirical/precautionary
+assumption, not a documented Alpaca guarantee).
 
 **Polling Strategy:**
 
@@ -1711,8 +1716,8 @@ We call these Alpaca endpoints:
    mint completed
 2. **`POST /v1/accounts/{account_id}/tokenization/callback/redeem`** - Initiate
    redemption
-3. **`GET /v1/accounts/{account_id}/tokenization/requests`** - List/poll
-   requests
+3. **`GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}`**
+   - Poll a single request's status
 
 ### Authentication
 

--- a/docs/ops-recovery-guide.md
+++ b/docs/ops-recovery-guide.md
@@ -50,14 +50,14 @@ accepting requests.
 
 ### Common failure patterns
 
-| Detail message contains                  | Cause                   | Action                                                                    |
-| ---------------------------------------- | ----------------------- | ------------------------------------------------------------------------- |
-| `error sending request for url`          | Transient network/API   | Reprocess/recover — will likely work on retry                             |
-| `reached terminal status: Failed`        | Fireblocks tx failed    | Check Fireblocks console (see below), then reprocess/recover              |
-| `sub_status: INSUFFICIENT_FUNDS_FOR_FEE` | Bot wallet out of gas   | Fund the bot wallet with native gas (ETH on Base), then reprocess/recover |
-| `is not whitelisted in Fireblocks`       | Missing contract        | Whitelist the contract in Fireblocks, then reprocess                      |
-| `Tokenization request not found`         | Alpaca request aged out | Cannot auto-recover — see "Alpaca request not found" below                |
-| `aggregate conflict` (409 response)      | Already recovered       | No action needed — it already completed                                   |
+| Detail message contains                  | Cause                                | Action                                                                          |
+| ---------------------------------------- | ------------------------------------ | ------------------------------------------------------------------------------- |
+| `error sending request for url`          | Transient network/API                | Reprocess/recover — will likely work on retry                                   |
+| `reached terminal status: Failed`        | Fireblocks tx failed                 | Check Fireblocks console (see below), then reprocess/recover                    |
+| `sub_status: INSUFFICIENT_FUNDS_FOR_FEE` | Bot wallet out of gas                | Fund the bot wallet with native gas (ETH on Base), then reprocess/recover       |
+| `is not whitelisted in Fireblocks`       | Missing contract                     | Whitelist the contract in Fireblocks, then reprocess                            |
+| `Tokenization request not found`         | Request genuinely absent from Alpaca | 404 returned by per-request GET endpoint — see "Alpaca request not found" below |
+| `aggregate conflict` (409 response)      | Already recovered                    | No action needed — it already completed                                         |
 
 The `INSUFFICIENT_FUNDS_FOR_FEE` sub-status appears in the `fireblocks_status`
 object of the `/admin/stuck` entry (the top-level `detail` just says
@@ -128,14 +128,15 @@ on-chain confirmation before responding.
 
 Possible responses:
 
-| Response message                                                           | Meaning                                                                                              |
-| -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `Recovered from Failed and executed burn immediately`                      | Success — burn submitted and confirmed on-chain.                                                     |
-| `Recovered to Detected — RedeemCallManager will re-call Alpaca`            | Failed before Alpaca was called; it will re-call Alpaca automatically.                               |
-| `Recovered to Burning but burn skipped: on-chain balance insufficient ...` | The bot doesn't hold the tokens to burn — manual intervention (see "Insufficient receipt balance").  |
-| `409 Conflict`                                                             | Already recovered/completed — no action needed.                                                      |
-| `422 Unprocessable`                                                        | Alpaca journal is still `Pending`, or was `Rejected` — cannot burn. See "Alpaca request rejected".   |
-| `502 Bad Gateway`                                                          | The Alpaca journal re-verification call failed (e.g. rate-limited, or request not found). See below. |
+| Response message                                                           | Meaning                                                                                             |
+| -------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `Recovered from Failed and executed burn immediately`                      | Success — burn submitted and confirmed on-chain.                                                    |
+| `Recovered to Detected — RedeemCallManager will re-call Alpaca`            | Failed before Alpaca was called; it will re-call Alpaca automatically.                              |
+| `Recovered to Burning but burn skipped: on-chain balance insufficient ...` | The bot doesn't hold the tokens to burn — manual intervention (see "Insufficient receipt balance"). |
+| `409 Conflict`                                                             | Already recovered/completed — no action needed.                                                     |
+| `422 Unprocessable`                                                        | Alpaca journal is still `Pending`, or was `Rejected` — cannot burn. See "Alpaca request rejected".  |
+| `404 Not Found`                                                            | The tokenization request is genuinely absent from Alpaca — see "Alpaca request not found" below.    |
+| `502 Bad Gateway`                                                          | The Alpaca journal re-verification call failed (e.g. rate-limited or network error). See below.     |
 
 Then check `/admin/stuck` again to confirm it cleared.
 
@@ -220,18 +221,25 @@ to coordinate returning the tokens to the AP or re-initiating the redemption.
 
 ## Alpaca request not found
 
-If `/admin/recover/redemption` returns `502` and the logs show
-`Tokenization request not found`, Alpaca no longer returns the tokenization
-request (it has aged out of Alpaca's system — seen on requests more than a
-couple weeks old). Recovery re-verifies the journal with Alpaca before burning,
-so it cannot proceed even though the redemption's own event history shows the
-journal completed.
+Journal polling now uses the keyed per-request GET endpoint
+(`/v1/accounts/{acct}/tokenization/requests/{id}`), which retrieves aged
+requests that no longer appear in the list endpoint (verified 2026-06-12:
+completed requests from June 11 were absent from the list at `?limit=500` but
+returned 200 from the keyed endpoint). This means the journal loop and
+`/admin/recover` can automatically handle requests that have aged out of the
+list endpoint.
 
-These redemptions still owe a burn (the journal completed, so the AP already
-received their shares and the on-chain tokens must be burned to keep 1:1
-backing). They **cannot be cleared through the admin endpoints today** —
-escalate to engineering for a manual burn or a recovery path that trusts the
-recorded `AlpacaJournalCompleted` event, gated on an on-chain balance check.
+A genuine `Tokenization request not found` (404 from the keyed endpoint) means
+the request truly does not exist in Alpaca — not merely that it is old.
+
+If `/admin/recover/redemption` returns `404` and the logs show
+`Tokenization request not found`, Alpaca has no record of this request at all.
+Recovery re-verifies the journal before burning, so it cannot proceed.
+
+These redemptions still owe a burn. They **cannot be cleared through the admin
+endpoints** — escalate to engineering for a manual burn or a recovery path that
+trusts the recorded `AlpacaJournalCompleted` event, gated on an on-chain balance
+check.
 
 ## Quick reference
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -12,7 +12,9 @@ use std::sync::Arc;
 use tracing::{error, info, warn};
 
 use crate::Quantity;
-use crate::alpaca::{AlpacaService, RedeemRequestStatus, TokenizationRequest};
+use crate::alpaca::{
+    AlpacaError, AlpacaService, RedeemRequestStatus, TokenizationRequest,
+};
 use crate::auth::InternalAuth;
 use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
@@ -410,12 +412,30 @@ async fn recover_post_alpaca(
         .poll_request_status(&alpaca_data.tokenization_request_id)
         .await
         .map_err(|err| {
+            let (status, msg) = match &err {
+                AlpacaError::RequestNotFound { .. } => (
+                    Status::NotFound,
+                    "Tokenization request not found at Alpaca (404)",
+                ),
+                AlpacaError::ResponseIdMismatch { .. } => (
+                    Status::BadGateway,
+                    "Alpaca returned a mismatched tokenization request id",
+                ),
+                AlpacaError::Reqwest(_)
+                | AlpacaError::Parse { .. }
+                | AlpacaError::Auth(_)
+                | AlpacaError::Api { .. } => (
+                    Status::BadGateway,
+                    "Failed to poll Alpaca for journal status",
+                ),
+            };
             error!(target: "admin", aggregate_id = %aggregate_id,
-                tokenization_request_id = %alpaca_data.tokenization_request_id.0,
+                tokenization_request_id = %alpaca_data.tokenization_request_id,
                 error = %err,
-                "Failed to poll Alpaca for journal status"
+                status = status.code,
+                "{msg}"
             );
-            Status::BadGateway
+            status
         })?;
 
     let (status, alpaca_updated_at) = match &request {
@@ -456,14 +476,14 @@ async fn recover_post_alpaca(
         RedeemRequestStatus::Completed => {}
         RedeemRequestStatus::Pending => {
             info!(target: "admin", aggregate_id = %aggregate_id,
-                tokenization_request_id = %alpaca_data.tokenization_request_id.0,
+                tokenization_request_id = %alpaca_data.tokenization_request_id,
                 "Cannot recover: Alpaca journal still pending"
             );
             return Err(Status::UnprocessableEntity);
         }
         RedeemRequestStatus::Rejected => {
             info!(target: "admin", aggregate_id = %aggregate_id,
-                tokenization_request_id = %alpaca_data.tokenization_request_id.0,
+                tokenization_request_id = %alpaca_data.tokenization_request_id,
                 "Cannot recover: Alpaca journal was rejected"
             );
             return Err(Status::UnprocessableEntity);
@@ -1941,8 +1961,17 @@ mod tests {
                             body: body.clone(),
                         }
                     }
-                    AlpacaError::RequestNotFound(id) => {
-                        AlpacaError::RequestNotFound(id.clone())
+                    AlpacaError::RequestNotFound { id, body } => {
+                        AlpacaError::RequestNotFound {
+                            id: id.clone(),
+                            body: body.clone(),
+                        }
+                    }
+                    AlpacaError::ResponseIdMismatch { requested, returned } => {
+                        AlpacaError::ResponseIdMismatch {
+                            requested: requested.clone(),
+                            returned: returned.clone(),
+                        }
                     }
                     AlpacaError::Auth(msg) => AlpacaError::Auth(msg.clone()),
                     _ => {
@@ -2955,6 +2984,93 @@ mod tests {
             Level::ERROR,
             &["Failed to execute recovered redemption burn"]
         ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_post_alpaca_recovery_request_not_found_returns_404()
+    {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let (metadata, _alpaca_data) = setup_post_alpaca_failure(&store).await;
+
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Error(AlpacaError::RequestNotFound {
+                id: TokenizationRequestId::new("tok-test-1"),
+                body: "not found".to_string(),
+            }),
+        });
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket =
+            post_alpaca_rocket(store, pool, alpaca, burn_recovery_state);
+
+        let (status, _body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(
+            status,
+            Status::NotFound,
+            "RequestNotFound from Alpaca must return 404, not 502"
+        );
+        assert_eq!(
+            burn_recovery.calls(),
+            0,
+            "Burn recovery must not be called"
+        );
+        assert!(
+            logs_contain_at!(Level::ERROR, &["Tokenization request not found"]),
+            "Expected error log for poll failure"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_endpoint_post_alpaca_recovery_response_id_mismatch_returns_502()
+     {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let (metadata, _alpaca_data) = setup_post_alpaca_failure(&store).await;
+
+        let requested = TokenizationRequestId::new("tok-test-1");
+        let returned = TokenizationRequestId::new("tok-other-id");
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Error(AlpacaError::ResponseIdMismatch {
+                requested: requested.clone(),
+                returned: returned.clone(),
+            }),
+        });
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+
+        let rocket =
+            post_alpaca_rocket(store, pool, alpaca, burn_recovery_state);
+
+        let (status, _body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(
+            status,
+            Status::BadGateway,
+            "ResponseIdMismatch from Alpaca must return 502"
+        );
+        assert_eq!(
+            burn_recovery.calls(),
+            0,
+            "Burn recovery must not be called"
+        );
+        assert!(
+            logs_contain_at!(
+                Level::ERROR,
+                &["mismatched tokenization request id"]
+            ),
+            "Expected error log for response id mismatch"
+        );
     }
 
     /// Drives a redemption to `Burning` state (post-journal, pre-burn) — the

--- a/src/alpaca/mock.rs
+++ b/src/alpaca/mock.rs
@@ -175,9 +175,14 @@ impl AlpacaService for MockAlpacaService {
                     updated_at: Some(Utc::now()),
                 })
             } else {
-                Err(AlpacaError::RequestNotFound(
-                    tokenization_request_id.clone(),
-                ))
+                let body = self
+                    .error_message
+                    .clone()
+                    .unwrap_or_else(|| "Mock error".to_string());
+                Err(AlpacaError::RequestNotFound {
+                    id: tokenization_request_id.clone(),
+                    body,
+                })
             }
         }
 

--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -50,11 +50,11 @@ pub(crate) trait AlpacaService: Send + Sync {
         request: RedeemRequest,
     ) -> Result<RedeemResponse, AlpacaError>;
 
-    /// Polls Alpaca's request list endpoint to find a matching redeem entry.
+    /// Polls Alpaca's keyed request endpoint for a specific tokenization request.
     ///
-    /// Deserializes all entries as [`TokenizationRequest`] (an enum of Mint
-    /// and Redeem variants), then finds the `Redeem` variant matching the
-    /// given `tokenization_request_id`.
+    /// Calls `GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}`
+    /// and deserializes the single-object response as [`TokenizationRequest`].
+    /// Maps HTTP 404 to [`AlpacaError::RequestNotFound`].
     async fn poll_request_status(
         &self,
         tokenization_request_id: &TokenizationRequestId,
@@ -132,10 +132,10 @@ pub(crate) enum RedeemRequestStatus {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct Fees(pub(crate) Decimal);
 
-/// Entry from Alpaca's tokenization request list endpoint.
+/// A tokenization request returned by Alpaca's keyed request endpoint.
 ///
-/// The endpoint returns both mint and redeem entries. This enum deserializes
-/// both variants via `#[serde(tag = "type")]`, with each variant carrying
+/// The endpoint returns a single object. This enum deserializes both Mint and
+/// Redeem variants via `#[serde(tag = "type")]`, with each variant carrying
 /// the appropriate `issuer_request_id` type.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
@@ -196,9 +196,19 @@ pub(crate) enum AlpacaError {
     /// Alpaca API returned an error response
     #[error("API error {status_code}: {body}")]
     Api { status_code: u16, body: String },
-    /// Tokenization request not found when polling status
-    #[error("Tokenization request not found: {0}")]
-    RequestNotFound(TokenizationRequestId),
+    /// HTTP 404 from the keyed endpoint. Treated as "definitively absent" for
+    /// recovery purposes (empirically verified 2026-06-12, not a published
+    /// Alpaca guarantee). `body` contains the raw 404 response for operator
+    /// diagnostics.
+    #[error("Tokenization request not found: {id}, body: {body}")]
+    RequestNotFound { id: TokenizationRequestId, body: String },
+    /// The keyed endpoint returned a request whose id differs from what was
+    /// requested — non-retryable data integrity violation.
+    #[error("Response id mismatch: requested {requested}, returned {returned}")]
+    ResponseIdMismatch {
+        requested: TokenizationRequestId,
+        returned: TokenizationRequestId,
+    },
 }
 
 impl AlpacaError {
@@ -208,9 +218,10 @@ impl AlpacaError {
             Self::Api { status_code, .. } => {
                 matches!(status_code, 500..=599 | 429)
             }
-            Self::Parse { .. } | Self::Auth(_) | Self::RequestNotFound(_) => {
-                false
-            }
+            Self::Parse { .. }
+            | Self::Auth(_)
+            | Self::RequestNotFound { .. }
+            | Self::ResponseIdMismatch { .. } => false,
         }
     }
 }

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -3,7 +3,7 @@ use backon::{ExponentialBuilder, Retryable};
 use clap::Args;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use super::{
     AlpacaError, AlpacaService, MintCallbackRequest, RedeemRequest,
@@ -246,13 +246,16 @@ impl AlpacaService for RealAlpacaService {
         &self,
         tokenization_request_id: &TokenizationRequestId,
     ) -> Result<TokenizationRequest, AlpacaError> {
+        // Alpaca tokenization_request_ids are server-generated UUIDs, so the
+        // path segment needs no percent-encoding.
         let url = format!(
-            "{}/v1/accounts/{}/tokenization/requests",
+            "{}/v1/accounts/{}/tokenization/requests/{}",
             self.base_url.trim_end_matches('/'),
-            self.account_id
+            self.account_id,
+            tokenization_request_id
         );
 
-        debug!(target: "alpaca", %url, method = "GET", "Polling Alpaca request status");
+        debug!(target: "alpaca", %url, method = "GET", %tokenization_request_id, "Polling Alpaca request status");
 
         (|| async {
             let response = self
@@ -269,27 +272,47 @@ impl AlpacaService for RealAlpacaService {
             match status {
                 reqwest::StatusCode::OK => {
                     let body = response.text().await?;
-                    let requests: Vec<TokenizationRequest> =
+                    let request: TokenizationRequest =
                         serde_json::from_str(&body).map_err(|e| {
                             tracing::error!(
                                 target: "alpaca",
                                 %body,
                                 error = %e,
-                                "Failed to parse Alpaca requests list response"
+                                "Failed to parse Alpaca request response"
                             );
-                            AlpacaError::Parse { body: body.clone(), source: e }
+                            AlpacaError::Parse { body, source: e }
                         })?;
-
-                    requests
-                        .into_iter()
-                        .find(|request| matches!(
-                            request,
-                            TokenizationRequest::Redeem { id, .. }
-                                if id == tokenization_request_id
-                        ))
-                        .ok_or_else(|| {
-                            AlpacaError::RequestNotFound(tokenization_request_id.clone())
-                        })
+                    // Keyed endpoint retrieves aged requests that no longer
+                    // appear in the list endpoint (empirically verified
+                    // 2026-06-12, see RAI-912).
+                    match &request {
+                        TokenizationRequest::Redeem { id, .. } => {
+                            debug!(target: "alpaca",
+                                tokenization_request_id = %id,
+                                "Alpaca keyed request response received"
+                            );
+                            if *id != *tokenization_request_id {
+                                return Err(AlpacaError::ResponseIdMismatch {
+                                    requested: tokenization_request_id.clone(),
+                                    returned: id.clone(),
+                                });
+                            }
+                        }
+                        TokenizationRequest::Mint {} => {
+                            warn!(target: "alpaca",
+                                %tokenization_request_id,
+                                "Alpaca keyed request response received Mint variant (unexpected for redemption polling)"
+                            );
+                        }
+                    }
+                    Ok(request)
+                }
+                reqwest::StatusCode::NOT_FOUND => {
+                    let body = response.text().await?;
+                    Err(AlpacaError::RequestNotFound {
+                        id: tokenization_request_id.clone(),
+                        body,
+                    })
                 }
                 reqwest::StatusCode::UNAUTHORIZED
                 | reqwest::StatusCode::FORBIDDEN => {
@@ -323,18 +346,19 @@ impl AlpacaService for RealAlpacaService {
 
 #[cfg(test)]
 mod tests {
-    use crate::alpaca::{RedeemRequestStatus, TokenizationRequestType};
-    use crate::mint::{Quantity, TokenizationRequestId};
-    use crate::redemption::IssuerRedemptionRequestId;
-    use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use alloy::primitives::{address, b256};
     use httpmock::prelude::*;
-    use serde_json::json;
+    use tracing_test::traced_test;
 
     use super::{
         AlpacaError, AlpacaService, MintCallbackRequest, RealAlpacaService,
         RedeemRequest, TokenizationRequest,
     };
+    use crate::alpaca::{RedeemRequestStatus, TokenizationRequestType};
+    use crate::mint::{Quantity, TokenizationRequestId};
+    use crate::redemption::IssuerRedemptionRequestId;
+    use crate::test_utils::logs_contain_at;
+    use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 
     fn create_test_request() -> MintCallbackRequest {
         let client_id = "55051234-0000-4abc-9000-4aabcdef0045".parse().unwrap();
@@ -910,33 +934,35 @@ mod tests {
     }
 
     #[tokio::test]
+    #[traced_test]
     async fn test_poll_request_status_success() {
         let server = MockServer::start();
 
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests")
+                .path(
+                    "/v1/accounts/test-account/tokenization/requests/tok-123",
+                )
                 .header("authorization", "Basic dGVzdC1rZXk6dGVzdC1zZWNyZXQ=")
                 .header("APCA-API-KEY-ID", "test-key")
                 .header("APCA-API-SECRET-KEY", "test-secret");
-            then.status(200).json_body(serde_json::json!([
-                {
-                    "tokenization_request_id": "tok-123",
-                    "issuer_request_id": "red-11223344",
-                    "created_at": "2025-09-12T17:28:48.642437-04:00",
-                    "updated_at": "2025-09-12T17:30:00.000000-04:00",
-                    "type": "redeem",
-                    "status": "completed",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "100",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.5"
-                }
-            ]));
+            then.status(200).json_body(serde_json::json!({
+                "tokenization_request_id": "tok-123",
+                "issuer_request_id": "red-11223344",
+                "type": "redeem",
+                "status": "completed",
+                "underlying_symbol": "AAPL",
+                "token_symbol": "tAAPL",
+                "qty": "100",
+                "client_external_account_id": "1481094OM",
+                "created_at": "2025-09-12T17:28:48.642437-04:00",
+                "updated_at": "2025-09-12T17:30:00.000000-04:00",
+                "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "network": "base",
+                "issuer": "test-issuer",
+                "fees": "0.5",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            }));
         });
 
         let service = RealAlpacaService::new(
@@ -961,117 +987,33 @@ mod tests {
                 ..
             }
         ));
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Polling Alpaca request status"]
+            ),
+            "Expected DEBUG log for poll request status"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Alpaca keyed request response received", "tok-123"]
+            ),
+            "Expected DEBUG log with tokenization_request_id tok-123"
+        );
         mock.assert();
     }
 
     #[tokio::test]
-    async fn test_poll_request_status_filters_correctly() {
-        let server = MockServer::start();
-
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
-            then.status(200).json_body(serde_json::json!([
-                {
-                    "tokenization_request_id": "tok-mint-1",
-                    "issuer_request_id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
-                    "created_at": "2025-09-12T17:25:00.000000-04:00",
-                    "type": "mint",
-                    "status": "completed",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "200",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.0"
-                },
-                {
-                    "tokenization_request_id": "tok-111",
-                    "issuer_request_id": "red-aa110001",
-                    "created_at": "2025-09-12T17:28:48.642437-04:00",
-                    "updated_at": "2025-09-12T17:28:48.642437-04:00",
-                    "type": "redeem",
-                    "status": "pending",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "100",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.0"
-                },
-                {
-                    "tokenization_request_id": "tok-222",
-                    "issuer_request_id": "red-bb220002",
-                    "created_at": "2025-09-12T17:30:00.000000-04:00",
-                    "updated_at": "2025-09-12T17:31:00.000000-04:00",
-                    "type": "redeem",
-                    "status": "completed",
-                    "underlying_symbol": "TSLA",
-                    "token_symbol": "tTSLA",
-                    "qty": "50",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x9876543210fedcba9876543210fedcba98765432",
-                    "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                    "fees": "0.0"
-                }
-            ]));
-        });
-
-        let service = RealAlpacaService::new(
-            server.base_url(),
-            "test-account".to_string(),
-            "test-key".to_string(),
-            "test-secret".to_string(),
-            10,
-            30,
-        )
-        .unwrap();
-
-        let result = service
-            .poll_request_status(&TokenizationRequestId::new("tok-222"))
-            .await;
-
-        let request = result.unwrap();
-        assert!(matches!(
-            request,
-            TokenizationRequest::Redeem {
-                status: RedeemRequestStatus::Completed,
-                ..
-            }
-        ));
-        mock.assert();
-    }
-
-    #[tokio::test]
+    #[traced_test]
     async fn test_poll_request_status_not_found() {
         let server = MockServer::start();
 
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
-            then.status(200).json_body(serde_json::json!([
-                {
-                    "tokenization_request_id": "tok-999",
-                    "issuer_request_id": "red-dd440999",
-                    "created_at": "2025-09-12T17:28:48.642437-04:00",
-                    "updated_at": "2025-09-12T17:28:48.642437-04:00",
-                    "type": "redeem",
-                    "status": "pending",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "100",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.0"
-                }
-            ]));
+            when.method(GET).path(
+                "/v1/accounts/test-account/tokenization/requests/tok-NOT-FOUND",
+            );
+            then.status(404).body("not found");
         });
 
         let service = RealAlpacaService::new(
@@ -1089,42 +1031,13 @@ mod tests {
         let result =
             service.poll_request_status(&tokenization_request_id).await;
 
-        match result {
-            Err(AlpacaError::RequestNotFound(id)) => {
-                assert_eq!(id.0, "tok-NOT-FOUND");
-            }
-            _ => panic!("Expected RequestNotFound error, got {result:?}"),
-        }
-
-        mock.assert();
-    }
-
-    #[tokio::test]
-    async fn test_poll_request_status_empty_list() {
-        let server = MockServer::start();
-
-        let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
-            then.status(200).json_body(serde_json::json!([]));
-        });
-
-        let service = RealAlpacaService::new(
-            server.base_url(),
-            "test-account".to_string(),
-            "test-key".to_string(),
-            "test-secret".to_string(),
-            10,
-            30,
-        )
-        .unwrap();
-
-        let result = service
-            .poll_request_status(&TokenizationRequestId::new("tok-123"))
-            .await;
-
-        assert!(matches!(result, Err(AlpacaError::RequestNotFound(_))));
-        mock.assert();
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, AlpacaError::RequestNotFound { ref id, ref body } if id.0 == "tok-NOT-FOUND" && body == "not found"),
+            "Expected RequestNotFound with correct id and body, got {err:?}"
+        );
+        assert!(!err.is_retryable(), "RequestNotFound must not be retryable");
+        mock.assert_calls(1);
     }
 
     #[tokio::test]
@@ -1132,8 +1045,9 @@ mod tests {
         let server = MockServer::start();
 
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
+            when.method(GET).path(
+                "/v1/accounts/test-account/tokenization/requests/tok-123",
+            );
             then.status(401).body("Unauthorized");
         });
 
@@ -1160,8 +1074,9 @@ mod tests {
         let server = MockServer::start();
 
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
+            when.method(GET).path(
+                "/v1/accounts/test-account/tokenization/requests/tok-123",
+            );
             then.status(500).body("Internal Server Error");
         });
 
@@ -1197,28 +1112,28 @@ mod tests {
         // Legacy auth requires both Basic auth AND the APCA headers
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests")
+                .path(
+                    "/v1/accounts/test-account/tokenization/requests/tok-auth-test",
+                )
                 .header("authorization", "Basic bXlrZXk6bXlzZWNyZXQ=")
                 .header("APCA-API-KEY-ID", "mykey")
                 .header("APCA-API-SECRET-KEY", "mysecret");
-            then.status(200).json_body(serde_json::json!([
-                {
-                    "tokenization_request_id": "tok-auth-test",
-                    "issuer_request_id": "red-abcdefab",
-                    "created_at": "2025-09-12T17:28:48.642437-04:00",
-                    "updated_at": "2025-09-12T17:28:48.642437-04:00",
-                    "type": "redeem",
-                    "status": "pending",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "100",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.0"
-                }
-            ]));
+            then.status(200).json_body(serde_json::json!({
+                "tokenization_request_id": "tok-auth-test",
+                "issuer_request_id": "red-abcdefab",
+                "created_at": "2025-09-12T17:28:48.642437-04:00",
+                "updated_at": "2025-09-12T17:28:48.642437-04:00",
+                "type": "redeem",
+                "status": "pending",
+                "underlying_symbol": "AAPL",
+                "token_symbol": "tAAPL",
+                "qty": "100",
+                "issuer": "test-issuer",
+                "network": "base",
+                "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "fees": "0.0"
+            }));
         });
 
         let service = RealAlpacaService::new(
@@ -1243,10 +1158,28 @@ mod tests {
     async fn test_poll_request_status_constructs_correct_url() {
         let server = MockServer::start();
 
+        // The mock only matches the exact path with account id and request id
+        // as path segments — verifying the URL is constructed correctly.
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/my-special-account/tokenization/requests");
-            then.status(200).json_body(serde_json::json!([]));
+            when.method(GET).path(
+                "/v1/accounts/my-special-account/tokenization/requests/tok-url-test",
+            );
+            then.status(200).json_body(serde_json::json!({
+                "tokenization_request_id": "tok-url-test",
+                "issuer_request_id": "red-11223344",
+                "created_at": "2025-09-12T17:28:48.642437-04:00",
+                "updated_at": "2025-09-12T17:30:00.000000-04:00",
+                "type": "redeem",
+                "status": "completed",
+                "underlying_symbol": "AAPL",
+                "token_symbol": "tAAPL",
+                "qty": "100",
+                "issuer": "test-issuer",
+                "network": "base",
+                "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "fees": "0.0"
+            }));
         });
 
         let service = RealAlpacaService::new(
@@ -1259,53 +1192,41 @@ mod tests {
         )
         .unwrap();
 
-        let _ = service
-            .poll_request_status(&TokenizationRequestId::new("tok-123"))
+        let result = service
+            .poll_request_status(&TokenizationRequestId::new("tok-url-test"))
             .await;
 
+        assert!(result.is_ok(), "Expected Ok, got {result:?}");
+        // mock.assert() verifies exactly this path was called — both account id
+        // and tokenization_request_id appear as segments in the URL.
         mock.assert();
     }
 
     #[tokio::test]
-    async fn test_poll_request_status_skips_legacy_mint_entries() {
+    #[traced_test]
+    async fn test_poll_request_status_response_id_mismatch() {
         let server = MockServer::start();
 
+        // Body returns tok-b but request was for tok-a — mismatch must be rejected.
         let mock = server.mock(|when, then| {
             when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
-            then.status(200).json_body(serde_json::json!([
-                {
-                    "tokenization_request_id": "tok-mint-legacy",
-                    "issuer_request_id": "00000000-0000-0000-0000-0000000abc01",
-                    "created_at": "2025-09-12T17:28:48.642437-04:00",
-                    "type": "mint",
-                    "status": "completed",
-                    "underlying_symbol": "AAPL",
-                    "token_symbol": "tAAPL",
-                    "qty": "100",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
-                    "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
-                    "fees": "0.0"
-                },
-                {
-                    "tokenization_request_id": "tok-redeem-valid",
-                    "issuer_request_id": "red-11223344",
-                    "created_at": "2025-09-12T17:30:00.000000-04:00",
-                    "updated_at": "2025-09-12T17:30:00.000000-04:00",
-                    "type": "redeem",
-                    "status": "pending",
-                    "underlying_symbol": "TSLA",
-                    "token_symbol": "tTSLA",
-                    "qty": "50",
-                    "issuer": "test-issuer",
-                    "network": "base",
-                    "wallet_address": "0x9876543210fedcba9876543210fedcba98765432",
-                    "tx_hash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-                    "fees": "0.0"
-                }
-            ]));
+                .path("/v1/accounts/test-account/tokenization/requests/tok-a");
+            then.status(200).json_body(serde_json::json!({
+                "tokenization_request_id": "tok-b",
+                "issuer_request_id": "red-11223344",
+                "created_at": "2025-09-12T17:28:48.642437-04:00",
+                "updated_at": "2025-09-12T17:30:00.000000-04:00",
+                "type": "redeem",
+                "status": "completed",
+                "underlying_symbol": "AAPL",
+                "token_symbol": "tAAPL",
+                "qty": "100",
+                "issuer": "test-issuer",
+                "network": "base",
+                "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "fees": "0.0"
+            }));
         });
 
         let service = RealAlpacaService::new(
@@ -1319,18 +1240,88 @@ mod tests {
         .unwrap();
 
         let result = service
-            .poll_request_status(&TokenizationRequestId::new("tok-mint-legacy"))
+            .poll_request_status(&TokenizationRequestId::new("tok-a"))
             .await;
 
-        match result {
-            Err(AlpacaError::RequestNotFound(id)) => {
-                assert_eq!(id.0, "tok-mint-legacy");
-            }
-            _ => panic!(
-                "Expected RequestNotFound for legacy mint entry, got {result:?}"
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                AlpacaError::ResponseIdMismatch {
+                    ref requested,
+                    ref returned
+                } if requested.0 == "tok-a" && returned.0 == "tok-b"
             ),
-        }
+            "Expected ResponseIdMismatch, got {err:?}"
+        );
+        assert!(
+            !err.is_retryable(),
+            "ResponseIdMismatch must not be retryable"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Alpaca keyed request response received", "tok-b"]
+            ),
+            "Expected DEBUG log with returned id tok-b"
+        );
+        mock.assert();
+    }
 
+    #[tokio::test]
+    #[traced_test]
+    async fn test_poll_request_status_returns_mint_variant_on_200() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(
+                "/v1/accounts/test-account/tokenization/requests/tok-mint-1",
+            );
+            then.status(200).json_body(serde_json::json!({
+                "tokenization_request_id": "tok-mint-1",
+                "issuer_request_id": "00000000-0000-4abc-9000-4aabcdef0045",
+                "created_at": "2025-09-12T17:28:48.642437-04:00",
+                "type": "mint",
+                "status": "completed",
+                "underlying_symbol": "AAPL",
+                "token_symbol": "tAAPL",
+                "qty": "100",
+                "issuer": "test-issuer",
+                "network": "base",
+                "wallet_address": "0x1234567890abcdef1234567890abcdef12345678",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "fees": "0.0"
+            }));
+        });
+
+        let service = RealAlpacaService::new(
+            server.base_url(),
+            "test-account".to_string(),
+            "test-key".to_string(),
+            "test-secret".to_string(),
+            10,
+            30,
+        )
+        .unwrap();
+
+        let result = service
+            .poll_request_status(&TokenizationRequestId::new("tok-mint-1"))
+            .await;
+
+        assert!(
+            matches!(result, Ok(TokenizationRequest::Mint { .. })),
+            "Expected Mint variant without Parse error, got {result:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &[
+                    "Alpaca keyed request response received Mint variant",
+                    "tok-mint-1"
+                ]
+            ),
+            "Expected WARN log for Mint variant with tokenization_request_id"
+        );
         mock.assert();
     }
 
@@ -1425,182 +1416,18 @@ mod tests {
         mock.assert_calls(1);
     }
 
-    /// Full production Alpaca response - exact payload from logs.
-    /// Used to verify parsing handles all field variations in real responses.
-    #[allow(clippy::too_many_lines)]
-    fn production_tokenization_requests_json() -> String {
-        serde_json::to_string(&json!([
-            {
-                "tokenization_request_id": "f466e81d-f7c9-4ea3-8b18-35b02775472e",
-                "issuer_request_id": "514113fd-0ff9-413a-8e0c-e1212ddf9ecf",
-                "type": "mint", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "1",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-01-16T15:37:31.205212Z",
-                "updated_at": "2026-01-17T13:33:03.766747Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.08",
-                "tx_hash": "0xac5c7d090d50dac63bfde725480eb411ec60fa06f8ec00c0e6673c69dbd8febf"
-            },
-            {
-                "tokenization_request_id": "65f62c42-0b14-494f-93d4-70379bc03592",
-                "issuer_request_id": "00000000-0000-0000-0000-000000000000",
-                "type": "mint", "status": "rejected",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "1",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-01-16T19:48:50.712619Z",
-                "updated_at": "2026-01-16T19:48:50.712619Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0", "tx_hash": ""
-            },
-            {
-                "tokenization_request_id": "f2354b82-89a1-41e7-86c8-75df9312d6fd",
-                "issuer_request_id": "red-008ab414",
-                "type": "redeem", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "1",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-01-26T15:39:37.472855Z",
-                "updated_at": "2026-01-26T15:39:37.755401Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.07",
-                "tx_hash": "0x008ab414f0e0d0c32a743b865b4f7d7aa509fbff74b6899189ac3085d4a4e026"
-            },
-            {
-                "tokenization_request_id": "b093448c-5871-4a68-ad8b-64611b9fffe7",
-                "issuer_request_id": "d6e63f65-345d-4dcd-8b84-e9643987b35e",
-                "type": "mint", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "3",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-01-26T16:17:15.136105Z",
-                "updated_at": "2026-01-26T16:17:15.757746Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.19",
-                "tx_hash": "0x28680a47f1129c83b83fd9cfaffa37bf462553337b5b9a60c4920133ff10d95f"
-            },
-            {
-                "tokenization_request_id": "f4a13943-ed97-4abc-8c70-505af8bc7d05",
-                "issuer_request_id": "069071bb-6c78-42d4-8d6f-8fbcf755dbd3",
-                "type": "mint", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "1",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-03T15:17:38.210539Z",
-                "updated_at": "2026-02-03T15:17:39.632607Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.06",
-                "tx_hash": "0xbb9e45fb122019f33ba2b7a83ae4bae90045e3bc6cf57e0b3ece70b244ac33f3"
-            },
-            {
-                "tokenization_request_id": "f2280c35-3a82-4460-8c0a-9c51a5526859",
-                "issuer_request_id": "red-942e171e",
-                "type": "redeem", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "1",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-03T15:27:01.815061Z",
-                "updated_at": "2026-02-03T15:27:01.907492Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.06",
-                "tx_hash": "0x942e171ed76ab0286064209315e320ccd540d2c998a0a536ac5ac839370b4637"
-            },
-            {
-                "tokenization_request_id": "0bdf6745-b513-469a-8ddd-874f5192cee8",
-                "issuer_request_id": "red-22e66b2d",
-                "type": "redeem", "status": "rejected",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB",
-                "qty": "0.450574852280275235",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-03T23:59:27.63446Z",
-                "updated_at": "2026-02-03T23:59:27.63446Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0",
-                "tx_hash": "0x22e66b2dfa9635e63158ef85e665229f222f2a19a92555ddd1b0d09f621cbc60"
-            },
-            {
-                "tokenization_request_id": "5319180c-d5b0-4db0-a4d3-346603b5b353",
-                "issuer_request_id": "00000000-0000-0000-0000-000000000001",
-                "type": "mint", "status": "rejected",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB",
-                "qty": "3.1762222348598623822654992091",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-04T10:20:58.185982Z",
-                "updated_at": "2026-02-04T10:20:58.185982Z",
-                "wallet_address": "0xe75f9042728c3ad626b1aa283fd9a7fcaf63bf1d",
-                "network": "base", "issuer": "st0x", "fees": "0", "tx_hash": ""
-            },
-            {
-                "tokenization_request_id": "a87b2566-e297-4240-99e2-9846c988c400",
-                "issuer_request_id": "1246cb25-25d9-42d1-bf04-f83d7bc9f615",
-                "type": "mint", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB",
-                "qty": "3.176222234",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-04T12:03:27.256796Z",
-                "updated_at": "2026-02-04T12:03:29.873395Z",
-                "wallet_address": "0xe75f9042728c3ad626b1aa283fd9a7fcaf63bf1d",
-                "network": "base", "issuer": "st0x", "fees": "0.2",
-                "tx_hash": "0xd391531167cae58f80a0984d1335b8e02b1d757417fdcaa5330fbf6ed024edb2"
-            },
-            {
-                "tokenization_request_id": "adb7d2f6-1e2d-40d8-bcb9-3b6ac382332d",
-                "issuer_request_id": "65bcf988-1907-4c87-916a-4b8808ffd26e",
-                "type": "mint", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB",
-                "qty": "1.588111117",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-04T12:47:38.92726Z",
-                "updated_at": "2026-02-04T12:47:41.805323Z",
-                "wallet_address": "0xe75f9042728c3ad626b1aa283fd9a7fcaf63bf1d",
-                "network": "base", "issuer": "st0x", "fees": "0.1",
-                "tx_hash": "0x1224289b2b8f901d74ea3287feb36bf9add03f22789068e9acfdd6902aa6ff73"
-            },
-            {
-                "tokenization_request_id": "8e085fe9-933e-400e-9f7e-6f985c331be0",
-                "issuer_request_id": "red-842331fb",
-                "type": "redeem", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB",
-                "qty": "4.764333351",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-04T14:17:41.396729Z",
-                "updated_at": "2026-02-04T16:40:23.393243Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.07",
-                "tx_hash": "0x842331fbcff22069db2702aa3cb8183ec24ed88943cf5a6aa85721c4204046db"
-            },
-            {
-                "tokenization_request_id": "8cd6c568-3de2-417a-8cea-312852e4a31c",
-                "issuer_request_id": "red-7ba33782",
-                "type": "redeem", "status": "completed",
-                "underlying_symbol": "RKLB", "token_symbol": "tRKLB", "qty": "3",
-                "account": "1481094OM",
-                "issuer_account": "58ced8fa-0cff-4573-aebd-3d6a3cb9f901",
-                "created_at": "2026-02-04T14:23:15.465284Z",
-                "updated_at": "2026-02-04T16:40:23.460721Z",
-                "wallet_address": "0xfcc6238ceb129c6308a567712edc8f8d36db2754",
-                "network": "base", "issuer": "st0x", "fees": "0.04",
-                "tx_hash": "0x7ba33782a0136bf449a2a6033deaeb0fa2b459d9c6d669e5d4b86d05b172cdca"
-            },
-        ]))
-        .unwrap()
-    }
-
     #[tokio::test]
     async fn test_poll_request_status_parses_full_production_response() {
+        let target_id = "00000000-0000-0000-0000-000000000001";
+        let prod_json = r#"{"tokenization_request_id":"00000000-0000-0000-0000-000000000001","issuer_request_id":"0x1111111111111111111111111111111111111111111111111111111111111111","type":"redeem","status":"completed","underlying_symbol":"SPYM","token_symbol":"tSPYM","qty":"0.000064248","client_external_account_id":"00000000-0000-0000-0000-000000000002","created_at":"2026-06-11T00:02:27.467568Z","updated_at":"2026-06-11T04:02:33.530523Z","wallet_address":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","network":"base","issuer":"st0x","fees":"0.01","tx_hash":"0x1111111111111111111111111111111111111111111111111111111111111111"}"#;
+
         let server = MockServer::start();
 
         let mock = server.mock(|when, then| {
-            when.method(GET)
-                .path("/v1/accounts/test-account/tokenization/requests");
-            then.status(200).body(production_tokenization_requests_json());
+            when.method(GET).path(format!(
+                "/v1/accounts/test-account/tokenization/requests/{target_id}"
+            ));
+            then.status(200).body(prod_json);
         });
 
         let service = RealAlpacaService::new(
@@ -1614,22 +1441,13 @@ mod tests {
         .unwrap();
 
         let result = service
-            .poll_request_status(&TokenizationRequestId::new(
-                "8e085fe9-933e-400e-9f7e-6f985c331be0",
-            ))
+            .poll_request_status(&TokenizationRequestId::new(target_id))
             .await;
 
         let request = result.unwrap();
         match &request {
-            TokenizationRequest::Redeem {
-                issuer_request_id, status, ..
-            } => {
-                assert_eq!(
-                    issuer_request_id,
-                    &"red-842331fb"
-                        .parse::<IssuerRedemptionRequestId>()
-                        .unwrap(),
-                );
+            TokenizationRequest::Redeem { id, status, .. } => {
+                assert_eq!(id.0, target_id);
                 assert!(matches!(status, RedeemRequestStatus::Completed));
             }
             other @ TokenizationRequest::Mint { .. } => {

--- a/src/redemption/journal_manager.rs
+++ b/src/redemption/journal_manager.rs
@@ -144,6 +144,7 @@ impl JournalManager {
         let max_duration = self.max_duration;
         let mut poll_interval = self.initial_poll_interval;
         let max_interval = self.max_interval;
+        let mut not_found_warned = false;
 
         loop {
             if start_time.elapsed() >= max_duration {
@@ -153,7 +154,7 @@ impl JournalManager {
             }
 
             debug!(target: "redemption", issuer_request_id = %issuer_request_id,
-                tokenization_request_id = %tokenization_request_id.0,
+                %tokenization_request_id,
                 poll_interval = ?poll_interval,
                 elapsed = ?start_time.elapsed(),
                 "Polling Alpaca for journal status"
@@ -171,6 +172,7 @@ impl JournalManager {
                     &tokenization_request_id,
                     start_time.elapsed(),
                     poll_interval,
+                    &mut not_found_warned,
                 )
                 .await?;
 
@@ -276,7 +278,12 @@ impl JournalManager {
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<Option<Redemption>, JournalManagerError> {
-        Ok(self.store.load(issuer_request_id).await?)
+        self.store.load(issuer_request_id).await.map_err(|source| {
+            JournalManagerError::StoreLoad {
+                issuer_request_id: issuer_request_id.clone(),
+                source: Box::new(source),
+            }
+        })
     }
 
     fn check_field_match<T: PartialEq + std::fmt::Debug>(
@@ -333,12 +340,55 @@ impl JournalManager {
         tokenization_request_id: &TokenizationRequestId,
         elapsed: Duration,
         poll_interval: Duration,
+        not_found_warned: &mut bool,
     ) -> Result<bool, JournalManagerError> {
         match request_result {
             Ok(request) => {
-                let status = self
+                let status = match self
                     .validate_request_fields(&request, issuer_request_id)
-                    .await?;
+                    .await
+                {
+                    Ok(status) => status,
+                    Err(err @ JournalManagerError::StoreLoad { .. }) => {
+                        // Transient store error — do not terminalize the redemption.
+                        // This polling session exits; the background recovery job
+                        // re-picks it on its next run.
+                        warn!(target: "redemption",
+                            issuer_request_id = %issuer_request_id,
+                            tokenization_request_id = %tokenization_request_id,
+                            error = %err,
+                            "Transient store error during validation, will retry"
+                        );
+                        return Err(err);
+                    }
+                    Err(err) => {
+                        warn!(target: "redemption",
+                            issuer_request_id = %issuer_request_id,
+                            tokenization_request_id = %tokenization_request_id,
+                            error = %err,
+                            "Validation failed for Alpaca response, marking redemption as failed"
+                        );
+                        if let Err(mark_err) = self
+                            .store
+                            .send(
+                                issuer_request_id,
+                                RedemptionCommand::MarkFailed {
+                                    issuer_request_id: issuer_request_id
+                                        .clone(),
+                                    reason: err.to_string(),
+                                },
+                            )
+                            .await
+                        {
+                            error!(target: "redemption",
+                                issuer_request_id = %issuer_request_id,
+                                error = %mark_err,
+                                "Failed to mark redemption as failed after validation failure"
+                            );
+                        }
+                        return Err(err);
+                    }
+                };
 
                 match status {
                     RedeemRequestStatus::Completed => {
@@ -397,6 +447,54 @@ impl JournalManager {
                     }
                 }
             }
+            Err(AlpacaError::RequestNotFound { ref id, .. }) => {
+                if *not_found_warned {
+                    debug!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tokenization_request_id = %id,
+                        next_poll_in = ?poll_interval,
+                        "Request not found at Alpaca keyed endpoint, will retry"
+                    );
+                } else {
+                    warn!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tokenization_request_id = %id,
+                        next_poll_in = ?poll_interval,
+                        "Request not found at Alpaca keyed endpoint (assumed transient), will retry"
+                    );
+                    *not_found_warned = true;
+                }
+                Ok(true)
+            }
+            Err(err @ AlpacaError::ResponseIdMismatch { .. }) => {
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    tokenization_request_id = %tokenization_request_id,
+                    error = %err,
+                    "Response id mismatch from Alpaca, marking redemption as failed (non-retryable)"
+                );
+
+                if let Err(mark_err) = self
+                    .store
+                    .send(
+                        issuer_request_id,
+                        RedemptionCommand::MarkFailed {
+                            issuer_request_id: issuer_request_id.clone(),
+                            reason: format!(
+                                "Alpaca response id mismatch: {err}"
+                            ),
+                        },
+                    )
+                    .await
+                {
+                    error!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        error = %mark_err,
+                        "Failed to mark redemption as failed after response id mismatch"
+                    );
+                }
+
+                Err(JournalManagerError::Alpaca(err))
+            }
             Err(err) => {
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     tokenization_request_id = %tokenization_request_id,
@@ -435,6 +533,12 @@ pub(crate) enum JournalManagerError {
     AccountNotFound { wallet: Address },
     #[error("Account not linked for wallet: {wallet}")]
     AccountNotLinked { wallet: Address },
+    #[error("Failed to load redemption {issuer_request_id}: {source}")]
+    StoreLoad {
+        issuer_request_id: IssuerRedemptionRequestId,
+        #[source]
+        source: Box<AggregateError<LifecycleError<Redemption>>>,
+    },
 }
 
 // `AggregateError<LifecycleError<Redemption>>` is large (it can carry a full
@@ -550,6 +654,8 @@ mod tests {
     enum MockResponse {
         Success(RedeemRequestStatus),
         Error { status_code: u16, body: String },
+        NotFound,
+        ResponseIdMismatch { returned_id: String },
     }
 
     struct StatefulMockAlpacaService {
@@ -564,6 +670,10 @@ mod tests {
             issuer_request_id: IssuerRedemptionRequestId,
         ) -> Self {
             Self { call_count: Mutex::new(0), responses, issuer_request_id }
+        }
+
+        fn call_count(&self) -> usize {
+            *self.call_count.lock().unwrap()
         }
 
         fn create_mock_request(
@@ -604,7 +714,7 @@ mod tests {
 
         async fn poll_request_status(
             &self,
-            _tokenization_request_id: &TokenizationRequestId,
+            tokenization_request_id: &TokenizationRequestId,
         ) -> Result<TokenizationRequest, AlpacaError> {
             let index = {
                 let mut count = self.call_count.lock().unwrap();
@@ -627,6 +737,16 @@ mod tests {
                     Err(AlpacaError::Api {
                         status_code: *status_code,
                         body: body.clone(),
+                    })
+                }
+                MockResponse::NotFound => Err(AlpacaError::RequestNotFound {
+                    id: tokenization_request_id.clone(),
+                    body: String::new(),
+                }),
+                MockResponse::ResponseIdMismatch { returned_id } => {
+                    Err(AlpacaError::ResponseIdMismatch {
+                        requested: tokenization_request_id.clone(),
+                        returned: TokenizationRequestId::new(returned_id),
                     })
                 }
             }
@@ -825,6 +945,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
     async fn test_poll_timeout_marks_as_failed() {
         let (store, pool) = setup_test_store().await;
 
@@ -870,6 +991,13 @@ mod tests {
         assert!(
             matches!(aggregate, Redemption::Failed { .. }),
             "Expected Failed state, got {aggregate:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &["Polling timeout reached, marking redemption as failed"]
+            ),
+            "Expected WARN log for polling timeout"
         );
     }
 
@@ -1011,6 +1139,154 @@ mod tests {
                 "Expected quantity mismatch error, got: {reason}"
             );
         }
+    }
+
+    /// When Alpaca returns a Mint variant (or any response that fails
+    /// validation), the redemption must be terminalized as Failed so it does
+    /// not remain stuck in AlpacaCalled.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_validation_failure_terminates_as_failed() {
+        let (store, pool) = setup_test_store().await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-mint-response");
+
+        struct MintVariantMock;
+
+        #[async_trait]
+        impl AlpacaService for MintVariantMock {
+            async fn send_mint_callback(
+                &self,
+                _request: crate::alpaca::MintCallbackRequest,
+            ) -> Result<(), AlpacaError> {
+                Ok(())
+            }
+
+            async fn call_redeem_endpoint(
+                &self,
+                _request: crate::alpaca::RedeemRequest,
+            ) -> Result<crate::alpaca::RedeemResponse, AlpacaError>
+            {
+                unreachable!()
+            }
+
+            async fn poll_request_status(
+                &self,
+                _tokenization_request_id: &TokenizationRequestId,
+            ) -> Result<TokenizationRequest, AlpacaError> {
+                Ok(TokenizationRequest::Mint {})
+            }
+        }
+
+        let mock = Arc::new(MintVariantMock);
+
+        let manager = JournalManager::new(
+            mock as Arc<dyn AlpacaService>,
+            store.clone(),
+            pool,
+        );
+
+        create_test_redemption_in_alpaca_called_state(
+            &store,
+            &issuer_request_id,
+            &tokenization_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_alpaca_called(
+                &test_alpaca_account(),
+                issuer_request_id.clone(),
+                tokenization_request_id,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(JournalManagerError::ValidationFailed { .. })),
+            "Expected ValidationFailed error, got {result:?}"
+        );
+
+        let aggregate = store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(aggregate, Redemption::Failed { .. }),
+            "Expected Failed state after Mint variant response, got {aggregate:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &[
+                    "Validation failed for Alpaca response, marking redemption as failed"
+                ]
+            ),
+            "Expected WARN log for validation failure termination"
+        );
+    }
+
+    /// When Alpaca returns a response id that doesn't match the requested id,
+    /// the redemption must be terminalized as Failed immediately (non-retryable).
+    #[tokio::test]
+    #[traced_test]
+    async fn test_response_id_mismatch_terminates_as_failed() {
+        let (store, pool) = setup_test_store().await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-tok-requested");
+
+        let mock = Arc::new(StatefulMockAlpacaService::new(
+            vec![MockResponse::ResponseIdMismatch {
+                returned_id: "alp-tok-different".to_string(),
+            }],
+            issuer_request_id.clone(),
+        ));
+
+        let manager = JournalManager::new(
+            mock as Arc<dyn AlpacaService>,
+            store.clone(),
+            pool,
+        );
+
+        create_test_redemption_in_alpaca_called_state(
+            &store,
+            &issuer_request_id,
+            &tokenization_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_alpaca_called(
+                &test_alpaca_account(),
+                issuer_request_id.clone(),
+                tokenization_request_id,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(JournalManagerError::Alpaca(
+                    AlpacaError::ResponseIdMismatch { .. }
+                ))
+            ),
+            "Expected Alpaca(ResponseIdMismatch) error, got {result:?}"
+        );
+
+        let aggregate = store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(aggregate, Redemption::Failed { .. }),
+            "Expected Failed state after ResponseIdMismatch, got {aggregate:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &[
+                    "Response id mismatch from Alpaca, marking redemption as failed"
+                ]
+            ),
+            "Expected WARN log for response id mismatch termination"
+        );
     }
 
     #[tokio::test]
@@ -1251,6 +1527,226 @@ mod tests {
         assert!(
             matches!(result, Err(JournalManagerError::AccountNotFound { .. })),
             "Expected AccountNotFound, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn test_poll_request_not_found_then_completed() {
+        let (store, pool) = setup_test_store().await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-not-found-then-ok");
+
+        let mock = Arc::new(StatefulMockAlpacaService::new(
+            vec![
+                MockResponse::NotFound,
+                MockResponse::NotFound,
+                MockResponse::Success(RedeemRequestStatus::Completed),
+            ],
+            issuer_request_id.clone(),
+        ));
+        let mock_ref = Arc::clone(&mock);
+
+        let manager = JournalManager::new(
+            mock as Arc<dyn AlpacaService>,
+            store.clone(),
+            pool,
+        );
+
+        create_test_redemption_in_alpaca_called_state(
+            &store,
+            &issuer_request_id,
+            &tokenization_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_alpaca_called(
+                &test_alpaca_account(),
+                issuer_request_id.clone(),
+                tokenization_request_id,
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "Expected Ok after 404s then Completed, got {result:?}"
+        );
+        // First NotFound logs at WARN; subsequent ones at DEBUG.
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &[
+                    "Request not found at Alpaca keyed endpoint (assumed transient), will retry",
+                    "alp-not-found-then-ok"
+                ]
+            ),
+            "Expected WARN log for first RequestNotFound"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &[
+                    "Request not found at Alpaca keyed endpoint, will retry",
+                    "alp-not-found-then-ok"
+                ]
+            ),
+            "Expected DEBUG log for subsequent RequestNotFound"
+        );
+
+        let aggregate = store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(aggregate, Redemption::Burning { .. }),
+            "Expected Burning state after ConfirmAlpacaComplete, got {aggregate:?}"
+        );
+        assert_eq!(
+            mock_ref.call_count(),
+            3,
+            "Expected exactly 3 poll calls (2 NotFound + 1 Completed)"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    #[traced_test]
+    async fn test_poll_request_not_found_until_timeout() {
+        let (store, pool) = setup_test_store().await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-not-found-timeout");
+
+        let mock = Arc::new(StatefulMockAlpacaService::new(
+            vec![MockResponse::NotFound],
+            issuer_request_id.clone(),
+        ));
+
+        let mut manager = JournalManager::new(
+            mock as Arc<dyn AlpacaService>,
+            store.clone(),
+            pool,
+        );
+
+        manager.max_duration = std::time::Duration::from_millis(100);
+        manager.initial_poll_interval = std::time::Duration::from_millis(10);
+
+        create_test_redemption_in_alpaca_called_state(
+            &store,
+            &issuer_request_id,
+            &tokenization_request_id,
+        )
+        .await;
+
+        let result = manager
+            .handle_alpaca_called(
+                &test_alpaca_account(),
+                issuer_request_id.clone(),
+                tokenization_request_id,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(JournalManagerError::Timeout { .. })),
+            "Expected Timeout error on perpetual 404, got {result:?}"
+        );
+
+        let aggregate = store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(aggregate, Redemption::Failed { .. }),
+            "Expected Failed state after 404 timeout, got {aggregate:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &[
+                    "Request not found at Alpaca keyed endpoint (assumed transient), will retry"
+                ]
+            ),
+            "Expected WARN log for first RequestNotFound"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &["Polling timeout reached, marking redemption as failed"]
+            ),
+            "Expected WARN log for polling timeout"
+        );
+    }
+
+    /// Verifies that a transient store-load failure during polling does NOT
+    /// permanently terminalize the redemption (no `MarkFailed` command). The
+    /// error must propagate as `StoreLoad` for retry, leaving the redemption
+    /// intact in `AlpacaCalled`.
+    ///
+    /// The transient failure is simulated by temporarily renaming the `events`
+    /// table out from under the store, so `Store::load` fails with an
+    /// infrastructure error. The table is restored before reading the
+    /// aggregate back for assertion.
+    #[tokio::test]
+    #[traced_test]
+    async fn test_store_load_error_does_not_mark_redemption_failed() {
+        let (store, pool) = setup_test_store().await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-store-fail-test");
+
+        create_test_redemption_in_alpaca_called_state(
+            &store,
+            &issuer_request_id,
+            &tokenization_request_id,
+        )
+        .await;
+
+        // Hide the events table to simulate a transient SQLite/IO error on the
+        // next load during polling.
+        sqlx::query("ALTER TABLE events RENAME TO events_hidden")
+            .execute(&pool)
+            .await
+            .expect("Failed to hide events table");
+
+        let mock = Arc::new(StatefulMockAlpacaService::new(
+            vec![MockResponse::Success(RedeemRequestStatus::Completed)],
+            issuer_request_id.clone(),
+        ));
+
+        let manager = JournalManager::new(
+            mock as Arc<dyn AlpacaService>,
+            store.clone(),
+            pool.clone(),
+        );
+
+        let result = manager
+            .handle_alpaca_called(
+                &test_alpaca_account(),
+                issuer_request_id.clone(),
+                tokenization_request_id,
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(JournalManagerError::StoreLoad { .. })),
+            "Expected StoreLoad error, not permanent failure, got {result:?}"
+        );
+
+        // Restore the events table so we can read the aggregate back.
+        sqlx::query("ALTER TABLE events_hidden RENAME TO events")
+            .execute(&pool)
+            .await
+            .expect("Failed to restore events table");
+
+        let aggregate = store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(aggregate, Redemption::AlpacaCalled { .. }),
+            "Redemption must remain in AlpacaCalled state (not Failed) after a transient store error; got {aggregate:?}"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &["Transient store error during validation, will retry"]
+            ),
+            "Expected WARN log for transient store error"
         );
     }
 }

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -308,6 +308,101 @@ mod tests {
         ));
     }
 
+    // Production regression (RAI-1083): the issuance bot crash-looped at startup
+    // because projection catch-up asserted each aggregate's events form a
+    // contiguous `1..N` run, aborting with a fatal `EventSequenceGap` otherwise.
+    // Real production data violates that: `ReceiptInventory` aggregates were
+    // written with a sequence counter shared across aggregates (sparse
+    // per-aggregate sequences such as `24, 4559, ...`), and a heavily-retried
+    // `Mint` carried a sequence hole. With the event-sorcery catch-up fix pinned,
+    // startup must replay whatever events exist in `sequence` order and rebuild
+    // the view rather than abort. `TokenizedAsset` exercises the same generic
+    // Table-projection catch-up path that crashed the `Mint` aggregate in prod.
+    #[traced_test]
+    #[tokio::test]
+    async fn build_rebuilds_view_despite_non_contiguous_event_sequences() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        // A genesis `Added` at a non-1 sequence followed by a `Frozen` after a
+        // large gap reproduces the sparse, shared-counter sequencing that aborted
+        // catch-up in production.
+        let added = serde_json::to_string(&TokenizedAssetEvent::Added {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::new("base"),
+            vault,
+            added_at: chrono::Utc::now(),
+        })
+        .unwrap();
+        let frozen = serde_json::to_string(&TokenizedAssetEvent::Frozen {
+            frozen_at: chrono::Utc::now(),
+        })
+        .unwrap();
+
+        for (sequence, event_type, payload) in [
+            (24_i64, "TokenizedAssetEvent::Added", added.as_str()),
+            (4559_i64, "TokenizedAssetEvent::Frozen", frozen.as_str()),
+        ] {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('TokenizedAsset', 'AAPL', ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(sequence)
+            .bind(event_type)
+            .bind(payload)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Catch-up must not abort on the gap: it replays both events in sequence
+        // order and rebuilds the view from scratch.
+        StoreBuilder::<TokenizedAsset>::new(pool.clone())
+            .build(())
+            .await
+            .expect("startup must tolerate non-contiguous event sequences");
+
+        // `Frozen` applied on top of `Added` proves in-order replay across the
+        // gap -- an out-of-order or dropped event could not yield `Frozen`.
+        let asset =
+            load_asset_by_underlying(&pool, &UnderlyingSymbol::new("AAPL"))
+                .await
+                .unwrap()
+                .expect("asset rebuilt despite the sequence gap");
+        assert_eq!(asset.status, AssetStatus::Frozen);
+        assert_eq!(asset.vault, vault);
+
+        // The view advances to the max event sequence, not the event count.
+        let (version,): (i64,) = sqlx::query_as(
+            "SELECT version FROM tokenized_asset_view WHERE view_id = 'AAPL'",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(version, 4559, "view advances to the max event sequence");
+    }
+
     #[tokio::test]
     async fn test_load_asset_by_underlying_errors_on_malformed_payload() {
         let harness = TestHarness::new().await;

--- a/tests/harness/alpaca_mocks.rs
+++ b/tests/harness/alpaca_mocks.rs
@@ -20,6 +20,7 @@ pub fn setup_mint_mocks(mock_alpaca: &MockServer) -> Mock<'_> {
     })
 }
 
+#[derive(Clone)]
 pub struct RedemptionState {
     pub issuer_request_id: String,
     pub tx_hash: String,
@@ -105,41 +106,65 @@ pub fn setup_redemption_mocks(
     let poll_mock = mock_alpaca.mock(|when, then| {
         when.method(GET)
             .path_matches(
-                r"^/v1/accounts/test-account/tokenization/requests.*",
+                r"^/v1/accounts/test-account/tokenization/requests/.+",
             )
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);
 
         then.status(200).respond_with(
-            move |_req: &httpmock::HttpMockRequest| {
-                let responses: Vec<_> = {
-                    let states = shared_state.lock().unwrap();
-                    states
-                        .iter()
-                        .map(|state| {
-                            json!({
-                                "tokenization_request_id": format!("tok-redeem-{}", state.issuer_request_id),
-                                "issuer_request_id": state.issuer_request_id,
-                                "created_at": "2025-09-12T17:28:48.642437-04:00",
-                                "updated_at": "2025-09-12T17:30:00.000000-04:00",
-                                "type": "redeem",
-                                "status": "completed",
-                                "underlying_symbol": state.underlying_symbol,
-                                "token_symbol": state.token_symbol,
-                                "qty": state.qty,
-                                "issuer": "test-issuer",
-                                "network": "base",
-                                "wallet_address": state.wallet_address,
-                                "tx_hash": state.tx_hash,
-                                "fees": "0.5"
-                            })
-                        })
-                        .collect()
+            move |req: &httpmock::HttpMockRequest| {
+                // Extract the tokenization_request_id from the URL path,
+                // stripping any query string before splitting.
+                // Path: /v1/accounts/test-account/tokenization/requests/{id}
+                let uri = req.uri_str();
+                let path = uri.split('?').next().unwrap_or(uri);
+                let tok_id = path.split('/').next_back().unwrap_or("");
+                if tok_id.is_empty() {
+                    return httpmock::HttpMockResponse {
+                        status: Some(404),
+                        headers: None,
+                        body: Some("not found".into()),
+                    };
+                }
+
+                let matched = shared_state
+                    .lock()
+                    .unwrap()
+                    .iter()
+                    .find(|s| {
+                        format!("tok-redeem-{}", s.issuer_request_id) == tok_id
+                    })
+                    .cloned();
+
+                let Some(state) = matched else {
+                    return httpmock::HttpMockResponse {
+                        status: Some(404),
+                        headers: None,
+                        body: Some("not found".into()),
+                    };
                 };
 
-                let response_body =
-                    serde_json::to_string(&responses).unwrap();
+                let tok_req_id =
+                    format!("tok-redeem-{}", state.issuer_request_id);
+
+                let response_body = serde_json::to_string(&json!({
+                    "tokenization_request_id": tok_req_id,
+                    "issuer_request_id": state.issuer_request_id,
+                    "created_at": "2025-09-12T17:28:48.642437-04:00",
+                    "updated_at": "2025-09-12T17:30:00.000000-04:00",
+                    "type": "redeem",
+                    "status": "completed",
+                    "underlying_symbol": state.underlying_symbol,
+                    "token_symbol": state.token_symbol,
+                    "qty": state.qty,
+                    "issuer": "test-issuer",
+                    "network": "base",
+                    "wallet_address": state.wallet_address,
+                    "tx_hash": state.tx_hash,
+                    "fees": "0.5"
+                }))
+                .unwrap();
 
                 httpmock::HttpMockResponse {
                     status: Some(200),

--- a/tests/redemption.rs
+++ b/tests/redemption.rs
@@ -153,7 +153,9 @@ fn setup_redemption_mocks_with_shared_state(
 
     let poll_mock = mock_alpaca.mock(|when, then| {
         when.method(GET)
-            .path_matches(r"^/v1/accounts/test-account/tokenization/requests.*")
+            .path_matches(
+                r"^/v1/accounts/test-account/tokenization/requests/tok-redeem-recovery$",
+            )
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);
@@ -176,24 +178,23 @@ fn setup_redemption_mocks_with_shared_state(
                     "pending"
                 };
 
-                let response_body =
-                    serde_json::to_string(&serde_json::json!([{
-                        "tokenization_request_id": "tok-redeem-recovery",
-                        "issuer_request_id": &issuer_request_id,
-                        "created_at": "2025-09-12T17:28:48.642437-04:00",
-                        "updated_at": "2025-09-12T17:30:00.000000-04:00",
-                        "type": "redeem",
-                        "status": status,
-                        "underlying_symbol": "AAPL",
-                        "token_symbol": "tAAPL",
-                        "qty": "50",
-                        "issuer": "test-issuer",
-                        "network": "base",
-                        "wallet_address": user_wallet,
-                        "tx_hash": tx_hash,
-                        "fees": "0.5"
-                    }]))
-                    .unwrap();
+                let response_body = serde_json::to_string(&serde_json::json!({
+                    "tokenization_request_id": "tok-redeem-recovery",
+                    "issuer_request_id": &issuer_request_id,
+                    "created_at": "2025-09-12T17:28:48.642437-04:00",
+                    "updated_at": "2025-09-12T17:30:00.000000-04:00",
+                    "type": "redeem",
+                    "status": status,
+                    "underlying_symbol": "AAPL",
+                    "token_symbol": "tAAPL",
+                    "qty": "50",
+                    "issuer": "test-issuer",
+                    "network": "base",
+                    "wallet_address": user_wallet,
+                    "tx_hash": tx_hash,
+                    "fees": "0.5"
+                }))
+                .unwrap();
 
                 httpmock::HttpMockResponse {
                     status: Some(200),

--- a/tests/redemption_dust.rs
+++ b/tests/redemption_dust.rs
@@ -213,7 +213,9 @@ fn setup_redemption_mocks_with_qty_capture(
 
     let poll_mock = mock_alpaca.mock(|when, then| {
         when.method(GET)
-            .path_matches(r"^/v1/accounts/test-account/tokenization/requests.*")
+            .path_matches(
+                r"^/v1/accounts/test-account/tokenization/requests/.+",
+            )
             .header("authorization", &basic_auth)
             .header("APCA-API-KEY-ID", &api_key)
             .header("APCA-API-SECRET-KEY", &api_secret);
@@ -224,7 +226,7 @@ fn setup_redemption_mocks_with_qty_capture(
                     shared_issuer_id.lock().unwrap().clone();
                 let tx_hash = shared_tx_hash.lock().unwrap().clone();
 
-                let response_body = serde_json::to_string(&json!([{
+                let response_body = serde_json::to_string(&json!({
                     "tokenization_request_id": "tok-redeem-dust",
                     "issuer_request_id": issuer_request_id,
                     "created_at": "2025-09-12T17:28:48.642437-04:00",
@@ -239,7 +241,7 @@ fn setup_redemption_mocks_with_qty_capture(
                     "wallet_address": user_wallet,
                     "tx_hash": tx_hash,
                     "fees": "0.001"
-                }]))
+                }))
                 .unwrap();
 
                 httpmock::HttpMockResponse {


### PR DESCRIPTION
## Motivation

- `poll_request_status()` checked one redemption's journal status by fetching the **full unfiltered** `GET /tokenization/requests` list and scanning client-side — run on every tick of the journal-poll loop (250ms→30s backoff, up to 1h) and in admin recovery, so payload/latency grew with account history on our hottest Alpaca path.
- The list only returns recent requests: a journal that completes after our 1h poll window (marked `Failed`) is no longer in the list, so `/admin/recover` returned `RequestNotFound` → `502` and the redemption could be left unrecoverable.
- Resolves [RAI-912](https://linear.app/makeitrain/issue/RAI-912/switch-alpaca-journal-polling-to-per-request-get-endpoints).

## Solution

- Poll the **keyed** endpoint `GET /v1/accounts/{account_id}/tokenization/requests/{tokenization_request_id}` (single-object response, deserialized directly into `TokenizationRequest`) — no list scan, intended/verified to retrieve aged requests. Existing field validation (issuer_request_id, symbols, qty, wallet, tx_hash) is unchanged.
- New typed `AlpacaError` variants: `RequestNotFound { id, body }` (mapped from a real HTTP 404) and `ResponseIdMismatch { requested, returned }` (the keyed response carried a different id than requested — a data-integrity guard the old list `.find()` provided implicitly).
- **404 handling differs by caller:** the journal poll loop treats a 404 as transient and retries until the 1h timeout (a freshly-created request may briefly be invisible); admin `recover_post_alpaca` treats it as definitive and returns `404` (was a misleading `502`). `ResponseIdMismatch` → `502`, via an exhaustive `match` (no wildcard).
- Journal poll loop (`handle_poll_result`): `ResponseIdMismatch` and genuine field-validation failures **fast-fail** to `MarkFailed` instead of retrying for an hour; transient event-store read errors get a distinct `StoreLoad` variant and **do not** terminalize (the background recovery job re-picks them).
- Observability (journal poll loop only): the first `RequestNotFound` per poll session logs at `WARN`, subsequent ticks at `DEBUG` (no loop spam); an unexpected `Mint` response logs at `WARN`. Admin recovery logs the 404 at `ERROR`.
- Docs: `SPEC.md`, `README.md`, and `docs/ops-recovery-guide.md` updated to the keyed endpoint and new 404/recover semantics.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic — unit, journal-manager, admin, and e2e-mock coverage for keyed polling, 404s, id mismatch, store-load errors, and recovery behavior (one fixture is a real captured prod keyed response)
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs — [RAI-912](https://linear.app/makeitrain/issue/RAI-912/switch-alpaca-journal-polling-to-per-request-get-endpoints)

_Self-reviewed via a 4-pass multi-model review loop (Fable/Sonnet/Codex + inspectors); findings resolved or consciously deferred._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API endpoint documentation to reflect keyed request polling instead of list endpoint.
  * Refined specification and ops recovery guide for improved redemption request status handling and error classification.

* **Bug Fixes**
  * Improved recovery handling for aged/missing redemption requests with more precise error responses (404 vs 502).
  * Enhanced retry logic to better distinguish between transient and permanent polling failures.

* **Tests**
  * Updated test infrastructure to validate new polling behavior and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->