### PR TITLE
feat: asset freeze status endpoint

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -946,6 +946,47 @@ struct TokenizedAsset {
 }
 ```
 
+#### Per-Asset Freeze Status
+
+**Endpoint:** `GET /tokenized-assets/<underlying>/status`
+
+Internal service-to-service endpoint (internal auth) consumed by the liquidity
+rebalance guard (RAI-1038) to skip frozen assets before starting a rebalancing
+flow. Returns the asset's listing + freeze status, or `404` if the asset is
+unknown.
+
+**Response:**
+
+```json
+{
+  "underlying": "SGOV",
+  "enabled": true,
+  "frozen": true
+}
+```
+
+- `enabled` — the asset is supported/listed. A frozen asset stays listed (see
+  the freeze invariant under "TokenizedAsset Aggregate"), so this stays `true`
+  when frozen.
+- `frozen` — new mints are currently rejected for this asset.
+
+**Status Codes:**
+
+- `200`: asset found — returns its listing + freeze status
+- `401`: missing or invalid internal API key
+- `404`: asset unknown
+- `500`: database or view-deserialization failure — the freeze status is
+  **indeterminate**. A consumer must NOT treat any non-`404` failure as "not
+  frozen"; treat `500` as "unknown, retry" rather than proceeding.
+
+`frozen: false` reflects the **projected** view state and is only as fresh as
+the projection. The view is updated asynchronously after a `Freeze`/`Unfreeze`
+event commits, so there is a brief window in which a just-committed freeze still
+reports `frozen: false`. A consumer gating an irreversible action on this signal
+(e.g. the rebalance guard) should confirm propagation — poll until
+`frozen: true`, or apply a safety delay after issuing a freeze — rather than
+trusting a single read.
+
 ### 3. Token Minting (Alpaca ITN Flow)
 
 #### Receipts and Backing
@@ -1707,6 +1748,8 @@ We run an HTTP server that implements these endpoints.
 3. **`DELETE /accounts/{client_id}/wallets/{wallet}`** - Un-whitelist wallet
    address for AP
 4. **`POST /tokenized-assets`** - Add a new tokenized asset
+5. **`GET /tokenized-assets/<underlying>/status`** - Per-asset listing + freeze
+   status, consumed by the liquidity rebalance guard (RAI-1038)
 
 ### Endpoints We Call
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -410,6 +410,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 account::unwhitelist_wallet,
                 tokenized_asset::list_tokenized_assets,
                 tokenized_asset::get_tokenized_asset,
+                tokenized_asset::get_tokenized_asset_status,
                 tokenized_asset::add_tokenized_asset,
                 mint::initiate_mint,
                 mint::confirm_journal,

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -61,6 +61,46 @@ pub(crate) async fn get_tokenized_asset(
     }
 }
 
+/// Per-asset freeze status, consumed by the liquidity rebalance guard
+/// (RAI-1038) to skip frozen assets before starting a rebalancing flow.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TokenizedAssetStatusResponse {
+    pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) enabled: bool,
+    pub(crate) frozen: bool,
+}
+
+#[tracing::instrument(skip(_auth, pool))]
+#[get("/tokenized-assets/<underlying>/status")]
+pub(crate) async fn get_tokenized_asset_status(
+    underlying: &str,
+    _auth: InternalAuth,
+    pool: &rocket::State<Pool<Sqlite>>,
+) -> Result<Json<TokenizedAssetStatusResponse>, Status> {
+    let underlying_symbol = UnderlyingSymbol::new(underlying);
+
+    let view =
+        super::view::load_asset_by_underlying(pool.inner(), &underlying_symbol)
+            .await
+            .map_err(|err| {
+                error!(target: "asset", error = %err,
+                    "Failed to load tokenized asset status"
+                );
+                Status::InternalServerError
+            })?;
+
+    match view {
+        Some(TokenizedAssetView { underlying, status, .. }) => {
+            Ok(Json(TokenizedAssetStatusResponse {
+                underlying,
+                enabled: status.is_listed(),
+                frozen: status.is_frozen(),
+            }))
+        }
+        None => Err(Status::NotFound),
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TokenizedAssetResponse {
     pub(crate) underlying: UnderlyingSymbol,
@@ -157,7 +197,9 @@ mod tests {
     use event_sorcery::StoreBuilder;
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
+    use serde_json::{Value, json};
     use sqlx::sqlite::SqlitePoolOptions;
+    use tracing_test::traced_test;
     use url::Url;
 
     use super::*;
@@ -165,6 +207,7 @@ mod tests {
     use crate::auth::{FailedAuthRateLimiter, test_auth_config};
     use crate::config::{Config, LogLevel};
     use crate::fireblocks::SignerConfig;
+    use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
 
     fn test_config() -> Config {
@@ -549,5 +592,351 @@ mod tests {
             .await;
 
         assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    async fn migrated_in_memory_pool() -> sqlx::Pool<sqlx::Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        pool
+    }
+
+    fn internal_api_key() -> Header<'static> {
+        Header::new("X-API-KEY", "test-key-12345678901234567890123456")
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_status_reflects_freeze() {
+        let pool = migrated_in_memory_pool().await;
+        let store = setup_tokenized_asset_store(&pool).await;
+
+        store
+            .send(
+                &UnderlyingSymbol::new("AAPL"),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL"),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::new("base"),
+                    vault: address!(
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    ),
+                },
+            )
+            .await
+            .expect("Failed to add asset");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let before = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(before.status(), Status::Ok);
+
+        // Assert the raw JSON body the external RAI-1038 guard parses — not a
+        // round-trip through the producer struct, which would mask a serde
+        // rename or a change to UnderlyingSymbol's wire encoding.
+        let before_body: Value =
+            before.into_json().await.expect("valid JSON response");
+        assert_eq!(
+            before_body,
+            json!({ "underlying": "AAPL", "enabled": true, "frozen": false })
+        );
+
+        store
+            .send(&UnderlyingSymbol::new("AAPL"), TokenizedAssetCommand::Freeze)
+            .await
+            .expect("Failed to freeze asset");
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Freezing tokenized asset", "AAPL"]
+        ));
+
+        let after = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(after.status(), Status::Ok);
+
+        // A frozen asset stays enabled (listed) for redemptions; only `frozen`
+        // flips to true.
+        let after_body: Value =
+            after.into_json().await.expect("valid JSON response");
+        assert_eq!(
+            after_body,
+            json!({ "underlying": "AAPL", "enabled": true, "frozen": true })
+        );
+
+        // Unfreezing must flip `frozen` back to false — the other half of the
+        // guard's lifecycle, exercised through the same HTTP + projection path.
+        store
+            .send(
+                &UnderlyingSymbol::new("AAPL"),
+                TokenizedAssetCommand::Unfreeze,
+            )
+            .await
+            .expect("Failed to unfreeze asset");
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Unfreezing tokenized asset", "AAPL"]
+        ));
+
+        let unfrozen = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(unfrozen.status(), Status::Ok);
+
+        let unfrozen_body: Value =
+            unfrozen.into_json().await.expect("valid JSON response");
+        assert_eq!(
+            unfrozen_body,
+            json!({ "underlying": "AAPL", "enabled": true, "frozen": false })
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_status_db_error_returns_500() {
+        let pool = migrated_in_memory_pool().await;
+
+        // A row whose `$.Live` payload does not deserialize into
+        // `TokenizedAssetView` forces the typed view load to error, exercising
+        // the handler's error -> 500 mapping and the operator-facing log that
+        // is the only signal for this failure mode.
+        sqlx::query(
+            r#"
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{"Live": {"bad_field": 1}}')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Failed to insert malformed view row");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::InternalServerError);
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Failed to load tokenized asset status"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_status_unknown_asset_returns_404() {
+        let pool = migrated_in_memory_pool().await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/UNKNOWN/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::NotFound);
+
+        // The 404 must not carry a parseable freeze status — the guard has to
+        // tell "unknown" apart from "known and not frozen", so a regression that
+        // returned a {enabled, frozen} body with 404 must fail here.
+        let body = response.into_string().await.unwrap_or_default();
+        assert!(
+            !body.contains("\"frozen\""),
+            "404 body must not expose a freeze status, got: {body}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_status_non_live_row_returns_500() {
+        let pool = migrated_in_memory_pool().await;
+
+        // A view row whose `$.Live` is null (a non-live lifecycle state) is a
+        // known-but-indeterminate asset, not an unknown one. It must map to 500
+        // ("indeterminate, retry"), NOT 404 — so the rebalance guard retries
+        // rather than treating the asset as permanently absent.
+        sqlx::query(
+            r#"
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{"Live": null}')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Failed to insert non-live view row");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::InternalServerError);
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Failed to load tokenized asset status"]
+        ));
+    }
+
+    // The detail endpoint shares `load_asset_by_underlying`, so a non-live
+    // (`$.Live` null) row now flips it from 404 to 500 too — pin that changed
+    // contract so the shared-helper behavior is not silently regressed.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_tokenized_asset_non_live_row_returns_500() {
+        let pool = migrated_in_memory_pool().await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{"Live": null}')
+            "#,
+        )
+        .execute(&pool)
+        .await
+        .expect("Failed to insert non-live view row");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::InternalServerError);
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Failed to load tokenized asset"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_status_without_auth_returns_401() {
+        let pool = migrated_in_memory_pool().await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response =
+            client.get("/tokenized-assets/AAPL/status").dispatch().await;
+
+        assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_status_wrong_api_key_returns_401() {
+        let pool = migrated_in_memory_pool().await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        // A present-but-wrong key must be rejected, not just a missing header:
+        // `InternalAuth` validates the key value, so knowing the header name is
+        // not enough to reach the endpoint.
+        let response = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(Header::new(
+                "X-API-KEY",
+                "wrong-key-00000000000000000000000000",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Unauthorized);
+
+        assert!(logs_contain_at!(tracing::Level::WARN, &["Invalid API key"]));
     }
 }

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -10,7 +10,8 @@ use event_sorcery::{EventSourced, Never, Table};
 use serde::{Deserialize, Serialize};
 
 pub(crate) use api::{
-    add_tokenized_asset, get_tokenized_asset, list_tokenized_assets,
+    add_tokenized_asset, get_tokenized_asset, get_tokenized_asset_status,
+    list_tokenized_assets,
 };
 pub(crate) use cmd::TokenizedAssetCommand;
 pub(crate) use event::TokenizedAssetEvent;

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -11,6 +11,10 @@ pub(crate) enum TokenizedAssetViewError {
     Database(#[from] sqlx::Error),
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
+    #[error(
+        "tokenized asset {underlying} has a non-live (null `$.Live`) projection row"
+    )]
+    NonLiveRow { underlying: UnderlyingSymbol },
 }
 
 /// Read model for a tokenized asset, projected from the
@@ -19,8 +23,9 @@ pub(crate) enum TokenizedAssetViewError {
 /// `tokenized_asset_view` stores the event-sorcery
 /// `Lifecycle<TokenizedAsset>` payload (`{"Live": {...}}`). The query helpers
 /// extract the `$.Live` sub-object, which mirrors this struct field-for-field,
-/// so it deserializes straight into `TokenizedAssetView`. Non-live rows have a
-/// NULL `$.Live` and are treated as "not found".
+/// so it deserializes straight into `TokenizedAssetView`. A non-live row has a
+/// NULL `$.Live` and is surfaced as a `NonLiveRow` error (known but
+/// indeterminate), distinct from an absent row ("not found").
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) struct TokenizedAssetView {
     pub(crate) underlying: UnderlyingSymbol,
@@ -59,8 +64,11 @@ pub(crate) async fn list_enabled_assets(
 
 /// Loads the full tokenized asset view for a given underlying symbol.
 ///
-/// Returns `Ok(Some(view))` if the asset exists, `Ok(None)` if not found,
-/// or an error on database failure.
+/// Returns `Ok(Some(view))` for a live asset, `Ok(None)` if no row exists
+/// (unknown asset), or an error — including
+/// [`TokenizedAssetViewError::NonLiveRow`] when a row exists but its `$.Live`
+/// is null (a non-live or corrupt projection: known but indeterminate, not
+/// "unknown").
 pub(crate) async fn load_asset_by_underlying(
     pool: &Pool<Sqlite>,
     underlying: &UnderlyingSymbol,
@@ -76,8 +84,19 @@ pub(crate) async fn load_asset_by_underlying(
     .fetch_optional(pool)
     .await?;
 
-    let Some(live) = row.and_then(|row| row.live) else {
+    let Some(row) = row else {
         return Ok(None);
+    };
+
+    // A row whose `$.Live` is NULL is a non-live lifecycle state (e.g. a
+    // `Failed` lifecycle) or a corrupt projection: the asset is *known* but its
+    // state is indeterminate, which is distinct from an unknown asset. Surface
+    // it as an error so the status endpoint returns 500 ("indeterminate,
+    // retry") rather than 404 ("unknown"). See SPEC.md's status-code semantics.
+    let Some(live) = row.live else {
+        return Err(TokenizedAssetViewError::NonLiveRow {
+            underlying: underlying.clone(),
+        });
     };
 
     let view: TokenizedAssetView = serde_json::from_str(&live)?;
@@ -87,10 +106,15 @@ pub(crate) async fn load_asset_by_underlying(
 
 /// Finds the vault address for a given underlying symbol.
 ///
-/// Returns `Ok(Some(vault))` if a supported asset with that underlying exists
+/// Delegates to [`load_asset_by_underlying`] and so inherits its contract:
+/// `Ok(Some(vault))` if a supported asset with that underlying exists
 /// (including a frozen one — in-flight redemptions and mints of a frozen asset
-/// must still resolve their vault), `Ok(None)` if not found, or an error on
-/// database failure.
+/// must still resolve their vault), `Ok(None)` only when no row exists (unknown
+/// asset), or an error on database/deserialization failure — including
+/// [`TokenizedAssetViewError::NonLiveRow`] when a row exists but its `$.Live`
+/// is null (known but indeterminate, not "not found"). Callers in the mint and
+/// redemption flows therefore see a propagated error, not `Ok(None)`, for a
+/// non-live row.
 pub(crate) async fn find_vault_by_underlying(
     pool: &Pool<Sqlite>,
     underlying: &UnderlyingSymbol,
@@ -430,6 +454,68 @@ mod tests {
         assert!(matches!(
             result.unwrap_err(),
             TokenizedAssetViewError::Deserialization(_)
+        ));
+    }
+
+    // A row whose `$.Live` is null is a non-live lifecycle state (known but
+    // indeterminate), distinct from an absent row. The helper must surface it
+    // as `NonLiveRow` rather than collapsing it into `Ok(None)`, so the status
+    // endpoint can return 500 ("indeterminate, retry") instead of 404. Only
+    // reachable via external DB manipulation — the projection always writes a
+    // live `$.Live` payload.
+    #[tokio::test]
+    async fn test_load_asset_by_underlying_errors_on_non_live_row() {
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, .. } = &harness;
+
+        sqlx::query(
+            "
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{\"Live\": null}')
+            ",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let result =
+            load_asset_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
+                .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            TokenizedAssetViewError::NonLiveRow { underlying }
+                if underlying.0 == "AAPL"
+        ));
+    }
+
+    // `find_vault_by_underlying` delegates to `load_asset_by_underlying`, so a
+    // non-live row must propagate as `NonLiveRow` rather than collapsing to
+    // `Ok(None)` — the mint/redemption vault-lookup callers see an error, not
+    // "asset not found", for a known-but-indeterminate row.
+    #[tokio::test]
+    async fn test_find_vault_by_underlying_errors_on_non_live_row() {
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, .. } = &harness;
+
+        sqlx::query(
+            "
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{\"Live\": null}')
+            ",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let result =
+            find_vault_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
+                .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            TokenizedAssetViewError::NonLiveRow { underlying }
+                if underlying.0 == "AAPL"
         ));
     }
 


### PR DESCRIPTION
## Motivation

The liquidity rebalance guard (RAI-1038) needs to skip frozen assets before starting a rebalancing flow, so it needs an issuance-side endpoint to read a per-asset freeze status. Part of RAI-1034 (issuance bot asset freezing); implements RAI-1037.

## Solution

Adds `GET /tokenized-assets/<underlying>/status` (internal auth) returning `{ underlying, enabled, frozen }`, read from `tokenized_asset_view` via the typed view helper. A dedicated endpoint keeps the liquidity guard's polling contract decoupled from the fuller asset-detail payload, which can evolve independently. `enabled` stays true for a frozen asset (frozen != de-listed); `frozen` reflects the freeze state. Documented in SPEC.md.

Stacked on #180 (RAI-1035), which introduces the freeze state this endpoint reads.

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs