### PR TITLE
test: e2e dogfood the issuance client over real HTTP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5504,6 +5504,7 @@ dependencies = [
  "serde_json",
  "sqlite-es",
  "sqlx",
+ "st0x-issuance-client",
  "st0x-issuance-dto",
  "subtle",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ proptest = "1.10.0"
 rand = "0.8"
 rsa = "0.9.10"
 rust_decimal_macros = "1.40.0"
+st0x-issuance-client = { path = "crates/client" }
 tempfile = "3.23.0"
 tokio = { workspace = true, features = ["macros"] }
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -21,10 +21,8 @@ pub(crate) use view::TokenizedAssetView;
 // The asset wire newtypes are defined once in the shared `st0x-issuance-dto`
 // crate so the API DTOs, Rust clients, and the TypeScript dashboard all share a
 // single definition.
-pub use st0x_issuance_dto::UnderlyingSymbol;
-pub(crate) use st0x_issuance_dto::{
-    Network, TokenSymbol, TokenizedAssetStatus,
-};
+pub(crate) use st0x_issuance_dto::{Network, TokenSymbol};
+pub use st0x_issuance_dto::{TokenizedAssetStatus, UnderlyingSymbol};
 
 /// Whether an asset accepts new mints.
 ///

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -16,10 +16,12 @@ use rocket::local::asynchronous::Client;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
 use std::collections::HashMap;
+use std::net::SocketAddr;
 use url::Url;
 
 use st0x_issuance::account::{AccountLinkResponse, RegisterAccountResponse};
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::initialize_rocket;
 use st0x_issuance::mint::MintResponse;
 use st0x_issuance::test_utils::{
     LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT, ROLE_WITHDRAW,
@@ -111,6 +113,93 @@ pub async fn wait_for_mock_hits(
                  (got {} after {}s)",
                 mock.calls_async().await,
                 timeout.as_secs()
+            )
+            .into());
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
+}
+
+/// Launches the full HTTP service on an OS-assigned ephemeral port in the
+/// background and returns its base URL once it accepts connections, so e2e
+/// tests can drive it through a real network client (e.g.
+/// `st0x_issuance_client::IssuanceClient`) over TCP rather than the in-process
+/// `rocket::local` client. Each call binds a distinct port, so test binaries
+/// that `cargo test` runs in parallel never collide.
+pub async fn spawn_http_server(
+    config: Config,
+) -> Result<Url, Box<dyn std::error::Error>> {
+    // Bind port 0 to let the OS pick a free port, read the assigned number,
+    // then drop the listener so Rocket can claim it. This replaces a fixed
+    // port that would collide across parallel test binaries. The release/rebind
+    // gap is a brief TOCTOU, but if anything grabs the port first the bind
+    // failure surfaces through `launch_err_rx` below as a clear error rather
+    // than a silent run against the wrong process.
+    let address: SocketAddr =
+        std::net::TcpListener::bind("127.0.0.1:0")?.local_addr()?;
+
+    let rocket = initialize_rocket(config).await?;
+
+    // `build_rocket` hard-codes port 8000 for production; override it with the
+    // ephemeral port for this test without touching the production path.
+    let figment =
+        rocket.figment().clone().merge((rocket::Config::PORT, address.port()));
+    let rocket = rocket.configure(figment);
+
+    // Forward a `launch()` failure on a oneshot rather than letting it vanish
+    // into a detached task: without this, a launch error (bind failure, ignite
+    // error) would degrade into the generic readiness timeout below with the
+    // real cause lost to stderr.
+    let (launch_err_tx, launch_err_rx) = tokio::sync::oneshot::channel();
+    tokio::spawn(async move {
+        if let Err(error) = rocket.launch().await {
+            // If readiness already won the select the receiver is gone and
+            // `send` hands the error back. `rocket::Error` panics on Drop unless
+            // it has been inspected, so Display it here (which also keeps the
+            // post-startup-failure diagnostic) instead of dropping it silently.
+            if let Err(unsent) = launch_err_tx.send(error) {
+                eprintln!("e2e HTTP server exited after startup: {unsent}");
+            }
+        }
+    });
+
+    // Race readiness against a launch failure so the actual error surfaces as
+    // the test failure instead of a 10s "never started listening" timeout.
+    tokio::select! {
+        biased;
+        launch_err = launch_err_rx => {
+            // `Ok` carries the launch error (Display-ing it also marks the
+            // rocket::Error handled, dodging its Drop panic); `Err` is a dropped
+            // sender, i.e. the server task ended without a launch error.
+            let message = launch_err.map_or_else(
+                |_| "e2e HTTP server exited before it became ready".to_string(),
+                |error| format!("e2e HTTP server failed to launch: {error}"),
+            );
+            Err(message.into())
+        }
+        ready = wait_until_listening(address) => {
+            ready?;
+            Ok(Url::parse(&format!("http://{address}/"))?)
+        }
+    }
+}
+
+async fn wait_until_listening(
+    address: SocketAddr,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = tokio::time::Instant::now();
+    let timeout = tokio::time::Duration::from_secs(10);
+    let poll_interval = tokio::time::Duration::from_millis(50);
+
+    loop {
+        if tokio::net::TcpStream::connect(address).await.is_ok() {
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "HTTP server never started listening on {address}"
             )
             .into());
         }
