### PR TITLE
feat: issuance client crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5518,6 +5518,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "st0x-issuance-client"
+version = "0.1.0"
+dependencies = [
+ "httpmock",
+ "reqwest",
+ "serde_json",
+ "st0x-issuance-dto",
+ "thiserror 2.0.18",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "st0x-issuance-dto"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ sqlx = { version = "0.9.0", features = [
   "macros",
   "migrate",
 ] }
-thiserror = "2.0.17"
+thiserror = { workspace = true }
 tracing = "0.1.41"
 chrono = { version = "0.4.42", features = ["serde"] }
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
@@ -37,8 +37,8 @@ alloy = { version = "1.0.41", features = [
   "rand",
 ] }
 rust_decimal = { version = "1.39.0", features = ["serde"] }
-tokio = { version = "1.48.0", features = ["time"] }
-reqwest = { version = "0.12.24", features = ["json", "blocking", "gzip"] }
+tokio = { workspace = true, features = ["time"] }
+reqwest = { workspace = true, features = ["blocking", "gzip"] }
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }
 tracing-opentelemetry = "0.31.0"
 opentelemetry = "0.30.0"
@@ -46,7 +46,7 @@ opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
 opentelemetry-otlp = "0.30.0"
 backon = "1.6.0"
 futures = "0.3.31"
-url = "2.5.7"
+url = { workspace = true }
 anyhow = "1.0.100"
 dotenvy = "0.15.7"
 itertools = "0.14.0"
@@ -64,24 +64,29 @@ alloy-sol-types = "1.4.1"
 event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2", features = [
   "test-support",
 ] }
-httpmock = "0.8.2"
+httpmock = { workspace = true }
 proptest = "1.10.0"
 rand = "0.8"
 rsa = "0.9.10"
 rust_decimal_macros = "1.40.0"
 tempfile = "3.23.0"
-tokio = { version = "1.48.0", features = ["macros"] }
+tokio = { workspace = true, features = ["macros"] }
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [workspace]
-members = ["crates/dto"]
+members = ["crates/dto", "crates/client"]
 
 [workspace.dependencies]
 alloy-primitives = { version = "1.6.0", features = ["serde"] }
 clap = { version = "4.5.49", features = ["derive"] }
+httpmock = "0.8.2"
+reqwest = { version = "0.12.24", features = ["json"] }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"
+thiserror = "2.0.17"
+tokio = { version = "1.48.0" }
 ts-rs = "11.0.1"
+url = "2.5.7"
 
 [workspace.lints.rust]
 unsafe_code = "forbid"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,16 +17,17 @@ COPY flake.nix flake.lock ./
 RUN nix develop --command echo "Nix dev env ready"
 
 COPY Cargo.toml Cargo.lock ./
-# Workspace members must exist at metadata-resolution time, so the dto member's
+# Workspace members must exist at metadata-resolution time, so each member's
 # manifest and a stub source tree have to be present before `cargo chef prepare`
 # (cook reconstructs the skeleton from recipe.json afterwards).
 COPY crates/dto/Cargo.toml crates/dto/Cargo.toml
+COPY crates/client/Cargo.toml crates/client/Cargo.toml
 
-RUN mkdir -p src/bin crates/dto/src && \
+RUN mkdir -p src/bin crates/dto/src crates/client/src && \
     echo 'fn main() {}' > src/main.rs && \
     echo 'fn main() {}' > src/bin/issuer.rs && \
     echo 'fn main() {}' > crates/dto/src/main.rs && \
