### PR TITLE
fix: unknown completed variant

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1841,6 +1841,24 @@ that snapshot, rather than replaying all events from the beginning. Snapshots
 can be deleted at any time - aggregates can always be rebuilt from the event
 store alone.
 
+**Snapshot schema versioning**: event-sorcery wraps each aggregate in
+`Lifecycle<Entity>` (`Uninitialized` / `Live` / `Failed`). Snapshot payloads
+therefore serialize as `{"Live": {<entity>}}`, not as the bare entity enum (e.g.
+`{"Completed": {...}}`). A snapshot written before a wire-format change is
+incompatible and bricks startup on deserialize.
+
+Each `EventSourced` aggregate declares `SCHEMA_VERSION`. On every
+`StoreBuilder::build`, the schema reconciler compares the stored version
+(registered in the `SchemaRegistry` event stream) against the code version. When
+they differ, all snapshots for that aggregate type are deleted before any load
+or projection catch-up runs. **Any change to aggregate snapshot serialization —
+including wrapping in `Lifecycle` — MUST bump `SCHEMA_VERSION`.** Startup also
+purges any snapshot rows whose payload is not `Lifecycle`-shaped (covers the
+case where the registry already records the new version but stale rows remain).
+Canonical `Table` projections for the same aggregate are cleared when schema
+reconciliation detects a version change, before `StoreBuilder::build` projection
+catch-up.
+
 ### View Tables
 
 All view tables follow the same pattern: `view_id` (primary key), `version`