@@ -235,6 +324,57 @@ pub async fn preseed_tokenized_asset_into_pool(
     .bind(&event_payload_str)
     .execute(pool)
     .await?;
+
+    Ok(())
+}
+
+/// Seeds an asset that is currently frozen by appending a `Frozen` event
+/// (sequence 2) after the `Added` event. Per the AGENTS.md setup-phase
+/// exception, only the event store is seeded; the view is rebuilt from these
+/// events by `initialize_rocket` at startup.
+pub async fn preseed_frozen_tokenized_asset(
+    db_url: &str,
+    vault: Address,
+    underlying: &str,
+    token: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+
+    sqlx::migrate!("./migrations").run(&pool).await?;
+
+    preseed_tokenized_asset_into_pool(&pool, vault, underlying, token).await?;
+
+    let frozen_payload = json!({
+        "Frozen": { "frozen_at": Utc::now() }
+    })
+    .to_string();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'TokenizedAsset',
+            ?,
+            2,
+            'TokenizedAssetEvent::Frozen', '1.0', ?, '{}'
+        )
+        ",
+    )
+    .bind(underlying)
+    .bind(&frozen_payload)
+    .execute(&pool)
+    .await?;
+
+    pool.close().await;
 
     Ok(())
 }

--- a/tests/tokenized_asset_status.rs
+++ b/tests/tokenized_asset_status.rs
@@ -1,0 +1,80 @@
+#![allow(clippy::unwrap_used)]
+
+mod harness;
+
+use httpmock::MockServer;
+
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::tokenized_asset::{TokenizedAssetStatus, UnderlyingSymbol};
+use st0x_issuance_client::IssuanceClient;
+
+const UNDERLYING: &str = "TSLA";
+const TOKEN: &str = "tTSLA";
+const FROZEN_UNDERLYING: &str = "NVDA";
+const FROZEN_TOKEN: &str = "tNVDA";
+const INTERNAL_API_KEY: &str = "test-key-12345678901234567890123456";
+
+/// Drives the running issuance service through the published Rust client
+/// (`st0x_issuance_client`) over a real TCP connection, dogfooding the typed
+/// client and shared DTOs against the live server for the non-Alpaca
+/// tokenized-asset status endpoint.
+#[tokio::test]
+async fn tokenized_asset_status_via_client()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("status.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        UNDERLYING,
+        TOKEN,
+    )
+    .await?;
+
+    harness::preseed_frozen_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        FROZEN_UNDERLYING,
+        FROZEN_TOKEN,
+    )
+    .await?;
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+
+    let base_url = harness::spawn_http_server(config).await?;
+    let client = IssuanceClient::new(base_url, INTERNAL_API_KEY)?;
+
+    let status = client
+        .tokenized_asset_status(&UnderlyingSymbol::new(UNDERLYING))
+        .await?
+        .expect("seeded asset has a status");
+    assert_eq!(status.underlying, UnderlyingSymbol::new(UNDERLYING));
+    assert_eq!(
+        status.status,
+        TokenizedAssetStatus::Enabled,
+        "seeded asset should be enabled (tradeable), not frozen"
+    );
+
+    let frozen = client
+        .tokenized_asset_status(&UnderlyingSymbol::new(FROZEN_UNDERLYING))
+        .await?
+        .expect("seeded frozen asset has a status");
+    assert_eq!(frozen.underlying, UnderlyingSymbol::new(FROZEN_UNDERLYING));
+    assert_eq!(
+        frozen.status,
+        TokenizedAssetStatus::Frozen,
+        "asset with a Frozen event should report frozen through the client"
+    );
+
+    let unknown =
+        client.tokenized_asset_status(&UnderlyingSymbol::new("NOPE")).await?;
+    assert!(unknown.is_none(), "unknown asset should have no status");
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

The `st0x-issuance-client` crate (#184) only had unit coverage against an `httpmock` server. This adds an end-to-end test that drives the actual running issuance service through the client over a real TCP connection -- the AGENTS.md e2e ideal of "an external consumer over the network" -- dogfooding the typed client and shared DTOs against the live server. Scoped to the non-Alpaca surface the client covers (the tokenized-asset status endpoint).

Implements RAI-1068.

## Solution

- New harness helper `spawn_http_server(config)` launches the full service (`initialize_rocket` + `rocket.launch()`) on its configured port and returns the base URL once it accepts TCP connections. Every existing e2e test uses the in-process `rocket::local` client, which has no port -- this is the harness's first real-HTTP path.
- New e2e test `tokenized_asset_status_via_client`: anvil + preseeded asset + launched service, then `IssuanceClient::tokenized_asset_status` over real TCP asserts the seeded asset's status (enabled, not frozen) and that an unknown asset returns `None`.
- `st0x-issuance-client` added as a dev-dependency.

No production code changed: the test launches on the existing hardcoded port (8000), and no other test binds a port, so there is no collision -- which avoids a `Config` -> `build_rocket` port refactor.

Stacked on the flake branch (#185), client crate (#184), and dto crate (#183).

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Publicly exposed `TokenizedAssetStatus` from the tokenized asset module (alongside `UnderlyingSymbol`) for simpler access.
* **Tests**
  * Enhanced the async test harness to start the Rocket HTTP service on an ephemeral port, wait until it’s reachable, and clearly report startup vs. readiness timeouts.
  * Added an integration test that queries tokenized asset status via the issuance client against a locally spawned server, covering `Enabled`, `Frozen`, and `None` for unknown underlyings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
