### PR TITLE
feat: frozen asset state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,11 +130,11 @@ audit trail, enable time-travel debugging, and provide a single source of truth.
 - `sqlx migrate revert` - Revert last migration
 - `sqlx db reset -y` - Drop the database and re-run all migrations
 - Database URL configured via `DATABASE_URL` environment variable
-- **Fixing "unable to open database file" errors** - If `cargo build` fails with
-  sqlx macro errors like
-  `error returned from database: (code: 14) unable to
-  open database file`, run
-  `sqlx db reset -y` to recreate the database
+- **CRITICAL: For ANY sqlx macro / compile-time DB error, the fix is
+  `sqlx db reset -y` inside `nix develop` — apply it directly, never
+  improvise.** Do NOT probe `DATABASE_URL`, look for a `.sqlx` cache, check for
+  `data.db`, or use an in-memory URL. After editing a migration:
+  `sqlx db reset -y`, then `cargo test`. Run all sqlx/cargo in `nix develop`.
 
 ### Development Tools
 
@@ -519,17 +519,16 @@ Environment variables are defined across the deployment pipeline:
   - **Group 2 - Internal**: our code via `crate::` / `super::`, no blank lines
     between them.
   - **FORBIDDEN**: Three+ groups; blank lines within a group; function-level
-    imports. **Sole exception**: enum variant imports (`use MyEnum::{A, B}`)
-    inside function bodies — never at module level.
+    imports. **Exceptions** (function-body `use` only): (1) enum variant imports
+    (`use MyEnum::{A, B}`) — never at module level; (2) imports used solely
+    inside `#[cfg(...)]`-gated code, where a module-scope import would warn as
+    unused under the inverse config.
   - Module declarations (`mod foo;`) may appear between imports.
     ```rust
     use std::sync::Arc;
-    use alloy::primitives::{Address, B256};
-    use cqrs_es::{CqrsFramework, EventStore};
-    use serde::{Deserialize, Serialize};
+    use alloy::primitives::Address;
 
     use crate::account::ClientId;
-    use crate::mint::TokenizationRequestId;
     use super::{Mint, MintCommand};
     ```
 - **Import Conventions**: Always import types and use them unqualified unless

--- a/SPEC.md
+++ b/SPEC.md
@@ -483,41 +483,67 @@ stateDiagram-v2
 ### TokenizedAsset Aggregate
 
 The `TokenizedAsset` aggregate manages which assets are supported for
-tokenization.
+tokenization. The aggregate id is the `UnderlyingSymbol`.
 
 **Aggregate State:**
 
 - `underlying`, `token`: Symbol identifiers
 - `network`: Blockchain network
-- `vault_address`: On-chain vault contract address
-- `enabled`: Whether asset is currently available for minting/redeeming
-- Timestamps
+- `vault`: On-chain vault contract address
+- `status`: `AssetStatus` — `Enabled` (mints accepted) or `Frozen` (mints
+  rejected, but the asset stays supported and in-flight redemptions still
+  complete)
+- `added_at`: Timestamp
 
 **Commands:**
 
-- `AddAsset { underlying, token, network, vault_address }` - Add new supported
-  asset
-- `EnableAsset { underlying }` - Enable asset for minting/redeeming
-- `DisableAsset { underlying, reason }` - Disable asset temporarily
-- `UpdateVaultAddress { underlying, vault_address }` - Update vault contract
-  address
+- `Add { underlying, token, network, vault }` - Add a new supported asset.
+  Re-adding with a different vault updates the vault address; re-adding with the
+  same vault is a no-op.
+- `Freeze` - Stop accepting new mints for this asset (idempotent — freezing a
+  frozen asset is a no-op).
+- `Unfreeze` - Resume accepting mints (idempotent).
 
 **Events:**
 
-- `AssetAdded { underlying, token, network, vault_address }` - New asset added
-- `AssetEnabled { underlying }` - Asset enabled
-- `AssetDisabled { underlying, reason }` - Asset disabled
-- `VaultAddressUpdated { underlying, vault_address, previous_address }` - Vault
-  address changed
+- `Added { underlying, token, network, vault, added_at }` - New asset added
+- `VaultAddressUpdated { vault, previous_vault, updated_at }` - Vault address
+  changed
+- `Frozen { frozen_at }` - Asset frozen (new mints rejected)
+- `Unfrozen { unfrozen_at }` - Asset unfrozen (mints resume)
 
 **Command -> Event Mappings:**
 
-| Command              | Events Produced       | Notes                                       |
-| -------------------- | --------------------- | ------------------------------------------- |
-| `AddAsset`           | `AssetAdded`          | New tokenized asset added to supported list |
-| `EnableAsset`        | `AssetEnabled`        | Asset enabled for minting/redeeming         |
-| `DisableAsset`       | `AssetDisabled`       | Asset temporarily disabled                  |
-| `UpdateVaultAddress` | `VaultAddressUpdated` | Vault contract address changed              |
+| Command    | Events Produced                 | Notes                                                         |
+| ---------- | ------------------------------- | ------------------------------------------------------------- |
+| `Add`      | `Added` / `VaultAddressUpdated` | New asset, or vault update if re-added with a different vault |
+| `Freeze`   | `Frozen`                        | No event if already frozen (idempotent)                       |
+| `Unfreeze` | `Unfrozen`                      | No event if already enabled (idempotent)                      |
+
+**Freeze State Machine:**
+
+```
+Enabled ⇄ Frozen
+   Freeze:   Enabled -> Frozen
+   Unfreeze: Frozen  -> Enabled
+```
+
+**Freeze invariant — frozen is not de-listed.** Freezing only gates _new_ mints:
+`POST /inkind/issuance` rejects a frozen asset with a distinct `AssetFrozen`
+error (separate from `AssetNotAvailable`), so the rejection is observable and
+not conflated with de-listing. A frozen asset stays in `list_enabled_assets()`,
+so in-flight redemption detection (`src/redemption/`) keeps working — issuance
+reacts to on-chain transfers and has no "reject redemption" point. Preventing
+_new_ redemptions of a frozen asset is the liquidity rebalance guard's job
+(RAI-1038), which reads the per-asset status endpoint (see "Tokenized Assets
+Data Endpoint"). This issuance-side freeze plus the liquidity guard form the
+single dividend freeze/unfreeze mechanism; no on-chain wrapper-contract freeze
+is involved here (that is separate, heavier supply-control work and out of
+scope).
+
+The `Freeze` / `Unfreeze` commands are emitted manually via the issuer-host CLI
+in M1 and automatically by the dividend scheduler in M3 — the same command path
+either way.
 
 ## Services
 
@@ -1886,10 +1912,10 @@ events.
 
 **TokenizedAssetView** - Supported assets:
 
-- Listens to: `AssetAdded`, `AssetEnabled`, `AssetDisabled`,
-  `VaultAddressUpdated`
-- Updates: Asset configuration, enabled status
+- Listens to: `Added`, `VaultAddressUpdated`, `Frozen`, `Unfrozen`
+- Updates: Asset configuration and freeze `status` (`Enabled` / `Frozen`)
 - Used for: Validating mint/redemption requests, listing available assets
+  (including frozen ones), and serving the per-asset freeze status endpoint
 
 ## Framework Wiring
 

--- a/migrations/20260615230714_migrate_tokenized_asset_view_freeze_status.sql
+++ b/migrations/20260615230714_migrate_tokenized_asset_view_freeze_status.sql
@@ -1,0 +1,14 @@
+-- The TokenizedAsset view payload now carries `status` (AssetStatus: "Enabled"
+-- / "Frozen") in place of the boolean `enabled`. Drop + recreate the view so
+-- `StoreBuilder::build`'s catch_up rebuilds every row from the event log with
+-- the new shape. The events table is unchanged — `originate` sets every asset
+-- to `Enabled`, and freeze state comes from the new `Frozen` / `Unfrozen`
+-- events. Existing rows carrying the old `enabled` field would otherwise fail
+-- to deserialize into the new view struct.
+DROP TABLE IF EXISTS tokenized_asset_view;
+
+CREATE TABLE tokenized_asset_view (
+    view_id TEXT PRIMARY KEY,
+    version BIGINT NOT NULL,
+    payload JSON NOT NULL
+);

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -104,6 +104,7 @@ mod tests {
     use rocket::routes;
     use rust_decimal::Decimal;
     use std::str::FromStr;
+    use tracing_test::traced_test;
 
     use super::initiate_mint;
     use crate::account::{AccountCommand, AlpacaAccountNumber, Email};
@@ -117,6 +118,7 @@ mod tests {
         Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
         view::find_by_issuer_request_id,
     };
+    use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::TokenizedAssetCommand;
 
     #[tokio::test]
@@ -216,6 +218,200 @@ mod tests {
         )
         .expect("valid JSON response");
 
+        assert!(!mint_response.issuer_request_id.to_string().is_empty());
+        assert_eq!(mint_response.status, "created");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_initiate_mint_rejects_frozen_asset() {
+        let harness = TestHarness::new().await;
+        let TestAccountAndAsset {
+            client_id, underlying, token, network, ..
+        } = harness.setup_account_and_asset().await;
+        let TestHarness {
+            pool,
+            account_store,
+            asset_store: tokenized_asset_store,
+            mint_store,
+        } = harness;
+
+        tokenized_asset_store
+            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .await
+            .expect("Failed to freeze asset");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(mint_store)
+            .manage(account_store)
+            .manage(tokenized_asset_store)
+            .manage(pool.clone())
+            .mount("/", routes![initiate_mint]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "tokenization_request_id": "alp-123",
+            "qty": "100.5",
+            "underlying_symbol": underlying.0,
+            "token_symbol": token.0,
+            "network": network.0,
+            "client_id": client_id,
+            "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
+        });
+
+        let response = client
+            .post("/inkind/issuance")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::BadRequest);
+
+        let error_response: ErrorResponse = serde_json::from_str(
+            &response.into_string().await.expect("valid response body"),
+        )
+        .expect("valid JSON response");
+
+        assert_eq!(
+            error_response.error,
+            "Asset Frozen: Minting is suspended for this asset"
+        );
+
+        // The rejection must happen before any mint command is dispatched, so no
+        // Mint events are persisted for a frozen-asset request.
+        let mint_event_count = sqlx::query_scalar!(
+            r#"
+            SELECT COUNT(*) as "count!: i64"
+            FROM events
+            WHERE aggregate_type = 'Mint'
+            "#
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("Failed to count mint events");
+
+        assert_eq!(
+            mint_event_count, 0,
+            "frozen-asset request must not create mint events"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Rejecting mint for frozen asset"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_initiate_mint_accepts_unfrozen_asset() {
+        let harness = TestHarness::new().await;
+        let TestAccountAndAsset {
+            client_id, underlying, token, network, ..
+        } = harness.setup_account_and_asset().await;
+        let TestHarness {
+            pool,
+            account_store,
+            asset_store: tokenized_asset_store,
+            mint_store,
+        } = harness;
+
+        // Keep an Arc handle so we can dispatch Unfreeze after Rocket takes
+        // ownership of the managed store.
+        let asset_store = tokenized_asset_store.clone();
+
+        asset_store
+            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .await
+            .expect("Failed to freeze asset");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(mint_store)
+            .manage(account_store)
+            .manage(tokenized_asset_store)
+            .manage(pool)
+            .mount("/", routes![initiate_mint]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "tokenization_request_id": "alp-123",
+            "qty": "100.5",
+            "underlying_symbol": underlying.0,
+            "token_symbol": token.0,
+            "network": network.0,
+            "client_id": client_id,
+            "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
+        });
+
+        let frozen_response = client
+            .post("/inkind/issuance")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(frozen_response.status(), Status::BadRequest);
+
+        // Asserted here, before the Unfreeze, so the WARN can only come from the
+        // frozen request — confirming the rejection fired for the freeze reason
+        // rather than some unrelated validation failure.
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Rejecting mint for frozen asset"]
+        ));
+
+        // Unfreezing must let new mints through again — the whole point of the
+        // toggle is that issuance resumes after Unfreeze.
+        asset_store
+            .send(&underlying, TokenizedAssetCommand::Unfreeze)
+            .await
+            .expect("Failed to unfreeze asset");
+
+        let unfrozen_response = client
+            .post("/inkind/issuance")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(unfrozen_response.status(), Status::Ok);
+
+        let mint_response: MintResponse = serde_json::from_str(
+            &unfrozen_response
+                .into_string()
+                .await
+                .expect("valid response body"),
+        )
+        .expect("valid JSON response");
+
+        // The 200 + "created" + non-empty issuer_request_id below is the
+        // unfrozen-path assertion: a frozen or rejected request never reaches a
+        // "created" mint response, so issuance demonstrably resumed.
         assert!(!mint_response.issuer_request_id.to_string().is_empty());
         assert_eq!(mint_response.status, "created");
     }

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -12,6 +12,7 @@ use super::{
     UnderlyingSymbol,
 };
 use crate::account::{AccountView, view::find_by_client_id};
