### PR TITLE
fix: align flake event-sorcery output hash with the 0.1.2 lock pin

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,8 +29,8 @@
         cargoVendorDir = craneLib.vendorCargoDeps {
           src = crateSrc;
           outputHashes = {
-            "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.1#d0ad3f66bb5a1da23161d898027bff1abb9dabd6" =
-              "sha256-fmBLdcyNoPh+Hktl1vVgeXdKtaxA+a1+xYi5Acxsr6o=";
+            "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.2#8f5c81f3472ac4ca84bbcebbddaa0b3b01f2cfea" =
+              "sha256-d0bl1jVmPeu9UPl4cNjY+cAaaLEDmLxw1BQhGrH5eV8=";
             "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#18227211082342818efaf6a1b58c89c65a6f17cd" =
               "sha256-KThUI0Cvh1JELem7SUQ1K3WqMccFeYfS3BqfLXwk2AE=";
           };


### PR DESCRIPTION
## Motivation

`Cargo.lock` pins `event-sorcery` to `tag=0.1.2` (bumped in #178), but the flake's `outputHashes` still pinned the old `tag=0.1.1` rev. That left the `0.1.1` entry dead and the live `0.1.2` git dep **without a hash**, so crane's `vendorCargoDeps` fell back to `builtins.fetchGit` (IFD) — the exact cross-repo footgun `AGENTS.md` warns about. `nix flake check` emitted `No output hash provided for git+…event-sorcery.git?tag=0.1.2#8f5c…` and only succeeded because `0.1.2` happens to be a reachable tag; the fetch is non-hermetic and fragile.

Implements RAI-1126.

## Solution

Point the `outputHashes` key at the `0.1.2` tag/rev now in the lockfile and pin its `sha256` (read from the hash-mismatch error). `nix flake check` now builds the vendored dep hermetically with no missing-hash warning.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic (N/A — flake hash pin; validated via `nix flake check`, which now passes without the missing-hash warning)
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs (RAI-1126; references #178, which bumped the lockfile)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a pinned build dependency to a newer release and refreshed its associated checksum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->