-    touch src/lib.rs crates/dto/src/lib.rs
+    touch src/lib.rs crates/dto/src/lib.rs crates/client/src/lib.rs
 
 RUN nix develop --command cargo chef prepare --recipe-path recipe.json
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "st0x-issuance-client"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+reqwest = { workspace = true }
+st0x-issuance-dto = { path = "../dto" }
+thiserror = { workspace = true }
+url = { workspace = true }
+
+[dev-dependencies]
+httpmock = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -1,0 +1,335 @@
+//! Typed Rust client for the st0x.issuance HTTP API.
+//!
+//! Wraps the endpoints behind typed async methods using the shared
+//! `st0x-issuance-dto` wire types, so consumers (e.g. the liquidity rebalance
+//! guard, RAI-1038) don't hand-roll `reqwest` calls or re-declare the wire
+//! shapes.
+//!
+//! ## Hand-written for now -- OpenAPI generation is the target
+//!
+//! The request paths below (e.g. `tokenized-assets/<underlying>/status`) are
+//! written by hand and duplicate the server's Rocket route declarations. A
+//! route change only surfaces as a mismatch at runtime -- a drift foot-gun. The
+//! intended fix is to make the server emit an OpenAPI document (e.g. `utoipa`
+//! over the routes + the shared DTO types) and generate this client from it
+//! (e.g. `progenitor`), so the spec is the single source of truth and no path
+//! is ever repeated. Deferred for now: most of the service is the Alpaca ITN
+//! integration, so the client's non-Alpaca surface is small enough that the
+//! codegen tooling isn't yet worth its weight. Revisit once that surface grows.
+
+use reqwest::StatusCode;
+use reqwest::redirect::Policy;
+use st0x_issuance_dto::{TokenizedAssetStatusResponse, UnderlyingSymbol};
+use std::time::Duration;
+use url::Url;
+
+const API_KEY_HEADER: &str = "X-API-KEY";
+
+/// Async client for the issuance HTTP API, authenticating with an internal API
+/// key.
+pub struct IssuanceClient {
+    base_url: Url,
+    api_key: String,
+    http: reqwest::Client,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ClientError {
+    #[error("failed to build HTTP client: {0}")]
+    Build(reqwest::Error),
+    #[error(
+        "base URL cannot be a base (has no path segments to extend): {base}"
+    )]
+    NotABase { base: Url },
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("failed to parse response body: {0}")]
+    ParseResponse(reqwest::Error),
+    #[error("unexpected status {status} from {url}")]
+    Status { status: StatusCode, url: Url },
+}
+
+impl IssuanceClient {
+    /// Creates a client targeting `base_url`, authenticating with `api_key`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError::Build`] if the HTTP client cannot be constructed
+    /// (e.g. the system TLS backend fails to initialise).
+    pub fn new(
+        base_url: Url,
+        api_key: impl Into<String>,
+    ) -> Result<Self, ClientError> {
+        // Timeouts are mandatory for a polling consumer (RAI-1038): reqwest sets
+        // none by default, so without these a single unresponsive request would
+        // hang the caller's task forever. Redirects are disabled because the
+        // issuance API does not redirect, and reqwest forwards a custom header
+        // like `X-API-KEY` to a cross-host redirect target by default — turning
+        // them off keeps the credential from leaking to an unexpected host.
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .connect_timeout(Duration::from_secs(10))
+            .redirect(Policy::none())
+            .build()
+            .map_err(ClientError::Build)?;
+
+        Ok(Self { base_url, api_key: api_key.into(), http })
+    }
+
+    /// Reads the freeze status of `underlying` via
+    /// `GET /tokenized-assets/<underlying>/status`, returning `Ok(None)` when
+    /// the asset is unknown (404).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError`] on URL/transport failures or an unexpected
+    /// response status.
+    pub async fn tokenized_asset_status(
+        &self,
+        underlying: &UnderlyingSymbol,
+    ) -> Result<Option<TokenizedAssetStatusResponse>, ClientError> {
+        // Build the URL by appending percent-encoded path segments to the base
+        // rather than `Url::join`ing a relative string: join drops a base path
+        // prefix (e.g. `/api`) when the base lacks a trailing slash, and a symbol
+        // containing `/`, `?`, or `#` would corrupt the path. `path_segments_mut`
+        // percent-encodes each segment and preserves the base prefix;
+        // `pop_if_empty` drops the empty trailing segment a base like `host/api/`
+        // leaves behind so we don't produce a `//`.
+        let underlying_segment = underlying.to_string();
+        let mut url = self.base_url.clone();
+        url.path_segments_mut()
+            .map_err(|()| ClientError::NotABase {
+                base: self.base_url.clone(),
+            })?
+            .pop_if_empty()
+            .extend([
+                "tokenized-assets",
+                underlying_segment.as_str(),
+                "status",
+            ]);
+
+        let response = self
+            .http
+            .get(url.clone())
+            .header(API_KEY_HEADER, &self.api_key)
+            .send()
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => Ok(Some(
+                response.json().await.map_err(ClientError::ParseResponse)?,
+            )),
+            StatusCode::NOT_FOUND => Ok(None),
+            // Carry the exact request URL (typed, no re-formatted path that can
+            // drift from what was actually sent). The API key is a header, not
+            // part of the URL, so this never leaks the credential.
+            status => Err(ClientError::Status { status, url }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::prelude::*;
+    use serde_json::json;
+    use st0x_issuance_dto::TokenizedAssetStatus;
+
+    use super::*;
+
+    fn client_for(server: &MockServer) -> IssuanceClient {
+        IssuanceClient::new(
+            Url::parse(&server.base_url()).expect("valid mock URL"),
+            "test-key",
+        )
+        .expect("client builds")
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_parses_response() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/tokenized-assets/SGOV/status")
+                .header(API_KEY_HEADER, "test-key");
+            then.status(200).json_body(json!({
+                "underlying": "SGOV",
+                "status": "frozen"
+            }));
+        });
+
+        let status = client_for(&server)
+            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .await
+            .expect("request succeeds")
+            .expect("asset exists");
+
+        mock.assert();
+        assert_eq!(status.underlying, UnderlyingSymbol::new("SGOV"));
+        assert_eq!(status.status, TokenizedAssetStatus::Frozen);
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_is_none_for_unknown_asset() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET)
+                .path("/tokenized-assets/UNKNOWN/status")
+                .header(API_KEY_HEADER, "test-key");
+            then.status(404);
+        });
+
+        let status = client_for(&server)
+            .tokenized_asset_status(&UnderlyingSymbol::new("UNKNOWN"))
+            .await
+            .expect("request succeeds");
+
+        mock.assert();
+        assert!(status.is_none());
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_errors_on_unexpected_status() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/SGOV/status");
+            then.status(500);
+        });
+
+        let err = client_for(&server)
+            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .await
+            .expect_err("a 500 must surface as an error, not None");
+
+        mock.assert();
+        assert!(
+            matches!(err, ClientError::Status { status, .. } if status == StatusCode::INTERNAL_SERVER_ERROR),
+            "expected Status(500), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_errors_on_malformed_body() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/SGOV/status");
+            then.status(200).body("not json");
+        });
+
+        let err = client_for(&server)
+            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .await
+            .expect_err("a malformed 200 body must surface as a parse error");
+
+        mock.assert();
+        assert!(
+            matches!(err, ClientError::ParseResponse(_)),
+            "expected ParseResponse, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_preserves_base_path_prefix() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/api/tokenized-assets/SGOV/status");
+            then.status(200).json_body(json!({
+                "underlying": "SGOV",
+                "status": "enabled"
+            }));
+        });
+
+        // Base URL with a path prefix and a trailing slash: the prefix must be
+        // preserved (Url::join would have dropped it).
+        let base = Url::parse(&format!("{}/api/", server.base_url()))
+            .expect("valid prefixed base URL");
+        let client =
+            IssuanceClient::new(base, "test-key").expect("client builds");
+
+        let status = client
+            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .await
+            .expect("request succeeds")
+            .expect("asset exists");
+
+        mock.assert();
+        assert_eq!(status.status, TokenizedAssetStatus::Enabled);
+    }
+
+    #[tokio::test]
+    async fn tokenized_asset_status_errors_on_non_base_url() {
+        // A cannot-be-a-base URL (e.g. `data:`) has no path segments to extend,
+        // so the request must fail fast with NotABase rather than panic.
+        let client = IssuanceClient::new(
+            Url::parse("data:text/plain,not-a-base").expect("valid data URL"),
+            "test-key",
+        )
+        .expect("client builds");
+
+        let err = client
+            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .await
+            .expect_err("a cannot-be-a-base URL must error");
+
+        assert!(
+            matches!(err, ClientError::NotABase { .. }),
+            "expected NotABase, got {err:?}"
+        );
+    }
+
+    // The path is built with `path_segments_mut` (not `Url::join`/interpolation)
+    // so a symbol containing a path-significant character is percent-encoded
+    // into a single segment instead of corrupting the path. Pin it: a `/` must
+    // arrive as `%2F` and stay one segment, not split into `.../FUND/A/...`
+    // (which would 404 -> Ok(None), masking a real asset as unknown to the
+    // rebalance guard).
+    #[tokio::test]
+    async fn tokenized_asset_status_percent_encodes_path_unsafe_symbols() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/tokenized-assets/FUND%2FA/status");
+            then.status(200).json_body(json!({
+                "underlying": "FUND/A",
+                "status": "enabled"
+            }));
+        });
+
+        let status = client_for(&server)
+            .tokenized_asset_status(&UnderlyingSymbol::new("FUND/A"))
+            .await
+            .expect("request succeeds")
+            .expect("asset exists");
+
+        mock.assert();
+        assert_eq!(status.status, TokenizedAssetStatus::Enabled);
+    }
+
+    // The freeze-gating contract is "only 404 -> None; every other status ->
+    // Err". Pin the auth/rate-limit codes the server can actually return so a
+    // future refactor can't silently collapse them into Ok(None) and let the
+    // rebalance guard treat a credential or rate-limit failure as "asset
+    // unknown".
+    #[tokio::test]
+    async fn tokenized_asset_status_errors_on_auth_and_rate_limit_statuses() {
+        for code in [401u16, 403, 429] {
+            let server = MockServer::start_async().await;
+            let mock = server.mock(|when, then| {
+                when.method(GET).path("/tokenized-assets/SGOV/status");
+                then.status(code);
+            });
+
+            let err = client_for(&server)
+                .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+                .await
+                .expect_err("a non-404 error status must surface as an error");
+
+            mock.assert();
+            assert!(
+                matches!(
+                    err,
+                    ClientError::Status { status, .. } if status.as_u16() == code
+                ),
+                "expected Status({code}), got {err:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Consumers of the issuance HTTP API (starting with the liquidity rebalance guard, RAI-1038, which polls the per-asset freeze-status endpoint) had to hand-roll `reqwest` calls and re-declare the wire shapes. Implements RAI-1059.

## Solution

Adds a `st0x-issuance-client` crate (`crates/client`) exposing a typed async `IssuanceClient` that wraps the issuance HTTP API behind typed methods, reusing the shared `st0x-issuance-dto` wire types. The first method, `tokenized_asset_status(&UnderlyingSymbol)`, calls `GET /tokenized-assets/<underlying>/status` with internal `X-API-KEY` auth and returns `Option<TokenizedAssetStatusResponse>` (None on 404). Minimal deps (reqwest/url/thiserror) declared via `[workspace.dependencies]`. Tested against a mocked server (httpmock).

Stacked on the DTO crate (#183) and the freeze stack (#180/#181/#182). More endpoint methods follow as consumers need them.

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new typed async HTTP client for the `st0x.issuance` API.
  * Provides an API-key authenticated method to fetch tokenized asset status for a given underlying symbol.
  * Supports “not found” responses by returning an empty result instead of an error.

* **Bug Fixes**
  * Improved handling of unexpected HTTP statuses, malformed responses, and invalid base URLs with clear error reporting.

* **Chores**
  * Updated workspace-based dependency configuration for consistent crate setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->