### PR TITLE
feat: openapi spec and swagger ui for internal endpoints

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,3 +8,6 @@ ALPACA_API_KEY=${ALPACA_API_KEY}
 ALPACA_API_SECRET=${ALPACA_API_SECRET}
 HYPERDX_API_KEY=${HYPERDX_API_KEY}
 SUBGRAPH_URL=${SUBGRAPH_URL}
+# Gates dev-only surfaces (OpenAPI docs / Swagger UI). Pinned to `production`
+# so the deployed image never exposes them; unset also defaults to production.
+ENVIRONMENT=production

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -797,6 +797,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1836,6 +1845,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,6 +2256,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -4666,6 +4687,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 
 [[package]]
+name = "rust-embed"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04113cb9355a377d83f06ef1f0a45b8ab8cd7d8b1288160717d66df5c7988d27"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0902e4c7c8e997159ab384e6d0fc91c221375f6894346ae107f47dd0f3ccaa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.117",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bcdef0be6fe7f6fa333b1073c949729274b05f123a0ad7efcb8efd878e5c3b1"
+dependencies = [
+ "sha2 0.10.9",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4796,6 +4851,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -5515,6 +5579,8 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "url",
+ "utoipa",
+ "utoipa-swagger-ui",
  "uuid",
 ]
 
@@ -5539,6 +5605,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ts-rs",
+ "utoipa",
 ]
 
 [[package]]
