### PR TITLE
refactor: extract a reusable durable-job runner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5737,6 +5737,8 @@ dependencies = [
  "alloy-sol-types",
  "anyhow",
  "apalis",
+ "apalis-codec",
+ "apalis-core",
  "apalis-sqlite",
  "async-trait",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,8 @@ utoipa-swagger-ui = { version = "9.0.2", features = ["rocket", "vendored"] }
 # migration as above) before this service goes to production.
 apalis = "=1.0.0-rc.9"
 apalis-sqlite = "=1.0.0-rc.8"
+apalis-core = "=1.0.0-rc.9"
+apalis-codec = "=0.1.0-rc.9"
 
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -15,6 +15,8 @@
 //! breaker, and test failure-injection arrive with their first
 //! request→outcome consumers.
 
+use std::error::Error as StdError;
+use std::sync::Arc;
 use apalis::prelude::{Data, TaskBuilder, TaskSink};
 use apalis_codec::json::JsonCodec;
 use apalis_core::backend::TaskSinkError;
@@ -22,8 +24,6 @@ use apalis_sqlite::fetcher::SqliteFetcher;
 use apalis_sqlite::{CompactType, SqlitePool, SqliteStorage, SqlxError};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use std::error::Error as StdError;
-use std::sync::Arc;
 
 /// apalis-sqlite storage specialised to JSON-encoded tasks. This is exactly the
 /// concrete type `SqliteStorage::new` returns, so naming it here pins the same

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -1,0 +1,118 @@
+//! Interim durable-job runner for st0x.issuance.
+//!
+//! A small, reusable abstraction over apalis-backed persistent jobs: a
+//! serializable [`Job`] impl is pushed into [`JobQueue`] and drained by an
+//! apalis worker that calls [`Job::perform`] via the generic [`work`] handler.
+//!
+//! This module is deliberately interim: it mirrors the durable-job machinery
+//! the `event-sorcery` library lifted from st0x.liquidity's `conductor::job`,
+//! and it is deleted once this service bumps onto the event-sorcery release
+//! that ships that job stack — the queue then comes from the library instead
+//! of living here. It sits at crate level (not inside a feature module)
+//! because it is feature-agnostic plumbing shared by every durable job, with
+//! [`crate::mint::recovery`] as the only consumer today. It ships only the
+//! core that consumer needs; the retry / fail-stop worker macros, circuit
+//! breaker, and test failure-injection arrive with their first
+//! request→outcome consumers.
+
+use apalis::prelude::{Data, TaskBuilder, TaskSink};
+use apalis_codec::json::JsonCodec;
+use apalis_core::backend::TaskSinkError;
+use apalis_sqlite::fetcher::SqliteFetcher;
+use apalis_sqlite::{CompactType, SqlitePool, SqliteStorage, SqlxError};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use std::error::Error as StdError;
+use std::sync::Arc;
+
+/// apalis-sqlite storage specialised to JSON-encoded tasks. This is exactly the
+/// concrete type `SqliteStorage::new` returns, so naming it here pins the same
+/// storage the runtime already uses — switching nothing about the on-disk
+/// `Jobs` encoding.
+type Storage<Task> = SqliteStorage<Task, JsonCodec<CompactType>, SqliteFetcher>;
+
+/// Handler-facing durable job queue backed by apalis `SqliteStorage`.
+///
+/// Constructed against the apalis-sqlite (sqlx 0.8) pool, distinct from the
+/// event store's sqlx 0.9 pool but addressing the same SQLite file.
+pub(crate) struct JobQueue<Task>(Storage<Task>);
+
+/// Error returned by [`JobQueue::push_with_idempotency_key`]. Wrapping
+/// [`TaskSinkError`] keeps the failure chain typed so callers can `#[from]` it.
+#[derive(Debug, thiserror::Error)]
+#[error("failed to enqueue apalis job: {0}")]
+pub(crate) struct QueuePushError(#[from] TaskSinkError<SqlxError>);
+
+impl<Task> Clone for JobQueue<Task> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static>
+    JobQueue<Task>
+{
+    pub(crate) fn new(pool: &SqlitePool) -> Self {
+        Self(SqliteStorage::new(pool))
+    }
+
+    /// Enqueues `task` keyed by `idempotency_key`. apalis collapses the insert
+    /// against any existing row sharing `(job_type, idempotency_key)` via
+    /// `ON CONFLICT DO NOTHING`, so a re-enqueue for a job that is still
+    /// in-flight — or already terminal — is a silent no-op.
+    pub(crate) async fn push_with_idempotency_key(
+        &mut self,
+        task: Task,
+        idempotency_key: impl AsRef<str>,
+    ) -> Result<(), QueuePushError> {
+        let task = TaskBuilder::new(task)
+            .with_idempotency_key(idempotency_key)
+            .build();
+        Ok(TaskSink::push_task(&mut self.0, task).await?)
+    }
+
+    /// Consumes the queue into the underlying `SqliteStorage` a worker drains.
+    pub(crate) fn into_storage(self) -> Storage<Task> {
+        self.0
+    }
+}
+
+/// A persistent, durable unit of work backed by apalis storage.
+///
+/// Implementations are serializable structs carrying the data needed to process
+/// a single job. `Ctx` bundles the runtime dependencies (stores, services,
+/// config) injected into the worker via apalis `Data` and handed to
+/// [`perform`](Job::perform) by reference.
+pub(crate) trait Job<Ctx>:
+    Serialize + DeserializeOwned + Send + 'static
+where
+    Ctx: Send + Sync + 'static,
+{
+    /// Value produced on successful completion.
+    type Output: Send + 'static;
+
+    /// Error returned by [`perform`](Job::perform).
+    type Error: StdError + Send + Sync + 'static;
+
+    /// Processes this job using the provided context.
+    async fn perform(&self, ctx: &Ctx) -> Result<Self::Output, Self::Error>;
+}
+
+/// Generic apalis handler adapting a [`Job`] impl to apalis's function-based
+/// worker API.
+///
+/// Returns the raw `J::Error` rather than boxing it: apalis maps a handler
+/// error to a job status by downcasting it, and an
+/// [`AbortError`](apalis::prelude::AbortError) returned by `perform` must stay
+/// downcastable so the job is marked `Killed` (terminal, not re-fetched) instead
+/// of a retryable `Failed`.
+pub(crate) async fn work<Ctx, J>(
+    job: J,
+    ctx: Data<Arc<Ctx>>,
+) -> Result<J::Output, J::Error>
+where
+    Ctx: Send + Sync + 'static,
+    J: Job<Ctx> + Sync,
+{
+    job.perform(&ctx).await
+}

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -15,8 +15,6 @@
 //! breaker, and test failure-injection arrive with their first
 //! request→outcome consumers.
 
-use std::error::Error as StdError;
-use std::sync::Arc;
 use apalis::prelude::{Data, TaskBuilder, TaskSink};
 use apalis_codec::json::JsonCodec;
 use apalis_core::backend::TaskSinkError;
@@ -24,6 +22,8 @@ use apalis_sqlite::fetcher::SqliteFetcher;
 use apalis_sqlite::{CompactType, SqlitePool, SqliteStorage, SqlxError};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use std::error::Error as StdError;
+use std::sync::Arc;
 
 /// apalis-sqlite storage specialised to JSON-encoded tasks. This is exactly the
 /// concrete type `SqliteStorage::new` returns, so naming it here pins the same

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,10 +25,11 @@ use crate::auth::FailedAuthRateLimiter;
 use crate::chain::{
     ChainRegistry, ConfiguredNetworks, validate_configured_asset_networks,
 };
+use crate::jobs::JobQueue;
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
-        DriveOutcome, MintRecoveryHandler, MintRecoveryJob, MintRecoveryQueue,
+        DriveOutcome, MintRecoveryHandler, MintRecoveryJob,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
         prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
         recover_mint, reset_orphaned_recovery_jobs,
@@ -73,6 +74,7 @@ pub(crate) mod auth;
 pub(crate) mod catchers;
 pub(crate) mod chain;
 pub(crate) mod config;
+pub(crate) mod jobs;
 mod openapi;
 pub(crate) mod poll_checkpoint;
 pub mod receipt_inventory;
@@ -1542,7 +1544,10 @@ fn spawn_mint_recovery_worker(
                 // A fresh worker id per registration is load-bearing for crash
                 // recovery — see [`MintRecoveryWorkerId`].
                 WorkerBuilder::new(MintRecoveryWorkerId::new().to_string())
-                    .backend(MintRecoveryQueue::new(&apalis_pool))
+                    .backend(
+                        JobQueue::<MintRecoveryJob>::new(&apalis_pool)
+                            .into_storage(),
+                    )
                     .data(mint_store.clone())
                     .data(vault_service.clone())
                     .build(MintRecoveryJob::run)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@ use crate::jobs::{JobQueue, work};
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
-        DriveOutcome, MintRecoveryHandler, MintRecoveryJob,
-        MintRecoveryJobCtx, MintRecoveryWorkerId,
-        enqueue_scheduled_mint_recovery, prune_unreferenced_recovery_workers,
-        reconcile_recoverable_mints, recover_mint, reset_orphaned_recovery_jobs,
+        DriveOutcome, MintRecoveryHandler, MintRecoveryJob, MintRecoveryJobCtx,
+        MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
+        prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
+        recover_mint, reset_orphaned_recovery_jobs,
         vacuum_terminal_recovery_jobs,
     },
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,14 +25,14 @@ use crate::auth::FailedAuthRateLimiter;
 use crate::chain::{
     ChainRegistry, ConfiguredNetworks, validate_configured_asset_networks,
 };
-use crate::jobs::JobQueue;
+use crate::jobs::{JobQueue, work};
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
         DriveOutcome, MintRecoveryHandler, MintRecoveryJob,
-        MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
-        prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
-        recover_mint, reset_orphaned_recovery_jobs,
+        MintRecoveryJobCtx, MintRecoveryWorkerId,
+        enqueue_scheduled_mint_recovery, prune_unreferenced_recovery_workers,
+        reconcile_recoverable_mints, recover_mint, reset_orphaned_recovery_jobs,
         vacuum_terminal_recovery_jobs,
     },
 };