+use crate::tokenized_asset::view::load_asset_by_underlying;
 
 mod confirm;
 mod initiate;
@@ -40,6 +41,9 @@ pub(crate) enum MintApiError {
 
     #[error("Asset not available on network")]
     AssetNotAvailable,
+
+    #[error("Asset is frozen; new mints are suspended")]
+    AssetFrozen,
 
     #[error("Client not eligible")]
     ClientNotEligible,
@@ -79,6 +83,9 @@ impl<'r> Responder<'r, 'static> for MintApiError {
             ),
             Self::AssetNotAvailable => MintErrorResponse::bad_request(
                 "Invalid Token: Token not available on the network",
+            ),
+            Self::AssetFrozen => MintErrorResponse::bad_request(
+                "Asset Frozen: Minting is suspended for this asset",
             ),
             Self::ClientNotEligible => MintErrorResponse::bad_request(
                 "Insufficient Eligibility: Client not eligible",
@@ -188,32 +195,32 @@ pub(crate) async fn validate_asset_exists(
     token: &TokenSymbol,
     network: &Network,
 ) -> Result<(), MintApiError> {
-    let underlying_str = &underlying.0;
-    let token_str = &token.0;
-    let network_str = &network.0;
+    let asset = load_asset_by_underlying(pool, underlying)
+        .await
+        .map_err(|query_error| {
+            error!(target: "mint", error = %query_error, "Failed to query asset");
+            MintApiError::AssetQueryFailed(query_error)
+        })?;
 
-    let count = sqlx::query_scalar!(
-        r#"
-        SELECT COUNT(*) as "count: i64"
-        FROM tokenized_asset_view
-        WHERE json_extract(payload, '$.Live.underlying') = ?
-            AND json_extract(payload, '$.Live.token') = ?
-            AND json_extract(payload, '$.Live.network') = ?
-            AND json_extract(payload, '$.Live.enabled') = 1
-        "#,
-        underlying_str,
-        token_str,
-        network_str
-    )
-    .fetch_one(pool)
-    .await
-    .map_err(|e| {
-        error!(target: "mint", "Failed to query asset: {e}");
-        MintApiError::AssetQueryFailed(e.into())
-    })?;
-
-    if count == 0 {
+    // An asset must exist for this exact (underlying, token, network) tuple. A
+    // frozen asset still exists and stays supported — it is rejected with a
+    // distinct `AssetFrozen` error so the suspension is observable and not
+    // conflated with de-listing.
+    let Some(asset) = asset
+        .filter(|asset| asset.token == *token && asset.network == *network)
+    else {
         return Err(MintApiError::AssetNotAvailable);
+    };
+
+    if asset.status.is_frozen() {
+        warn!(
+            target: "mint",
+            underlying = %underlying.0,
+            token = %token.0,
+            network = %network.0,
+            "Rejecting mint for frozen asset"
+        );
+        return Err(MintApiError::AssetFrozen);
     }
 
     Ok(())

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -318,7 +318,7 @@ async fn find_matching_asset(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, U256, address, b256};
-    use event_sorcery::{Store, test_store};
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use sqlx::SqlitePool;
     use std::sync::Arc;
     use tracing_test::traced_test;
@@ -329,6 +329,9 @@ mod tests {
         create_transfer_log, setup_test_db_with_asset,
     };
     use crate::test_utils::logs_contain_at;
+    use crate::tokenized_asset::{
+        TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
+    };
     use crate::vault::mock::MockVaultService;
 
     fn setup_test_store(pool: &SqlitePool) -> Arc<Store<Redemption>> {
@@ -371,6 +374,61 @@ mod tests {
             assert!(
                 matches!(redemption, Redemption::Detected { .. }),
                 "Expected Detected state, got {redemption:?}"
+            );
+        }
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Redemption transfer detected"]
+        ));
+    }
+
+    // Freezing an asset gates new mints but must NOT stop redemption detection:
+    // in-flight redemptions of a frozen asset still need to detect and complete.
+    #[traced_test]
+    #[tokio::test]
+    async fn detect_transfer_succeeds_for_frozen_asset() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let ap_wallet = address!("0x9999999999999999999999999999999999999999");
+
+        let pool = setup_test_db_with_asset(vault, Some(ap_wallet)).await;
+
+        let (asset_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        asset_store
+            .send(&UnderlyingSymbol::new("AAPL"), TokenizedAssetCommand::Freeze)
+            .await
+            .expect("Failed to freeze asset");
+
+        let store = setup_test_store(&pool);
+
+        let value = U256::from_str_radix("100000000000000000000", 10).unwrap();
+        let tx_hash = b256!(
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+
+        let log = create_transfer_log(
+            vault, ap_wallet, bot_wallet, value, tx_hash, 12345,
+        );
+
+        let result = detect_transfer(&log, vault, &store, &pool).await;
+
+        let outcome = result.expect("Expected success");
+        assert!(
+            matches!(outcome, TransferOutcome::Detected { .. }),
+            "frozen asset must still detect redemptions, got {outcome:?}"
+        );
+
+        if let TransferOutcome::Detected { issuer_request_id, .. } = outcome {
+            let redemption =
+                store.load(&issuer_request_id).await.unwrap().unwrap();
+            assert!(
+                matches!(redemption, Redemption::Detected { .. }),
+                "frozen asset redemption must persist Detected state, got {redemption:?}"
             );
         }
 

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -48,14 +48,14 @@ pub(crate) async fn get_tokenized_asset(
             token,
             network,
             vault,
-            enabled,
+            status,
             ..
         }) => Ok(Json(TokenizedAssetDetailResponse {
             underlying,
             token,
             network,
             vault,
-            enabled,
+            enabled: status.is_listed(),
         })),
         None => Err(Status::NotFound),
     }

--- a/src/tokenized_asset/cmd.rs
+++ b/src/tokenized_asset/cmd.rs
@@ -11,4 +11,6 @@ pub(crate) enum TokenizedAssetCommand {
         network: Network,
         vault: Address,
     },
+    Freeze,
+    Unfreeze,
 }