--- a/src/account/mod.rs
+++ b/src/account/mod.rs
@@ -132,7 +132,7 @@ impl EventSourced for Account {
 
     const AGGREGATE_TYPE: &'static str = "Account";
     const PROJECTION: Table = Table("account_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -297,15 +297,18 @@ pub(crate) enum AccountError {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
-    use event_sorcery::{LifecycleError, TestHarness, replay};
+    use chrono::Utc;
+    use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
+    use sqlx::sqlite::SqlitePoolOptions;
     use tracing::Level;
     use tracing_test::traced_test;
-    use uuid::Uuid;
+    use uuid::{Uuid, uuid};
 
     use super::{
         Account, AccountCommand, AccountError, AccountEvent,
         AlpacaAccountNumber, ClientId, Email,
     };
+    use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
 
     #[tokio::test]
@@ -916,5 +919,177 @@ mod tests {
             Level::ERROR,
             &["cqrs", "lifecycle failed during evolve"]
         ));
+    }
+
+    /// Regression: pre-event-sorcery snapshot and `account_view` payloads must
+    /// be cleared before `StoreBuilder::build` projection catch-up.
+    #[tokio::test]
+    async fn pre_lifecycle_snapshot_and_view_cleared_before_store_build() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let client_id = ClientId(uuid!("6ba7b810-9dad-11d1-80b4-00c04fd430c9"));
+        let client_id_str = client_id.to_string();
+        let now = Utc::now();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Account", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Account',
+                ?,
+                1,
+                'AccountEvent::Registered',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(client_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Registered": {
+                    "client_id": client_id_str,
+                    "email": "user@example.com",
+                    "registered_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let stale = serde_json::json!({
+            "LinkedToAlpaca": {
+                "client_id": client_id_str,
+                "email": "user@example.com",
+                "alpaca_account": "ALPACA-1",
+                "whitelisted_wallets": [],
+                "registered_at": now,
+                "linked_at": now,
+            }
+        });
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'Account',
+                ?,
+                1,
+                0,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(client_id_str.as_str())
+        .bind(stale.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO account_view (view_id, version, payload) VALUES (?, 1, ?)",
+        )
+        .bind(client_id_str.as_str())
+        .bind(stale.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        prepare_event_sourced_startup::<Account>(&pool).await.unwrap();
+
+        StoreBuilder::<Account>::new(pool.clone()).build(()).await.unwrap();
+
+        let stale_snapshot_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM snapshots
+            WHERE aggregate_type = 'Account'
+              AND aggregate_id = ?
+            ",
+        )
+        .bind(client_id_str.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stale_snapshot_count, 0,
+            "Startup must clear incompatible Account snapshots"
+        );
+
+        let view_payload: String = sqlx::query_scalar(
+            "SELECT payload FROM account_view WHERE view_id = ?",
+        )
+        .bind(client_id_str.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&view_payload).unwrap();
+        assert!(
+            payload
+                .get("Live")
+                .and_then(|live| live.get("Registered"))
+                .is_some(),
+            "Projection catch-up must rebuild account_view with Lifecycle payload, got {payload}"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 use alloy::primitives::{Address, U256};
 use alloy::providers::Provider;
-use event_sorcery::{Store, StoreBuilder};
+use event_sorcery::{
+    EventSourced, ReconcileError, Reconciler, Store, StoreBuilder,
+};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use rocket::routes;
 use rust_decimal::{Decimal, prelude::ToPrimitive};
@@ -222,12 +224,15 @@ pub async fn initialize_rocket(
     let pool = create_pool(&config).await?;
     sqlx::migrate!("./migrations").run(&pool).await?;
 
+    prepare_event_sourced_startup::<TokenizedAsset>(&pool).await?;
     let (tokenized_asset_store, _tokenized_asset_projection) =
         StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
 
+    prepare_event_sourced_startup::<Account>(&pool).await?;
     let (account_store, _account_projection) =
         StoreBuilder::<Account>::new(pool.clone()).build(()).await?;
 
+    prepare_event_sourced_startup::<ReceiptInventory>(&pool).await?;
     let receipt_inventory_store =
         StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
 
@@ -441,6 +446,7 @@ async fn setup_aggregate_cqrs(
     // Mint's canonical `mint_view` projection is auto-wired by StoreBuilder; the
     // secondary `receipt_inventory_view` (formerly a View<Mint> GenericQuery) is
     // maintained by the registered reactor.
+    prepare_event_sourced_startup::<Mint>(pool).await?;
     let (mint_store, mint_projection) = StoreBuilder::<Mint>::new(pool.clone())
         .with(Arc::new(ReceiptInventoryViewReactor::new(pool.clone())))
         .build(mint_services)
@@ -459,6 +465,7 @@ async fn setup_aggregate_cqrs(
     // Failed and tracking re-entry timestamps the aggregate state discards) and
     // `receipt_burns_view` (burns keyed by redemption aggregate_id, joined with
     // receipt_inventory_view at query time to compute available balance).
+    prepare_event_sourced_startup::<Redemption>(pool).await?;
     let redemption_store = StoreBuilder::<Redemption>::new(pool.clone())
         .with(Arc::new(RedemptionViewReactor::new(pool.clone())))
         .with(Arc::new(ReceiptBurnsViewReactor::new(pool.clone())))
@@ -466,6 +473,98 @@ async fn setup_aggregate_cqrs(
         .await?;
 
     Ok(AggregateCqrsSetup { mint_store, redemption_store })
+}
+
+/// Startup hygiene for event-sourced aggregates before `StoreBuilder::build`.
+///
+/// 1. Schema reconciliation — clears all snapshots when `SCHEMA_VERSION` changed
+/// 2. Purges any remaining snapshots whose payload is not `Lifecycle`-shaped
+/// 3. Clears canonical `Table` projections when schema version changed
+///    (`catch_up` runs before `rebuild_all` and would brick on stale rows)
+pub(crate) async fn prepare_event_sourced_startup<Entity>(
+    pool: &Pool<Sqlite>,
+) -> Result<(), ReconcileError>
+where
+    Entity: EventSourced,
+{
+    let schema_changed =
+        Reconciler::new(pool.clone()).reconcile::<Entity>().await?;
+
+    let purged =
+        purge_incompatible_lifecycle_snapshots(pool, Entity::AGGREGATE_TYPE)
+            .await?;
+
+    if purged > 0 {
+        info!(
+            target: "startup",
+            aggregate = Entity::AGGREGATE_TYPE,
+            purged,
+            "Purged incompatible snapshot rows"
+        );
+    }
+
+    if schema_changed {
+        clear_canonical_projection_for_aggregate(pool, Entity::AGGREGATE_TYPE)
+            .await?;
+    }
+
+    Ok(())
+}
+
+async fn purge_incompatible_lifecycle_snapshots(
+    pool: &Pool<Sqlite>,
+    aggregate_type: &str,
+) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query!(
+        "
+        DELETE FROM snapshots
+        WHERE aggregate_type = ?
+          AND json_extract(payload, '$.Live') IS NULL
+          AND json_extract(payload, '$.Uninitialized') IS NULL
+          AND json_extract(payload, '$.Failed') IS NULL
+        ",
+        aggregate_type
+    )
+    .execute(pool)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+async fn clear_canonical_projection_for_aggregate(
+    pool: &Pool<Sqlite>,
+    aggregate_type: &str,
+) -> Result<(), ReconcileError> {
+    let table = match aggregate_type {
+        "Account" => "account_view",
+        "Mint" => "mint_view",
+        "TokenizedAsset" => "tokenized_asset_view",
+        _ => return Ok(()),
+    };
+
+    info!(
+        target: "startup",
+        aggregate = aggregate_type,
+        table,
+        "Clearing canonical projection after schema version change",
+    );
+
+    match table {
+        "account_view" => {
+            sqlx::query!("DELETE FROM account_view").execute(pool).await?
+        }
+        "mint_view" => {
+            sqlx::query!("DELETE FROM mint_view").execute(pool).await?
+        }
+        "tokenized_asset_view" => {
+            sqlx::query!("DELETE FROM tokenized_asset_view")
+                .execute(pool)
+                .await?
+        }
+        _ => unreachable!("table derived from supported aggregate types"),
+    };
+
+    Ok(())
 }
 
 fn setup_redemption_managers(

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1781,7 +1781,7 @@ impl EventSourced for Mint {
 
     const AGGREGATE_TYPE: &'static str = "Mint";
     const PROJECTION: Table = Table("mint_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -2142,7 +2142,7 @@ pub(crate) mod tests {
     use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
-    use uuid::Uuid;
+    use uuid::{Uuid, uuid};
 
     use super::{
         AutomaticRetryDecision, ClientId, IssuerMintRequestId, Mint,
@@ -2151,8 +2151,9 @@ pub(crate) mod tests {
         UnderlyingSymbol, find_by_issuer_request_id,
     };
     use crate::alpaca::mock::MockAlpacaService;
+    use crate::prepare_event_sourced_startup;
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::log_count_at;
+    use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
@@ -3432,6 +3433,405 @@ pub(crate) mod tests {
                 .unwrap();
 
         (mint_store, pool)
+    }
+
+    /// Regression: pre-event-sorcery snapshot payloads (`{"Completed": ...}`)
+    /// must be cleared by schema reconciliation before projection catch-up
+    /// calls `load_with_context`, which deserializes into `Lifecycle<Mint>`.
+    #[traced_test]
+    #[tokio::test]
+    async fn pre_lifecycle_snapshot_cleared_before_projection_catch_up() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let mint_id = IssuerMintRequestId::new(uuid!(
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+        let mint_id_str = mint_id.to_string();
+        let now = Utc::now();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Mint", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                ?,
+                1,
+                'MintEvent::Initiated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(mint_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Initiated": {
+                    "issuer_request_id": mint_id_str,
+                    "tokenization_request_id": "tok-stale",
+                    "quantity": "1.0",
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "network": "base",
+                    "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                    "wallet": "0x1234567890123456789012345678901234567890",
+                    "initiated_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'Mint',
+                ?,
+                1,
+                0,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(mint_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Completed": {
+                    "issuer_request_id": mint_id_str,
+                    "tokenization_request_id": "tok-stale",
+                    "quantity": "1.0",
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "network": "base",
+                    "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                    "wallet": "0x1234567890123456789012345678901234567890",
+                    "initiated_at": now,
+                    "journal_confirmed_at": now,
+                    "tx_hash": "0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d",
+                    "receipt_id": "1",
+                    "shares_minted": "1000000000000000000",
+                    "gas_used": 21000,
+                    "block_number": 1,
+                    "minted_at": now,
+                    "completed_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let (asset_store, _asset_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        asset_store
+            .send(
+                &UnderlyingSymbol::new("AAPL"),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL"),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::new("base"),
+                    vault: VAULT,
+                },
+            )
+            .await
+            .unwrap();
+
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+
+        let services = MintServices {
+            vault: Arc::new(MockVaultService::new_success()),
+            alpaca: Arc::new(MockAlpacaService::new_success()),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool: pool.clone(),
+            bot: BOT,
+        };
+
+        prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
+        StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
+
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Cleared stale snapshots", "Mint"]
+        ));
+
+        let stale_snapshot_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM snapshots
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+            ",
+        )
+        .bind(mint_id_str.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stale_snapshot_count, 0,
+            "Schema reconciliation must delete incompatible Mint snapshots"
+        );
+    }
+
+    async fn seed_pre_lifecycle_mint_view_row(
+        pool: &Pool<Sqlite>,
+        mint_id: &str,
+        version: i64,
+        payload: &serde_json::Value,
+    ) {
+        sqlx::query(
+            "
+            INSERT INTO mint_view (view_id, version, payload)
+            VALUES (?, ?, ?)
+            ",
+        )
+        .bind(mint_id)
+        .bind(version)
+        .bind(payload.to_string())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    /// Regression: pre-event-sorcery `mint_view` payloads (`{"Completed": ...}`)
+    /// must be cleared on schema version change before projection catch-up calls
+    /// `load_with_context`, which deserializes into `Lifecycle<Mint>`.
+    #[tokio::test]
+    async fn pre_lifecycle_mint_view_cleared_before_projection_catch_up() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let mint_id = IssuerMintRequestId::new(uuid!(
+            "550e8400-e29b-41d4-a716-446655440000"
+        ));
+        let mint_id_str = mint_id.to_string();
+        let now = Utc::now();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Mint", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                ?,
+                1,
+                'MintEvent::Initiated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(mint_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Initiated": {
+                    "issuer_request_id": mint_id_str,
+                    "tokenization_request_id": "tok-stale-view",
+                    "quantity": "1.0",
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "network": "base",
+                    "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                    "wallet": "0x1234567890123456789012345678901234567890",
+                    "initiated_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        seed_pre_lifecycle_mint_view_row(
+            &pool,
+            &mint_id_str,
+            1,
+            &serde_json::json!({
+                "Completed": {
+                    "issuer_request_id": mint_id_str,
+                    "tokenization_request_id": "tok-stale-view",
+                    "quantity": "1.0",
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "network": "base",
+                    "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                    "wallet": "0x1234567890123456789012345678901234567890",
+                    "initiated_at": now,
+                    "journal_confirmed_at": now,
+                    "tx_hash": "0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d",
+                    "receipt_id": "1",
+                    "shares_minted": "1000000000000000000",
+                    "gas_used": 21000,
+                    "block_number": 1,
+                    "minted_at": now,
+                    "completed_at": now,
+                }
+            }),
+        )
+        .await;
+
+        let (asset_store, _asset_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+
+        asset_store
+            .send(
+                &UnderlyingSymbol::new("AAPL"),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL"),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::new("base"),
+                    vault: VAULT,
+                },
+            )
+            .await
+            .unwrap();
+
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+
+        let services = MintServices {
+            vault: Arc::new(MockVaultService::new_success()),
+            alpaca: Arc::new(MockAlpacaService::new_success()),
+            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool: pool.clone(),
+            bot: BOT,
+        };
+
+        prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
+        StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
+
+        let view_payload: String = sqlx::query_scalar(
+            "
+            SELECT payload
+            FROM mint_view
+            WHERE view_id = ?
+            ",
+        )
+        .bind(mint_id_str.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&view_payload).unwrap();
+        assert!(
+            payload
+                .get("Live")
+                .and_then(|live| live.get("Initiated"))
+                .is_some(),
+            "Projection catch-up must rebuild mint_view with Lifecycle payload, got {payload}"
+        );
     }
 
     #[tokio::test]

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -1038,7 +1038,7 @@ impl EventSourced for ReceiptInventory {
 
     const AGGREGATE_TYPE: &'static str = "ReceiptInventory";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -1131,12 +1131,14 @@ fn required_burns_by_receipt(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Bytes, TxHash, address, b256};
-    use event_sorcery::test_store;
+    use event_sorcery::{StoreBuilder, test_store};
+    use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
 
     const TEST_OA_SCHEMA: &str =
@@ -2926,6 +2928,110 @@ mod tests {
             receipts[0].receipt_info,
             Some(receipt_info),
             "receipt_info should be stored by register_minted_receipt"
+        );
+    }
+
+    /// Regression: pre-event-sorcery snapshot payloads must be cleared before
+    /// `StoreBuilder::build` projection catch-up.
+    #[tokio::test]
+    async fn pre_lifecycle_snapshot_cleared_before_store_build() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let aggregate_id = format!("{vault:#x}");
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "ReceiptInventory", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'ReceiptInventory',
+                ?,
+                1,
+                0,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(aggregate_id.as_str())
+        .bind(
+            serde_json::json!({
+                "receipts": {},
+                "itn_receipts": {},
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        prepare_event_sourced_startup::<ReceiptInventory>(&pool).await.unwrap();
+        StoreBuilder::<ReceiptInventory>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let stale_snapshot_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM snapshots
+            WHERE aggregate_type = 'ReceiptInventory'
+              AND aggregate_id = ?
+            ",
+        )
+        .bind(aggregate_id.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stale_snapshot_count, 0,
+            "Startup must clear incompatible ReceiptInventory snapshots"
         );
     }
 }

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -828,7 +828,7 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {
@@ -1271,9 +1271,10 @@ impl Redemption {
 mod tests {
     use alloy::primitives::{TxHash, U256, address, b256, uint};
     use chrono::Utc;
-    use event_sorcery::{LifecycleError, TestHarness, replay};
+    use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
+    use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
 
     use super::{
@@ -1283,6 +1284,7 @@ mod tests {
         next_burn_retry_external_tx_id_from_history,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
+    use crate::prepare_event_sourced_startup;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{MultiBurnEntry, VaultService};
@@ -3191,5 +3193,158 @@ mod tests {
             prop_assert!(display.starts_with("0x"));
             prop_assert_eq!(display.len(), 66);
         }
+    }
+
+    /// Regression: pre-event-sorcery snapshot payloads must be cleared before
+    /// `StoreBuilder::build` projection catch-up.
+    #[tokio::test]
+    async fn pre_lifecycle_snapshot_cleared_before_store_build() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let tx_hash = b256!(
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+        let redemption_id = IssuerRedemptionRequestId::new(tx_hash);
+        let redemption_id_str = redemption_id.to_string();
+        let now = Utc::now();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Redemption", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                1,
+                'RedemptionEvent::Detected',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(redemption_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Detected": {
+                    "issuer_request_id": redemption_id_str,
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "wallet": "0x1234567890123456789012345678901234567890",
+                    "quantity": "1.0",
+                    "tx_hash": redemption_id_str,
+                    "block_number": 1,
+                    "detected_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                1,
+                0,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(redemption_id_str.as_str())
+        .bind(
+            serde_json::json!({
+                "Completed": {
+                    "issuer_request_id": redemption_id_str,
+                    "burn_tx_hash": redemption_id_str,
+                    "completed_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        prepare_event_sourced_startup::<Redemption>(&pool).await.unwrap();
+        StoreBuilder::<Redemption>::new(pool.clone())
+            .build(mock_services())
+            .await
+            .unwrap();
+
+        let stale_snapshot_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM snapshots
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+            ",
+        )
+        .bind(redemption_id_str.as_str())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stale_snapshot_count, 0,
+            "Startup must clear incompatible Redemption snapshots"
+        );
     }
 }

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -117,7 +117,7 @@ impl EventSourced for TokenizedAsset {
 
     const AGGREGATE_TYPE: &'static str = "TokenizedAsset";
     const PROJECTION: Table = Table("tokenized_asset_view");
-    const SCHEMA_VERSION: u64 = 1;
+    const SCHEMA_VERSION: u64 = 2;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -300,13 +300,16 @@ impl EventSourced for TokenizedAsset {
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{Address, address};
-    use event_sorcery::{TestHarness, replay};
+    use chrono::Utc;
+    use event_sorcery::{StoreBuilder, TestHarness, replay};
+    use sqlx::sqlite::SqlitePoolOptions;
     use tracing_test::traced_test;
 
     use super::{
         AssetStatus, Network, TokenSymbol, TokenizedAsset,
         TokenizedAssetCommand, TokenizedAssetEvent, UnderlyingSymbol,
     };
+    use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
 
     #[traced_test]
@@ -726,5 +729,182 @@ mod tests {
     fn test_network_display() {
         let network = Network::new("base");
         assert_eq!(format!("{network}"), "base");
+    }
+
+    /// Regression: pre-event-sorcery snapshot and `tokenized_asset_view` payloads
+    /// must be cleared before `StoreBuilder::build` projection catch-up.
+    #[tokio::test]
+    async fn pre_lifecycle_snapshot_and_view_cleared_before_store_build() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let underlying = "AAPL";
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let now = Utc::now();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "TokenizedAsset", "version": 1 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'TokenizedAsset',
+                ?,
+                1,
+                'TokenizedAssetEvent::Added',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(underlying)
+        .bind(
+            serde_json::json!({
+                "Added": {
+                    "underlying": underlying,
+                    "token": "tAAPL",
+                    "network": "base",
+                    "vault": vault,
+                    "added_at": now,
+                }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let stale = serde_json::json!({
+            "underlying": underlying,
+            "token": "tAAPL",
+            "network": "base",
+            "vault": vault,
+            "status": "Enabled",
+            "added_at": now,
+        });
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'TokenizedAsset',
+                ?,
+                1,
+                0,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(underlying)
+        .bind(stale.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES (?, 1, ?)
+            ",
+        )
+        .bind(underlying)
+        .bind(stale.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        prepare_event_sourced_startup::<TokenizedAsset>(&pool).await.unwrap();
+        StoreBuilder::<TokenizedAsset>::new(pool.clone())
+            .build(())
+            .await
+            .unwrap();
+
+        let stale_snapshot_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM snapshots
+            WHERE aggregate_type = 'TokenizedAsset'
+              AND aggregate_id = ?
+            ",
+        )
+        .bind(underlying)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            stale_snapshot_count, 0,
+            "Startup must clear incompatible TokenizedAsset snapshots"
+        );
+
+        let view_payload: String = sqlx::query_scalar(
+            "SELECT payload FROM tokenized_asset_view WHERE view_id = ?",
+        )
+        .bind(underlying)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+        let payload: serde_json::Value =
+            serde_json::from_str(&view_payload).unwrap();
+        assert!(
+            payload
+                .get("Live")
+                .and_then(|live| live.get("underlying"))
+                .is_some(),
+            "Projection catch-up must rebuild tokenized_asset_view with Lifecycle payload, got {payload}"
+        );
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -501,3 +501,139 @@ pub async fn perform_mint_and_confirm_with(
 
     Ok(issuer_request_id)
 }
+
+/// Seeds a `SchemaRegistry` event recording the last-known schema version for
+/// an aggregate. Used in setup phases to simulate production DB state before a
+/// `SCHEMA_VERSION` bump.
+pub async fn seed_schema_registry_version(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    aggregate_name: &str,
+    version: u64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sequence: i64 = sqlx::query_scalar(
+        "
+        SELECT COALESCE(MAX(sequence), 0) + 1
+        FROM events
+        WHERE aggregate_type = 'SchemaRegistry'
+          AND aggregate_id = 'schema'
+        ",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let payload = json!({
+        "VersionUpdated": {
+            "name": aggregate_name,
+            "version": version,
+        }
+    })
+    .to_string();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'SchemaRegistry',
+            'schema',
+            ?,
+            'SchemaRegistryEvent::VersionUpdated',
+            '1.0',
+            ?,
+            '{}'
+        )
+        ",
+    )
+    .bind(sequence)
+    .bind(payload)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Inserts a pre-event-sorcery snapshot row: bare aggregate enum JSON (e.g.
+/// `{"Completed": {...}}`) rather than the `Lifecycle` wrapper
+/// (`{"Live": {...}}`). Reproduces production DB state that bricks startup if
+/// stale snapshots are not cleared before projection catch-up.
+pub async fn seed_pre_lifecycle_snapshot(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    aggregate_type: &str,
+    aggregate_id: &str,
+    last_sequence: i64,
+    payload: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    sqlx::query(
+        "
+        INSERT INTO snapshots (
+            aggregate_type,
+            aggregate_id,
+            last_sequence,
+            snapshot_version,
+            payload,
+            timestamp
+        )
+        VALUES (?, ?, ?, 0, ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        ",
+    )
+    .bind(aggregate_type)
+    .bind(aggregate_id)
+    .bind(last_sequence)
+    .bind(payload.to_string())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Inserts a pre-event-sorcery canonical projection row (bare aggregate JSON).
+pub async fn seed_pre_lifecycle_view_row(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    table: &str,
+    view_id: &str,
+    version: i64,
+    payload: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let query = match table {
+        "account_view" => {
+            "
+            INSERT INTO account_view (view_id, version, payload)
+            VALUES (?, ?, ?)
+        "
+        }
+        "mint_view" => {
+            "
+            INSERT INTO mint_view (view_id, version, payload)
+            VALUES (?, ?, ?)
+        "
+        }
+        "tokenized_asset_view" => {
+            "
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES (?, ?, ?)
+        "
+        }
+        other => {
+            return Err(format!(
+                "unsupported view table for pre-Lifecycle fixture: {other}"
+            )
+            .into());
+        }
+    };
+
+    sqlx::query(query)
+        .bind(view_id)
+        .bind(version)
+        .bind(payload.to_string())
+        .execute(pool)
+        .await?;
+
+    Ok(())
+}

--- a/tests/startup_snapshot_compat.rs
+++ b/tests/startup_snapshot_compat.rs
@@ -1,0 +1,468 @@
+#![allow(clippy::unwrap_used)]
+
+//! Startup compatibility when the DB contains pre-event-sorcery snapshot or
+//! canonical projection rows for any event-sourced aggregate.
+//!
+//! All five aggregates (`Mint`, `Redemption`, `Account`, `TokenizedAsset`,
+//! `ReceiptInventory`) use `prepare_event_sourced_startup` before
+//! `StoreBuilder::build`. Table-projected aggregates also need stale view
+//! fixtures cleared before projection `catch_up`.
+//!
+//! Setup intentionally deviates from strict e2e rules (AGENTS.md): stale derived
+//! rows are the fixtures under test, not the event store. Complements per-aggregate
+//! `pre_lifecycle_*` unit tests in `src/*/mod.rs`.
+
+mod harness;
+
+use chrono::Utc;
+use httpmock::prelude::*;
+use serde_json::json;
+use sqlx::sqlite::SqlitePoolOptions;
+
+use harness::alpaca_mocks::{setup_mint_mocks, setup_redemption_mocks};
+use st0x_issuance::initialize_rocket;
+use st0x_issuance::test_utils::LocalEvm;
+
+const UNDERLYING: &str = "AAPL";
+const TOKEN: &str = "tAAPL";
+
+async fn open_seeded_db(
+    db_name: &str,
+    evm: &LocalEvm,
+) -> Result<
+    (tempfile::TempDir, String, sqlx::Pool<sqlx::Sqlite>),
+    Box<dyn std::error::Error>,
+> {
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join(db_name);
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        UNDERLYING,
+        TOKEN,
+    )
+    .await?;
+
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
+
+    Ok((temp_dir, db_url, pool))
+}
+
+async fn initialize_server(
+    db_url: &str,
+    mock_alpaca: &MockServer,
+    evm: &LocalEvm,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _mint_callback_mock = setup_mint_mocks(mock_alpaca);
+    let (_redeem_mock, _poll_mock) = setup_redemption_mocks(mock_alpaca);
+
+    let (config, _mock_subgraph) =
+        harness::create_config_with_db(db_url, mock_alpaca, evm)?;
+
+    initialize_rocket(config).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_mint_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let mint_id = "550e8400-e29b-41d4-a716-446655440000";
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_mint_snapshot.db", &evm).await?;
+    let now = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'Mint',
+            ?,
+            1,
+            'MintEvent::Initiated',
+            '1.0',
+            ?,
+            '{}'
+        )
+        ",
+    )
+    .bind(mint_id)
+    .bind(
+        json!({
+            "Initiated": {
+                "issuer_request_id": mint_id,
+                "tokenization_request_id": "tok-pre-lifecycle",
+                "quantity": "10.0",
+                "underlying": UNDERLYING,
+                "token": TOKEN,
+                "network": "base",
+                "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                "wallet": "0x1234567890123456789012345678901234567890",
+                "initiated_at": now,
+            }
+        })
+        .to_string(),
+    )
+    .execute(&pool)
+    .await?;
+
+    harness::seed_schema_registry_version(&pool, "Mint", 1).await?;
+    harness::seed_pre_lifecycle_snapshot(
+        &pool,
+        "Mint",
+        mint_id,
+        1,
+        &json!({
+            "Completed": {
+                "issuer_request_id": mint_id,
+                "tokenization_request_id": "tok-pre-lifecycle",
+                "quantity": "10.0",
+                "underlying": UNDERLYING,
+                "token": TOKEN,
+                "network": "base",
+                "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                "wallet": "0x1234567890123456789012345678901234567890",
+                "initiated_at": now,
+                "journal_confirmed_at": now,
+                "tx_hash": "0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d",
+                "receipt_id": "1",
+                "shares_minted": "1000000000000000000",
+                "gas_used": 21000,
+                "block_number": 1,
+                "minted_at": now,
+                "completed_at": now,
+            }
+        }),
+    )
+    .await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_mint_view()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let mint_id = "550e8400-e29b-41d4-a716-446655440001";
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_mint_view.db", &evm).await?;
+    let now = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'Mint',
+            ?,
+            1,
+            'MintEvent::Initiated',
+            '1.0',
+            ?,
+            '{}'
+        )
+        ",
+    )
+    .bind(mint_id)
+    .bind(
+        json!({
+            "Initiated": {
+                "issuer_request_id": mint_id,
+                "tokenization_request_id": "tok-pre-lifecycle-view",
+                "quantity": "10.0",
+                "underlying": UNDERLYING,
+                "token": TOKEN,
+                "network": "base",
+                "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+                "wallet": "0x1234567890123456789012345678901234567890",
+                "initiated_at": now,
+            }
+        })
+        .to_string(),
+    )
+    .execute(&pool)
+    .await?;
+
+    let completed_payload = json!({
+        "Completed": {
+            "issuer_request_id": mint_id,
+            "tokenization_request_id": "tok-pre-lifecycle-view",
+            "quantity": "10.0",
+            "underlying": UNDERLYING,
+            "token": TOKEN,
+            "network": "base",
+            "client_id": "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+            "wallet": "0x1234567890123456789012345678901234567890",
+            "initiated_at": now,
+            "journal_confirmed_at": now,
+            "tx_hash": "0xbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00dbaadf00d",
+            "receipt_id": "1",
+            "shares_minted": "1000000000000000000",
+            "gas_used": 21000,
+            "block_number": 1,
+            "minted_at": now,
+            "completed_at": now,
+        }
+    });
+
+    harness::seed_pre_lifecycle_view_row(
+        &pool,
+        "mint_view",
+        mint_id,
+        1,
+        &completed_payload,
+    )
+    .await?;
+    harness::seed_schema_registry_version(&pool, "Mint", 1).await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_redemption_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let redemption_id =
+        "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_redemption_snapshot.db", &evm).await?;
+    let now = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'Redemption',
+            ?,
+            1,
+            'RedemptionEvent::Detected',
+            '1.0',
+            ?,
+            '{}'
+        )
+        ",
+    )
+    .bind(redemption_id)
+    .bind(
+        json!({
+            "Detected": {
+                "issuer_request_id": redemption_id,
+                "underlying": UNDERLYING,
+                "token": TOKEN,
+                "wallet": "0x1234567890123456789012345678901234567890",
+                "quantity": "1.0",
+                "tx_hash": redemption_id,
+                "block_number": 1,
+                "detected_at": now,
+            }
+        })
+        .to_string(),
+    )
+    .execute(&pool)
+    .await?;
+
+    harness::seed_schema_registry_version(&pool, "Redemption", 1).await?;
+    harness::seed_pre_lifecycle_snapshot(
+        &pool,
+        "Redemption",
+        redemption_id,
+        1,
+        &json!({
+            "Completed": {
+                "issuer_request_id": redemption_id,
+                "burn_tx_hash": redemption_id,
+                "completed_at": now,
+            }
+        }),
+    )
+    .await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_account_snapshot_and_view()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let client_id = "6ba7b810-9dad-11d1-80b4-00c04fd430c9";
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_account_snapshot.db", &evm).await?;
+    let now = Utc::now().to_rfc3339();
+
+    sqlx::query(
+        "
+        INSERT INTO events (
+            aggregate_type,
+            aggregate_id,
+            sequence,
+            event_type,
+            event_version,
+            payload,
+            metadata
+        )
+        VALUES (
+            'Account',
+            ?,
+            1,
+            'AccountEvent::Registered',
+            '1.0',
+            ?,
+            '{}'
+        )
+        ",
+    )
+    .bind(client_id)
+    .bind(
+        json!({
+            "Registered": {
+                "client_id": client_id,
+                "email": "user@example.com",
+                "registered_at": now,
+            }
+        })
+        .to_string(),
+    )
+    .execute(&pool)
+    .await?;
+
+    let stale = json!({
+        "LinkedToAlpaca": {
+            "client_id": client_id,
+            "email": "user@example.com",
+            "alpaca_account": "ALPACA-1",
+            "whitelisted_wallets": [],
+            "registered_at": now,
+            "linked_at": now,
+        }
+    });
+
+    harness::seed_schema_registry_version(&pool, "Account", 1).await?;
+    harness::seed_pre_lifecycle_snapshot(
+        &pool, "Account", client_id, 1, &stale,
+    )
+    .await?;
+    harness::seed_pre_lifecycle_view_row(
+        &pool,
+        "account_view",
+        client_id,
+        1,
+        &stale,
+    )
+    .await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_tokenized_asset_snapshot_and_view()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_tokenized_asset_snapshot.db", &evm).await?;
+    let now = Utc::now().to_rfc3339();
+    let vault = evm.vault_address;
+
+    let stale = json!({
+        "underlying": UNDERLYING,
+        "token": TOKEN,
+        "network": "base",
+        "vault": vault,
+        "status": "Enabled",
+        "added_at": now,
+    });
+
+    harness::seed_schema_registry_version(&pool, "TokenizedAsset", 1).await?;
+    harness::seed_pre_lifecycle_snapshot(
+        &pool,
+        "TokenizedAsset",
+        UNDERLYING,
+        1,
+        &stale,
+    )
+    .await?;
+    harness::seed_pre_lifecycle_view_row(
+        &pool,
+        "tokenized_asset_view",
+        UNDERLYING,
+        1,
+        &stale,
+    )
+    .await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn startup_survives_pre_lifecycle_receipt_inventory_snapshot()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let (_temp_dir, db_url, pool) =
+        open_seeded_db("startup_receipt_inventory_snapshot.db", &evm).await?;
+    let aggregate_id = format!("{:#x}", evm.vault_address);
+
+    harness::seed_schema_registry_version(&pool, "ReceiptInventory", 1).await?;
+    harness::seed_pre_lifecycle_snapshot(
+        &pool,
+        "ReceiptInventory",
+        &aggregate_id,
+        1,
+        &json!({
+            "receipts": {},
+            "itn_receipts": {},
+        }),
+    )
+    .await?;
+
+    pool.close().await;
+    initialize_server(&db_url, &mock_alpaca, &evm).await?;
+
+    Ok(())
+}


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

Production deploy bricked the issuance bot on startup:

```
issuance-bot  | Error: unknown variant `Completed`, expected one of `Uninitialized`, `Live`, `Failed` at line 1 column 12
issuance-bot exited with code 1
```

Pre-event-sorcery snapshots stored bare aggregate enums (e.g. `{"Completed": {...}}`). After the event-sorcery migration, aggregates load as `Lifecycle<Entity>`, which expects `{"Live": {<entity>}}`. `SCHEMA_VERSION` was not bumped during the Lifecycle migration, so the schema reconciler never cleared incompatible snapshots. Projection `catch_up` then calls `load_with_context`, deserializes the stale row, and startup fails.

Closes RAI-1082.

## Solution

- **One-time migration** (`20260617144935_clear_pre_lifecycle_snapshots.sql`) deletes pre-Lifecycle snapshot rows for all event-sourced aggregates.
- **`SCHEMA_VERSION` bumped `1 → 2`** on `Mint`, `Redemption`, `Account`, `TokenizedAsset`, and `ReceiptInventory` so `StoreBuilder::build` clears stale snapshots before any load/catch-up on future wire-format changes.
- **SPEC.md** documents the snapshot schema versioning contract.
- **Regression tests** reproduce the exact production failure path:
  - `tests/startup_snapshot_compat.rs` — seeds old snapshot + registry v1, asserts `initialize_rocket` succeeds
  - `mint::pre_lifecycle_snapshot_cleared_before_projection_catch_up` — asserts reconcile deletes incompatible snapshots before projection catch-up

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs