### PR TITLE
refactor: model Network as a closed enum

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -53,19 +53,32 @@ impl std::fmt::Display for TokenSymbol {
     }
 }
 
-/// Blockchain network the tokenized asset lives on, e.g. `base`.
+/// Blockchain network a tokenized asset lives on.
+///
+/// A closed set -- only `base` is supported today. Serialized as the lowercase
+/// wire string (`"base"`) it has always used, so the JSON contract and the
+/// values already persisted in the event store are unchanged. Modeling it as an
+/// enum (rather than an opaque `String`) means an unsupported network is now a
+/// deserialization error instead of a value that silently flows through.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
-pub struct Network(pub String);
+#[serde(rename_all = "snake_case")]
+pub enum Network {
+    Base,
+}
 
 impl Network {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
+    /// The lowercase wire string for this network, matching the serde encoding.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Base => "base",
+        }
     }
 }
 
 impl std::fmt::Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
+        f.write_str(self.as_str())
     }
 }
 
@@ -181,10 +194,7 @@ mod tests {
             serde_json::to_value(TokenSymbol::new("tSGOV")).unwrap(),
             json!("tSGOV")
         );
-        assert_eq!(
-            serde_json::to_value(Network::new("base")).unwrap(),
-            json!("base")
-        );
+        assert_eq!(serde_json::to_value(Network::Base).unwrap(), json!("base"));
     }
 
     #[test]
@@ -199,15 +209,30 @@ mod tests {
         );
         assert_eq!(
             serde_json::from_value::<Network>(json!("base")).unwrap(),
-            Network::new("base")
+            Network::Base
         );
+    }
+
+    // `Network` is a closed enum, so an unsupported or wrong-cased network must
+    // fail to deserialize rather than flow through as an opaque string — the
+    // invariant that replaced the old unvalidated `Network(String)` newtype.
+    #[test]
+    fn network_rejects_unknown_and_non_snake_case_variants() {
+        for invalid in
+            [json!("ethereum"), json!("Base"), json!("BASE"), json!("")]
+        {
+            assert!(
+                serde_json::from_value::<Network>(invalid.clone()).is_err(),
+                "{invalid} must not deserialize as Network"
+            );
+        }
     }
 
     #[test]
     fn newtypes_display_their_inner_value() {
         assert_eq!(UnderlyingSymbol::new("SGOV").to_string(), "SGOV");
         assert_eq!(TokenSymbol::new("tSGOV").to_string(), "tSGOV");
-        assert_eq!(Network::new("base").to_string(), "base");
+        assert_eq!(Network::Base.to_string(), "base");
     }
 
     #[test]
@@ -273,7 +298,7 @@ mod tests {
             tokens: vec![TokenizedAssetResponse {
                 underlying: UnderlyingSymbol::new("SGOV"),
                 token: TokenSymbol::new("tSGOV"),
-                networks: vec![Network::new("base")],
+                networks: vec![Network::Base],
             }],
         };
 
