### PR TITLE
feat: expose dto/client crates and TS bindings from the flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ target/
 claude-local-ctx/
 .claude/
 .tmp/
+/result
+/result-*

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1780532242,
+        "narHash": "sha256-D+BsdpxmtUwtqGoY0IXPhHgTlmqgcZKCEo1oMyn7ep0=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "59a82a1222dd3b2080b5cc52a1a2e8d5f1b77f37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -248,6 +263,7 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
         "rainix": "rainix"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,14 +4,106 @@
   inputs = {
     flake-utils.url = "github:numtide/flake-utils";
     rainix.url = "github:rainprotocol/rainix";
+    crane.url = "github:ipetkov/crane";
   };
 
   outputs =
-    { flake-utils, rainix, ... }:
+    {
+      flake-utils,
+      rainix,
+      crane,
+      ...
+    }:
     flake-utils.lib.eachDefaultSystem (
       system:
       let
         pkgs = rainix.pkgs.${system};
+
+        craneLib = (crane.mkLib pkgs).overrideToolchain rainix.rust-toolchain.${system};
+
+        crateSrc = craneLib.cleanCargoSource ./.;
+
+        # Vendoring reads the whole workspace lock, so the main crate's two git
+        # deps (event-sorcery/sqlite-es + fireblocks-sdk) need pinned hashes
+        # even though the dto/client crates never pull them in.
+        cargoVendorDir = craneLib.vendorCargoDeps {
+          src = crateSrc;
+          outputHashes = {
+            "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6" =
+              "sha256-fmBLdcyNoPh+Hktl1vVgeXdKtaxA+a1+xYi5Acxsr6o=";
+            "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#18227211082342818efaf6a1b58c89c65a6f17cd" =
+              "sha256-KThUI0Cvh1JELem7SUQ1K3WqMccFeYfS3BqfLXwk2AE=";
+          };
+        };
+
+        # The dto + client crates are pure-Rust wire/HTTP helpers: no sqlx, no
+        # Rain `sol!` ABIs, no workspace git deps in their tree. Scoping every
+        # cargo invocation to them with `-p` keeps the main crate's database,
+        # ABI, and Fireblocks machinery out of the nix closure entirely, so we
+        # never need the live DB, ST0X_*_ABI env, or sqlite-es migrations the
+        # main crate's nix build would require.
+        crateArgs = {
+          src = crateSrc;
+          inherit cargoVendorDir;
+          strictDeps = true;
+          # The dto/client crates are pure Rust with sandbox-safe tests (temp-dir
+          # binding export + loopback httpmock), so run them under `nix flake
+          # check` for extra CI coverage rather than only type-checking.
+          doCheck = true;
+          nativeBuildInputs = [ pkgs.pkg-config ];
+          buildInputs = [
+            pkgs.openssl
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk_15 ];
+          cargoExtraArgs = "-p st0x-issuance-dto -p st0x-issuance-client";
+        };
+
+        cargoArtifacts = craneLib.buildDepsOnly crateArgs;
+
+        st0x-issuance-dto = craneLib.buildPackage (
+          crateArgs
+          // {
+            pname = "st0x-issuance-dto";
+            inherit cargoArtifacts;
+            cargoExtraArgs = "-p st0x-issuance-dto";
+            meta.description = "st0x issuance API DTO types + TypeScript binding exporter";
+          }
+        );
+
+        st0x-issuance-client = craneLib.buildPackage (
+          crateArgs
+          // {
+            pname = "st0x-issuance-client";
+            inherit cargoArtifacts;
+            cargoExtraArgs = "-p st0x-issuance-client";
+            meta.description = "Typed Rust client for the st0x issuance HTTP API";
+          }
+        );
+
+        # Reproducible TypeScript bindings: run the dto exporter into $out so the
+        # dashboard can `nix build .#st0x-issuance-dto-typescript` for the `.ts`
+        # files instead of running cargo. For codegen straight into a checkout,
+        # use `nix run .#st0x-issuance-dto -- <dir>`.
+        st0x-issuance-dto-typescript = pkgs.runCommand "st0x-issuance-dto-typescript" { } ''
+          mkdir -p "$out"
+          ${st0x-issuance-dto}/bin/st0x-issuance-dto "$out"
+          # Fail the build if the exporter ran clean but emitted nothing, so a
+          # silent codegen regression can't pass CI with an empty bindings dir.
+          if ! find "$out" -type f -name '*.ts' -print -quit | grep -q .; then
+            echo "st0x-issuance-dto exporter produced no .ts files" >&2
+            exit 1
+          fi
+        '';
+
+        # Single source for the issuance derivations exported from both `packages`
+        # and `checks`, so the two lists can't drift apart.
+        issuanceBuilds = {
+          inherit
+            st0x-issuance-dto
+            st0x-issuance-client
+            st0x-issuance-dto-typescript
+            ;
+        };
       in
       rec {
         packages =
@@ -40,7 +132,13 @@
                 exec nu ${./scripts/smoke-test-image.nu} "$@"
               '';
             };
-          };
+          }
+          // issuanceBuilds;
+
+        # `nix flake check` (run in both rainix.yaml CI jobs) evaluates the
+        # `checks` output, not `packages`; aliasing the crate derivations here is
+        # what builds them and runs the TypeScript exporter in CI.
+        checks = issuanceBuilds;
 
         devShell = pkgs.mkShell {
           inherit (rainix.devShells.${system}.default) shellHook;


### PR DESCRIPTION
## Motivation

The dashboard and other nix consumers need the issuance API's TypeScript bindings plus the dto/client crates built reproducibly -- the same way st0x.liquidity exposes `st0x-dto` from its flake. Implements RAI-1060.

## Solution

Adds `crane` to the flake and exposes three derivations, scoping every cargo invocation to the two pure crates so the main crate's sqlx / Rain `sol!` ABI / Fireblocks machinery stays out of the nix closure entirely:

- `st0x-issuance-dto` -- the dto crate (lib + the `ts-rs` binding-exporter binary)
- `st0x-issuance-client` -- the Rust HTTP client crate
- `st0x-issuance-dto-typescript` -- runs the exporter into `$out` so the dashboard can `nix build .#st0x-issuance-dto-typescript` for the `.ts` files; `nix run .#st0x-issuance-dto -- <dir>` generates straight into a checkout

The two workspace git deps (event-sorcery/sqlite-es, fireblocks-sdk) still need pinned `outputHashes` because vendoring reads the whole lock, even though neither pure crate pulls them in.

CI: the three derivations are aliased into `checks`, so the existing `nix flake check` in both rainix.yaml jobs builds them and runs the exporter. `result*` is gitignored.

Stacked on the client crate (#184), dto crate (#183), and the freeze stack (#180 / #181 / #182).

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved build configuration to produce more reproducible Rust artifacts and vendor dependencies deterministically.
  * Extended build outputs to expose the two Rust packages plus generated TypeScript definitions derived from the DTOs.
  * Updated version control ignores to exclude generated runtime/output artifacts (e.g., `/result` and `/result-*`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->