--- a/src/tokenized_asset/event.rs
+++ b/src/tokenized_asset/event.rs
@@ -19,6 +19,12 @@ pub(crate) enum TokenizedAssetEvent {
         previous_vault: Address,
         updated_at: DateTime<Utc>,
     },
+    Frozen {
+        frozen_at: DateTime<Utc>,
+    },
+    Unfrozen {
+        unfrozen_at: DateTime<Utc>,
+    },
 }
 
 impl DomainEvent for TokenizedAssetEvent {
@@ -27,6 +33,10 @@ impl DomainEvent for TokenizedAssetEvent {
             Self::Added { .. } => "TokenizedAssetEvent::Added".to_string(),
             Self::VaultAddressUpdated { .. } => {
                 "TokenizedAssetEvent::VaultAddressUpdated".to_string()
+            }
+            Self::Frozen { .. } => "TokenizedAssetEvent::Frozen".to_string(),
+            Self::Unfrozen { .. } => {
+                "TokenizedAssetEvent::Unfrozen".to_string()
             }
         }
     }

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -69,13 +69,40 @@ impl Network {
     }
 }
 
+/// Whether an asset accepts new mints.
+///
+/// `Frozen` gates *only* new minting — a frozen asset stays supported and in the
+/// `list_enabled_assets()` set so in-flight redemptions still detect and
+/// complete. This is orthogonal to listing; see the freeze invariant in
+/// SPEC.md. Serializes to the bare strings `"Enabled"` / `"Frozen"`, which the
+/// view queries match against `$.Live.status`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum AssetStatus {
+    Enabled,
+    Frozen,
+}
+
+impl AssetStatus {
+    /// Whether the asset is supported (appears in `list_enabled_assets`). Both
+    /// `Enabled` and `Frozen` assets are supported — freezing gates minting, not
+    /// listing, so this must never conflate freeze with de-listing.
+    pub(crate) const fn is_listed(&self) -> bool {
+        matches!(self, Self::Enabled | Self::Frozen)
+    }
+
+    /// Whether new mints are currently rejected for this asset.
+    pub(crate) const fn is_frozen(&self) -> bool {
+        matches!(self, Self::Frozen)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct TokenizedAsset {
     underlying: UnderlyingSymbol,
     token: TokenSymbol,
     network: Network,
     vault: Address,
-    enabled: bool,
+    status: AssetStatus,
     added_at: DateTime<Utc>,
 }
 
@@ -112,10 +139,14 @@ impl EventSourced for TokenizedAsset {
                 token: token.clone(),
                 network: network.clone(),
                 vault: *vault,
-                enabled: true,
+                status: AssetStatus::Enabled,
                 added_at: *added_at,
             }),
-            TokenizedAssetEvent::VaultAddressUpdated { .. } => None,
+            // Vault updates and freeze/unfreeze are only reachable after an
+            // `Added` genesis — they never start a stream.
+            TokenizedAssetEvent::VaultAddressUpdated { .. }
+            | TokenizedAssetEvent::Frozen { .. }
+            | TokenizedAssetEvent::Unfrozen { .. } => None,
         }
     }
 
