### PR TITLE
fix: deploy on a glibc-compatible base and smoke-test the image in CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,12 +9,15 @@ env:
   DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
   REGISTRY_NAME: stox
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           android: true
           dotnet: true
@@ -23,14 +26,14 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f  # v2
         with:
           token: ${{ env.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -63,7 +66,7 @@ jobs:
           echo "PREP_SCRIPT=$(base64 -w 0 prep-docker-compose.sh)" >> $GITHUB_ENV
 
       - name: Deploy to Droplet
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262  # v1.0.3
         with:
           host: ${{ secrets.DROPLET_HOST }}
           username: root

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,6 +27,8 @@ jobs:
         with:
           submodules: recursive
 
+      - uses: nixbuild/nix-quick-install-action@v30
+
       - name: Install doctl
         uses: digitalocean/action-doctl@v2
         with:
@@ -35,27 +37,24 @@ jobs:
       - name: Build Docker image
         run: |
           SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          IMAGE=registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot
           echo "SHORT_SHA=$SHORT_SHA" >> $GITHUB_ENV
+          echo "IMAGE=$IMAGE" >> $GITHUB_ENV
 
           docker build \
-            -t registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot:$SHORT_SHA \
-            -t registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot:latest .
+            -t "$IMAGE:$SHORT_SHA" \
+            -t "$IMAGE:latest" .
 
       - name: Test image runs
-        run: |
-          docker run -d --name test-container registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot:${{ env.SHORT_SHA }}
-          sleep 5
-          docker ps -a
-          docker logs test-container
-          docker rm -f test-container
+        run: nix run .#smoke-test-image -- "$IMAGE:$SHORT_SHA"
 
       - name: Log in to DO Container Registry
         run: doctl registry login --expiry-seconds 1200
 
       - name: Push image to DO Registry
         run: |
-          docker push registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot:${{ env.SHORT_SHA }}
-          docker push registry.digitalocean.com/${{ env.REGISTRY_NAME }}/issuance-bot:latest
+          docker push "$IMAGE:$SHORT_SHA"
+          docker push "$IMAGE:latest"
 
       - name: Encode file contents
         run: |

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
+          persist-credentials: false
 
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -6,12 +6,15 @@ concurrency:
   group: ${{ github.ref }}-docker-build
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           android: true
           dotnet: true
@@ -20,33 +23,36 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a  # v6
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
           gc-max-store-size-linux: 5G
+          # Only main writes the cache (branches restore-only) to prevent poisoning.
+          save: ${{ github.ref == 'refs/heads/main' }}
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Build Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
         with:
           context: .
           load: true
           tags: issuance-bot:ci
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Mirror the Nix cache: only main writes the layer cache (branches read-only).
+          cache-to: ${{ github.ref == 'refs/heads/main' && 'type=gha,mode=max' || '' }}
 
       - name: Smoke-test the image
         run: nix run .#smoke-test-image -- issuance-bot:ci

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,52 @@
+name: Docker build
+
+on: [push]
+
+concurrency:
+  group: ${{ github.ref }}-docker-build
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: false
+          docker-images: false
+          swap-storage: false
+
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: nixbuild/nix-quick-install-action@v30
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
+
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 5G
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: issuance-bot:ci
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Smoke-test the image
+        run: nix run .#smoke-test-image -- issuance-bot:ci

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:
@@ -68,6 +69,7 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:

--- a/.github/workflows/rainix.yaml
+++ b/.github/workflows/rainix.yaml
@@ -13,7 +13,7 @@ jobs:
       DATABASE_URL: "sqlite:issuance.db"
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           android: true
           dotnet: true
@@ -22,19 +22,19 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a  # v6
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-
@@ -55,7 +55,7 @@ jobs:
       DATABASE_URL: "sqlite:issuance.db"
     steps:
       - name: Free disk space
-        uses: jlumbroso/free-disk-space@v1.3.1
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           android: true
           dotnet: true
@@ -64,19 +64,19 @@ jobs:
           docker-images: false
           swap-storage: false
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           submodules: recursive
           fetch-depth: 0
 
-      - uses: nixbuild/nix-quick-install-action@v30
+      - uses: nixbuild/nix-quick-install-action@5bb6a3b3abe66fd09bbf250dce8ada94f856a703  # v30
         with:
           nix_conf: |
             keep-env-derivations = true
             keep-outputs = true
 
       - name: Restore and save Nix store
-        uses: nix-community/cache-nix-action@v6
+        uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a  # v6
         with:
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
           restore-prefixes-first-match: nix-${{ runner.os }}-

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -26,14 +26,14 @@ jobs:
           fi
           echo "Confirmation validated. Proceeding with rollback..."
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Encode rollback script
         run: |
           echo "ROLLBACK_SCRIPT=$(base64 -w 0 rollback.sh)" >> "$GITHUB_ENV"
 
       - name: Execute rollback on droplet
-        uses: appleboy/ssh-action@v1.0.3
+        uses: appleboy/ssh-action@029f5b4aeeeb58fdfe1410a5d17f967dacf36262  # v1.0.3
         with:
           host: ${{ secrets.DROPLET_HOST }}
           username: root

--- a/.github/workflows/rollback.yaml
+++ b/.github/workflows/rollback.yaml
@@ -27,6 +27,8 @@ jobs:
           echo "Confirmation validated. Proceeding with rollback..."
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          persist-credentials: false
 
       - name: Encode rollback script
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest AS builder
+FROM ubuntu:24.04 AS builder
 
 ARG BUILD_PROFILE=release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends patchelf && \
     patchelf --set-interpreter /lib64/ld-linux-x86-64.so.2 /app/target/${BUILD_PROFILE}/st0x-issuance && \
     apt-get remove -y patchelf && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 
-FROM debian:12-slim
+FROM debian:trixie-slim
 
 ARG BUILD_PROFILE=release
 

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,17 @@
                 (cd lib/ethgild && forge build)
               '';
             };
+
+            smoke-test-image = pkgs.writeShellApplication {
+              name = "smoke-test-image";
+              runtimeInputs = [
+                pkgs.nushell
+                pkgs.coreutils
+              ];
+              text = ''
+                exec nu ${./scripts/smoke-test-image.nu} "$@"
+              '';
+            };
           };
 
         devShell = pkgs.mkShell {

--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,7 @@
               runtimeInputs = [
                 pkgs.nushell
                 pkgs.coreutils
+                pkgs.docker-client
               ];
               text = ''
                 exec nu ${./scripts/smoke-test-image.nu} "$@"

--- a/scripts/smoke-test-image.nu
+++ b/scripts/smoke-test-image.nu
@@ -14,6 +14,11 @@ def main [image: string] {
 
   print $output
 
+  if $result.exit_code == 124 {
+    print "::error::server binary timed out after 30s"
+    exit 1
+  }
+
   if not ($output | str contains "Failed to parse configuration") {
     print "::error::server binary did not start"
     exit 1

--- a/scripts/smoke-test-image.nu
+++ b/scripts/smoke-test-image.nu
@@ -1,0 +1,22 @@
+#!/usr/bin/env nu
+
+# Smoke-tests an already-built issuance-bot image by running the server binary
+# the way production does (compose runs `./server`) and asserting it actually
+# starts. With no config the binary loads, reaches clap, and exits on the
+# missing required RPC_URL, printing usage that names `st0x-issuance`. That
+# marker proves the binary executed; anything that stops it from running fails
+# to produce it, so the captured output is printed for diagnosis.
+
+def main [image: string] {
+  let result = (^timeout 30 docker run --rm $image ./server | complete)
+  let output = $"($result.stdout)($result.stderr)"
+
+  print $output
+
+  if not ($output | str contains "st0x-issuance") {
+    print "::error::server binary did not start"
+    exit 1
+  }
+
+  print "server binary started"
+}

--- a/scripts/smoke-test-image.nu
+++ b/scripts/smoke-test-image.nu
@@ -2,10 +2,11 @@
 
 # Smoke-tests an already-built issuance-bot image by running the server binary
 # the way production does (compose runs `./server`) and asserting it actually
-# starts. With no config the binary loads, reaches clap, and exits on the
-# missing required RPC_URL, printing usage that names `st0x-issuance`. That
-# marker proves the binary executed; anything that stops it from running fails
-# to produce it, so the captured output is printed for diagnosis.
+# starts. With no config the binary loads, reaches its own config parsing, and
+# exits with "Failed to parse configuration" — its error for the missing
+# required env. That marker proves the binary executed and reached application
+# code; anything that stops it from running fails to produce it, so the captured
+# output is printed for diagnosis.
 
 def main [image: string] {
   let result = (^timeout 30 docker run --rm $image ./server | complete)
@@ -13,7 +14,7 @@ def main [image: string] {
 
   print $output
 
-  if not ($output | str contains "st0x-issuance") {
+  if not ($output | str contains "Failed to parse configuration") {
     print "::error::server binary did not start"
     exit 1
   }


### PR DESCRIPTION
## Motivation

The deployed `issuance-bot` was crash-looping on the droplet:

```
./server: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by ./server)
```

The server binary is linked (inside `nix develop`) against a newer glibc than the `debian:12-slim` runtime base (glibc 2.36) provides. CI never caught it: the "Test image runs" step launched the base image's default shell instead of `./server`, and the image was only built on push to `main`, so a non-runnable image could merge and deploy.

## Solution

**Deploy fix + CI coverage**
- **Runtime base** `debian:12-slim` → `debian:trixie-slim` (glibc 2.36 → 2.41), satisfying the binary's `GLIBC_2.38` requirement. This is the actual fix.
- **New `docker-build.yaml`** builds the image and smoke-tests it on every push — not just post-merge — with Docker-layer and Nix-store caching.
- **Smoke test is a Nix-packaged Nushell app** (`scripts/smoke-test-image.nu`, run via `nix run .#smoke-test-image`), shared by CI and deploy. It runs `./server` as production does and asserts the binary *starts* — a general health check, not a grep for one specific bug.

**Workflow hardening** — applied across **all four** workflows (not only the ones this PR adds), so the mitigations are actually complete:
- **Every GitHub Action pinned to a commit SHA** (with `# version` comments) — defends against tag-moving / compromised-action supply-chain attacks.
- **`permissions: contents: read`** — least-privilege `GITHUB_TOKEN`, limiting the blast radius of a compromised step.
- **Caches write only from `main`** (the Nix `save` and the buildx `cache-to` are gated on `refs/heads/main`; branches restore-only) so the shared caches can't be poisoned. Builder base pinned `ubuntu:latest` → `ubuntu:24.04` for reproducibility.

First step toward replacing the shell-script-driven Docker flow with the Nix-app pattern from `st0x.liquidity`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [ ] made this PR as small as possible
- [ ] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions across multiple workflows to use pinned commit SHAs instead of floating version tags.
  * Added Docker build caching layer support in continuous integration workflows.

* **Infrastructure**
  * Updated Docker base images to Ubuntu 24.04 and Debian Trixie for improved stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->