@@ -6363,6 +6430,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "utoipa"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bde15df68e80b16c7d16b9616e80770ad158988daa56a27dccd1e55558b0160"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba0b99ee52df3028635d93840c797102da61f8a7bb3cf751032455895b52ef8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "9.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
+dependencies = [
+ "base64",
+ "mime_guess",
+ "regex",
+ "rocket",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "url",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6399,6 +6508,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -7178,7 +7297,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ default-run = "st0x-issuance"
 workspace = true
 
 [dependencies]
-st0x-issuance-dto = { path = "crates/dto" }
+st0x-issuance-dto = { path = "crates/dto", features = ["utoipa"] }
 event-sorcery = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2" }
 sqlite-es = { git = "https://github.com/ST0X-Technology/event-sorcery.git", tag = "0.1.2" }
 cqrs-es = "0.5.0"
@@ -57,6 +57,8 @@ governor = "0.10.2"
 fireblocks-sdk = { git = "https://github.com/0xgleb/fireblocks-sdk-rs.git", branch = "fix/confirming-not-terminal" }
 ciborium = "0.2.2"
 flate2 = "1.1.9"
+utoipa = { version = "5.5.0", features = ["rocket_extras"] }
+utoipa-swagger-ui = { version = "9.0.2", features = ["rocket"] }
 
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"

--- a/crates/dto/Cargo.toml
+++ b/crates/dto/Cargo.toml
@@ -7,9 +7,13 @@ edition = "2024"
 alloy-primitives = { workspace = true }
 serde = { workspace = true }
 ts-rs = { workspace = true }
+utoipa = { version = "5.5.0", optional = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
 
 [lints]
 workspace = true
+
+[features]
+utoipa = ["dep:utoipa"]

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -15,6 +15,7 @@ use ts_rs::TS;
 
 /// Underlying equity symbol, e.g. `SGOV`. Also the `TokenizedAsset` aggregate id.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct UnderlyingSymbol(pub String);
 
 impl UnderlyingSymbol {
@@ -39,6 +40,7 @@ impl FromStr for UnderlyingSymbol {
 
 /// Tokenized share symbol, e.g. `tSGOV`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TokenSymbol(pub String);
 
 impl TokenSymbol {
@@ -61,6 +63,7 @@ impl std::fmt::Display for TokenSymbol {
 /// enum (rather than an opaque `String`) means an unsupported network is now a
 /// deserialization error instead of a value that silently flows through.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum Network {
     Base,
@@ -89,11 +92,13 @@ impl std::fmt::Display for Network {
 /// frozen asset as enabled. The enum keeps the freeze state visible to
 /// consumers and the contradictory states unrepresentable.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TokenizedAssetDetailResponse {
     pub underlying: UnderlyingSymbol,
     pub token: TokenSymbol,
     pub network: Network,
     #[ts(type = "string")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub vault: Address,
     pub status: TokenizedAssetStatus,
 }
@@ -107,6 +112,7 @@ pub struct TokenizedAssetDetailResponse {
 /// `{ enabled, frozen }` boolean combinations (e.g. de-listed yet frozen) that
 /// the old two-bool shape allowed are now unrepresentable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 #[serde(rename_all = "snake_case")]
 pub enum TokenizedAssetStatus {
     /// Accepting new mints (not frozen).
@@ -119,6 +125,7 @@ pub enum TokenizedAssetStatus {
 /// `GET /tokenized-assets/<underlying>/status` and consumed by the liquidity
 /// rebalance guard.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TokenizedAssetStatusResponse {
     pub underlying: UnderlyingSymbol,
     pub status: TokenizedAssetStatus,
@@ -140,16 +147,19 @@ pub struct TokenizedAssetsListResponse {
 
 /// Request body of `POST /tokenized-assets`.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct AddTokenizedAssetRequest {
     pub underlying: UnderlyingSymbol,
     pub token: TokenSymbol,
     pub network: Network,
     #[ts(type = "string")]
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub vault: Address,
 }
 
 /// Response body of `POST /tokenized-assets`.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct AddTokenizedAssetResponse {
     pub underlying: UnderlyingSymbol,
 }

--- a/src/account/api.rs
+++ b/src/account/api.rs
@@ -67,16 +67,33 @@ impl<'r> Responder<'r, 'static> for ApiError {
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct RegisterAccountRequest {
+    #[schema(value_type = String)]
     pub(crate) email: Email,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RegisterAccountResponse {
+    #[schema(value_type = String)]
     pub client_id: ClientId,
 }
 
+#[utoipa::path(
+    post,
+    path = "/accounts",
+    tag = "accounts",
+    request_body = RegisterAccountRequest,
+    responses(
+        (status = 200, description = "Account registered",
+            body = RegisterAccountResponse),
+        (status = 400, description = "Invalid registration command"),
+        (status = 409, description = "Email already registered"),
+        (status = 422, description = "Malformed or invalid email payload"),
+        (status = 500, description = "Email claim or event-store failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store, pool), fields(email = %request.email.0))]
 #[post("/accounts", format = "json", data = "<request>")]
 pub(crate) async fn register_account(
@@ -192,16 +209,35 @@ pub(crate) async fn connect_account(
     Ok(Json(AccountLinkResponse { client_id }))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct WhitelistWalletRequest {
+    #[schema(value_type = String)]
     pub(crate) wallet: Address,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct WhitelistWalletResponse {
     pub success: bool,
 }
 
+#[utoipa::path(
+    post,
+    path = "/accounts/{client_id}/wallets",
+    tag = "accounts",
+    params(
+        ("client_id" = String, Path,
+            description = "Client UUID of the Alpaca-linked account")
+    ),
+    request_body = WhitelistWalletRequest,
+    responses(
+        (status = 200, description = "Wallet whitelisted",
+            body = WhitelistWalletResponse),
+        (status = 404, description = "Account not found or not linked to Alpaca"),
+        (status = 422, description = "Malformed wallet payload"),
+        (status = 500, description = "View load or event-store failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store, pool), fields(
     client_id = %client_id,
     wallet = ?request.wallet
@@ -229,6 +265,24 @@ pub(crate) async fn whitelist_wallet(
     Ok(Json(WhitelistWalletResponse { success: true }))
 }
 
+#[utoipa::path(
+    delete,
+    path = "/accounts/{client_id}/wallets/{wallet}",
+    tag = "accounts",
+    params(
+        ("client_id" = String, Path,
+            description = "Client UUID of the Alpaca-linked account"),
+        ("wallet" = String, Path,
+            description = "Wallet address to remove from the whitelist")
+    ),
+    responses(
+        (status = 200, description = "Wallet removed from the whitelist",
+            body = WhitelistWalletResponse),
+        (status = 404, description = "Account not found or not linked to Alpaca"),
+        (status = 500, description = "View load or event-store failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store, pool), fields(
     client_id = %client_id,
     wallet = %wallet.0
@@ -271,7 +325,7 @@ mod tests {
     use crate::account::Account;
     use crate::alpaca::service::AlpacaConfig;
     use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-    use crate::config::{Config, LogLevel};
+    use crate::config::{Config, Environment, LogLevel};
     use crate::fireblocks::SignerConfig;
     use crate::test_utils::logs_contain_at;
 
@@ -286,6 +340,7 @@ mod tests {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -1,4 +1,4 @@
-mod api;
+pub(crate) mod api;
 mod cmd;
 mod event;
 pub(crate) mod view;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -73,14 +73,14 @@ impl RedemptionBurnRecovery for BurnManager {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum AggregateKind {
     Mint,
     Redemption,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub(crate) struct ReprocessResponse {
     aggregate_type: AggregateKind,
     aggregate_id: String,
@@ -88,24 +88,28 @@ pub(crate) struct ReprocessResponse {
     message: String,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub(crate) struct StuckAggregate {
     aggregate_type: AggregateKind,
     aggregate_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = String)]
     tokenization_request_id: Option<TokenizationRequestId>,
     state: String,
     detail: String,
+    #[schema(value_type = String)]
     timestamp: DateTime<Utc>,
     #[serde(skip_serializing_if = "Option::is_none")]
     underlying: Option<UnderlyingSymbol>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = String)]
     quantity: Option<Quantity>,
     /// Primary on-chain transaction hash for this aggregate, when known.
     /// For redemptions this is the detected transfer tx hash. For mints this
     /// is the successful mint tx hash, or a Fireblocks network hash when the
     /// signing backend exposes one.
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = String)]
     tx_hash: Option<B256>,
     /// Fireblocks transaction ID associated with this aggregate's current
     /// stuck step. For mints, sourced from the most recent
@@ -120,7 +124,7 @@ pub(crate) struct StuckAggregate {
     fireblocks_status: Option<FireblocksTxStatus>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub(crate) struct StuckResponse {
     stuck: Vec<StuckAggregate>,
 }
@@ -291,6 +295,28 @@ async fn load_reprocess_context(
 /// - **Post-Alpaca failures**: Polls Alpaca to verify the journal completed, then
 ///   resumes to `Burning` and invokes burn recovery immediately.
 ///   Refuses if Alpaca's journal hasn't completed (to avoid burning without backing).
+#[utoipa::path(
+    post,
+    path = "/admin/recover/redemption/{issuer_request_id}",
+    tag = "admin",
+    params(
+        ("issuer_request_id" = String, Path,
+            description = "Issuer redemption request id of the stuck redemption")
+    ),
+    responses(
+        (status = 200, description = "Recovery initiated; describes the path taken",
+            body = ReprocessResponse),
+        (status = 404, description = "No redemption found for this id"),
+        (status = 409, description = "Redemption already completed"),
+        (status = 422,
+            description = "Cannot recover: Alpaca journal pending/rejected, \
+                Fireblocks burn still pending, or invalid aggregate state"),
+        (status = 502,
+            description = "Alpaca poll, Fireblocks lookup, or burn execution failed"),
+        (status = 500, description = "Event load/deserialize or internal failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(
     _auth,
     store,
@@ -741,7 +767,7 @@ const fn map_redemption_error(
     }
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct CloseRedemptionRequest {
     reason: String,
 }
@@ -754,6 +780,24 @@ pub(crate) struct CloseRedemptionRequest {
 /// off-chain reconciliation). For a redemption whose burn *did* land on-chain,
 /// use `/admin/force-complete/redemption` instead. Closed redemptions do not
 /// appear in stuck queries.
+#[utoipa::path(
+    post,
+    path = "/admin/close/redemption/{issuer_request_id}",
+    tag = "admin",
+    params(
+        ("issuer_request_id" = String, Path,
+            description = "Issuer redemption request id to close")
+    ),
+    request_body = CloseRedemptionRequest,
+    responses(
+        (status = 200, description = "Redemption closed by admin",
+            body = ReprocessResponse),
+        (status = 409, description = "Redemption already completed"),
+        (status = 422, description = "Invalid state transition for close"),
+        (status = 500, description = "Event load/deserialize or internal failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store, pool))]
 #[post(
     "/admin/close/redemption/<issuer_request_id>",
@@ -802,10 +846,11 @@ pub(crate) async fn close_redemption(
     }))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct ForceCompleteRedemptionRequest {
     /// On-chain transaction hash that burned the redemption's shares. Verified
     /// against the chain before the redemption is terminalized.
+    #[schema(value_type = String)]
     burn_tx_hash: B256,
     /// Operator-supplied audit reason recorded with the terminal event.
     reason: String,
@@ -819,6 +864,26 @@ pub(crate) struct ForceCompleteRedemptionRequest {
 /// shares) before the redemption is moved to `Completed`, recording the proving
 /// tx hash for audit. Ambiguous cases with no verifiable on-chain burn are
 /// rejected (`422`) — use `/admin/close/redemption` for those.
+#[utoipa::path(
+    post,
+    path = "/admin/force-complete/redemption/{issuer_request_id}",
+    tag = "admin",
+    params(
+        ("issuer_request_id" = String, Path,
+            description = "Issuer redemption request id to force-complete")
+    ),
+    request_body = ForceCompleteRedemptionRequest,
+    responses(
+        (status = 200, description = "Burn verified on-chain; redemption completed",
+            body = ReprocessResponse),
+        (status = 422,
+            description = "Supplied hash is not a verifiable burn, or invalid \
+                aggregate state"),
+        (status = 502, description = "On-chain/RPC verification failure"),
+        (status = 500, description = "Event load/deserialize or internal failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, pool, burn_recovery))]
 #[post(
     "/admin/force-complete/redemption/<issuer_request_id>",
@@ -952,6 +1017,24 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
     }
 }
 
+#[utoipa::path(
+    post,
+    path = "/admin/reprocess/mint/{aggregate_id}",
+    tag = "admin",
+    params(
+        ("aggregate_id" = String, Path,
+            description = "Issuer mint request id (UUID) to reprocess")
+    ),
+    responses(
+        (status = 200, description = "Recovery initiated", body = ReprocessResponse),
+        (status = 400, description = "Aggregate id is not a valid UUID"),
+        (status = 404, description = "No mint found for this id"),
+        (status = 409, description = "Mint already completed or closed"),
+        (status = 422, description = "Invalid state transition for recovery"),
+        (status = 500, description = "View query or internal failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store, pool))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
@@ -1034,7 +1117,7 @@ pub(crate) async fn reprocess_mint(
     }))
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct CloseMintRequest {
     reason: String,
 }
@@ -1042,6 +1125,23 @@ pub(crate) struct CloseMintRequest {
 /// Admin endpoint to close a mint that cannot be automatically recovered.
 ///
 /// Valid from any non-terminal state. Closed mints do not appear in stuck queries.
+#[utoipa::path(
+    post,
+    path = "/admin/close/mint/{aggregate_id}",
+    tag = "admin",
+    params(
+        ("aggregate_id" = String, Path,
+            description = "Issuer mint request id (UUID) to close")
+    ),
+    request_body = CloseMintRequest,
+    responses(
+        (status = 200, description = "Mint closed by admin", body = ReprocessResponse),
+        (status = 400, description = "Aggregate id is not a valid UUID"),
+        (status = 422, description = "Invalid state transition for close"),
+        (status = 500, description = "Internal failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store))]
 #[post("/admin/close/mint/<aggregate_id>", format = "json", data = "<body>")]
 pub(crate) async fn close_mint(
@@ -1092,6 +1192,17 @@ pub(crate) async fn close_mint(
 /// leaves a redemption in `Burning` indefinitely with no terminal event).
 const STUCK_THRESHOLD: chrono::Duration = chrono::Duration::hours(1);
 
+#[utoipa::path(
+    get,
+    path = "/admin/stuck",
+    tag = "admin",
+    responses(
+        (status = 200, description = "Stuck mints and redemptions, enriched with \
+            best-effort Fireblocks status", body = StuckResponse),
+        (status = 500, description = "Failed to query stuck aggregates")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, pool, vault_service))]
 #[get("/admin/stuck")]
 pub(crate) async fn list_stuck(
@@ -1732,7 +1843,7 @@ fn tx_hash_from_fireblocks_status(status: &FireblocksTxStatus) -> Option<B256> {
 }
 
 /// Response for the Fireblocks transaction status lookup endpoint.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, utoipa::ToSchema)]
 pub(crate) struct FireblocksTxResponse {
     fireblocks_tx_id: String,
     #[serde(flatten)]
@@ -1743,6 +1854,23 @@ pub(crate) struct FireblocksTxResponse {
 ///
 /// Useful for checking orphaned transactions that were submitted but never
 /// recorded in the event store (e.g. due to recovery timeout).
+#[utoipa::path(
+    get,
+    path = "/admin/fireblocks/tx/{fireblocks_tx_id}",
+    tag = "admin",
+    params(
+        ("fireblocks_tx_id" = String, Path,
+            description = "Fireblocks transaction id to look up")
+    ),
+    responses(
+        (status = 200, description = "Live Fireblocks transaction status",
+            body = FireblocksTxResponse),
+        (status = 404,
+            description = "Unknown tx, or backend is non-Fireblocks (Local signer)"),
+        (status = 502, description = "Fireblocks lookup failed")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, vault_service))]
 #[get("/admin/fireblocks/tx/<fireblocks_tx_id>")]
 pub(crate) async fn check_fireblocks_tx(
@@ -2647,7 +2775,7 @@ mod tests {
     ) {
         use crate::alpaca::service::AlpacaConfig;
         use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-        use crate::config::{Config, LogLevel};
+        use crate::config::{Config, Environment, LogLevel};
         use crate::fireblocks::SignerConfig;
         use alloy::primitives::B256;
         use url::Url;
@@ -2662,6 +2790,7 @@ mod tests {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
@@ -2817,7 +2946,7 @@ mod tests {
     ) -> rocket::Rocket<rocket::Build> {
         use crate::alpaca::service::AlpacaConfig;
         use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-        use crate::config::{Config, LogLevel};
+        use crate::config::{Config, Environment, LogLevel};
         use crate::fireblocks::SignerConfig;
         use alloy::primitives::B256;
         use url::Url;
@@ -2832,6 +2961,7 @@ mod tests {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
@@ -3129,7 +3259,7 @@ mod tests {
     ) -> rocket::Rocket<rocket::Build> {
         use crate::alpaca::service::AlpacaConfig;
         use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-        use crate::config::{Config, LogLevel};
+        use crate::config::{Config, Environment, LogLevel};
         use crate::fireblocks::SignerConfig;
         use alloy::primitives::B256;
         use url::Url;
@@ -3143,6 +3273,7 @@ mod tests {
             backfill_start_block: 0,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -324,7 +324,7 @@ mod tests {
 
     use super::*;
     use crate::alpaca::service::AlpacaConfig;
-    use crate::config::LogLevel;
+    use crate::config::{Environment, LogLevel};
     use crate::fireblocks::SignerConfig;
 
     #[rocket::get("/issuer-test")]
@@ -348,6 +348,7 @@ mod tests {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ pub struct Config {
     pub receipt_poll_interval: Duration,
     pub auth: AuthConfig,
     pub log_level: LogLevel,
+    pub environment: Environment,
     pub hyperdx: Option<HyperDxConfig>,
     pub alpaca: AlpacaConfig,
     pub subgraph_url: Url,
@@ -174,6 +175,15 @@ struct Env {
     #[clap(long, env, default_value = "debug")]
     log_level: LogLevel,
 
+    #[arg(
+        long,
+        env = "ENVIRONMENT",
+        default_value = "production",
+        help = "Deployment environment; gates dev-only surfaces such as the \
+                OpenAPI docs (one of: development, staging, production)"
+    )]
+    environment: Environment,
+
     #[clap(flatten)]
     hyperdx: HyperDxEnv,
 
@@ -213,6 +223,7 @@ impl Env {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: self.auth,
             log_level: self.log_level,
+            environment: self.environment,
             hyperdx,
             alpaca: self.alpaca,
             subgraph_url: self.subgraph_url,
@@ -249,6 +260,28 @@ impl From<&LogLevel> for Level {
             LogLevel::Info => Self::INFO,
             LogLevel::Warn => Self::WARN,
             LogLevel::Error => Self::ERROR,
+        }
+    }
+}
+
+/// Deployment environment. Gates developer-facing surfaces that must not be
+/// exposed in production. Defaults to `Production` so an unset `ENVIRONMENT`
+/// fails closed (docs hidden) rather than open.
+#[derive(clap::ValueEnum, Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Environment {
+    Development,
+    Staging,
+    Production,
+}
+
+impl Environment {
+    /// Whether the interactive OpenAPI docs (SwaggerUI + `/api-docs/openapi.json`)
+    /// should be served. They expose the full internal/admin API surface, so they
+    /// are served only outside production.
+    pub(crate) const fn exposes_api_docs(self) -> bool {
+        match self {
+            Self::Development | Self::Staging => true,
+            Self::Production => false,
         }
     }
 }
@@ -390,6 +423,25 @@ mod tests {
         let env = Env::try_parse_from(args).unwrap();
 
         assert_eq!(env.auth.alpaca_ip_ranges, IpWhitelist::AllowAll);
+    }
+
+    #[test]
+    fn api_docs_exposed_only_outside_production() {
+        assert!(Environment::Development.exposes_api_docs());
+        assert!(Environment::Staging.exposes_api_docs());
+        assert!(!Environment::Production.exposes_api_docs());
+    }
+
+    #[test]
+    fn environment_defaults_to_production_and_parses_explicit_value() {
+        // An unset ENVIRONMENT must fail closed to production (docs hidden).
+        let default_env = Env::try_parse_from(minimal_args()).unwrap();
+        assert_eq!(default_env.environment, Environment::Production);
+
+        let mut args = minimal_args();
+        args.extend_from_slice(&["--environment", "staging"]);
+        let staging_env = Env::try_parse_from(args).unwrap();
+        assert_eq!(staging_env.environment, Environment::Staging);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub(crate) mod auth;
 pub(crate) mod catchers;
 pub(crate) mod config;
 pub(crate) mod fireblocks;
+mod openapi;
 pub(crate) mod poll_checkpoint;
 pub mod receipt_inventory;
 pub(crate) mod telemetry;
@@ -62,7 +63,7 @@ pub mod bindings;
 
 pub use alpaca::AlpacaConfig;
 pub use auth::{AuthConfig, IpWhitelist, IssuerApiKey};
-pub use config::{Config, LogLevel, setup_tracing};
+pub use config::{Config, Environment, LogLevel, setup_tracing};
 pub use fireblocks::SignerConfig;
 pub use telemetry::TelemetryGuard;
 pub use test_utils::ANVIL_CHAIN_ID;
@@ -391,7 +392,10 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         // client IP at the network layer (e.g., PROXY protocol) rather than headers.
         .merge(("ip_header", false));
 
-    rocket::custom(figment)
+    // Read before `state.config` is moved into management below.
+    let environment = state.config.environment;
+
+    let rocket = rocket::custom(figment)
         .manage(state.config)
         .manage(state.rate_limiter)
         .manage(state.account_store)
@@ -424,7 +428,31 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 admin::check_fireblocks_tx,
             ],
         )
-        .register("/", catchers::json_catchers())
+        .register("/", catchers::json_catchers());
+
+    mount_api_docs(rocket, environment)
+}
+
+/// Mounts the SwaggerUI and `/api-docs/openapi.json` endpoints, but only outside
+/// production. The docs expose the full internal/admin API surface (paths,
+/// parameters, schemas), so unlike the handlers themselves they carry no
+/// `InternalAuth`/`IssuerAuth` guard; gating them on `ENVIRONMENT` keeps that
+/// schema off a production host entirely. See [`Environment::exposes_api_docs`].
+fn mount_api_docs(
+    rocket: rocket::Rocket<rocket::Build>,
+    environment: Environment,
+) -> rocket::Rocket<rocket::Build> {
+    if !environment.exposes_api_docs() {
+        return rocket;
+    }
+
+    rocket.mount(
+        "/",
+        utoipa_swagger_ui::SwaggerUi::new("/swagger-ui/<_..>").url(
+            "/api-docs/openapi.json",
+            <openapi::ApiDoc as utoipa::OpenApi>::openapi(),
+        ),
+    )
 }
 
 async fn setup_aggregate_cqrs(
@@ -1003,8 +1031,30 @@ mod tests {
     use std::str::FromStr;
 
     use super::{
-        Quantity, QuantityConversionError, next_receipt_backfill_block,
+        Environment, Quantity, QuantityConversionError, mount_api_docs,
+        next_receipt_backfill_block,
     };
+
+    #[test]
+    fn api_docs_mounted_only_outside_production() {
+        // Production must serve no docs routes at all; a bare rocket has none,
+        // so the gated mount adding nothing leaves the count at zero.
+        assert_eq!(
+            mount_api_docs(rocket::build(), Environment::Production)
+                .routes()
+                .count(),
+            0,
+            "production must not expose the OpenAPI docs"
+        );
+
+        for environment in [Environment::Development, Environment::Staging] {
+            assert!(
+                mount_api_docs(rocket::build(), environment).routes().count()
+                    > 0,
+                "{environment:?} must serve the OpenAPI docs"
+            );
+        }
+    }
 
     #[test]
     fn test_quantity_display() {

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -10,7 +10,7 @@ use crate::account::{
 use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
 use crate::auth::test_auth_config;
-use crate::config::{Config, LogLevel};
+use crate::config::{Config, Environment, LogLevel};
 use crate::fireblocks::SignerConfig;
 use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
 use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
@@ -28,6 +28,7 @@ pub(crate) fn test_config() -> Config {
         receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
         auth: test_auth_config().unwrap(),
         log_level: LogLevel::Debug,
+        environment: Environment::Development,
         hyperdx: None,
         alpaca: AlpacaConfig::test_default(),
         subgraph_url: Url::parse("http://localhost:0/subgraph")

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -1,0 +1,196 @@
+//! OpenAPI document for the internal and operator (admin) HTTP surface.
+//!
+//! The Alpaca ITN endpoints (`/accounts/connect`, `GET /tokenized-assets`,
+//! `/inkind/issuance`, `/inkind/issuance/confirm`) are intentionally omitted:
+//! their contract is governed by Alpaca's own documentation, not ours.
+
+use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+use utoipa::{Modify, OpenApi};
+
+#[derive(OpenApi)]
+#[openapi(
+    info(
+        title = "st0x.issuance internal API",
+        description = "Internal and operator (admin) endpoints. The Alpaca ITN \
+endpoints are documented by Alpaca and excluded here.\n\nEvery endpoint here \
+requires the `X-API-KEY` header AND a request from an allowlisted internal IP \
+(`INTERNAL_IP_RANGES`): a missing or invalid key returns 401, and a valid key \
+from a non-allowlisted address returns 403. The security scheme below documents \
+the header; the IP allowlist is enforced at the network layer and cannot be \
+expressed as an OpenAPI scheme."
+    ),
+    paths(
+        crate::tokenized_asset::api::get_tokenized_asset,
+        crate::tokenized_asset::api::get_tokenized_asset_status,
+        crate::tokenized_asset::api::add_tokenized_asset,
+        crate::account::api::register_account,
+        crate::account::api::whitelist_wallet,
+        crate::account::api::unwhitelist_wallet,
+        crate::admin::recover_redemption,
+        crate::admin::close_redemption,
+        crate::admin::force_complete_redemption,
+        crate::admin::reprocess_mint,
+        crate::admin::close_mint,
+        crate::admin::list_stuck,
+        crate::admin::check_fireblocks_tx,
+    ),
+    components(schemas(
+        st0x_issuance_dto::TokenizedAssetDetailResponse,
+        st0x_issuance_dto::TokenizedAssetStatusResponse,
+        st0x_issuance_dto::TokenizedAssetStatus,
+        st0x_issuance_dto::AddTokenizedAssetRequest,
+        st0x_issuance_dto::AddTokenizedAssetResponse,
+        st0x_issuance_dto::UnderlyingSymbol,
+        st0x_issuance_dto::TokenSymbol,
+        st0x_issuance_dto::Network,
+        crate::account::api::RegisterAccountRequest,
+        crate::account::api::RegisterAccountResponse,
+        crate::account::api::WhitelistWalletRequest,
+        crate::account::api::WhitelistWalletResponse,
+        crate::admin::AggregateKind,
+        crate::admin::ReprocessResponse,
+        crate::admin::StuckAggregate,
+        crate::admin::StuckResponse,
+        crate::admin::CloseRedemptionRequest,
+        crate::admin::ForceCompleteRedemptionRequest,
+        crate::admin::CloseMintRequest,
+        crate::admin::FireblocksTxResponse,
+        crate::vault::FireblocksTxStatus,
+    )),
+    modifiers(&SecurityAddon),
+    tags(
+        (name = "tokenized-assets",
+            description = "Internal tokenized-asset administration"),
+        (name = "accounts", description = "Internal account management"),
+        (name = "admin", description = "Operator admin and recovery endpoints")
+    )
+)]
+pub(crate) struct ApiDoc;
+
+/// Registers the `X-API-KEY` header auth scheme that the internal/admin
+/// endpoints reference via `security(("internal_api_key" = []))`.
+struct SecurityAddon;
+
+impl Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        let components =
+            openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "internal_api_key",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new(
+                "X-API-KEY",
+            ))),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn documents_internal_surface_and_excludes_alpaca_itn() {
+        let spec = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let paths = spec["paths"].as_object().expect("paths object");
+
+        // Every internal/operator endpoint is documented. Listed exhaustively
+        // (not a representative sample) so dropping a `#[utoipa::path]` from the
+        // `ApiDoc` `paths(...)` set fails the test rather than silently shrinking
+        // the published surface. `/tokenized-assets` (POST) is asserted below
+        // alongside the GET-exclusion check.
+        for path in [
+            "/tokenized-assets/{underlying}",
+            "/tokenized-assets/{underlying}/status",
+            "/accounts",
+            "/accounts/{client_id}/wallets",
+            "/accounts/{client_id}/wallets/{wallet}",
+            "/admin/stuck",
+            "/admin/fireblocks/tx/{fireblocks_tx_id}",
+            "/admin/recover/redemption/{issuer_request_id}",
+            "/admin/close/redemption/{issuer_request_id}",
+            "/admin/force-complete/redemption/{issuer_request_id}",
+            "/admin/reprocess/mint/{aggregate_id}",
+            "/admin/close/mint/{aggregate_id}",
+        ] {
+            assert!(
+                paths.contains_key(path),
+                "missing documented path: {path}"
+            );
+        }
+
+        // The add-asset POST is documented, but the GET list is the Alpaca ITN
+        // endpoint and must NOT be: same path, different method.
+        assert!(paths["/tokenized-assets"]["post"].is_object());
+        assert!(
+            paths["/tokenized-assets"].get("get").is_none(),
+            "GET /tokenized-assets is an Alpaca ITN endpoint and must be excluded"
+        );
+
+        // The remaining Alpaca ITN endpoints are absent entirely.
+        for path in [
+            "/accounts/connect",
+            "/inkind/issuance",
+            "/inkind/issuance/confirm",
+        ] {
+            assert!(
+                !paths.contains_key(path),
+                "Alpaca ITN endpoint must be excluded: {path}"
+            );
+        }
+
+        // The X-API-KEY auth scheme the endpoints reference is registered, with
+        // the exact semantics clients depend on. Asserting type/in/name (not just
+        // presence) catches a drift away from the `X-API-KEY` header apiKey form.
+        let scheme = &spec["components"]["securitySchemes"]["internal_api_key"];
+        assert!(
+            scheme.is_object(),
+            "internal_api_key security scheme must be registered"
+        );
+        assert_eq!(scheme["type"], "apiKey");
+        assert_eq!(scheme["in"], "header");
+        assert_eq!(scheme["name"], "X-API-KEY");
+    }
+
+    // The DTO `ToSchema` derives and `schema(value_type = String)` overrides are
+    // the OpenAPI half of the wire contract (the serde and ts_rs halves are
+    // pinned in the dto crate's own tests). Without this, dropping a derive or a
+    // `value_type` override silently drifts the published schema -- e.g. the
+    // `UnderlyingSymbol(String)` newtype leaking as a wrapper object, or `vault`
+    // exposing alloy's `Address` representation instead of the 0x-hex string the
+    // dashboard parses. Assert the component shapes, not just their presence.
+    #[test]
+    fn dto_component_schemas_match_the_wire_contract() {
+        let spec = serde_json::to_value(ApiDoc::openapi()).unwrap();
+        let schemas =
+            spec["components"]["schemas"].as_object().expect("schemas object");
+
+        // The symbol newtypes are transparent strings on the wire: utoipa must
+        // unwrap `UnderlyingSymbol(String)`/`TokenSymbol(String)` to a bare
+        // string schema, never a `{ "0": string }` wrapper object.
+        assert_eq!(schemas["UnderlyingSymbol"]["type"], "string");
+        assert_eq!(schemas["TokenSymbol"]["type"], "string");
+
+        // `vault` carries `schema(value_type = String)` to override alloy's
+        // `Address`; the override must hold in both the request and the detail
+        // response so the schema advertises the 0x-hex string clients parse.
+        assert_eq!(
+            schemas["AddTokenizedAssetRequest"]["properties"]["vault"]["type"],
+            "string"
+        );
+        assert_eq!(
+            schemas["TokenizedAssetDetailResponse"]["properties"]["vault"]["type"],
+            "string"
+        );
+
+        // `Network` and `TokenizedAssetStatus` are closed enums; their schema
+        // must be a string enum over the exact lowercase wire values clients
+        // switch on, not an open string or a struct.
+        assert_eq!(schemas["Network"]["type"], "string");
+        assert_eq!(schemas["Network"]["enum"], serde_json::json!(["base"]));
+        assert_eq!(schemas["TokenizedAssetStatus"]["type"], "string");
+        assert_eq!(
+            schemas["TokenizedAssetStatus"]["enum"],
+            serde_json::json!(["enabled", "frozen"])
+        );
+    }
+}

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -25,7 +25,7 @@ use crate::bindings::{
     CloneFactory, OffchainAssetReceiptVault,
     OffchainAssetReceiptVaultAuthorizerV1, Receipt,
 };
-use crate::config::{Config, LogLevel};
+use crate::config::{Config, Environment, LogLevel};
 use crate::fireblocks::SignerConfig;
 use crate::mint::{Mint, MintServices};
 use crate::receipt_inventory::{
@@ -65,6 +65,7 @@ fn test_config() -> Result<Config, anyhow::Error> {
         receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
         auth: test_auth_config()?,
         log_level: LogLevel::Debug,
+        environment: Environment::Development,
         hyperdx: None,
         alpaca: AlpacaConfig::test_default(),
         subgraph_url: Url::parse("http://localhost:0/subgraph")?,

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -17,6 +17,22 @@ use super::{
 };
 use crate::auth::{InternalAuth, IssuerAuth};
 
+#[utoipa::path(
+    get,
+    path = "/tokenized-assets/{underlying}",
+    tag = "tokenized-assets",
+    params(
+        ("underlying" = String, Path,
+            description = "Underlying equity symbol, e.g. SGOV")
+    ),
+    responses(
+        (status = 200, description = "Asset detail including freeze status",
+            body = TokenizedAssetDetailResponse),
+        (status = 404, description = "Unknown asset"),
+        (status = 500, description = "View load or deserialization failure")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, pool))]
 #[get("/tokenized-assets/<underlying>")]
 pub(crate) async fn get_tokenized_asset(
@@ -55,6 +71,23 @@ pub(crate) async fn get_tokenized_asset(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/tokenized-assets/{underlying}/status",
+    tag = "tokenized-assets",
+    params(
+        ("underlying" = String, Path,
+            description = "Underlying equity symbol, e.g. SGOV")
+    ),
+    responses(
+        (status = 200, description = "Per-asset freeze status",
+            body = TokenizedAssetStatusResponse),
+        (status = 404, description = "Unknown asset"),
+        (status = 500,
+            description = "Indeterminate (view load failure); retry, do not treat as enabled")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, pool))]
 #[get("/tokenized-assets/<underlying>/status")]
 pub(crate) async fn get_tokenized_asset_status(
@@ -111,6 +144,18 @@ pub(crate) async fn list_tokenized_assets(
     Ok(Json(TokenizedAssetsListResponse { tokens }))
 }
 
+#[utoipa::path(
+    post,
+    path = "/tokenized-assets",
+    tag = "tokenized-assets",
+    request_body = AddTokenizedAssetRequest,
+    responses(
+        (status = 201, description = "Asset added (idempotent: also 201 if it already existed)",
+            body = AddTokenizedAssetResponse),
+        (status = 500, description = "Failed to add asset")
+    ),
+    security(("internal_api_key" = []))
+)]
 #[tracing::instrument(skip(_auth, store), fields(
     underlying = %request.underlying,
     token = %request.token,
@@ -164,7 +209,7 @@ mod tests {
     use super::*;
     use crate::alpaca::service::AlpacaConfig;
     use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-    use crate::config::{Config, LogLevel};
+    use crate::config::{Config, Environment, LogLevel};
     use crate::fireblocks::SignerConfig;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
@@ -182,6 +227,7 @@ mod tests {
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             auth: test_auth_config().unwrap(),
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -1,4 +1,4 @@
-mod api;
+pub(crate) mod api;
 pub(crate) mod cli;
 mod cmd;
 mod event;

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -190,11 +190,15 @@ pub(crate) fn verify_burn_in_receipt(
 }
 
 /// Status of a Fireblocks transaction, as returned by `check_fireblocks_tx`.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 #[serde(tag = "status", rename_all = "snake_case")]
 pub(crate) enum FireblocksTxStatus {
     /// Transaction completed on-chain.
-    Completed { tx_hash: B256, block_number: u64 },
+    Completed {
+        #[schema(value_type = String)]
+        tx_hash: B256,
+        block_number: u64,
+    },
     /// Transaction is still pending (submitted, confirming, etc.).
     Pending,
     /// Transaction reached a terminal failure status.

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -27,8 +27,8 @@ use st0x_issuance::test_utils::{
     LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT, ROLE_WITHDRAW,
 };
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, IpWhitelist, LogLevel,
-    SignerConfig,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
+    LogLevel, SignerConfig,
 };
 
 pub async fn wait_for_shares<T>(
@@ -515,6 +515,7 @@ pub fn create_config_with_db(
                     .expect("Valid IP ranges"),
             },
             log_level: LogLevel::Debug,
+            environment: Environment::Development,
             hyperdx: None,
             alpaca: AlpacaConfig {
                 api_base_url: mock_alpaca.base_url(),

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -18,8 +18,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::bindings::Receipt::ReceiptInstance;
 use st0x_issuance::test_utils::{LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT};
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, IpWhitelist, LogLevel,
-    SignerConfig, initialize_rocket,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
+    LogLevel, SignerConfig, initialize_rocket,
 };
 
 async fn wait_for_receipt_depleted(
@@ -303,6 +303,7 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
                 .expect("Valid IP ranges"),
         },
         log_level: LogLevel::Debug,
+        environment: Environment::Development,
         hyperdx: None,
         alpaca: AlpacaConfig {
             api_base_url: mock_alpaca.base_url(),

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -14,8 +14,8 @@ use url::Url;
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, IpWhitelist, LogLevel,
-    SignerConfig, initialize_rocket,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
+    LogLevel, SignerConfig, initialize_rocket,
 };
 
 #[tokio::test]
@@ -60,6 +60,7 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
                 .expect("Valid IP ranges"),
         },
         log_level: LogLevel::Debug,
+        environment: Environment::Development,
         hyperdx: None,
         alpaca: AlpacaConfig {
             api_base_url: mock_alpaca.base_url(),


### PR DESCRIPTION
## Motivation

The internal and operator (admin) HTTP endpoints had no machine-readable API
description, so there was nothing to generate clients from or hand to operators.
The Alpaca ITN endpoints are deliberately out of scope -- their contract is
governed by Alpaca's own documentation, not ours.

## Solution

Adds utoipa OpenAPI generation and a served Swagger UI:

- `utoipa` 5 (`rocket_extras`) + `utoipa-swagger-ui` 9 (`rocket`). `utoipa` is an
  **optional feature on the shared `st0x-issuance-dto` crate**, enabled by the
  server, so st0x.liquidity (which also consumes the crate) does not inherit it.
- `#[utoipa::path]` on the 13 internal/operator endpoints (tokenized-asset
  detail/status/add, account register/whitelist/unwhitelist, all `/admin/*`),
  `ToSchema` on their DTOs, and an `X-API-KEY` security scheme.
- The 4 Alpaca ITN endpoints (`/accounts/connect`, `GET /tokenized-assets`,
  `/inkind/issuance`, `/inkind/issuance/confirm`) are intentionally excluded.
- Served at `GET /api-docs/openapi.json`, Swagger UI at `/swagger-ui/`.

A unit test pins that the spec documents the internal surface and excludes the
Alpaca ITN endpoints. `alloy`/UUID/`Decimal`/`DateTime` fields are documented as
their JSON string forms via `schema(value_type = String)`.

Stacked on #188.

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added interactive Swagger UI and an OpenAPI spec at `/api-docs/openapi.json`.
  * Expanded Swagger/OpenAPI coverage for account, tokenized-asset, and administrative/operator endpoints with request/response schemas and operation metadata.

* **Documentation**
  * Improved schema accuracy for specific fields (string representations) to match existing wire behavior.

* **Configuration**
  * API docs are now mounted only in non-production environments; added `ENVIRONMENT` to `.env.example` and environment handling to configuration and tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->