@@ -294,7 +319,7 @@ mod tests {
         let response = TokenizedAssetDetailResponse {
             underlying: UnderlyingSymbol::new("SGOV"),
             token: TokenSymbol::new("tSGOV"),
-            network: Network::new("base"),
+            network: Network::Base,
             vault: vault(),
             status: TokenizedAssetStatus::Frozen,
         };
@@ -329,7 +354,7 @@ mod tests {
 
         assert_eq!(request.underlying, UnderlyingSymbol::new("SGOV"));
         assert_eq!(request.token, TokenSymbol::new("tSGOV"));
-        assert_eq!(request.network, Network::new("base"));
+        assert_eq!(request.network, Network::Base);
         assert_eq!(request.vault, vault());
     }
 
@@ -376,6 +401,17 @@ mod tests {
             status_enum_ts.contains("\"enabled\"")
                 && status_enum_ts.contains("\"frozen\""),
             "TokenizedAssetStatus must be an \"enabled\" | \"frozen\" union in TS:\n{status_enum_ts}"
+        );
+
+        // `Network` is a closed enum, so ts_rs must emit a string-literal union
+        // (`"base"`), not the bare `string` alias the old transparent newtype
+        // produced — the dashboard switches on this exact wire string, so a
+        // regression to `string` must fail here.
+        let network_ts =
+            std::fs::read_to_string(out_dir.join("Network.ts")).unwrap();
+        assert!(
+            network_ts.contains("\"base\""),
+            "Network must be a \"base\" string-literal union in TS:\n{network_ts}"
         );
 
         // The newtypes must resolve to a bare `string`, matching their

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3815,7 +3815,7 @@ mod tests {
         let tokenization_request_id = TokenizationRequestId::new("alp-stuck-1");
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
         let quantity = crate::mint::Quantity::new(Decimal::from(100));
@@ -3961,7 +3961,7 @@ mod tests {
                 quantity: crate::mint::Quantity::new(Decimal::from(100)),
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 client_id: ClientId::new(),
                 wallet: address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
                 initiated_at: failed_at,

--- a/src/alpaca/mock.rs
+++ b/src/alpaca/mock.rs
@@ -233,7 +233,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let result = mock.send_mint_callback(request).await;
@@ -255,7 +255,7 @@ mod tests {
             tx_hash: b256!(
                 "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let result = mock.send_mint_callback(request).await;
@@ -283,7 +283,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         mock.send_mint_callback(request.clone()).await.unwrap();
@@ -303,7 +303,7 @@ mod tests {
             token: TokenSymbol::new("tAAPL"),
             client_id: ClientId::new(),
             quantity: Quantity::new(Decimal::from(100)),
-            network: Network::new("base"),
+            network: Network::Base,
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
@@ -367,7 +367,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let redeem_request = create_redeem_request();
@@ -441,7 +441,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let redeem_request = create_redeem_request();

--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -254,7 +254,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let serialized = serde_json::to_value(&request).unwrap();
@@ -293,7 +293,7 @@ mod tests {
             token: TokenSymbol::new("tAAPL"),
             client_id,
             quantity: Quantity::new(Decimal::new(10050, 2)),
-            network: Network::new("base"),
+            network: Network::Base,
             wallet: address!("0x9999999999999999999999999999999999999999"),
             tx_hash,
         };
@@ -337,7 +337,7 @@ mod tests {
             tx_hash: b256!(
                 "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         };
 
         let json = serde_json::to_string(&request).unwrap();

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -374,7 +374,7 @@ mod tests {
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
             ),
-            network: Network::new("base"),
+            network: Network::Base,
         }
     }
 
@@ -602,7 +602,7 @@ mod tests {
             token: TokenSymbol::new("tAAPL"),
             client_id,
             quantity: Quantity::new(rust_decimal::Decimal::from(100)),
-            network: Network::new("base"),
+            network: Network::Base,
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             tx_hash: b256!(
                 "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -162,7 +162,7 @@ mod tests {
 
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let asset_cmd = TokenizedAssetCommand::Add {
@@ -259,7 +259,7 @@ mod tests {
             "qty": "100.5",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
         });
@@ -353,7 +353,7 @@ mod tests {
             "qty": "100.5",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
         });
@@ -566,7 +566,7 @@ mod tests {
 
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let asset_cmd = TokenizedAssetCommand::Add {
@@ -662,7 +662,7 @@ mod tests {
             "qty": "50.0",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
         });
@@ -741,7 +741,7 @@ mod tests {
             "qty": "75.5",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
         });
@@ -831,7 +831,7 @@ mod tests {
             "qty": "100.5",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": "invalid-address"
         });
@@ -899,17 +899,12 @@ mod tests {
             .dispatch()
             .await;
 
-        assert_eq!(response.status(), Status::BadRequest);
-
-        let error_response: ErrorResponse = serde_json::from_str(
-            &response.into_string().await.expect("valid response body"),
-        )
-        .expect("valid JSON response");
-
-        assert_eq!(
-            error_response.error,
-            "Invalid Token: Token not available on the network"
-        );
+        // `Network` is a closed enum, so an unsupported network is
+        // unrepresentable: the request is rejected at JSON deserialization
+        // (Rocket's data guard -> 422) before the handler's asset-availability
+        // check runs. A mismatched-but-parseable network can no longer be
+        // expressed, so the old handler-level 400 path is unreachable here.
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     #[tokio::test]
@@ -1022,7 +1017,7 @@ mod tests {
             "qty": "100.5",
             "underlying_symbol": underlying.0,
             "token_symbol": token.0,
-            "network": network.0,
+            "network": network.as_str(),
             "client_id": client_id,
             "wallet_address": non_whitelisted_wallet.to_string()
         });

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -217,7 +217,7 @@ pub(crate) async fn validate_asset_exists(
             target: "mint",
             underlying = %underlying.0,
             token = %token.0,
-            network = %network.0,
+            network = %network,
             "Rejecting mint for frozen asset"
         );
         return Err(MintApiError::AssetFrozen);

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -132,7 +132,7 @@ impl TestHarness {
 
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let asset_cmd = TokenizedAssetCommand::Add {

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -2354,7 +2354,7 @@ pub(crate) mod tests {
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
                         token: TokenSymbol::new("tAAPL"),
-                        network: Network::new("base"),
+                        network: Network::Base,
                         vault: VAULT,
                     },
                 )
@@ -2432,7 +2432,7 @@ pub(crate) mod tests {
                 quantity: Quantity::new(Decimal::from(100)),
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 client_id: ClientId::new(),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
                 initiated_at: failed_at,
@@ -2517,7 +2517,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -2582,7 +2582,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -2627,7 +2627,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(50));
         let underlying = UnderlyingSymbol::new("TSLA");
         let token = TokenSymbol::new("tTSLA");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
         let initiated_at = chrono::Utc::now();
@@ -2679,7 +2679,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -2723,7 +2723,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -2771,7 +2771,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -2818,7 +2818,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -2857,7 +2857,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let reason = "Insufficient funds";
@@ -2919,7 +2919,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -2960,7 +2960,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
@@ -3000,7 +3000,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -3062,7 +3062,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -3132,7 +3132,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -3194,7 +3194,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -3267,7 +3267,7 @@ pub(crate) mod tests {
         let quantity = Quantity::new(Decimal::from(100));
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let initiated_at = Utc::now();
@@ -3376,7 +3376,7 @@ pub(crate) mod tests {
                 quantity: Quantity::new(Decimal::from(100)),
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 client_id: ClientId::new(),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             }
@@ -3408,7 +3408,7 @@ pub(crate) mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: VAULT,
                 },
             )
@@ -3591,7 +3591,7 @@ pub(crate) mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: VAULT,
                 },
             )
@@ -3790,7 +3790,7 @@ pub(crate) mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: VAULT,
                 },
             )
@@ -4302,7 +4302,7 @@ pub(crate) mod tests {
                 quantity: Quantity::new(Decimal::from(100)),
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 client_id: ClientId::new(),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
                 initiated_at: now,
@@ -4378,7 +4378,7 @@ pub(crate) mod tests {
                     quantity: Quantity::new(Decimal::from(100)),
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     client_id: ClientId::new(),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -4421,7 +4421,7 @@ pub(crate) mod tests {
                     quantity: Quantity::new(Decimal::from(100)),
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     client_id: ClientId::new(),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -4465,7 +4465,7 @@ pub(crate) mod tests {
             quantity: Quantity::new(Decimal::from(100)),
             underlying: UnderlyingSymbol::new("AAPL"),
             token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
+            network: Network::Base,
             client_id: ClientId::new(),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             initiated_at: now,
@@ -4478,7 +4478,7 @@ pub(crate) mod tests {
             quantity: Quantity::new(Decimal::from(100)),
             underlying: UnderlyingSymbol::new("AAPL"),
             token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
+            network: Network::Base,
             client_id: ClientId::new(),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             initiated_at: now,

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -391,7 +391,7 @@ mod tests {
                     TokenizedAssetCommand::Add {
                         underlying: UnderlyingSymbol::new("AAPL"),
                         token: TokenSymbol::new("tAAPL"),
-                        network: Network::new("base"),
+                        network: Network::Base,
                         vault: VAULT,
                     },
                 )
@@ -562,7 +562,7 @@ mod tests {
                 quantity: Quantity::new(Decimal::from(100)),
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 client_id: ClientId::new(),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
                 initiated_at: now,

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -368,7 +368,7 @@ mod tests {
                     quantity: Quantity::new(Decimal::from(50)),
                     underlying: UnderlyingSymbol::new("TSLA"),
                     token: TokenSymbol::new("tTSLA"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     client_id: ClientId::new(),
                     wallet: address!(
                         "0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"
@@ -405,7 +405,7 @@ mod tests {
         assert_eq!(found_quantity, Quantity::new(Decimal::from(50)));
         assert_eq!(found_underlying, UnderlyingSymbol::new("TSLA"));
         assert_eq!(found_token, TokenSymbol::new("tTSLA"));
-        assert_eq!(found_network, Network::new("base"));
+        assert_eq!(found_network, Network::Base);
     }
 
     #[tokio::test]
@@ -428,7 +428,7 @@ mod tests {
             quantity: Quantity::new(Decimal::from(100)),
             underlying: UnderlyingSymbol::new("AAPL"),
             token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
+            network: Network::Base,
             client_id: ClientId::new(),
             wallet: address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
             initiated_at: Utc::now(),

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -334,7 +334,7 @@ mod tests {
             quantity: Quantity::new(Decimal::from(100)),
             underlying,
             token,
-            network: Network::new("base"),
+            network: Network::Base,
             client_id: ClientId::new(),
             wallet,
             initiated_at: Utc::now(),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -1576,7 +1576,7 @@ mod tests {
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
                         token: TokenSymbol::new(format!("t{}", underlying.0)),
-                        network: Network::new("base"),
+                        network: Network::Base,
                         vault,
                     },
                 )

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -231,7 +231,7 @@ impl RedeemCallManager {
                     underlying = %response.underlying.0,
                     token = %response.token.0,
                     quantity = %response.quantity.0,
-                    network = %response.network.0,
+                    network = %response.network,
                     wallet = %response.wallet,
                     tx_hash = %response.tx_hash,
                     fees = ?response.fees.as_ref().map(|f| f.0),
@@ -559,7 +559,7 @@ mod tests {
         .await;
 
         let client_id = ClientId::new();
-        let network = Network::new("base");
+        let network = Network::Base;
 
         let result = manager
             .handle_redemption_detected(
@@ -602,7 +602,7 @@ mod tests {
         .await;
 
         let client_id = ClientId::new();
-        let network = Network::new("base");
+        let network = Network::Base;
 
         let result = manager
             .handle_redemption_detected(
@@ -652,7 +652,7 @@ mod tests {
         };
 
         let client_id = ClientId::new();
-        let network = Network::new("base");
+        let network = Network::Base;
 
         let result = manager
             .handle_redemption_detected(
@@ -729,7 +729,7 @@ mod tests {
         let manager = harness.create_manager(alpaca_service);
 
         let underlying = UnderlyingSymbol::new("AAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
 
         harness.add_asset(&underlying, &network).await;
 
@@ -785,7 +785,7 @@ mod tests {
         let client_id = ClientId::new();
         let alpaca_account = AlpacaAccountNumber("acc-recovery".to_string());
         let underlying = UnderlyingSymbol::new("AAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
 
         harness
             .register_and_link_account(

--- a/src/redemption/test_utils.rs
+++ b/src/redemption/test_utils.rs
@@ -37,7 +37,7 @@ pub(crate) async fn setup_test_db_with_asset(
 
     let underlying = UnderlyingSymbol::new("AAPL");
     let token = TokenSymbol::new("tAAPL");
-    let network = Network::new("base");
+    let network = Network::Base;
 
     asset_store
         .send(

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -155,23 +155,21 @@ async fn seed_test_assets(
         (
             "AAPL",
             "tAAPL",
-            "base",
             address!("0x1234567890abcdef1234567890abcdef12345678"),
         ),
         (
             "TSLA",
             "tTSLA",
-            "base",
             address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
         ),
     ];
 
-    for (underlying, token, network, vault) in assets {
+    for (underlying, token, vault) in assets {
         let underlying = UnderlyingSymbol::new(underlying);
         let command = TokenizedAssetCommand::Add {
             underlying: underlying.clone(),
             token: TokenSymbol::new(token),
-            network: Network::new(network),
+            network: Network::Base,
             vault,
         };
 

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -210,7 +210,7 @@ mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: address!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     ),
@@ -593,7 +593,7 @@ mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: address!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     ),
@@ -704,7 +704,7 @@ mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: UnderlyingSymbol::new("AAPL"),
                     token: TokenSymbol::new("tAAPL"),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: address!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     ),

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -410,7 +410,7 @@ mod tests {
                 TokenizedAssetCommand::Add {
                     underlying: underlying.clone(),
                     token: TokenSymbol::new(format!("t{underlying}")),
-                    network: Network::new("base"),
+                    network: Network::Base,
                     vault: address!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     ),

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -276,7 +276,7 @@ mod tests {
     async fn test_add_asset_creates_new_asset() {
         let underlying = UnderlyingSymbol::new("AAPL");
         let token = TokenSymbol::new("tAAPL");
-        let network = Network::new("base");
+        let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
 
         let events = TestHarness::<TokenizedAsset>::with(())
@@ -324,14 +324,14 @@ mod tests {
             .given(vec![TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault,
                 added_at: chrono::Utc::now(),
             }])
             .when(TokenizedAssetCommand::Add {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault,
             })
             .await
@@ -353,14 +353,14 @@ mod tests {
             .given(vec![TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             }])
             .when(TokenizedAssetCommand::Add {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_b,
             })
             .await
@@ -392,7 +392,7 @@ mod tests {
         TokenizedAssetEvent::Added {
             underlying: UnderlyingSymbol::new("AAPL"),
             token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
+            network: Network::Base,
             vault,
             added_at: chrono::Utc::now(),
         }
@@ -549,7 +549,7 @@ mod tests {
     fn test_apply_asset_added_updates_state() {
         let underlying = UnderlyingSymbol::new("TSLA");
         let token = TokenSymbol::new("tTSLA");
-        let network = Network::new("base");
+        let network = Network::Base;
         let vault = address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc");
         let added_at = chrono::Utc::now();
 
@@ -590,7 +590,7 @@ mod tests {
             TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             },
@@ -620,14 +620,14 @@ mod tests {
             TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             },
             TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL2"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_b,
                 added_at: chrono::Utc::now(),
             },
@@ -652,7 +652,7 @@ mod tests {
             TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             },
@@ -660,7 +660,7 @@ mod tests {
             TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL2"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault: vault_b,
                 added_at: chrono::Utc::now(),
             },
@@ -686,7 +686,7 @@ mod tests {
 
     #[test]
     fn test_network_display() {
-        let network = Network::new("base");
+        let network = Network::Base;
         assert_eq!(format!("{network}"), "base");
     }
 

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -173,7 +173,7 @@ mod tests {
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
                         token: TokenSymbol::new(format!("t{}", underlying.0)),
-                        network: Network::new("base"),
+                        network: Network::Base,
                         vault,
                     },
                 )
@@ -279,7 +279,7 @@ mod tests {
             serde_json::to_string(&TokenizedAssetEvent::Added {
                 underlying: UnderlyingSymbol::new("AAPL"),
                 token: TokenSymbol::new("tAAPL"),
-                network: Network::new("base"),
+                network: Network::Base,
                 vault,
                 added_at: chrono::Utc::now(),
             })
@@ -364,7 +364,7 @@ mod tests {
         let added = serde_json::to_string(&TokenizedAssetEvent::Added {
             underlying: UnderlyingSymbol::new("AAPL"),
             token: TokenSymbol::new("tAAPL"),
-            network: Network::new("base"),
+            network: Network::Base,
             vault,
             added_at: chrono::Utc::now(),
         })


### PR DESCRIPTION
## Motivation

`Network` was an opaque `String` newtype whose `new()` did no validation, so an
unsupported network was just a value that flowed through the system. A value
that is "one of N things" should be an enum, not a wrapped string. This is the
substantive response to the dto-crate review feedback (privatizing the inner
`String` would only have papered over a newtype that carries no invariant).

## Solution

Models `Network` as a closed enum (`Base` today), serialized as the lowercase
wire string (`"base"`) it has always used via `#[serde(rename_all = "snake_case")]`.
The JSON contract and the values already persisted in the event store are
unchanged; `Display` / `as_str()` reproduce the wire string. The ~80
`Network::new("base")` sites become `Network::Base`; the few `network.0`
accessors use `as_str()` / `Display`.

An unsupported network is now unrepresentable, so it is rejected earlier:

- `POST /inkind/issuance` (Alpaca mint) carrying a non-`base` network is now
  rejected at the JSON data guard (**422**) rather than by the handler's
  asset-availability check (**400**). Alpaca only ever sends `base`, so this
  defensive path is never exercised in practice, and a parseable-but-mismatched
  network can no longer be expressed. The corresponding test asserts 422.

`UnderlyingSymbol` / `TokenSymbol` stay string newtypes for a follow-up (the
former wants a validating constructor; the latter is derivable from the
underlying).

Stacked on the dto-crate stack (#183).

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected HTTP response code for unsupported network requests from 400 to 422, providing more accurate error semantics.

* **Refactor**
  * Improved network type validation to restrict accepted values to known, supported networks, enhancing system reliability and data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->