@@ -128,13 +159,41 @@ impl EventSourced for TokenizedAsset {
                 Ok(Some(Self { vault: *vault, ..entity.clone() }))
             }
 
-            // A second `Added` re-adds the asset, overwriting in place — the
-            // pre-migration `apply` did this silently. event-sorcery turns an
+            TokenizedAssetEvent::Frozen { .. } => {
+                Ok(Some(Self { status: AssetStatus::Frozen, ..entity.clone() }))
+            }
+
+            TokenizedAssetEvent::Unfrozen { .. } => Ok(Some(Self {
+                status: AssetStatus::Enabled,
+                ..entity.clone()
+            })),
+
+            // A second `Added` re-adds the asset, overwriting identity and vault
+            // in place but preserving the current freeze `status` — re-adding
+            // must not silently clear a freeze, since there would be no
+            // `Unfrozen` event to explain the transition. event-sorcery turns an
             // unhandled event (`Ok(None)`) into a permanent `Failed` lifecycle,
             // which startup `catch_up` would hit for any stream carrying a
             // duplicate `Added` (only reachable via direct event-store seeding),
             // so handle it explicitly rather than bricking the aggregate.
-            TokenizedAssetEvent::Added { .. } => Ok(Self::originate(event)),
+            TokenizedAssetEvent::Added {
+                underlying,
+                token,
+                network,
+                vault,
+                added_at,
+            } => Ok(Some(Self {
+                underlying: underlying.clone(),
+                token: token.clone(),
+                network: network.clone(),
+                vault: *vault,
+                added_at: *added_at,
+                // Preserve only the freeze `status`; everything else comes from
+                // the authoritative `Added` event. Naming the single carried-over
+                // field keeps the no-silent-unfreeze invariant local, and stops a
+                // future field from being silently carried from stale state.
+                status: entity.status.clone(),
+            })),
         }
     }
 