@@ -1548,9 +1548,11 @@ fn spawn_mint_recovery_worker(
                         JobQueue::<MintRecoveryJob>::new(&apalis_pool)
                             .into_storage(),
                     )
-                    .data(mint_store.clone())
-                    .data(vault_service.clone())
-                    .build(MintRecoveryJob::run)
+                    .data(Arc::new(MintRecoveryJobCtx {
+                        mint_store: mint_store.clone(),
+                        vault_service: vault_service.clone(),
+                    }))
+                    .build(work::<MintRecoveryJobCtx, MintRecoveryJob>)
             });
 
             match monitor.run().await {

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -17,7 +17,7 @@ use super::{
     AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
     MintRecoveryMode, find_all_recoverable_mints,
 };
-use crate::jobs::JobQueue;
+use crate::jobs::{Job, JobQueue};
 use crate::receipt_inventory::ItnReceiptHandler;
 use crate::vault::VaultService;
 
@@ -217,15 +217,27 @@ pub(crate) struct MintRecoveryJob {
     issuer_request_id: IssuerMintRequestId,
 }
 
-impl MintRecoveryJob {
-    pub(crate) async fn run(
-        self,
-        mint_store: Data<Arc<Store<Mint>>>,
-        vault_service: Data<Arc<dyn VaultService>>,
+/// Runtime dependencies injected into the [`MintRecoveryJob`] worker.
+///
+/// Bundled so the generic [`crate::jobs::work`] adapter can take a single
+/// `Data<Arc<Ctx>>` while recovery still needs both the mint store and the
+/// vault service for on-chain retry.
+pub(crate) struct MintRecoveryJobCtx {
+    pub(crate) mint_store: Arc<Store<Mint>>,
+    pub(crate) vault_service: Arc<dyn VaultService>,
+}
+
+impl Job<MintRecoveryJobCtx> for MintRecoveryJob {
+    type Output = ();
+    type Error = AbortError;
+
+    async fn perform(
+        &self,
+        ctx: &MintRecoveryJobCtx,
     ) -> Result<(), AbortError> {
         match recover_mint_until_automatic_budget_exhausted(
-            &mint_store,
-            &vault_service,
+            &ctx.mint_store,
+            &ctx.vault_service,
             &self.issuer_request_id,
             SCHEDULED_RECOVERY_BACKOFF,
         )
@@ -2516,10 +2528,10 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
 
         let result = MintRecoveryJob { issuer_request_id }
-            .run(
-                Data::new(fixture.mint_store.clone()),
-                Data::new(fixture.vault.clone()),
-            )
+            .perform(&MintRecoveryJobCtx {
+                mint_store: fixture.mint_store.clone(),
+                vault_service: fixture.vault.clone(),
+            })
             .await;
 
         assert!(
@@ -2562,10 +2574,10 @@ mod tests {
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let error = MintRecoveryJob { issuer_request_id }
-            .run(
-                Data::new(fixture.mint_store.clone()),
-                Data::new(fixture.vault.clone()),
-            )
+            .perform(&MintRecoveryJobCtx {
+                mint_store: fixture.mint_store.clone(),
+                vault_service: fixture.vault.clone(),
+            })
             .await
             .expect_err("an exhausted mint must abort, not resolve");
 

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::TxHash;
-use apalis::prelude::{AbortError, Data, TaskBuilder, TaskSink};
-use apalis_sqlite::{SqlitePool, SqliteStorage};
+use apalis::prelude::AbortError;
+use apalis_sqlite::SqlitePool;
 use async_trait::async_trait;
 use chrono::Utc;
 use cqrs_es::AggregateError;
@@ -17,6 +17,7 @@ use super::{
     AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
     MintRecoveryMode, find_all_recoverable_mints,
 };
+use crate::jobs::JobQueue;
 use crate::receipt_inventory::ItnReceiptHandler;
 use crate::vault::VaultService;
 
@@ -250,11 +251,6 @@ impl MintRecoveryJob {
     }
 }
 
-/// The apalis storage that persists and drains [`MintRecoveryJob`]s. Backed by
-/// the apalis-sqlite (sqlx 0.8) pool, distinct from the event store's sqlx 0.9
-/// pool but addressing the same SQLite file.
-pub(crate) type MintRecoveryQueue = SqliteStorage<MintRecoveryJob, (), ()>;
-
 /// A unique apalis worker id for one [`MintRecoveryJob`] worker registration.
 ///
 /// A FRESH id per registration is load-bearing for crash recovery: apalis
@@ -349,21 +345,23 @@ pub(crate) async fn push_mint_recovery_job(
     issuer_request_id: IssuerMintRequestId,
 ) -> Result<(), anyhow::Error> {
     let mut attempt = 0;
-    // The storage handle is reusable across attempts (`push_task` takes
-    // `&mut self`); only the `task` is consumed per iteration, so build the
-    // queue once rather than reconstructing it on every retry.
-    let mut queue = MintRecoveryQueue::new(apalis_pool);
+    // The queue handle is reusable across attempts
+    // (`push_with_idempotency_key` takes `&mut self`); build it once rather
+    // than reconstructing it on every retry.
+    let mut queue = JobQueue::<MintRecoveryJob>::new(apalis_pool);
 
     loop {
         attempt += 1;
 
-        let task = TaskBuilder::new(MintRecoveryJob {
-            issuer_request_id: issuer_request_id.clone(),
-        })
-        .with_idempotency_key(issuer_request_id.to_string())
-        .build();
-
-        match queue.push_task(task).await {
+        match queue
+            .push_with_idempotency_key(
+                MintRecoveryJob {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+                issuer_request_id.to_string(),
+            )
+            .await
+        {
             Ok(()) => return Ok(()),
             Err(error) if attempt < ENQUEUE_ATTEMPTS => {
                 debug!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -2508,9 +2506,9 @@ mod tests {
         );
     }
 
-    /// `MintRecoveryJob::run` resolves cleanly (`Ok`) when there is nothing to
-    /// recover — an absent mint — so apalis records the job as Done. Also
-    /// exercises the job's `Data`-injected dispatch into the budget loop.
+    /// `MintRecoveryJob::perform` resolves cleanly (`Ok`) when there is nothing
+    /// to recover — an absent mint — so apalis records the job as Done. Also
+    /// exercises the job's dispatch into the budget loop.
     #[traced_test]
     #[tokio::test]
     async fn run_resolves_when_mint_absent() {
@@ -2539,11 +2537,11 @@ mod tests {
         );
     }
 
-    /// `MintRecoveryJob::run` returns `Err(AbortError)` when recovery abandons a
-    /// still-incomplete mint (here, automatic retries exhausted), so apalis marks
-    /// the job Killed instead of a `Done` that would hide the stuck mint. This is
-    /// the load-bearing Abandoned→Err arm; without it a stuck mint looks like a
-    /// successful recovery.
+    /// `MintRecoveryJob::perform` returns `Err(AbortError)` when recovery
+    /// abandons a still-incomplete mint (here, automatic retries exhausted), so
+    /// apalis marks the job Killed instead of a `Done` that would hide the stuck
+    /// mint. This is the load-bearing Abandoned→Err arm; without it a stuck mint
+    /// looks like a successful recovery.
     #[traced_test]
     #[tokio::test]
     async fn run_returns_abort_error_when_recovery_abandons() {


### PR DESCRIPTION
## Motivation

PR #118 brought up apalis in st0x.issuance with a **bespoke** `MintRecoveryJob` —
hand-rolled worker registration, enqueue, and storage, with no reusable
abstraction. Before the Mint (RAI-935) and Redemption (RAI-936) extractions move
their handler side effects into durable jobs, that wiring needs generalizing into
a small reusable runner so the two extractions don't each duplicate the
queue/worker plumbing. This is the interim shape ADR-0002 prescribes — mirroring
the machinery `event-sorcery` lifted from st0x.liquidity's `conductor::job` —
deleted again at the phase-2 bump (RAI-932).

Implements RAI-1176.

## Solution

New `src/jobs/mod.rs` with the reusable core, with `MintRecoveryJob` retrofitted
onto it:

- **`Job<Ctx>` trait** (`Output` / `Error` / `async perform`) — the contract the
  RAI-935/936 jobs will implement.
- **Generic `work<Ctx, J>`** apalis adapter that returns the raw `J::Error` so an
  `AbortError` returned by `perform` stays downcastable → the job is marked
  `Killed` (terminal), not a retryable `Failed`.
- **`JobQueue<Task>`** over `SqliteStorage<_, JsonCodec<CompactType>,
  SqliteFetcher>` with `new`, `push_with_idempotency_key`, `into_storage`.
- `MintRecoveryJob` implements `Job<MintRecoveryJobCtx>` (mint store + vault);
  enqueue routes through `JobQueue::push_with_idempotency_key`; the worker
  registers via `work::<MintRecoveryJobCtx, MintRecoveryJob>`. **Behavior is
  unchanged** — `perform` still returns `AbortError` → `Killed`, default poll
  config, unlimited worker concurrency.

Crate-level `jobs` is intentional interim shared plumbing for the immediately
following stack (`#207`/`#208`/redemption); it is deleted at the event-sorcery
bump, not a permanent technical layer.

Scoped to the core that has a real consumer today. The retry / fail-stop worker
macro, circuit breaker, and test failure-injection are **deferred to RAI-935/936**
with their first request→outcome consumers.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Verified with:

- `cargo test -q --lib mint::recovery`
- `cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`