### PR TITLE
ci: deploy only via manual workflow dispatch

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,8 +2,6 @@ name: Build and deploy
 
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
 
 env:
   DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}


### PR DESCRIPTION
## Motivation

Pushing to `main` auto-triggered a production deploy via the workflow's `push` trigger. We're moving to deliberate, manual deploys so merging to `main` no longer ships to the droplet on its own.

## Solution

Drop the `push: branches: [main]` trigger from the deploy workflow, leaving only `workflow_dispatch`. Deploys now run exclusively when manually dispatched.

## Checks

- [x] made this PR as small as possible
- [ ] added comprehensive test coverage for any changes in logic (N/A — workflow trigger change, no logic)
- [ ] linked any relevant issues or PRs (Linear issue to follow)