@@ -142,21 +201,37 @@ impl EventSourced for TokenizedAsset {
         command: Self::Command,
         _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
-        let TokenizedAssetCommand::Add { underlying, token, network, vault } =
-            command;
+        match command {
+            TokenizedAssetCommand::Add {
+                underlying,
+                token,
+                network,
+                vault,
+            } => {
+                tracing::info!(target: "asset", underlying = %underlying.0,
+                    vault = %vault,
+                    "Adding new tokenized asset"
+                );
 
-        tracing::info!(target: "asset", underlying = %underlying.0,
-            vault = %vault,
-            "Adding new tokenized asset"
-        );
+                Ok(vec![TokenizedAssetEvent::Added {
+                    underlying,
+                    token,
+                    network,
+                    vault,
+                    added_at: Utc::now(),
+                }])
+            }
 
-        Ok(vec![TokenizedAssetEvent::Added {
-            underlying,
-            token,
-            network,
-            vault,
-            added_at: Utc::now(),
-        }])
+            // Freezing or unfreezing an asset that was never added is a no-op:
+            // there is nothing to gate. Callers (the issuer CLI) check existence
+            // first and report "not found" rather than silently dispatching.
+            TokenizedAssetCommand::Freeze | TokenizedAssetCommand::Unfreeze => {
+                tracing::warn!(target: "asset",
+                    "Ignoring freeze/unfreeze for an asset that does not exist"
+                );
+                Ok(vec![])
+            }
+        }
     }
 
     async fn transition(
@@ -164,37 +239,73 @@ impl EventSourced for TokenizedAsset {
         command: Self::Command,
         _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
-        let TokenizedAssetCommand::Add { underlying, vault, .. } = command;
+        match command {
+            TokenizedAssetCommand::Add { underlying, vault, .. } => {
+                if self.vault == vault {
+                    tracing::debug!(target: "asset", underlying = %underlying.0,
+                        "Asset already added with same vault, skipping"
+                    );
+                    return Ok(vec![]);
+                }
 
-        if self.vault == vault {
-            tracing::debug!(target: "asset", underlying = %underlying.0,
-                "Asset already added with same vault, skipping"
-            );
-            return Ok(vec![]);
+                tracing::info!(target: "asset", underlying = %underlying.0,
+                    previous_vault = %self.vault,
+                    new_vault = %vault,
+                    "Updating vault address for asset"
+                );
+                Ok(vec![TokenizedAssetEvent::VaultAddressUpdated {
+                    vault,
+                    previous_vault: self.vault,
+                    updated_at: Utc::now(),
+                }])
+            }
+
+            TokenizedAssetCommand::Freeze => {
+                if self.status == AssetStatus::Frozen {
+                    tracing::debug!(target: "asset",
+                        underlying = %self.underlying.0,
+                        "Asset already frozen, skipping"
+                    );
+                    return Ok(vec![]);
+                }
+
+                tracing::info!(target: "asset",
+                    underlying = %self.underlying.0,
+                    "Freezing tokenized asset"
+                );
+                Ok(vec![TokenizedAssetEvent::Frozen { frozen_at: Utc::now() }])
+            }
+
+            TokenizedAssetCommand::Unfreeze => {
+                if self.status == AssetStatus::Enabled {
+                    tracing::debug!(target: "asset",
+                        underlying = %self.underlying.0,
+                        "Asset already enabled, skipping"
+                    );
+                    return Ok(vec![]);
+                }
+
+                tracing::info!(target: "asset",
+                    underlying = %self.underlying.0,
+                    "Unfreezing tokenized asset"
+                );
+                Ok(vec![TokenizedAssetEvent::Unfrozen {
+                    unfrozen_at: Utc::now(),
+                }])
+            }
         }
-
-        tracing::info!(target: "asset", underlying = %underlying.0,
-            previous_vault = %self.vault,
-            new_vault = %vault,
-            "Updating vault address for asset"
-        );
-        Ok(vec![TokenizedAssetEvent::VaultAddressUpdated {
-            vault,
-            previous_vault: self.vault,
-            updated_at: Utc::now(),
-        }])
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::address;
+    use alloy::primitives::{Address, address};
     use event_sorcery::{TestHarness, replay};
     use tracing_test::traced_test;
 
     use super::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
-        TokenizedAssetEvent, UnderlyingSymbol,
+        AssetStatus, Network, TokenSymbol, TokenizedAsset,
+        TokenizedAssetCommand, TokenizedAssetEvent, UnderlyingSymbol,
     };
     use crate::test_utils::logs_contain_at;
 
@@ -304,7 +415,7 @@ mod tests {
                 assert_eq!(*vault, vault_b);
                 assert_eq!(*previous_vault, vault_a);
             }
-            other @ TokenizedAssetEvent::Added { .. } => {
+            other => {
                 panic!("Expected VaultAddressUpdated, got: {other:?}")
             }
         }
@@ -313,6 +424,163 @@ mod tests {
             tracing::Level::INFO,
             &["Updating vault address for asset", "AAPL"]
         ));
+    }
+
+    fn added_event(vault: Address) -> TokenizedAssetEvent {
+        TokenizedAssetEvent::Added {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::new("base"),
+            vault,
+            added_at: chrono::Utc::now(),
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_freeze_enabled_asset_emits_frozen() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        let events = TestHarness::<TokenizedAsset>::with(())
+            .given(vec![added_event(vault)])
+            .when(TokenizedAssetCommand::Freeze)
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1, "Expected exactly one event");
+
+        let TokenizedAssetEvent::Frozen { frozen_at } = &events[0] else {
+            panic!("Expected Frozen event, got: {:?}", events[0])
+        };
+        assert!(frozen_at.timestamp() > 0);
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Freezing tokenized asset", "AAPL"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_freeze_already_frozen_is_idempotent() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        TestHarness::<TokenizedAsset>::with(())
+            .given(vec![
+                added_event(vault),
+                TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
+            ])
+            .when(TokenizedAssetCommand::Freeze)
+            .await
+            .then_expect_events(&[]);
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Asset already frozen, skipping", "AAPL"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_unfreeze_frozen_asset_emits_unfrozen() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        let events = TestHarness::<TokenizedAsset>::with(())
+            .given(vec![
+                added_event(vault),
+                TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
+            ])
+            .when(TokenizedAssetCommand::Unfreeze)
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1, "Expected exactly one event");
+
+        let TokenizedAssetEvent::Unfrozen { unfrozen_at } = &events[0] else {
+            panic!("Expected Unfrozen event, got: {:?}", events[0])
+        };
+        assert!(unfrozen_at.timestamp() > 0);
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Unfreezing tokenized asset", "AAPL"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_unfreeze_enabled_asset_is_idempotent() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        TestHarness::<TokenizedAsset>::with(())
+            .given(vec![added_event(vault)])
+            .when(TokenizedAssetCommand::Unfreeze)
+            .await
+            .then_expect_events(&[]);
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Asset already enabled, skipping", "AAPL"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_freeze_nonexistent_asset_is_noop() {
+        TestHarness::<TokenizedAsset>::with(())
+            .given_no_previous_events()
+            .when(TokenizedAssetCommand::Freeze)
+            .await
+            .then_expect_events(&[]);
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Ignoring freeze/unfreeze for an asset that does not exist"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_unfreeze_nonexistent_asset_is_noop() {
+        TestHarness::<TokenizedAsset>::with(())
+            .given_no_previous_events()
+            .when(TokenizedAssetCommand::Unfreeze)
+            .await
+            .then_expect_events(&[]);
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Ignoring freeze/unfreeze for an asset that does not exist"]
+        ));
+    }
+
+    #[test]
+    fn test_apply_frozen_sets_status_frozen() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        let asset = replay::<TokenizedAsset>(vec![
+            added_event(vault),
+            TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(asset.status, AssetStatus::Frozen);
+    }
+
+    #[test]
+    fn test_apply_unfrozen_sets_status_enabled() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+
+        let asset = replay::<TokenizedAsset>(vec![
+            added_event(vault),
+            TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
+            TokenizedAssetEvent::Unfrozen { unfrozen_at: chrono::Utc::now() },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(asset.status, AssetStatus::Enabled);
     }
 
     #[test]
@@ -339,7 +607,7 @@ mod tests {
             token: added_token,
             network: added_network,
             vault: added_vault,
-            enabled,
+            status,
             added_at: added_at_timestamp,
         } = asset;
 
@@ -347,7 +615,7 @@ mod tests {
         assert_eq!(added_token, token);
         assert_eq!(added_network, network);
         assert_eq!(added_vault, vault);
-        assert!(enabled);
+        assert_eq!(status, AssetStatus::Enabled);
         assert_eq!(added_at_timestamp, added_at);
     }
 
@@ -407,6 +675,39 @@ mod tests {
 
         assert_eq!(asset.vault, vault_b);
         assert_eq!(asset.token, TokenSymbol::new("tAAPL2"));
+    }
+
+    // A re-`Added` on a frozen asset must overwrite identity/vault but keep the
+    // freeze `status` — there is no `Unfrozen` event to explain a transition back
+    // to `Enabled`, so silently clearing the freeze would resume minting with no
+    // audit trail.
+    #[test]
+    fn test_apply_duplicate_added_preserves_freeze_status() {
+        let vault_a = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let vault_b = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let asset = replay::<TokenizedAsset>(vec![
+            TokenizedAssetEvent::Added {
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::new("base"),
+                vault: vault_a,
+                added_at: chrono::Utc::now(),
+            },
+            TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
+            TokenizedAssetEvent::Added {
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL2"),
+                network: Network::new("base"),
+                vault: vault_b,
+                added_at: chrono::Utc::now(),
+            },
+        ])
+        .expect("duplicate Added must not fail the lifecycle")
+        .expect("aggregate must stay live after a duplicate Added");
+
+        assert_eq!(asset.vault, vault_b);
+        assert_eq!(asset.status, AssetStatus::Frozen);
     }
 
     #[test]

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 
-use super::{Network, TokenSymbol, UnderlyingSymbol};
+use super::{AssetStatus, Network, TokenSymbol, UnderlyingSymbol};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TokenizedAssetViewError {
@@ -27,10 +27,17 @@ pub(crate) struct TokenizedAssetView {
     pub(crate) token: TokenSymbol,
     pub(crate) network: Network,
     pub(crate) vault: Address,
-    pub(crate) enabled: bool,
+    pub(crate) status: AssetStatus,
     pub(crate) added_at: DateTime<Utc>,
 }
 
+/// Lists all supported assets, including frozen ones.
+///
+/// Freezing gates new minting only — a frozen asset stays in this set so
+/// in-flight redemption detection (`src/redemption/`) and receipt backfilling
+/// keep working. The filter matches `$.Live.status` against the supported
+/// states rather than excluding `Frozen`, preserving the freeze invariant (see
+/// SPEC.md).
 pub(crate) async fn list_enabled_assets(
     pool: &Pool<Sqlite>,
 ) -> Result<Vec<TokenizedAssetView>, TokenizedAssetViewError> {
@@ -38,7 +45,7 @@ pub(crate) async fn list_enabled_assets(
         r#"
         SELECT json_extract(payload, '$.Live') as "live: String"
         FROM tokenized_asset_view
-        WHERE json_extract(payload, '$.Live.enabled') = 1
+        WHERE json_extract(payload, '$.Live.status') IN ('Enabled', 'Frozen')
         "#
     )
     .fetch_all(pool)
@@ -80,15 +87,17 @@ pub(crate) async fn load_asset_by_underlying(
 
 /// Finds the vault address for a given underlying symbol.
 ///
-/// Returns `Ok(Some(vault))` if an enabled asset with that underlying exists,
-/// `Ok(None)` if not found or disabled, or an error on database failure.
+/// Returns `Ok(Some(vault))` if a supported asset with that underlying exists
+/// (including a frozen one — in-flight redemptions and mints of a frozen asset
+/// must still resolve their vault), `Ok(None)` if not found, or an error on
+/// database failure.
 pub(crate) async fn find_vault_by_underlying(
     pool: &Pool<Sqlite>,
     underlying: &UnderlyingSymbol,
 ) -> Result<Option<Address>, TokenizedAssetViewError> {
     Ok(load_asset_by_underlying(pool, underlying)
         .await?
-        .and_then(|asset| asset.enabled.then_some(asset.vault)))
+        .map(|asset| asset.vault))
 }
 
 #[cfg(test)]
@@ -102,7 +111,7 @@ mod tests {
     use super::*;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        TokenizedAsset, TokenizedAssetCommand, TokenizedAssetEvent,
+        AssetStatus, TokenizedAsset, TokenizedAssetCommand, TokenizedAssetEvent,
     };
 
     struct TestHarness {
@@ -352,5 +361,47 @@ mod tests {
             Some(vault_b),
             "view must reflect the updated vault after VaultAddressUpdated"
         );
+    }
+
+    // Freezing must project `status: Frozen` into the view AND keep the asset in
+    // `list_enabled_assets` — the freeze invariant that lets in-flight
+    // redemptions of a frozen asset keep detecting (see SPEC.md).
+    #[tokio::test]
+    async fn test_freeze_projects_status_and_keeps_asset_listed() {
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, store } = &harness;
+
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        harness.add_asset("AAPL", vault).await;
+
+        let before = load_asset_by_underlying(pool, &underlying)
+            .await
+            .unwrap()
+            .expect("asset exists before freeze");
+        assert_eq!(before.status, AssetStatus::Enabled);
+
+        store
+            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .await
+            .expect("Failed to freeze asset");
+
+        let after = load_asset_by_underlying(pool, &underlying)
+            .await
+            .unwrap()
+            .expect("asset exists after freeze");
+        assert_eq!(after.status, AssetStatus::Frozen);
+
+        let listed =
+            list_enabled_assets(pool).await.expect("Query should succeed");
+        assert_eq!(listed.len(), 1, "frozen asset must stay listed");
+        assert_eq!(listed[0].status, AssetStatus::Frozen);
+
+        // A frozen asset must still resolve its vault so in-flight redemptions
+        // and mints can complete.
+        let resolved = find_vault_by_underlying(pool, &underlying)
+            .await
+            .expect("Query should succeed");
+        assert_eq!(resolved, Some(vault));
     }
 }


### PR DESCRIPTION
## Motivation

Around a dividend ex-date the issuer must stop creating new supply for an asset (RAI-1034). This adds the CQRS freeze/unfreeze state machine and mint-side enforcement — the foundation for the single dividend freeze/unfreeze mechanism (issuance freeze + the liquidity rebalance guard). Freeze is modeled as its own state, orthogonal to listing, so in-flight redemptions still complete. Implements RAI-1035.

## Solution

- `TokenizedAsset` gains an `AssetStatus` (`Enabled` | `Frozen`) replacing the always-true `enabled` flag; new idempotent `Freeze` / `Unfreeze` commands and `Frozen` / `Unfrozen` events.
- `POST /inkind/issuance` rejects a frozen asset with a new typed `AssetFrozen` error, distinct from `AssetNotAvailable`, so the suspension is observable and not conflated with de-listing.
- A frozen asset stays in `list_enabled_assets()` and keeps resolving its vault, so redemption detection and burns of a frozen asset keep working (proven by test).
- View migration drops + recreates `tokenized_asset_view` so catch_up rebuilds rows with the new `status` field. SPEC.md state machine updated.
- Also tightens AGENTS.md's sqlx-DB-error guidance (use `sqlx db reset -y`, don't improvise).

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Assets can now be frozen to prevent minting while maintaining redemption functionality

* **Bug Fixes**
  * Mint endpoint now properly rejects minting requests for frozen assets with a clear error response

* **Refactor**
  * Updated internal asset status model to support frozen state alongside enabled state

<!-- end of auto-generated comment: release notes by coderabbit.ai -->