### PR TITLE
refactor: drop the unused st0x-issuance-client flake derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
 
         # Vendoring reads the whole workspace lock, so the main crate's two git
         # deps (event-sorcery/sqlite-es + fireblocks-sdk) need pinned hashes
-        # even though the dto/client crates never pull them in.
+        # even though the dto crate never pulls them in.
         cargoVendorDir = craneLib.vendorCargoDeps {
           src = crateSrc;
           outputHashes = {
@@ -36,26 +36,24 @@
           };
         };
 
-        # The dto + client crates are pure-Rust wire/HTTP helpers: no sqlx, no
-        # Rain `sol!` ABIs, no workspace git deps in their tree. Scoping every
-        # cargo invocation to them with `-p` keeps the main crate's database,
-        # ABI, and Fireblocks machinery out of the nix closure entirely, so we
-        # never need the live DB, ST0X_*_ABI env, or sqlite-es migrations the
-        # main crate's nix build would require.
+        # The dto crate is a pure-Rust wire-types helper: no sqlx, no Rain
+        # `sol!` ABIs, no workspace git deps in its tree. Scoping every cargo
+        # invocation to it with `-p` keeps the main crate's database, ABI, and
+        # Fireblocks dependencies from being compiled and keeps their build-time
+        # requirements out of the build, so we never need the live DB,
+        # ST0X_*_ABI env, or sqlite-es migrations the main crate's nix build
+        # would require. (The vendored sources for those git deps are still
+        # fetched — see the outputHashes above — but cargo only compiles the dto
+        # crate.)
         crateArgs = {
           src = crateSrc;
           inherit cargoVendorDir;
           strictDeps = true;
-          # The dto/client crates are pure Rust with sandbox-safe tests (temp-dir
-          # binding export + loopback httpmock), so run them under `nix flake
-          # check` for extra CI coverage rather than only type-checking.
+          # The dto crate is pure Rust with sandbox-safe tests (temp-dir binding
+          # export), so run it under `nix flake check` for extra CI coverage
+          # rather than only type-checking.
           doCheck = true;
-          nativeBuildInputs = [ pkgs.pkg-config ];
-          buildInputs = [
-            pkgs.openssl
-          ]
-          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.apple-sdk_15 ];
-          cargoExtraArgs = "-p st0x-issuance-dto -p st0x-issuance-client";
+          cargoExtraArgs = "-p st0x-issuance-dto";
         };
 
         cargoArtifacts = craneLib.buildDepsOnly crateArgs;
@@ -67,16 +65,6 @@
             inherit cargoArtifacts;
             cargoExtraArgs = "-p st0x-issuance-dto";
             meta.description = "st0x issuance API DTO types + TypeScript binding exporter";
-          }
-        );
-
-        st0x-issuance-client = craneLib.buildPackage (
-          crateArgs
-          // {
-            pname = "st0x-issuance-client";
-            inherit cargoArtifacts;
-            cargoExtraArgs = "-p st0x-issuance-client";
-            meta.description = "Typed Rust client for the st0x issuance HTTP API";
           }
         );
 
@@ -100,7 +88,6 @@
         issuanceBuilds = {
           inherit
             st0x-issuance-dto
-            st0x-issuance-client
             st0x-issuance-dto-typescript
             ;
         };


### PR DESCRIPTION
## Motivation

The Nix flake exposed `st0x-issuance-client` as its own derivation (RAI-1060), but it earns no place: st0x.liquidity consumes the client crate as a Cargo **git dependency** and builds it from source inside its own crane closure (its `rust.nix` fetches by rev and never imports this flake), so the derivation does **not** improve liquidity caching; and the client crate's tests already run under `cargo test --workspace`, making the `nix flake check` build redundant. The client is also now generatable from the OpenAPI spec (RAI-1112).

Implements RAI-1115.

## Solution

Drop `st0x-issuance-client` from the flake and from the shared `issuanceBuilds` set, so it leaves both `packages` and `checks`. Keep `st0x-issuance-dto` (the dashboard's TypeScript bindings are built from it) and `st0x-issuance-dto-typescript`. Scope the deps-only build args to `-p st0x-issuance-dto` and refresh the now-stale comments. Also drop the now-dead `pkg-config` / `openssl` / `apple-sdk_15` build inputs — the dto-only closure is pure Rust, so they were dead weight (`deadnix` and `nix flake check` confirm). `nix flake check` passes building only dto + the TS bindings.

## Checks

- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
- [ ] added comprehensive test coverage for any changes in logic (N/A — build-config change; dto tests still run under both `nix flake check` and `cargo test --workspace`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated the build configuration to focus on the core DTO outputs, narrowing the overall build scope to what’s needed for those artifacts.
* Removed the issuance client package from the published build/distribution outputs.
* Updated the automated build checks to align with the reduced build set, keeping only the DTO-related checks and TypeScript bindings export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
