### PR TITLE
feat: move mint recovery onto durable jobs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -191,49 +191,39 @@ initial request through journal confirmation to on-chain minting and callback.
   `MintingStarted`. Intent is persisted before the network call so that a crash
   during submission leaves the aggregate in a recoverable `Minting` state rather
   than `JournalConfirmed` (which would lose track of the submission)
-- `PrepareMint { issuer_request_id }` - Build and sign the exact on-chain
-  deposit transaction. Requires `Minting` state. Produces `MintTxIntended`,
-  which persists the raw transaction, hash, nonce, signing time, and stable
-  external transaction ID before any broadcast
-- `SubmitMint { issuer_request_id }` - Broadcast the exact transaction stored by
-  `MintTxIntended`. Requires `MintIntended` state. Produces `MintTxSubmitted` on
-  success. An uncertain broadcast failure leaves the aggregate in
-  `MintIntended`, so recovery rebroadcasts the same bytes
-- `ConfirmMint { issuer_request_id, tx_id }` - Confirm a previously submitted
-  mint transaction. Re-fetches the on-chain receipt for the stored `tx_id` and
-  produces `TokensMinted` or `MintingFailed`
-- `SendCallback { issuer_request_id }` - Send the callback to Alpaca confirming
-  mint completion
-- `Recover { issuer_request_id, mode }` - Recover a mint stuck in an incomplete
-  state. Startup recovery drives any mint in `JournalConfirmed`, `Minting`,
-  `MintIntended`, `TxSubmitted`, `MintingFailed`, or `CallbackPending` state; at
-  runtime, live retry scheduling is triggered specifically when a mint lands in
-  `MintingFailed` during the journal-confirmation flow. Both paths hand a mint
-  that is waiting on a retry window to a background scheduled-recovery task, so
-  retries fire on schedule without waiting for a restart. Queries the receipt
-  inventory for a receipt matching the `issuer_request_id`. If a matching
-  receipt is found, the mint already succeeded on-chain, so recovery records the
-  existing mint (`ExistingMintRecovered`) and proceeds to callback. If no
-  receipt is found and the previous transaction is terminally failed, automatic
-  recovery submits up to four retry transactions after 1m, 10m, 30m, and 1h
-  delays. Manual admin reprocess uses the same recovery path but bypasses the
-  automatic retry cap so an operator can retry after fixing the underlying
-  cause. This prevents double-minting after crashes while ensuring terminal
-  failures can be retried with new `externalTxId`s
-- `RecoverWalletStep { issuer_request_id, mode }` - Internal recovery variant
-  used only while the wallet lock is held. It performs the same recoverable
-  on-chain steps as `Recover`, but becomes a no-op if a concurrent transition
-  already reached `CallbackPending`; the next recovery iteration then sends the
-  callback without the wallet lock
-- `RecoverFromReceipt { issuer_request_id, tx_hash }` - Recover a mint that
-  failed during the minting step, or whose broadcast outcome was not persisted,
-  when an ITN receipt is discovered on-chain. Triggered by the receipt monitor
-  when it finds a Deposit event with a matching `issuer_request_id`. Accepts
-  `MintIntended`, because the persisted transaction may have been mined before
-  submission recording, and `MintingFailed` when the non-failed predecessor was
-  `Minting`. Rejects `JournalConfirmed` and `Minting` because neither state
-  proves a transaction was signed or submitted. Emits `ExistingMintRecovered`
-  and proceeds to callback
+- `RecordTxSubmitted { issuer_request_id, external_tx_id, signer_tx_id }` -
+  Records a successful on-chain submission performed by `SubmitMintJob`. Pure,
+  requires `Minting`, emits `MintTxSubmitted`
+- `RecordTokensMinted { issuer_request_id, signer_tx_id, tx_hash, receipt_id, shares_minted, gas_used, block_number }` -
+  Records a confirmed mint performed by `ConfirmMintJob`. Pure, requires
+  `TxSubmitted`, emits `TokensMinted`
+- `RecordCallbackSent { issuer_request_id }` - Records the Alpaca completion
+  callback performed by `SendCallbackJob`. Pure, requires `CallbackPending`,
+  emits `MintCompleted`
+- `RecordMintFailed { issuer_request_id, error }` - Records a side-effect
+  failure reported by a job. Pure, emits `MintingFailed`
+- `RecordExistingMint { issuer_request_id, tx_hash, receipt_id, shares_minted, block_number }` -
+  Records a mint whose on-chain transaction already succeeded (a receipt
+  exists), reported by `SubmitMintJob` before it re-submits. Pure double-mint
+  guard; emits `ExistingMintRecovered` and advances to `CallbackPending`
+- `RetryMint { issuer_request_id }` - Transitions `MintingFailed` -> `Minting`,
+  advancing the automatic-retry attempt counter. Pure, emits `MintRetryStarted`.
+  Recovery sends this before re-enqueuing a `SubmitMintJob`
+- `CloseMint { issuer_request_id, reason }` - Admin-closes a mint that cannot be
+  automatically recovered. Valid from any non-terminal state; emits `MintClosed`
+  (terminal)
+
+The external mint side effects run in **durable apalis jobs**, not in the
+command handlers — closing the crash window between a signer submission and
+the event commit (ADR-0001). The handlers above are pure: each job performs one
+external call and reports the outcome via the matching `Record…` command. The
+job chain is `SubmitMintJob` (calls `vault.submit_mint`) -> `ConfirmMintJob`
+(polls `vault.confirm_mint`, registers the receipt) -> `SendCallbackJob` (calls
+Alpaca); `process_journal_completion` resolves the vault and enqueues the first
+job. `SubmitMintJob` uses the configured network's Turnkey-backed vault service
+to prepare and submit the signed transaction. It also preserves compatibility
+with a legacy `MintIntended` state by rebroadcasting the exact persisted
+transaction bytes instead of preparing a replacement.
 
 **Events:**
 
@@ -251,6 +241,7 @@ initial request through journal confirmation to on-chain minting and callback.
 - `ExistingMintRecovered` - Existing on-chain mint discovered during recovery
   (carries tx details)
 - `MintRetryStarted` - Mint retry started during recovery
+- `MintClosed` - Admin-closed mint that cannot be auto-recovered (terminal)
 
 Newly persisted transaction IDs use an explicitly tagged `hash` or `legacy`
 representation so replay preserves the original `TxId` variant, including a
@@ -269,40 +260,25 @@ dual-format reader or restore the pre-cutover backup.
 
 **Command -> Event Mappings:**
 
-| Command              | Events                  | Notes                                          |
-| -------------------- | ----------------------- | ---------------------------------------------- |
-| `Initiate`           | `Initiated`             | Mint request created                           |
-| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                              |
-| `RejectJournal`      | `JournalRejected`       | Terminal failure                               |
-| `Deposit`            | `MintingStarted`        | Records intent (no network call)               |
-| `PrepareMint`        | `MintTxIntended`        | Persists exact signed tx before broadcast      |
-| `SubmitMint`         | `MintTxSubmitted`       | Broadcasts the persisted transaction           |
-| `ConfirmMint`        | See below               | Confirms submitted tx                          |
-| `SendCallback`       | `MintCompleted`         | Calls Alpaca callback                          |
-| `Recover`            | See below               | Checks receipt inventory                       |
-| `RecoverWalletStep`  | See below               | Never sends callbacks while wallet-locked      |
-| `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt recovery from intended or failed state |
+| Command                     | Events                  | Notes                                  |
+| --------------------------- | ----------------------- | -------------------------------------- |
+| `Initiate`                  | `Initiated`             | Mint request created                   |
+| `ConfirmJournal`            | `JournalConfirmed`      | Journal confirmed                      |
+| `RejectJournal`             | `JournalRejected`       | Terminal failure                       |
+| `Deposit`                   | `MintingStarted`        | Records intent (no network call)       |
+| `RecordTxSubmitted`         | `MintTxSubmitted`       | `SubmitMintJob` outcome                |
+| `RecordTokensMinted`        | `TokensMinted`          | `ConfirmMintJob` outcome               |
+| `RecordCallbackSent`        | `MintCompleted`         | `SendCallbackJob` outcome              |
+| `RecordMintFailed`          | `MintingFailed`         | Job-reported side-effect failure       |
+| `RecordExistingMint`        | `ExistingMintRecovered` | Double-mint guard (receipt exists)     |
+| `RetryMint`                 | `MintRetryStarted`      | `MintingFailed` -> `Minting` for retry |
+| `CloseMint`                 | `MintClosed`            | Admin-close (terminal)                 |
 
-`Deposit` emits only `MintingStarted` (business intent). `PrepareMint` builds
-and signs the transaction, then persists the exact bytes and hash in
-`MintTxIntended`. Only `SubmitMint` may broadcast those persisted bytes. A crash
-before `MintTxIntended` cannot have broadcast anything; a crash after it causes
-recovery to rebroadcast or poll that same transaction, never prepare a second
-one. A crash after broadcast but before `MintTxSubmitted` therefore remains safe
-because rebroadcasting identical signed bytes is idempotent. Preparing,
-persisting, and initially broadcasting a mint transaction share one wallet
-critical section. Startup mint recovery processes its persisted intents in nonce
-order before mint states that may prepare a new transaction. Mint and redemption
-recovery run concurrently so persisted transactions from either domain can fill
-lower nonce gaps while higher transactions await confirmation. Live mint and
-burn preparation query the authoritative event log and are blocked while any
-other wallet intent remains unresolved; this safety check does not depend on a
-fallible read-model projection. Together these rules prevent two aggregate
-commands from signing the same wallet nonce without relying on in-memory nonce
-state that would be lost on restart. Each live burn attempt waits at most 30
-seconds behind an earlier unresolved wallet intent. On timeout it prepares and
-broadcasts nothing, leaves the redemption recoverable, and defers the burn to
-recovery rather than occupying the live flow indefinitely.
+`Deposit` emits only `MintingStarted` (intent). The actual submission is handled
+by `SubmitMintJob`, whose outcome command emits either `MintTxSubmitted`
+(success) or `MintingFailed` (failure). This two-step design persists intent
+before the network call, so a crash during submission leaves the aggregate in
+`Minting` state (recoverable) rather than `JournalConfirmed`.
 
 The issuer is a single-writer service: exactly one process may own a given
 SQLite event store and signing wallet at a time. Horizontal replicas sharing a
@@ -310,36 +286,26 @@ wallet are unsupported because the wallet critical section is process-local.
 Deployments must terminate the old process before the replacement begins serving
 or recovering work.
 
-`ConfirmMint` re-fetches the on-chain receipt for the submitted `tx_id` and
-emits either `TokensMinted` (success) or `MintingFailed` (failure).
+**Recovery.** A durable `MintRecoveryJob` re-drives a stuck or failed mint. Its
+budget loop (driven by `automatic_retry_decision`) enqueues the per-state job
+for the mint's current state — `SubmitMintJob` from `Minting`, `ConfirmMintJob`
+from `TxSubmitted`, `SendCallbackJob` from `CallbackPending` — or issues
+the pure transition that precedes it (`Deposit` from `JournalConfirmed`,
+`RetryMint` from `MintingFailed`). The startup re-scan, the periodic reconciler,
+the receipt monitor (on ITN-receipt discovery), and the admin reprocess endpoint
+all route through the same enqueue path.
 
-`Recover` checks the receipt inventory for a receipt matching the
-`issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
-in `Minting` state, prepares and persists `MintTxIntended`. If in
-`MintIntended`, rebroadcasts the persisted raw transaction. If in `TxSubmitted`
-(or `MintingFailed` with a known prior transaction), calls `ConfirmMint` with
-the stored `tx_id` to re-fetch the on-chain receipt. `TxSubmitted` means the
-persisted transaction was broadcast; it does not mean the transaction succeeded
-on-chain. `ConfirmMint` waits for the receipt and emits `TokensMinted` for a
-successful transaction or `MintingFailed` for a reverted or otherwise failed
-transaction. Retry transactions use `mint-{issuer_request_id}-retry-{n}` where
-automatic retries use n = 1..4 and the delay schedule is 1m, 10m, 30m, then 1h.
-
-The retry-delay/exhaustion schedule is driven by a `MintingFailed` attempt
-counter. A transaction-preparation failure records `MintingFailed`; an uncertain
-broadcast failure instead preserves `MintIntended` and recovery rebroadcasts the
-exact same signed bytes without advancing the attempt. A running service keeps
-driving deferred retries via a background scheduled-recovery task (also spawned
-at startup and after a manual reprocess), rather than waiting for the next
-restart.
-
-`RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
-receipt for a mint in `MintIntended`, or in `MintingFailed` where the
-predecessor was `Minting`. It emits `ExistingMintRecovered`, transitions to
-`CallbackPending`, then continues through the existing `SendCallback` ->
-`MintCompleted` flow without rebroadcasting. Automated recovery persists the
-`CallbackPending` boundary before delivering the callback, so receipt polling
-and Alpaca requests do not hold the wallet transaction lock.
+Re-submission is double-mint-safe: before submitting, `SubmitMintJob` checks the
+receipt inventory and, if the mint already succeeded on-chain, sends
+`RecordExistingMint` (emitting `ExistingMintRecovered`) instead of submitting
+again; the deterministic `external_tx_id` (`mint-{issuer_request_id}`) lets
+a deduplicating signing backend drop repeats. The retry-delay/exhaustion
+schedule is driven by a `MintingFailed` attempt counter (retries due after 1m,
+10m, 30m, 1h, then exhausted). A discovered receipt bypasses the backoff so a
+mint that actually succeeded is recorded immediately rather than waiting out
+the retry window. A pre-existing `MintIntended` state is recovered by submitting
+its persisted signed transaction, preserving the Turnkey migration's
+rebroadcast behavior.
 
 ### Redemption Aggregate
 
@@ -1311,11 +1277,11 @@ sequenceDiagram
     Alpaca->>Us: POST /inkind/issuance/confirm<br/>{status: "completed"}
     Note right of Us: ConfirmJournal command<br/>Event: JournalConfirmed
     Note right of Us: Deposit command<br/>Event: MintingStarted
-    Note right of Us: PrepareMint command<br/>Event: MintTxIntended<br/>(signed transaction persisted)
+    Note right of Us: Enqueue SubmitMintJob
 
     rect rgb(200, 220, 250)
         Note over Us,Blockchain: Single Atomic Transaction (multicall)
-        Us->>Blockchain: SubmitMint: broadcast persisted transaction
+        Us->>Blockchain: SubmitMintJob: prepare and submit transaction
         Note right of Us: Event: MintTxSubmitted
         Note right of Blockchain: 1. deposit(10 AAPL, bot_wallet)
         Note right of Blockchain: Bot receives shares + receipts
@@ -1323,10 +1289,10 @@ sequenceDiagram
         Note right of Blockchain: Bot transfers shares to AP<br/>(keeps receipts)
     end
     Blockchain->>Us: Transaction confirmed (both steps succeeded)
-    Note right of Us: ConfirmMint command<br/>Event: TokensMinted
+    Note right of Us: Deposit + durable submit/confirm jobs<br/>Events: MintingStarted,<br/>MintTxSubmitted, TokensMinted
 
     Us->>Alpaca: POST /tokenization/callback/mint<br/>{tx_hash, wallet_address}
-    Note right of Us: SendCallback command<br/>Event: MintCompleted<br/>Status: completed
+    Note right of Us: SendCallbackJob -> RecordCallbackSent<br/>Event: MintCompleted<br/>Status: completed
 
     Alpaca->>AP: Mint completed ✓
     Note left of AP: AP now has 10 AAPL0x<br/>share tokens in their wallet<br/>(Bot holds receipts)
@@ -1593,19 +1559,25 @@ stateDiagram-v2
     PendingJournal --> JournalConfirmed: ConfirmJournal
     PendingJournal --> JournalRejected: RejectJournal
     JournalConfirmed --> Minting: Deposit (MintingStarted)
-    Minting --> MintIntended: PrepareMint (MintTxIntended)
-    Minting --> MintingFailed: PrepareMint (MintingFailed)
-    MintIntended --> TxSubmitted: SubmitMint (MintTxSubmitted)
-    MintIntended --> MintIntended: SubmitMint uncertain failure (no event)
-    MintIntended --> CallbackPending: Recover or RecoverFromReceipt (ExistingMintRecovered)
-    TxSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
-    TxSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
-    MintingFailed --> MintIntended: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + MintTxIntended)
-    MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
-    MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
-    CallbackPending --> Completed: SendCallback
+    Minting --> TxSubmitted: RecordTxSubmitted (MintTxSubmitted)
+    Minting --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
+    Minting --> MintingFailed: RecordMintFailed (MintingFailed)
+    MintIntended --> TxSubmitted: SubmitMintJob (legacy persisted intent)
+    MintIntended --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
+    TxSubmitted --> CallbackPending: RecordTokensMinted (TokensMinted)
+    TxSubmitted --> MintingFailed: RecordMintFailed (MintingFailed)
+    MintingFailed --> Minting: RetryMint (MintRetryStarted)
+    MintingFailed --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
+    CallbackPending --> Completed: RecordCallbackSent (MintCompleted)
+    JournalConfirmed --> Closed: CloseMint (MintClosed)
+    Minting --> Closed: CloseMint (MintClosed)
+    MintIntended --> Closed: CloseMint (MintClosed)
+    TxSubmitted --> Closed: CloseMint (MintClosed)
+    CallbackPending --> Closed: CloseMint (MintClosed)
+    MintingFailed --> Closed: CloseMint (MintClosed)
     JournalRejected --> [*]
     Completed --> [*]
+    Closed --> [*]
 ```
 
 **Data Structures:**
@@ -2430,9 +2402,13 @@ Auto-detects the right recovery path from the event history:
 
 **Mint:** `POST /admin/reprocess/mint/<aggregate_id>`
 
-Dispatches the manual `Recover` command which handles `JournalConfirmed`,
-`Minting`, `MintingFailed`, and `CallbackPending` states. Manual reprocess can
-submit the next deterministic retry even after automatic retries have exhausted.
+Enqueues a durable `MintRecoveryJob` — the same path the startup re-scan, the
+periodic reconciler, and the receipt monitor use — which re-drives the mint
+through the per-state jobs from whatever incomplete state it is in
+(`JournalConfirmed`, `Minting`, `TxSubmitted`, `MintingFailed`,
+`CallbackPending`). The recovery budget loop honours the automatic-retry
+schedule, so a mint whose automatic retries are already exhausted is not retried
+again by a manual reprocess; close it with `/admin/close/mint` instead.
 
 **Post-Alpaca with existing on-chain burn:** If a `BurningFailed` event carries
 a tx ID, the endpoint scans on-chain for the transaction. If the tx completed

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,6 +191,9 @@ initial request through journal confirmation to on-chain minting and callback.
   `MintingStarted`. Intent is persisted before the network call so that a crash
   during submission leaves the aggregate in a recoverable `Minting` state rather
   than `JournalConfirmed` (which would lose track of the submission)
+- `RecordTxIntended { issuer_request_id, prepared_tx }` - Persist the exact
+  signed transaction prepared by `SubmitMintJob` before broadcast. Pure,
+  requires `Minting`, emits `MintTxIntended`
 - `RecordTxSubmitted { issuer_request_id, external_tx_id, signer_tx_id }` -
   Records a successful on-chain submission performed by `SubmitMintJob`. Pure,
   requires `Minting`, emits `MintTxSubmitted`
@@ -214,16 +217,18 @@ initial request through journal confirmation to on-chain minting and callback.
   (terminal)
 
 The external mint side effects run in **durable apalis jobs**, not in the
-command handlers — closing the crash window between a signer submission and
-the event commit (ADR-0001). The handlers above are pure: each job performs one
+command handlers — closing the crash window between a signer submission and the
+event commit (ADR-0001). The handlers above are pure: each job performs one
 external call and reports the outcome via the matching `Record…` command. The
-job chain is `SubmitMintJob` (calls `vault.submit_mint`) -> `ConfirmMintJob`
-(polls `vault.confirm_mint`, registers the receipt) -> `SendCallbackJob` (calls
+job chain is `SubmitMintJob` (prepares the transaction, persists
+`MintTxIntended`, then calls `vault.submit_mint`) -> `ConfirmMintJob` (polls
+`vault.confirm_mint`, registers the receipt) -> `SendCallbackJob` (calls
 Alpaca); `process_journal_completion` resolves the vault and enqueues the first
 job. `SubmitMintJob` uses the configured network's Turnkey-backed vault service
-to prepare and submit the signed transaction. It also preserves compatibility
-with a legacy `MintIntended` state by rebroadcasting the exact persisted
-transaction bytes instead of preparing a replacement.
+to prepare and submit the signed transaction. A retry with an unresolved
+`MintIntended` predecessor rebroadcasts those exact persisted bytes instead of
+preparing a replacement, and other mint jobs wait while that wallet intent is
+unresolved.
 
 **Events:**
 
@@ -260,19 +265,19 @@ dual-format reader or restore the pre-cutover backup.
 
 **Command -> Event Mappings:**
 
-| Command                     | Events                  | Notes                                  |
-| --------------------------- | ----------------------- | -------------------------------------- |
-| `Initiate`                  | `Initiated`             | Mint request created                   |
-| `ConfirmJournal`            | `JournalConfirmed`      | Journal confirmed                      |
-| `RejectJournal`             | `JournalRejected`       | Terminal failure                       |
-| `Deposit`                   | `MintingStarted`        | Records intent (no network call)       |
-| `RecordTxSubmitted`         | `MintTxSubmitted`       | `SubmitMintJob` outcome                |
-| `RecordTokensMinted`        | `TokensMinted`          | `ConfirmMintJob` outcome               |
-| `RecordCallbackSent`        | `MintCompleted`         | `SendCallbackJob` outcome              |
-| `RecordMintFailed`          | `MintingFailed`         | Job-reported side-effect failure       |
-| `RecordExistingMint`        | `ExistingMintRecovered` | Double-mint guard (receipt exists)     |
-| `RetryMint`                 | `MintRetryStarted`      | `MintingFailed` -> `Minting` for retry |
-| `CloseMint`                 | `MintClosed`            | Admin-close (terminal)                 |
+| Command              | Events                  | Notes                                  |
+| -------------------- | ----------------------- | -------------------------------------- |
+| `Initiate`           | `Initiated`             | Mint request created                   |
+| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                      |
+| `RejectJournal`      | `JournalRejected`       | Terminal failure                       |
+| `Deposit`            | `MintingStarted`        | Records intent (no network call)       |
+| `RecordTxSubmitted`  | `MintTxSubmitted`       | `SubmitMintJob` outcome                |
+| `RecordTokensMinted` | `TokensMinted`          | `ConfirmMintJob` outcome               |
+| `RecordCallbackSent` | `MintCompleted`         | `SendCallbackJob` outcome              |
+| `RecordMintFailed`   | `MintingFailed`         | Job-reported side-effect failure       |
+| `RecordExistingMint` | `ExistingMintRecovered` | Double-mint guard (receipt exists)     |
+| `RetryMint`          | `MintRetryStarted`      | `MintingFailed` -> `Minting` for retry |
+| `CloseMint`          | `MintClosed`            | Admin-close (terminal)                 |
 
 `Deposit` emits only `MintingStarted` (intent). The actual submission is handled
 by `SubmitMintJob`, whose outcome command emits either `MintTxSubmitted`
@@ -289,23 +294,23 @@ or recovering work.
 **Recovery.** A durable `MintRecoveryJob` re-drives a stuck or failed mint. Its
 budget loop (driven by `automatic_retry_decision`) enqueues the per-state job
 for the mint's current state — `SubmitMintJob` from `Minting`, `ConfirmMintJob`
-from `TxSubmitted`, `SendCallbackJob` from `CallbackPending` — or issues
-the pure transition that precedes it (`Deposit` from `JournalConfirmed`,
-`RetryMint` from `MintingFailed`). The startup re-scan, the periodic reconciler,
-the receipt monitor (on ITN-receipt discovery), and the admin reprocess endpoint
-all route through the same enqueue path.
+from `TxSubmitted`, `SendCallbackJob` from `CallbackPending` — or issues the
+pure transition that precedes it (`Deposit` from `JournalConfirmed`, `RetryMint`
+from `MintingFailed`). The startup re-scan, the periodic reconciler, the receipt
+monitor (on ITN-receipt discovery), and the admin reprocess endpoint all route
+through the same enqueue path.
 
 Re-submission is double-mint-safe: before submitting, `SubmitMintJob` checks the
 receipt inventory and, if the mint already succeeded on-chain, sends
 `RecordExistingMint` (emitting `ExistingMintRecovered`) instead of submitting
-again; the deterministic `external_tx_id` (`mint-{issuer_request_id}`) lets
-a deduplicating signing backend drop repeats. The retry-delay/exhaustion
-schedule is driven by a `MintingFailed` attempt counter (retries due after 1m,
-10m, 30m, 1h, then exhausted). A discovered receipt bypasses the backoff so a
-mint that actually succeeded is recorded immediately rather than waiting out
-the retry window. A pre-existing `MintIntended` state is recovered by submitting
-its persisted signed transaction, preserving the Turnkey migration's
-rebroadcast behavior.
+again; the deterministic `external_tx_id` (`mint-{issuer_request_id}`) lets a
+deduplicating signing backend drop repeats. The retry-delay/exhaustion schedule
+is driven by a `MintingFailed` attempt counter (retries due after 1m, 10m, 30m,
+1h, then exhausted). A discovered receipt bypasses the backoff so a mint that
+actually succeeded is recorded immediately rather than waiting out the retry
+window. A pre-existing `MintIntended` state is recovered by submitting its
+persisted signed transaction, preserving the Turnkey migration's rebroadcast
+behavior.
 
 ### Redemption Aggregate
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,5 +1,6 @@
 use alloy::network::ReceiptResponse;
 use alloy::primitives::B256;
+use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::AggregateError;
@@ -18,9 +19,9 @@ use crate::alpaca::{
 };
 use crate::auth::InternalAuth;
 use crate::mint::{
-    DriveOutcome, IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
+    IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
     TokenizationRequestId, find_by_issuer_request_id,
-    find_stuck as find_stuck_mints, recover_mint_manually,
+    find_stuck as find_stuck_mints, recovery::enqueue_scheduled_mint_recovery,
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -1117,13 +1118,12 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, store, vault_services, pool))]
+#[tracing::instrument(skip(_auth, pool, apalis_pool))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
     _auth: InternalAuth,
-    store: &rocket::State<Arc<Store<Mint>>>,
-    vault_services: &rocket::State<NetworkVaultServices>,
     pool: &rocket::State<Pool<Sqlite>>,
+    apalis_pool: &rocket::State<ApalisSqlitePool>,
     aggregate_id: &str,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let issuer_request_id: IssuerMintRequestId = aggregate_id
@@ -1132,7 +1132,7 @@ pub(crate) async fn reprocess_mint(
         .map_err(|_| Status::BadRequest)?;
 
     // Check current state via view
-    let (current_state, network) = match find_by_issuer_request_id(
+    let current_state = match find_by_issuer_request_id(
         pool.inner(),
         &issuer_request_id,
     )
@@ -1153,14 +1153,7 @@ pub(crate) async fn reprocess_mint(
                 MintView::CallbackPending { .. } => "CallbackPending",
                 MintView::MintingFailed { .. } => "MintingFailed",
             };
-            let (_, _, network) = mint_view_asset(&view);
-            let Some(network) = network else {
-                error!(target: "admin", aggregate_id = aggregate_id,
-                    "Mint view has no network — cannot select a vault service"
-                );
-                return Err(Status::InternalServerError);
-            };
-            (state.to_string(), network)
+            state.to_string()
         }
         Ok(None) => return Err(Status::NotFound),
         Err(err) => {
@@ -1169,31 +1162,27 @@ pub(crate) async fn reprocess_mint(
         }
     };
 
-    let vault_service = vault_services.service(network).map_err(|error| {
-        error!(target: "admin", aggregate_id = aggregate_id,
-            error = %error,
-            "Cannot reprocess mint on an unconfigured network"
-        );
-        Status::UnprocessableEntity
-    })?;
-
-    let outcome = recover_mint_manually(
-        store.inner().as_ref(),
-        vault_service,
+    // Manual reprocess enqueues a durable recovery job — the same path the
+    // automatic startup re-scan and the periodic reconciler use. It frees any
+    // terminal recovery job for this mint and re-drives it through the per-state
+    // jobs to completion.
+    enqueue_scheduled_mint_recovery(
+        pool.inner(),
+        apalis_pool.inner(),
         issuer_request_id,
     )
-    .await;
-    if !matches!(outcome, DriveOutcome::Done) {
+    .await
+    .map_err(|error| {
         error!(target: "admin", aggregate_id = aggregate_id,
-            ?outcome,
-            "Failed to drive manual mint recovery to completion"
+            error = %error,
+            "Failed to enqueue scheduled mint recovery"
         );
-        return Err(Status::UnprocessableEntity);
-    }
+        Status::InternalServerError
+    })?;
 
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
-        "Mint reprocessed successfully"
+        "Mint reprocess enqueued successfully"
     );
 
     Ok(Json(ReprocessResponse {

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -19,9 +19,9 @@ use crate::alpaca::{
 };
 use crate::auth::InternalAuth;
 use crate::mint::{
-    IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
-    TokenizationRequestId, find_by_issuer_request_id,
-    find_stuck as find_stuck_mints, recovery::enqueue_scheduled_mint_recovery,
+    IssuerMintRequestId, ManualRecoveryDecision, Mint, MintCommand, MintEvent,
+    MintView, TokenizationRequestId, find_stuck as find_stuck_mints,
+    recovery::enqueue_scheduled_mint_recovery,
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -1118,12 +1118,14 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, pool, apalis_pool))]
+#[tracing::instrument(skip(_auth, pool, apalis_pool, store, vault_services))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
     apalis_pool: &rocket::State<ApalisSqlitePool>,
+    store: &rocket::State<Arc<Store<Mint>>>,
+    vault_services: &rocket::State<NetworkVaultServices>,
     aggregate_id: &str,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let issuer_request_id: IssuerMintRequestId = aggregate_id
@@ -1131,36 +1133,33 @@ pub(crate) async fn reprocess_mint(
         .map(IssuerMintRequestId::new)
         .map_err(|_| Status::BadRequest)?;
 
-    // Check current state via view
-    let current_state = match find_by_issuer_request_id(
-        pool.inner(),
-        &issuer_request_id,
-    )
-    .await
-    {
-        Ok(Some(view)) => {
-            let state = match &view {
-                MintView::NotFound => return Err(Status::NotFound),
-                MintView::Completed { .. } | MintView::Closed { .. } => {
-                    return Err(Status::Conflict);
-                }
-                MintView::Initiated { .. } => "Initiated",
-                MintView::JournalConfirmed { .. } => "JournalConfirmed",
-                MintView::JournalRejected { .. } => "JournalRejected",
-                MintView::Minting { .. } => "Minting",
-                MintView::MintIntended { .. } => "MintIntended",
-                MintView::MintTxSubmitted { .. } => "MintTxSubmitted",
-                MintView::CallbackPending { .. } => "CallbackPending",
-                MintView::MintingFailed { .. } => "MintingFailed",
-            };
-            state.to_string()
-        }
+    let mint = match store.load(&issuer_request_id).await {
+        Ok(Some(mint)) => mint,
         Ok(None) => return Err(Status::NotFound),
-        Err(err) => {
-            error!(target: "admin", error = %err, "Failed to query mint view");
+        Err(error) => {
+            error!(target: "admin", aggregate_id, error = %error, "Failed to load mint");
             return Err(Status::InternalServerError);
         }
     };
+    match mint.manual_recovery_decision() {
+        ManualRecoveryDecision::Eligible => {}
+        ManualRecoveryDecision::AlreadyTerminal => {
+            return Err(Status::Conflict);
+        }
+        ManualRecoveryDecision::Unrecoverable => {
+            return Err(Status::UnprocessableEntity);
+        }
+    }
+    let Some(network) = mint.network() else {
+        return Err(Status::UnprocessableEntity);
+    };
+    if let Err(error) = vault_services.service(network) {
+        error!(target: "admin", aggregate_id, ?network, error = %error,
+            "No vault service configured for mint network"
+        );
+        return Err(Status::UnprocessableEntity);
+    }
+    let current_state = mint.state_name().to_string();
 
     // Manual reprocess enqueues a durable recovery job — the same path the
     // automatic startup re-scan and the periodic reconciler use. It frees any

--- a/src/alpaca/mock.rs
+++ b/src/alpaca/mock.rs
@@ -63,13 +63,6 @@ impl MockAlpacaService {
         }
     }
 
-    #[cfg(test)]
-    #[must_use]
-    pub(crate) const fn with_callback_delay(mut self, delay_ms: u64) -> Self {
-        self.callback_delay_ms = delay_ms;
-        self
-    }
-
     /// Returns the number of times `send_mint_callback()` was called.
     #[cfg(test)]
     pub(crate) fn get_call_count(&self) -> usize {

--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -10,6 +10,7 @@ use crate::redemption::IssuerRedemptionRequestId;
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 
 pub(crate) mod itn;
+#[cfg(test)]
 pub(crate) mod mock;
 pub(crate) mod service;
 

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -38,6 +38,14 @@ use std::time::Duration;
 /// `Jobs` encoding.
 type Storage<Task> = SqliteStorage<Task, JsonCodec<CompactType>, SqliteFetcher>;
 
+/// The `job_type` apalis-sqlite assigns to `Task`: `SqliteStorage::new` derives
+/// it from `std::any::type_name::<Task>()` and binds that on both push and fetch.
+/// Cleanup queries that scope a `DELETE` to one job type must derive it the same
+/// way, so they match exactly the rows apalis actually wrote.
+pub(crate) fn job_type<Task>() -> &'static str {
+    std::any::type_name::<Task>()
+}
+
 /// Handler-facing durable job queue backed by apalis `SqliteStorage`.
 ///
 /// Constructed against the apalis-sqlite (sqlx 0.8) pool, distinct from the

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -43,7 +43,7 @@ type Storage<Task> = SqliteStorage<Task, JsonCodec<CompactType>, SqliteFetcher>;
 /// Cleanup queries that scope a `DELETE` to one job type must derive it the same
 /// way, so they match exactly the rows apalis actually wrote.
 pub(crate) fn job_type<Task>() -> &'static str {
-    std::any::type_name::<Task>()
+    type_name::<Task>()
 }
 
 /// Handler-facing durable job queue backed by apalis `SqliteStorage`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,10 +34,10 @@ use crate::mint::job::{
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
-        DriveOutcome, MintRecoveryHandler, MintRecoveryJob, MintRecoveryJobCtx,
+        MintRecoveryContext, MintRecoveryHandler, MintRecoveryJob,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
-        prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
-        recover_mint, reset_orphaned_recovery_jobs,
+        prune_unreferenced_recovery_workers, push_mint_recovery_job,
+        reconcile_recoverable_mints, reset_orphaned_recovery_jobs,
         vacuum_terminal_recovery_jobs,
     },
 };
@@ -387,8 +387,9 @@ pub async fn initialize_rocket(
     // draining moments later.
     spawn_mint_recovery_worker(
         apalis_pool.clone(),
+        pool.clone(),
         mint_store.clone(),
-        vault_service_for_rocket.clone(),
+        network_vault_services.clone(),
     );
 
     // Drain the per-step mint side-effect jobs (submit -> confirm -> callback).
@@ -426,11 +427,7 @@ pub async fn initialize_rocket(
             bot_wallet,
             backfill_start_block: runtime.backfill_start_block,
             receipt_poll_interval: config.receipt_poll_interval,
-            handler: MintRecoveryHandler::new(
-                mint_store.clone(),
-                pool.clone(),
-                apalis_pool.clone(),
-            ),
+            handler: MintRecoveryHandler::new(pool.clone(), apalis_pool.clone()),
         });
     }
 
@@ -751,8 +748,6 @@ fn setup_redemption_managers(
 async fn run_mint_recovery(
     pool: &Pool<Sqlite>,
     apalis_pool: &ApalisSqlitePool,
-    mint_store: &Arc<Store<Mint>>,
-    vault_service: &Arc<dyn vault::VaultService>,
 ) {
     info!(target: "mint", "Running mint recovery");
 
@@ -808,35 +803,27 @@ async fn run_mint_recovery(
     debug!(target: "mint", count, "Recovering mints");
 
     for (issuer_request_id, _view) in recoverable_mints {
-        // Drive one synchronous pass so mints that can finish immediately
-        // (e.g. an on-chain receipt already exists) complete before the HTTP
-        // server starts. If the pass does not reach a terminal/exhausted state
-        // — waiting on a retry window, or a transient failure — hand the mint
-        // to a background scheduled-recovery task so it keeps progressing while
-        // the service runs instead of waiting for the next restart.
-        match recover_mint(mint_store, vault_service, issuer_request_id.clone())
-            .await
+        // Hand each recoverable mint to the durable scheduled-recovery worker,
+        // which re-drives it via the per-state jobs. Recovery is no longer
+        // driven inline before the server starts — its safety rests on cqrs-es
+        // optimistic concurrency and the deterministic signer externalTxId,
+        // not on completing before HTTP is up.
+        if let Err(error) = enqueue_scheduled_mint_recovery(
+            pool,
+            apalis_pool,
+            issuer_request_id.clone(),
+        )
+        .await
         {
-            DriveOutcome::RetryNotDue | DriveOutcome::Failed => {
-                if let Err(error) = enqueue_scheduled_mint_recovery(
-                    pool,
-                    apalis_pool,
-                    issuer_request_id.clone(),
-                )
-                .await
-                {
-                    // Degraded but self-recovering: the periodic reconciler
-                    // re-scans recoverable mints and re-enqueues this one, so a
-                    // failed enqueue here delays recovery rather than losing it.
-                    // WARN, not ERROR — an ERROR would raise a false
-                    // unrecoverable alert for a transient, self-healing miss.
-                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        error = %error,
-                        "Failed to enqueue scheduled mint recovery"
-                    );
-                }
-            }
-            DriveOutcome::Done | DriveOutcome::Exhausted => {}
+            // Degraded but self-recovering: the periodic reconciler re-scans
+            // recoverable mints and re-enqueues this one, so a failed enqueue
+            // here delays recovery rather than losing it. WARN, not ERROR — an
+            // ERROR would raise a false unrecoverable alert for a transient,
+            // self-healing miss.
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Failed to enqueue scheduled mint recovery"
+            );
         }
     }
 
@@ -930,12 +917,7 @@ async fn run_recovery_with_timeout(
 ) {
     let recovery = async {
         tokio::join!(
-            Box::pin(run_mint_recovery(
-                pool,
-                apalis_pool,
-                mint_store,
-                vault_service,
-            )),
+            Box::pin(run_mint_recovery(pool, apalis_pool)),
             Box::pin(run_redemption_recovery(
                 &managers.redeem_call,
                 &managers.journal,
@@ -1555,27 +1537,36 @@ const MINT_RECOVERY_WORKER_RESTART_BACKOFF: Duration = Duration::from_secs(5);
 /// restarts the monitor after the same backoff.
 fn spawn_mint_recovery_worker(
     apalis_pool: ApalisSqlitePool,
+    pool: Pool<Sqlite>,
     mint_store: Arc<Store<Mint>>,
-    vault_service: Arc<dyn vault::VaultService>,
+    vault_services: NetworkVaultServices,
 ) {
     tokio::spawn(async move {
         loop {
             let apalis_pool = apalis_pool.clone();
+            let pool = pool.clone();
             let mint_store = mint_store.clone();
-            let vault_service = vault_service.clone();
+            let vault_services = vault_services.clone();
             let monitor = Monitor::new().register(move |_worker_index| {
                 // A fresh worker id per registration is load-bearing for crash
                 // recovery — see [`MintRecoveryWorkerId`].
+                let ctx = Arc::new(MintRecoveryContext {
+                    mint_store: mint_store.clone(),
+                    pool: pool.clone(),
+                    vault_services: vault_services.clone(),
+                    submit_queue: JobQueue::new(&apalis_pool),
+                    confirm_queue: JobQueue::new(&apalis_pool),
+                    callback_queue: JobQueue::new(&apalis_pool),
+                });
                 WorkerBuilder::new(MintRecoveryWorkerId::new().to_string())
                     .backend(
-                        JobQueue::<MintRecoveryJob>::new(&apalis_pool)
-                            .into_storage(),
+                        JobQueue::<MintRecoveryJob>::with_fast_poll(
+                            &apalis_pool,
+                        )
+                        .into_storage(),
                     )
-                    .data(Arc::new(MintRecoveryJobCtx {
-                        mint_store: mint_store.clone(),
-                        vault_service: vault_service.clone(),
-                    }))
-                    .build(work::<MintRecoveryJobCtx, MintRecoveryJob>)
+                    .data(ctx)
+                    .build(work::<MintRecoveryContext, MintRecoveryJob>)
             });
 
             match monitor.run().await {
@@ -1718,8 +1709,10 @@ fn spawn_mint_job_workers(workers: MintJobWorkers) {
         Arc::new(SubmitMintContext {
             mint_store: mint_store.clone(),
             vaults: vaults.clone(),
+            receipts: receipts.clone(),
             bot,
             confirm_queue: JobQueue::new(&apalis_pool),
+            callback_queue: JobQueue::new(&apalis_pool),
             pool: pool.clone(),
             apalis_pool: apalis_pool.clone(),
         }),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,8 +37,8 @@ use crate::mint::{
         MintRecoveryContext, MintRecoveryHandler, MintRecoveryJob,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
         prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
-        reset_orphaned_recovery_jobs, vacuum_terminal_mint_side_effect_jobs,
-        vacuum_terminal_recovery_jobs,
+        reset_orphaned_mint_side_effect_jobs, reset_orphaned_recovery_jobs,
+        vacuum_terminal_mint_side_effect_jobs, vacuum_terminal_recovery_jobs,
     },
 };
 use crate::receipt_inventory::backfill::{
@@ -735,6 +735,14 @@ async fn run_mint_recovery(
     if let Err(error) = reset_orphaned_recovery_jobs(pool).await {
         warn!(target: "mint", error = %error,
             "Failed to reset orphaned mint-recovery jobs"
+        );
+    }
+
+    // Same for the submit/confirm/callback chain: a crash leaves `Running`
+    // rows that would otherwise block re-enqueue until apalis's orphan timeout.
+    if let Err(error) = reset_orphaned_mint_side_effect_jobs(pool).await {
+        warn!(target: "mint", error = %error,
+            "Failed to reset orphaned mint side-effect jobs"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -359,13 +359,8 @@ pub async fn initialize_rocket(
         .map(|config| (config.chain_id, config.vault))
         .collect();
 
-    run_recovery_with_timeout(
-        &pool,
-        &apalis_pool,
-        &managers,
-        &receipt_vaults,
-    )
-    .await;
+    run_recovery_with_timeout(&pool, &apalis_pool, &managers, &receipt_vaults)
+        .await;
 
     // Drain MintRecoveryJobs in the background: the worker runs the per-mint
     // recovery budget loop for each enqueued job. Spawned only AFTER the
@@ -419,7 +414,10 @@ pub async fn initialize_rocket(
             bot_wallet,
             backfill_start_block: runtime.backfill_start_block,
             receipt_poll_interval: config.receipt_poll_interval,
-            handler: MintRecoveryHandler::new(pool.clone(), apalis_pool.clone()),
+            handler: MintRecoveryHandler::new(
+                pool.clone(),
+                apalis_pool.clone(),
+            ),
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,11 +32,11 @@ use crate::mint::job::{
     SubmitMintContext, SubmitMintJob,
 };
 use crate::mint::{
-    Mint, MintServices, MintView, find_all_recoverable_mints,
+    Mint, MintView, find_all_recoverable_mints,
     recovery::{
         MintRecoveryContext, MintRecoveryHandler, MintRecoveryJob,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
-        prune_unreferenced_recovery_workers, push_mint_recovery_job,
+        prune_unreferenced_recovery_workers,
         reconcile_recoverable_mints, reset_orphaned_recovery_jobs,
         vacuum_terminal_mint_side_effect_jobs,
         vacuum_terminal_recovery_jobs,
@@ -305,14 +305,7 @@ pub async fn initialize_rocket(
     let network_vault_services = chain_registry.network_vault_services();
 
     let AggregateCqrsSetup { mint_store, redemption_store } =
-        setup_aggregate_cqrs(
-            &pool,
-            &receipt_inventory_store,
-            &network_vault_services,
-            alpaca_service.clone(),
-            bot_wallet,
-        )
-        .await?;
+        setup_aggregate_cqrs(&pool, &network_vault_services).await?;
 
     let managers = setup_redemption_managers(
         &config,
@@ -370,8 +363,6 @@ pub async fn initialize_rocket(
     run_recovery_with_timeout(
         &pool,
         &apalis_pool,
-        &mint_store,
-        &vault_service_for_rocket,
         &managers,
         &receipt_vaults,
     )
@@ -567,29 +558,17 @@ fn mount_api_docs(
 
 async fn setup_aggregate_cqrs(
     pool: &Pool<Sqlite>,
-    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     network_vault_services: &NetworkVaultServices,
-    alpaca_service: Arc<dyn AlpacaService>,
-    bot_wallet: Address,
 ) -> Result<AggregateCqrsSetup, anyhow::Error> {
-    // Create MintServices with all dependencies
-    let receipt_service =
-        Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
-    let mint_services = MintServices::new(
-        network_vault_services.clone(),
-        alpaca_service,
-        receipt_service,
-        pool.clone(),
-        bot_wallet,
-    );
-
-    // Mint's canonical `mint_view` projection is auto-wired by StoreBuilder; the
-    // secondary `receipt_inventory_view` (formerly a View<Mint> GenericQuery) is
-    // maintained by the registered reactor.
+    // The Mint aggregate's command handlers are pure (its side effects run in
+    // durable jobs), so it needs no services. Its canonical `mint_view`
+    // projection is auto-wired by StoreBuilder; the secondary
+    // `receipt_inventory_view` (formerly a View<Mint> GenericQuery) is maintained
+    // by the registered reactor.
     prepare_event_sourced_startup::<Mint>(pool).await?;
     let (mint_store, mint_projection) = StoreBuilder::<Mint>::new(pool.clone())
         .with(Arc::new(ReceiptInventoryViewReactor::new(pool.clone())))
-        .build(mint_services)
+        .build(())
         .await?;
 
     // Rebuild `mint_view` from scratch so it reflects the current event log even
@@ -921,8 +900,6 @@ const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 async fn run_recovery_with_timeout(
     pool: &Pool<Sqlite>,
     apalis_pool: &ApalisSqlitePool,
-    mint_store: &Arc<Store<Mint>>,
-    vault_service: &Arc<dyn vault::VaultService>,
     managers: &RedemptionManagers,
     receipt_vaults: &[(u64, Address)],
 ) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,7 +299,6 @@ pub async fn initialize_rocket(
     );
     info!(target: "startup", "Bot wallet address: {bot_wallet}");
 
-    let vault_service_for_rocket = base.vault_service.clone();
     let configured_networks = chain_registry.configured_networks();
     let network_vault_services = chain_registry.network_vault_services();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ use crate::mint::{
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
         prune_unreferenced_recovery_workers, push_mint_recovery_job,
         reconcile_recoverable_mints, reset_orphaned_recovery_jobs,
+        vacuum_terminal_mint_side_effect_jobs,
         vacuum_terminal_recovery_jobs,
     },
 };
@@ -390,6 +391,7 @@ pub async fn initialize_rocket(
         pool.clone(),
         mint_store.clone(),
         network_vault_services.clone(),
+        Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone())),
     );
 
     // Drain the per-step mint side-effect jobs (submit -> confirm -> callback).
@@ -775,6 +777,15 @@ async fn run_mint_recovery(
     if let Err(error) = prune_unreferenced_recovery_workers(pool).await {
         warn!(target: "mint", error = %error,
             "Failed to prune unreferenced mint-recovery workers"
+        );
+    }
+
+    // Free the per-state side-effect jobs' idempotency keys from any terminal
+    // rows left by a prior run, so a restart-driven recovery of a rolled-back
+    // mint can re-enqueue them instead of colliding with the prior `Done` row.
+    if let Err(error) = vacuum_terminal_mint_side_effect_jobs(pool).await {
+        warn!(target: "mint", error = %error,
+            "Failed to vacuum terminal mint side-effect jobs"
         );
     }
 
@@ -1540,6 +1551,7 @@ fn spawn_mint_recovery_worker(
     pool: Pool<Sqlite>,
     mint_store: Arc<Store<Mint>>,
     vault_services: NetworkVaultServices,
+    receipts: Arc<dyn ReceiptService>,
 ) {
     tokio::spawn(async move {
         loop {
@@ -1547,6 +1559,7 @@ fn spawn_mint_recovery_worker(
             let pool = pool.clone();
             let mint_store = mint_store.clone();
             let vault_services = vault_services.clone();
+            let receipts = receipts.clone();
             let monitor = Monitor::new().register(move |_worker_index| {
                 // A fresh worker id per registration is load-bearing for crash
                 // recovery — see [`MintRecoveryWorkerId`].
@@ -1554,6 +1567,7 @@ fn spawn_mint_recovery_worker(
                     mint_store: mint_store.clone(),
                     pool: pool.clone(),
                     vault_services: vault_services.clone(),
+                    receipts: receipts.clone(),
                     submit_queue: JobQueue::new(&apalis_pool),
                     confirm_queue: JobQueue::new(&apalis_pool),
                     callback_queue: JobQueue::new(&apalis_pool),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,8 @@ use crate::mint::{
     recovery::{
         MintRecoveryContext, MintRecoveryHandler, MintRecoveryJob,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
-        prune_unreferenced_recovery_workers,
-        reconcile_recoverable_mints, reset_orphaned_recovery_jobs,
-        vacuum_terminal_mint_side_effect_jobs,
+        prune_unreferenced_recovery_workers, reconcile_recoverable_mints,
+        reset_orphaned_recovery_jobs, vacuum_terminal_mint_side_effect_jobs,
         vacuum_terminal_recovery_jobs,
     },
 };

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -169,16 +169,9 @@ async fn process_journal_completion(
     // off the request path; each job records its outcome via an idempotent
     // command and enqueues the next. A domain failure flips the mint to
     // `MintingFailed`, which recovery retries on its own schedule.
-    let (underlying, network) = match mint_store.load(&issuer_request_id).await
-    {
-        Ok(Some(ref mint @ Mint::Minting { ref underlying, .. })) => {
-            let Some(network) = mint.network() else {
-                error!(target: "mint", issuer_request_id = %issuer_request_id,
-                    "Minting mint missing network — cannot enqueue submission"
-                );
-                return;
-            };
-            (underlying.clone(), network)
+    let (underlying, network) = match mint_store.load(&issuer_request_id).await {
+        Ok(Some(Mint::Minting { underlying, network, .. })) => {
+            (underlying, network)
         }
         Ok(Some(mint)) => {
             // Concurrent recovery may have already advanced the mint.

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -252,9 +252,11 @@ async fn process_journal_completion(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
+    use event_sorcery::Store;
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
     use rust_decimal::Decimal;
+    use std::sync::Arc;
     use std::time::Duration;
 
     use super::confirm_journal;
@@ -263,9 +265,11 @@ mod tests {
         TestAccountAndAsset, TestHarness, network_vault_services, test_config,
     };
     use crate::mint::{
-        IssuerMintRequestId, MintCommand, MintView, Quantity,
-        TokenizationRequestId, view::find_by_issuer_request_id,
+        ClientId, IssuerMintRequestId, Mint, MintCommand, MintView, Network,
+        Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        view::find_by_issuer_request_id,
     };
+    use crate::test_utils::setup_test_rocket;
 
     #[tokio::test]
     async fn test_confirm_journal_completed_returns_ok() {
@@ -479,11 +483,15 @@ mod tests {
     /// shared `Jobs` table.
     #[tokio::test]
     async fn confirm_enqueues_submit_job() {
-        let harness = TestHarness::new().await;
-        let TestAccountAndAsset {
-            client_id, underlying, token, network, ..
-        } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
+        let rocket = setup_test_rocket().await.expect("valid test Rocket");
+        let pool = rocket
+            .state::<sqlx::Pool<sqlx::Sqlite>>()
+            .expect("event-store pool is managed")
+            .clone();
+        let mint_store = rocket
+            .state::<Arc<Store<Mint>>>()
+            .expect("mint store is managed")
+            .clone();
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -496,10 +504,10 @@ mod tests {
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     quantity: Quantity::new(Decimal::from(100)),
-                    underlying,
-                    token,
-                    network,
-                    client_id,
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::Base,
+                    client_id: ClientId::new(),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
                     ),
@@ -507,15 +515,6 @@ mod tests {
             )
             .await
             .expect("Failed to initiate mint");
-
-        let rocket = rocket::build()
-            .manage(test_config())
-            .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_store)
-            .manage(pool.clone())
-            .manage(apalis_pool)
-            .manage(network_vault_services(vault))
-            .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
             .await

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -169,7 +169,8 @@ async fn process_journal_completion(
     // off the request path; each job records its outcome via an idempotent
     // command and enqueues the next. A domain failure flips the mint to
     // `MintingFailed`, which recovery retries on its own schedule.
-    let (underlying, network) = match mint_store.load(&issuer_request_id).await {
+    let (underlying, network) = match mint_store.load(&issuer_request_id).await
+    {
         Ok(Some(Mint::Minting { underlying, network, .. })) => {
             (underlying, network)
         }

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -1,6 +1,6 @@
 use alloy::primitives::{Address, B256, address};
 use apalis_sqlite::SqlitePool as ApalisSqlitePool;
-use event_sorcery::{Store, StoreBuilder, test_store};
+use event_sorcery::{Store, StoreBuilder};
 use sqlx::sqlite::{SqliteJournalMode, SqlitePoolOptions};
 use std::str::FromStr;
 use std::sync::Arc;
@@ -10,12 +10,10 @@ use url::Url;
 use crate::account::{
     Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
 };
-use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
 use crate::auth::test_auth_config;
 use crate::config::{Config, Environment, LogLevel};
-use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
-use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+use crate::mint::{Mint, Network, TokenSymbol, UnderlyingSymbol};
 use crate::test_utils::ANVIL_CHAIN_ID;
 use crate::tokenized_asset::{AssetKey, TokenizedAsset, TokenizedAssetCommand};
 use crate::vault::mock::MockVaultService;
@@ -68,15 +66,9 @@ pub(crate) struct TestHarness {
 
 impl TestHarness {
     pub(crate) async fn new() -> Self {
-        Self::new_with_mint_vault(Arc::new(MockVaultService::new_success()))
-            .await
-    }
+        let vault: Arc<dyn VaultService> =
+            Arc::new(MockVaultService::new_success());
 
-    /// Like [`new`](Self::new), but with a caller-chosen vault so failure-path
-    /// tests can drive a mint into `MintingFailed`.
-    pub(crate) async fn new_with_mint_vault(
-        vault: Arc<dyn VaultService>,
-    ) -> Self {
         // Both pools must address the SAME SQLite file: the apalis-sqlite (0.8)
         // pool needs the `Jobs`/`Workers` tables our migrations create on the
         // event-store (0.9) pool, and the two sqlx majors do not share a private
@@ -123,23 +115,9 @@ impl TestHarness {
                 .await
                 .expect("Failed to build tokenized asset store");
 
-        let receipt_inventory_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let mint_services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            vault.clone(),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
-            pool.clone(),
-            bot,
-        );
-
         let (mint_store, _mint_projection) =
             StoreBuilder::<Mint>::new(pool.clone())
-                .build(mint_services)
+                .build(())
                 .await
                 .expect("Failed to build mint store");
 

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -5,7 +5,7 @@ use super::{
     ClientId, IssuerMintRequestId, MintExternalTxId, Network, Quantity,
     TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
 };
-use crate::vault::TxId;
+use crate::vault::{PreparedMintTx, TxId};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum MintCommand {
@@ -34,6 +34,13 @@ pub(crate) enum MintCommand {
     /// is performed by the durable `SubmitMintJob`.
     Deposit {
         issuer_request_id: IssuerMintRequestId,
+    },
+
+    /// Persists the exact signed transaction before the durable submit job
+    /// broadcasts it, so crash recovery can rebroadcast the same bytes.
+    RecordTxIntended {
+        issuer_request_id: IssuerMintRequestId,
+        prepared_tx: PreparedMintTx,
     },
 
     /// Records the outcome of a successful on-chain mint submission performed

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256, TxHash, U256};
+use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 
 use super::{
@@ -6,12 +6,6 @@ use super::{
     TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
 };
 use crate::vault::TxId;
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub(crate) enum MintRecoveryMode {
-    Automatic,
-    Manual,
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum MintCommand {
@@ -37,38 +31,8 @@ pub(crate) enum MintCommand {
     /// `Minting` state. Pure state transition — no network call or vault lookup.
     ///
     /// Produces `MintingStarted`. The actual submission to the signing backend
-    /// is handled by the subsequent `SubmitMint` command.
+    /// is performed by the durable `SubmitMintJob`.
     Deposit {
-        issuer_request_id: IssuerMintRequestId,
-    },
-
-    /// Builds and signs the exact mint transaction, then persists it before
-    /// any broadcast.
-    PrepareMint {
-        issuer_request_id: IssuerMintRequestId,
-    },
-
-    /// Submits the on-chain deposit (minting) transaction to the signing backend.
-    ///
-    /// Requires `MintIntended` state (set by prior `PrepareMint` command) and
-    /// broadcasts only the persisted signed bytes.
-    SubmitMint {
-        issuer_request_id: IssuerMintRequestId,
-    },
-
-    /// Confirms a previously submitted mint transaction.
-    ///
-    /// Polls the signing backend for the transaction identified by
-    /// `tx_id`, then produces `TokensMinted` or `MintingFailed`.
-    ConfirmMint {
-        issuer_request_id: IssuerMintRequestId,
-        tx_id: TxId,
-    },
-
-    /// Sends the callback to Alpaca to confirm mint completion.
-    ///
-    /// Calls the Alpaca service, producing `MintCompleted` on success.
-    SendCallback {
         issuer_request_id: IssuerMintRequestId,
     },
 
@@ -137,28 +101,6 @@ pub(crate) enum MintCommand {
         block_number: u64,
     },
 
-    /// Recovers a mint stuck in an incomplete state.
-    ///
-    /// For mints in `Minting` or `MintingFailed` state:
-    /// - Checks receipt inventory for existing receipt
-    /// - If found: records the existing mint (produces `ExistingMintRecovered`)
-    /// - If not found: retries the mint (produces `MintRetryStarted` then executes mint)
-    ///
-    /// For mints in `CallbackPending` state:
-    /// - Retries sending the callback
-    Recover {
-        issuer_request_id: IssuerMintRequestId,
-        mode: MintRecoveryMode,
-    },
-
-    /// Runs only recovery work that is safe while holding the wallet lock.
-    /// If the mint concurrently advances to callback delivery, this command
-    /// becomes a no-op so the next recovery iteration can send it unlocked.
-    RecoverWalletStep {
-        issuer_request_id: IssuerMintRequestId,
-        mode: MintRecoveryMode,
-    },
-
     /// Admin-closes a mint that cannot be automatically recovered.
     ///
     /// Valid from any non-terminal state. Closed mints are excluded from
@@ -166,18 +108,5 @@ pub(crate) enum MintCommand {
     CloseMint {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
-    },
-
-    /// Recovers a mint that failed during transaction submission but whose
-    /// on-chain transaction actually succeeded, as evidenced by a receipt
-    /// discovered by the receipt monitor.
-    ///
-    /// Only accepts `MintingFailed` state (with `Minting` predecessor).
-    /// When recovery succeeds, atomically sends the Alpaca callback in the
-    /// same command execution to avoid racing with the normal flow's
-    /// `SendCallback` command.
-    RecoverFromReceipt {
-        issuer_request_id: IssuerMintRequestId,
-        tx_hash: TxHash,
     },
 }

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -124,6 +124,19 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
     },
 
+    /// Records a mint whose on-chain transaction already succeeded, as evidenced
+    /// by a receipt the `SubmitMintJob` found before submitting. Pure: produces
+    /// `ExistingMintRecovered` (no I/O) and advances to `CallbackPending`,
+    /// avoiding a double-mint where re-submission would mint again. Idempotent —
+    /// a no-op once the mint is already minted.
+    RecordExistingMint {
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        receipt_id: U256,
+        shares_minted: U256,
+        block_number: u64,
+    },
+
     /// Recovers a mint stuck in an incomplete state.
     ///
     /// For mints in `Minting` or `MintingFailed` state:

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -30,7 +30,7 @@ use super::{IssuerMintRequestId, Mint, MintCommand};
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::{
-    MintedReceiptParams, ReceiptId, ReceiptService, Shares,
+    MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
 };
 use crate::tokenized_asset::Network;
 use crate::vault::{
@@ -49,6 +49,8 @@ pub(crate) enum MintJobError {
     Enqueue(#[from] QueuePushError),
     #[error(transparent)]
     Alpaca(#[from] AlpacaError),
+    #[error(transparent)]
+    ReceiptLookup(#[from] ReceiptLookupError),
 }
 
 /// Submits the on-chain mint to the signing backend, then hands off to
@@ -67,8 +69,10 @@ pub(crate) struct SubmitMintContext {
     /// shared `VaultService` would submit every mint against the default
     /// (Base) chain.
     pub(crate) vaults: NetworkVaultServices,
+    pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) bot: Address,
     pub(crate) confirm_queue: JobQueue<ConfirmMintJob>,
+    pub(crate) callback_queue: JobQueue<SendCallbackJob>,
     /// Event-store pool; the post-failure recovery enqueue releases terminal
     /// job rows on it (see [`enqueue_scheduled_mint_recovery`]).
     pub(crate) pool: Pool<Sqlite>,
@@ -108,6 +112,38 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                 journal_confirmed_at,
                 ..
             } => {
+                // Defence against double-mint: if the on-chain mint already
+                // succeeded (a receipt exists for this mint), record it instead
+                // of re-submitting. Re-submission would mint again where the
+                // signer does not dedup on the external_tx_id.
+                if let Some(receipt) = ctx
+                    .receipts
+                    .find_by_issuer_request_id(
+                        self.chain_id,
+                        &self.vault,
+                        &self.issuer_request_id,
+                    )
+                    .await?
+                {
+                    ctx.mint_store
+                        .send(
+                            &self.issuer_request_id,
+                            MintCommand::RecordExistingMint {
+                                issuer_request_id: self
+                                    .issuer_request_id
+                                    .clone(),
+                                tx_hash: receipt.tx_hash,
+                                receipt_id: receipt.receipt_id,
+                                shares_minted: receipt.shares,
+                                block_number: receipt.block_number,
+                            },
+                        )
+                        .await?;
+
+                    self.enqueue_callback(ctx).await?;
+                    return Ok(());
+                }
+
                 let Some(vault) =
                     self.resolve_vault_service(ctx, *network).await?
                 else {
@@ -339,6 +375,25 @@ impl SubmitMintJob {
                     vault: self.vault,
                     chain_id: self.chain_id,
                     tx_id,
+                },
+                self.issuer_request_id.to_string(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    /// Enqueued after recording an already-succeeded mint
+    /// (`RecordExistingMint` advances it straight to `CallbackPending`).
+    async fn enqueue_callback(
+        &self,
+        ctx: &SubmitMintContext,
+    ) -> Result<(), MintJobError> {
+        ctx.callback_queue
+            .clone()
+            .push_with_idempotency_key(
+                SendCallbackJob {
+                    issuer_request_id: self.issuer_request_id.clone(),
                 },
                 self.issuer_request_id.to_string(),
             )
@@ -708,8 +763,10 @@ mod tests {
                 ANVIL_CHAIN_ID,
                 vault,
             ),
+            receipts: cqrs_receipts(&harness.pool),
             bot: BOT,
             confirm_queue: JobQueue::new(&harness.apalis_pool),
+            callback_queue: JobQueue::new(&harness.apalis_pool),
             pool: harness.pool.clone(),
             apalis_pool: harness.apalis_pool.clone(),
         }
@@ -888,8 +945,10 @@ mod tests {
                     },
                 ),
             ])),
+            receipts: cqrs_receipts(&harness.pool),
             bot: BOT,
             confirm_queue: JobQueue::new(&harness.apalis_pool),
+            callback_queue: JobQueue::new(&harness.apalis_pool),
             pool: harness.pool.clone(),
             apalis_pool: harness.apalis_pool.clone(),
         };

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -12,10 +12,10 @@
 //! schedule — and after recording it the job immediately enqueues the scheduled
 //! recovery job, so the first automatic retry starts right away instead of
 //! waiting for the periodic reconciler — while an infrastructure failure
-//! surfaces as a job error that apalis re-drives. Re-runs are safe —
-//! `submit_mint` derives a deterministic `external_tx_id` from the
-//! `issuer_request_id` (the signing backend dedups duplicate submissions), and
-//! every outcome command is a no-op once its event is recorded.
+//! surfaces as a job error that apalis re-drives. Re-runs are safe: the exact
+//! signed transaction is persisted before broadcast and reused until its
+//! submission resolves, while every outcome command is a no-op once its event
+//! is recorded.
 
 use alloy::primitives::Address;
 use apalis_sqlite::SqlitePool;
@@ -23,10 +23,12 @@ use event_sorcery::{SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::warn;
+use tracing::{info, warn};
 
 use super::recovery::enqueue_scheduled_mint_recovery;
-use super::{IssuerMintRequestId, Mint, MintCommand};
+use super::{
+    IssuerMintRequestId, Mint, MintCommand, has_unresolved_mint_intent,
+};
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::{
@@ -51,6 +53,12 @@ pub(crate) enum MintJobError {
     Alpaca(#[from] AlpacaError),
     #[error(transparent)]
     ReceiptLookup(#[from] ReceiptLookupError),
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+    #[error(
+        "mint {issuer_request_id} is waiting for another persisted wallet intent"
+    )]
+    UnresolvedWalletIntent { issuer_request_id: IssuerMintRequestId },
 }
 
 /// Submits the on-chain mint to the signing backend, then hands off to
@@ -112,35 +120,7 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                 journal_confirmed_at,
                 ..
             } => {
-                // Defence against double-mint: if the on-chain mint already
-                // succeeded (a receipt exists for this mint), record it instead
-                // of re-submitting. Re-submission would mint again where the
-                // signer does not dedup on the external_tx_id.
-                if let Some(receipt) = ctx
-                    .receipts
-                    .find_by_issuer_request_id(
-                        self.chain_id,
-                        &self.vault,
-                        &self.issuer_request_id,
-                    )
-                    .await?
-                {
-                    ctx.mint_store
-                        .send(
-                            &self.issuer_request_id,
-                            MintCommand::RecordExistingMint {
-                                issuer_request_id: self
-                                    .issuer_request_id
-                                    .clone(),
-                                tx_hash: receipt.tx_hash,
-                                receipt_id: receipt.receipt_id,
-                                shares_minted: receipt.shares,
-                                block_number: receipt.block_number,
-                            },
-                        )
-                        .await?;
-
-                    self.enqueue_callback(ctx).await?;
+                if self.record_existing_receipt(ctx).await? {
                     return Ok(());
                 }
 
@@ -193,27 +173,55 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     .map(super::MintExternalTxId::into_string);
 
                 let wallet_guard = vault.lock_wallet().await;
-                let prepared = match vault
-                    .prepare_mint_tx(
-                        self.vault,
-                        assets,
-                        ctx.bot,
-                        *wallet,
-                        receipt_info,
-                        external_tx_id,
-                    )
-                    .await
+                if has_unresolved_mint_intent(
+                    &ctx.pool,
+                    Some(&self.issuer_request_id),
+                )
+                .await?
                 {
-                    Ok(prepared) => prepared,
-                    Err(error) => {
-                        drop(wallet_guard);
-                        self.record_submission_failure(ctx, error).await?;
-                        return Ok(());
-                    }
+                    return Err(MintJobError::UnresolvedWalletIntent {
+                        issuer_request_id: self.issuer_request_id.clone(),
+                    });
+                }
+                let prepared = if let Some(prepared) =
+                    mint.pending_prepared_tx()
+                {
+                    prepared
+                } else {
+                    let prepared = match vault
+                        .prepare_mint_tx(
+                            self.vault,
+                            assets,
+                            ctx.bot,
+                            *wallet,
+                            receipt_info,
+                            external_tx_id,
+                        )
+                        .await
+                    {
+                        Ok(prepared) => prepared,
+                        Err(error) => {
+                            drop(wallet_guard);
+                            self.record_submission_failure(ctx, error).await?;
+                            return Ok(());
+                        }
+                    };
+
+                    ctx.mint_store
+                        .send(
+                            &self.issuer_request_id,
+                            MintCommand::RecordTxIntended {
+                                issuer_request_id: self
+                                    .issuer_request_id
+                                    .clone(),
+                                prepared_tx: prepared.clone(),
+                            },
+                        )
+                        .await?;
+                    prepared
                 };
 
                 let submitted = vault.submit_mint(&prepared).await;
-                drop(wallet_guard);
 
                 match submitted {
                     Ok(submitted) => {
@@ -240,15 +248,30 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                         self.record_submission_failure(ctx, error).await?;
                     }
                 }
+                drop(wallet_guard);
             }
             // Crash recovery for a prepare-then-submit job that persisted
             // intent via the inline PrepareMint path before the job rewrite.
             Mint::TxIntended { prepared_tx, network, .. } => {
+                if self.record_existing_receipt(ctx).await? {
+                    return Ok(());
+                }
                 let Some(vault) =
                     self.resolve_vault_service(ctx, *network).await?
                 else {
                     return Ok(());
                 };
+                let wallet_guard = vault.lock_wallet().await;
+                if has_unresolved_mint_intent(
+                    &ctx.pool,
+                    Some(&self.issuer_request_id),
+                )
+                .await?
+                {
+                    return Err(MintJobError::UnresolvedWalletIntent {
+                        issuer_request_id: self.issuer_request_id.clone(),
+                    });
+                }
 
                 match vault.submit_mint(prepared_tx).await {
                     Ok(submitted) => {
@@ -275,6 +298,7 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                         self.record_submission_failure(ctx, error).await?;
                     }
                 }
+                drop(wallet_guard);
             }
             // A re-run after the submission was already recorded: the
             // confirm job may not have been enqueued before a crash, so
@@ -298,6 +322,45 @@ impl Job<SubmitMintContext> for SubmitMintJob {
 }
 
 impl SubmitMintJob {
+    async fn record_existing_receipt(
+        &self,
+        ctx: &SubmitMintContext,
+    ) -> Result<bool, MintJobError> {
+        let Some(receipt) = ctx
+            .receipts
+            .find_by_issuer_request_id(
+                self.chain_id,
+                &self.vault,
+                &self.issuer_request_id,
+            )
+            .await?
+        else {
+            return Ok(false);
+        };
+
+        info!(
+            target: "mint",
+            issuer_request_id = %self.issuer_request_id,
+            tx_hash = %receipt.tx_hash,
+            block_number = receipt.block_number,
+            "Found existing receipt, recording recovery"
+        );
+        ctx.mint_store
+            .send(
+                &self.issuer_request_id,
+                MintCommand::RecordExistingMint {
+                    issuer_request_id: self.issuer_request_id.clone(),
+                    tx_hash: receipt.tx_hash,
+                    receipt_id: receipt.receipt_id,
+                    shares_minted: receipt.shares,
+                    block_number: receipt.block_number,
+                },
+            )
+            .await?;
+        self.enqueue_callback(ctx).await?;
+        Ok(true)
+    }
+
     /// Resolves the signing backend for `network`. An unconfigured network is
     /// deterministic for this deploy, so it is recorded as `MintingFailed`
     /// instead of surfacing as a job error apalis would re-drive forever.
@@ -686,6 +749,7 @@ async fn kick_mint_recovery(
 
 #[cfg(test)]
 mod tests {
+    use alloy::primitives::{B256, U256};
     use async_trait::async_trait;
     use cqrs_es::{AggregateError, DomainEvent};
     use event_sorcery::test_store;
@@ -801,6 +865,21 @@ mod tests {
         {
             *event_network = network;
         }
+        events
+    }
+
+    fn events_through_tx_intended(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = events_through_minting(issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: crate::vault::PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: chrono::Utc::now(),
+        });
         events
     }
 
@@ -1025,6 +1104,201 @@ mod tests {
             Level::WARN,
             &[test, "Mint submission failed"]
         ));
+    }
+
+    #[tokio::test]
+    async fn submit_mint_job_waits_for_another_persisted_wallet_intent() {
+        let harness = TestHarness::new().await;
+        let pending_id = IssuerMintRequestId::random();
+        let mut pending_events = events_through_minting(&pending_id);
+        pending_events.push(MintEvent::MintTxIntended {
+            issuer_request_id: pending_id.clone(),
+            prepared_tx: crate::vault::PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{pending_id}"),
+            ),
+            intended_at: chrono::Utc::now(),
+        });
+        seed_mint_events(&harness.pool, &pending_id, pending_events).await;
+
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_minting(&issuer_request_id),
+        )
+        .await;
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id,
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .expect_err("another unresolved signed transaction must defer minting");
+
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "the blocked job must not prepare another signed transaction"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_mint_job_persists_signed_intent_before_resolution() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_minting(&issuer_request_id),
+        )
+        .await;
+        let ctx =
+            submit_ctx(&harness, Arc::new(MockVaultService::new_success()));
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let intent_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM events WHERE aggregate_type = 'Mint' AND aggregate_id = ? AND event_type = 'MintEvent::MintTxIntended'",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(intent_count, 1);
+    }
+
+    #[tokio::test]
+    async fn submit_mint_job_retry_reuses_persisted_signed_intent() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: crate::vault::PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: chrono::Utc::now(),
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "submission outcome unknown".to_string(),
+            failed_at: chrono::Utc::now(),
+        });
+        events.push(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            started_at: chrono::Utc::now(),
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "recovery must rebroadcast the persisted bytes, not prepare a new transaction"
+        );
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::TxSubmitted { .. }));
+    }
+
+    #[tokio::test]
+    async fn tx_intended_submission_acquires_wallet_lock() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id,
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(vault.get_wallet_lock_call_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn tx_intended_with_existing_receipt_records_without_resubmitting() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+        let receipts = cqrs_receipts(&harness.pool);
+        let receipt_info = ReceiptInformation::new(
+            super::super::TokenizationRequestId::new("tok-123"),
+            issuer_request_id.clone(),
+            super::super::UnderlyingSymbol::new("AAPL").unwrap(),
+            crate::Quantity::new(rust_decimal::Decimal::from(100)),
+            chrono::Utc::now(),
+            None,
+        );
+        receipts
+            .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
+                vault: VAULT,
+                receipt_id: ReceiptId::from(U256::from(7)),
+                shares: Shares::new(U256::from(100)),
+                block_number: 1_234,
+                tx_hash: B256::ZERO,
+                receipt_info_bytes: receipt_info.encode(None).unwrap(),
+                receipt_info,
+            })
+            .await
+            .unwrap();
+        let vault = Arc::new(MockVaultService::new_success());
+        let mut ctx = submit_ctx(&harness, vault.clone());
+        ctx.receipts = receipts;
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::CallbackPending { .. }));
+        assert_eq!(vault.get_call_count(), 0);
     }
 
     /// A re-run of the submit job after the submission was already recorded

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -758,15 +758,11 @@ mod tests {
     ) -> SubmitMintContext {
         SubmitMintContext {
             mint_store: harness.mint_store.clone(),
-<<<<<<< HEAD
             vaults: NetworkVaultServices::with_single_vault(
                 Network::Base,
                 ANVIL_CHAIN_ID,
                 vault,
             ),
-=======
-            vault,
->>>>>>> 15a77f85 (refactor: remove the superseded inline mint recovery commands)
             receipts: cqrs_receipts(&harness.pool),
             bot: BOT,
             confirm_queue: JobQueue::new(&harness.apalis_pool),

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -758,11 +758,15 @@ mod tests {
     ) -> SubmitMintContext {
         SubmitMintContext {
             mint_store: harness.mint_store.clone(),
+<<<<<<< HEAD
             vaults: NetworkVaultServices::with_single_vault(
                 Network::Base,
                 ANVIL_CHAIN_ID,
                 vault,
             ),
+=======
+            vault,
+>>>>>>> 15a77f85 (refactor: remove the superseded inline mint recovery commands)
             receipts: cqrs_receipts(&harness.pool),
             bot: BOT,
             confirm_queue: JobQueue::new(&harness.apalis_pool),

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -23,9 +23,7 @@ pub use api::MintResponse;
 pub(crate) use api::{confirm_journal, initiate_mint};
 pub(crate) use cmd::MintCommand;
 pub(crate) use event::MintEvent;
-pub(crate) use view::{
-    MintView, find_all_recoverable_mints, find_by_issuer_request_id, find_stuck,
-};
+pub(crate) use view::{MintView, find_all_recoverable_mints, find_stuck};
 
 /// Returns whether another mint has a prepared transaction whose terminal
 /// submission outcome has not yet been persisted.
@@ -334,11 +332,18 @@ pub(crate) enum AutomaticRetryDecision {
     NotRecoverable,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ManualRecoveryDecision {
+    Eligible,
+    AlreadyTerminal,
+    Unrecoverable,
+}
+
 impl Mint {
     pub(crate) const MAX_AUTOMATIC_MINT_RETRY_ATTEMPT: u32 = 4;
     const RETRY_EXTERNAL_TX_MARKER: &'static str = "-retry-";
 
-    const fn state_name(&self) -> &'static str {
+    pub(crate) const fn state_name(&self) -> &'static str {
         match self {
             Self::Initiated { .. } => "Initiated",
             Self::JournalConfirmed { .. } => "JournalConfirmed",
@@ -378,6 +383,13 @@ impl Mint {
             Self::TxSubmitted { external_tx_id, .. } => {
                 Some(external_tx_id.clone())
             }
+            _ => None,
+        }
+    }
+
+    pub(super) fn pending_prepared_tx(&self) -> Option<PreparedMintTx> {
+        match self.non_failed_predecessor() {
+            Self::TxIntended { prepared_tx, .. } => Some(prepared_tx.clone()),
             _ => None,
         }
     }
@@ -481,6 +493,46 @@ impl Mint {
             .map_or(AutomaticRetryDecision::Ready, AutomaticRetryDecision::Wait)
     }
 
+    pub(crate) fn manual_recovery_decision(&self) -> ManualRecoveryDecision {
+        match self {
+            Self::Completed { .. } | Self::Closed { .. } => {
+                ManualRecoveryDecision::AlreadyTerminal
+            }
+            Self::Initiated { .. } | Self::JournalRejected { .. } => {
+                ManualRecoveryDecision::Unrecoverable
+            }
+            Self::MintingFailed { .. }
+                if matches!(
+                    self.automatic_retry_decision(Utc::now()),
+                    AutomaticRetryDecision::Exhausted
+                ) =>
+            {
+                ManualRecoveryDecision::Unrecoverable
+            }
+            Self::JournalConfirmed { .. }
+            | Self::Minting { .. }
+            | Self::TxIntended { .. }
+            | Self::TxSubmitted { .. }
+            | Self::CallbackPending { .. }
+            | Self::MintingFailed { .. } => ManualRecoveryDecision::Eligible,
+        }
+    }
+
+    pub(crate) const fn network(&self) -> Option<Network> {
+        match self {
+            Self::Initiated { network, .. }
+            | Self::JournalConfirmed { network, .. }
+            | Self::JournalRejected { network, .. }
+            | Self::Minting { network, .. }
+            | Self::TxIntended { network, .. }
+            | Self::TxSubmitted { network, .. }
+            | Self::CallbackPending { network, .. }
+            | Self::MintingFailed { network, .. }
+            | Self::Completed { network, .. } => Some(*network),
+            Self::Closed { .. } => None,
+        }
+    }
+
     pub(crate) const fn tokenization_request_id(
         &self,
     ) -> Option<&TokenizationRequestId> {
@@ -496,21 +548,6 @@ impl Mint {
             | Self::Completed { tokenization_request_id, .. } => {
                 Some(tokenization_request_id)
             }
-            Self::Closed { .. } => None,
-        }
-    }
-
-    pub(crate) const fn network(&self) -> Option<Network> {
-        match self {
-            Self::Initiated { network, .. }
-            | Self::JournalConfirmed { network, .. }
-            | Self::JournalRejected { network, .. }
-            | Self::Minting { network, .. }
-            | Self::TxIntended { network, .. }
-            | Self::TxSubmitted { network, .. }
-            | Self::CallbackPending { network, .. }
-            | Self::MintingFailed { network, .. }
-            | Self::Completed { network, .. } => Some(*network),
             Self::Closed { .. } => None,
         }
     }
@@ -622,6 +659,33 @@ impl Mint {
                 }])
             }
             Self::TxSubmitted { .. }
+            | Self::CallbackPending { .. }
+            | Self::Completed { .. } => Ok(vec![]),
+            _ => Err(MintError::NotInMintingState {
+                current_state: self.state_name().to_string(),
+            }),
+        }
+    }
+
+    fn handle_record_tx_intended(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+        prepared_tx: PreparedMintTx,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
+            Self::Minting { issuer_request_id: expected_id, .. } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+                Ok(vec![MintEvent::MintTxIntended {
+                    issuer_request_id,
+                    prepared_tx,
+                    intended_at: Utc::now(),
+                }])
+            }
+            Self::TxIntended { .. }
+            | Self::TxSubmitted { .. }
             | Self::CallbackPending { .. }
             | Self::Completed { .. } => Ok(vec![]),
             _ => Err(MintError::NotInMintingState {
@@ -781,6 +845,7 @@ impl Mint {
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::Minting { issuer_request_id: expected_id, .. }
+            | Self::TxIntended { issuer_request_id: expected_id, .. }
             | Self::TxSubmitted { issuer_request_id: expected_id, .. }
             | Self::MintingFailed { issuer_request_id: expected_id, .. } => {
                 Self::validate_issuer_request_id(
@@ -1106,6 +1171,14 @@ impl Mint {
                     + 1,
                 Box::new(self.clone()),
             ),
+            Self::TxIntended { prepared_tx, .. } => (
+                Self::retry_attempt_from_external_tx_id(
+                    &prepared_tx.external_tx_id,
+                )
+                .unwrap_or(0)
+                    + 1,
+                Box::new(self.clone()),
+            ),
             Self::Minting { retry: Some(context), .. } => {
                 (context.attempts + 1, context.failed_from.clone())
             }
@@ -1113,6 +1186,19 @@ impl Mint {
         };
 
         let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::TxIntended {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -1435,7 +1521,8 @@ impl EventSourced for Mint {
                     current_state: "Uninitialized".to_string(),
                 })
             }
-            MintCommand::RecordTxSubmitted { .. }
+            MintCommand::RecordTxIntended { .. }
+            | MintCommand::RecordTxSubmitted { .. }
             | MintCommand::RecordExistingMint { .. } => {
                 Err(MintError::NotInMintingState {
                     current_state: "Uninitialized".to_string(),
@@ -1502,6 +1589,10 @@ impl EventSourced for Mint {
             MintCommand::Deposit { issuer_request_id } => {
                 self.handle_deposit(issuer_request_id)
             }
+            MintCommand::RecordTxIntended {
+                issuer_request_id,
+                prepared_tx,
+            } => self.handle_record_tx_intended(issuer_request_id, prepared_tx),
             MintCommand::RecordTxSubmitted {
                 issuer_request_id,
                 external_tx_id,
@@ -1763,9 +1854,9 @@ pub(crate) mod tests {
     use uuid::{Uuid, uuid};
 
     use super::{
-        ClientId, IssuerMintRequestId, Mint, MintCommand, MintError, MintEvent,
-        MintExternalTxId, Network, Quantity, TokenSymbol,
-        TokenizationRequestId, UnderlyingSymbol,
+        ClientId, IssuerMintRequestId, ManualRecoveryDecision, Mint,
+        MintCommand, MintError, MintEvent, MintExternalTxId, Network, Quantity,
+        TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
@@ -1877,6 +1968,21 @@ pub(crate) mod tests {
         events
     }
 
+    fn events_through_tx_intended(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = events_through_minting(issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: Utc::now(),
+        });
+        events
+    }
+
     fn events_through_completed(
         issuer_request_id: &IssuerMintRequestId,
     ) -> Vec<MintEvent> {
@@ -1886,6 +1992,71 @@ pub(crate) mod tests {
             completed_at: Utc::now(),
         });
         events
+    }
+
+    #[test]
+    fn manual_recovery_decision_rejects_nonrecoverable_states() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let minting = events_through_minting(&issuer_request_id);
+        let initiated =
+            replay::<Mint>(vec![minting[0].clone()]).unwrap().unwrap();
+        let journal_confirmed =
+            replay::<Mint>(minting[..2].to_vec()).unwrap().unwrap();
+        let completed =
+            replay::<Mint>(events_through_completed(&issuer_request_id))
+                .unwrap()
+                .unwrap();
+        let failed_at = Utc::now() - chrono::Duration::hours(2);
+        let mut exhausted_events =
+            events_through_tx_submitted(&issuer_request_id);
+        for _ in 0..5 {
+            exhausted_events.push(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+            });
+        }
+        let exhausted = replay::<Mint>(exhausted_events).unwrap().unwrap();
+
+        assert_eq!(
+            initiated.manual_recovery_decision(),
+            ManualRecoveryDecision::Unrecoverable
+        );
+        assert_eq!(
+            journal_confirmed.manual_recovery_decision(),
+            ManualRecoveryDecision::Eligible
+        );
+        assert_eq!(
+            completed.manual_recovery_decision(),
+            ManualRecoveryDecision::AlreadyTerminal
+        );
+        assert_eq!(
+            exhausted.manual_recovery_decision(),
+            ManualRecoveryDecision::Unrecoverable
+        );
+    }
+
+    #[tokio::test]
+    async fn record_tx_intended_from_minting_emits_event() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared_tx = PreparedMintTx::valid_for_test(
+            1,
+            format!("mint-{issuer_request_id}"),
+        );
+
+        let events = TestHarness::<Mint>::with(())
+            .given(events_through_minting(&issuer_request_id))
+            .when(MintCommand::RecordTxIntended {
+                issuer_request_id,
+                prepared_tx,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [MintEvent::MintTxIntended { .. }]
+        ));
     }
 
     #[tokio::test]
@@ -1917,18 +2088,9 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn record_tx_submitted_from_tx_intended_emits_event() {
         let issuer_request_id = IssuerMintRequestId::random();
-        let mut events = events_through_minting(&issuer_request_id);
-        events.push(MintEvent::MintTxIntended {
-            issuer_request_id: issuer_request_id.clone(),
-            prepared_tx: PreparedMintTx::valid_for_test(
-                1,
-                format!("mint-{issuer_request_id}"),
-            ),
-            intended_at: Utc::now(),
-        });
 
         let recorded = TestHarness::<Mint>::with(())
-            .given(events)
+            .given(events_through_tx_intended(&issuer_request_id))
             .when(MintCommand::RecordTxSubmitted {
                 issuer_request_id: issuer_request_id.clone(),
                 external_tx_id: MintExternalTxId::from_string(
@@ -1944,6 +2106,51 @@ pub(crate) mod tests {
             &recorded[0],
             MintEvent::MintTxSubmitted { tx_id, .. }
                 if tx_id == &TxId::Legacy("fb-1".to_string())
+        ));
+    }
+
+    #[test]
+    fn minting_failed_from_tx_intended_replays_to_failed() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut mint =
+            replay::<Mint>(events_through_tx_intended(&issuer_request_id))
+                .unwrap()
+                .unwrap();
+
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "legacy broadcast failed".to_string(),
+            failed_at: Utc::now(),
+        });
+
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "a persisted failure must replay to MintingFailed, got {}",
+            mint.state_name()
+        );
+    }
+
+    #[tokio::test]
+    async fn record_existing_mint_from_tx_intended_emits_event() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let events = TestHarness::<Mint>::with(())
+            .given(events_through_tx_intended(&issuer_request_id))
+            .when(MintCommand::RecordExistingMint {
+                issuer_request_id,
+                tx_hash: b256!(
+                    "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+                ),
+                receipt_id: uint!(7_U256),
+                shares_minted: uint!(100_000000000000000000_U256),
+                block_number: 1_234,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [MintEvent::ExistingMintRecovered { .. }]
         ));
     }
 
@@ -2126,6 +2333,42 @@ pub(crate) mod tests {
             matches!(failed_from.as_ref(), Mint::TxSubmitted { .. }),
             "the predecessor chain must survive a failed retry"
         );
+    }
+
+    #[test]
+    fn retry_failure_after_persisted_intent_keeps_escalating_attempts() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let now = Utc::now();
+        let mut mint = replay::<Mint>(minting_events_for_retry(
+            &issuer_request_id,
+            "mint-retry-seed".to_string(),
+            now - chrono::Duration::hours(2),
+        ))
+        .unwrap()
+        .unwrap();
+        mint.apply_event(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            started_at: now,
+        });
+        mint.apply_event(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}-retry-1"),
+            ),
+            intended_at: now,
+        });
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "retry submission outcome unknown".to_string(),
+            failed_at: now,
+        });
+
+        let Mint::MintingFailed { attempts, .. } = mint else {
+            panic!("expected MintingFailed");
+        };
+        assert_eq!(attempts, 2);
     }
 
     #[tokio::test]

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -5,95 +5,30 @@ pub(crate) mod job;
 pub(crate) mod recovery;
 mod view;
 
-use alloy::primitives::{Address, B256, TxHash, U256};
+use alloy::primitives::{Address, B256, U256};
 use async_trait::async_trait;
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
-use std::sync::Arc;
-use tracing::{debug, info, warn};
 use uuid::Uuid;
 
-use crate::alpaca::{AlpacaService, MintCallbackRequest};
-use crate::receipt_inventory::{
-    MintedReceiptParams, ReceiptId, ReceiptService, Shares,
-};
-use crate::redemption::has_unresolved_burn_intent;
 use crate::tokenized_asset::view::{
-    TokenizedAssetViewError, TokenizedAssetViewFailure, find_vault,
+    TokenizedAssetViewError, TokenizedAssetViewFailure,
 };
-use crate::vault::{
-    NetworkVaultServices, PreparedMintTx, ReceiptInformation, TxId,
-    UnconfiguredNetworkError, VaultError, VaultService,
-};
+use crate::vault::{PreparedMintTx, TxId, UnconfiguredNetworkError};
 
 pub use api::MintResponse;
 
 pub(crate) use api::{confirm_journal, initiate_mint};
-pub(crate) use cmd::{MintCommand, MintRecoveryMode};
+pub(crate) use cmd::MintCommand;
 pub(crate) use event::MintEvent;
-pub(crate) use recovery::{DriveOutcome, recover_mint_manually};
 pub(crate) use view::{
     MintView, find_all_recoverable_mints, find_by_issuer_request_id, find_stuck,
 };
 
-/// Services required by the Mint aggregate for command handling.
-///
-/// Mint side effects resolve [`VaultService`] per aggregate `network` via
-/// [`Self::vault_for`] ([RAI-1206]).
-pub(crate) struct MintServices {
-    vaults: NetworkVaultServices,
-    pub(crate) alpaca: Arc<dyn AlpacaService>,
-    pub(crate) receipts: Arc<dyn ReceiptService>,
-    pub(crate) pool: Pool<Sqlite>,
-    pub(crate) bot: Address,
-}
-
-impl MintServices {
-    pub(crate) fn new(
-        vaults: NetworkVaultServices,
-        alpaca: Arc<dyn AlpacaService>,
-        receipts: Arc<dyn ReceiptService>,
-        pool: Pool<Sqlite>,
-        bot: Address,
-    ) -> Self {
-        Self { vaults, alpaca, receipts, pool, bot }
-    }
-
-    pub(crate) fn with_single_vault(
-        network: Network,
-        chain_id: u64,
-        vault: Arc<dyn VaultService>,
-        alpaca: Arc<dyn AlpacaService>,
-        receipts: Arc<dyn ReceiptService>,
-        pool: Pool<Sqlite>,
-        bot: Address,
-    ) -> Self {
-        Self::new(
-            NetworkVaultServices::with_single_vault(network, chain_id, vault),
-            alpaca,
-            receipts,
-            pool,
-            bot,
-        )
-    }
-
-    pub(crate) fn chain_id_for(
-        &self,
-        network: Network,
-    ) -> Result<u64, MintError> {
-        Ok(self.vaults.chain_id(network)?)
-    }
-
-    fn vault_for(
-        &self,
-        network: Network,
-    ) -> Result<&Arc<dyn VaultService>, MintError> {
-        Ok(self.vaults.service(network)?)
-    }
-}
-
+/// Returns whether another mint has a prepared transaction whose terminal
+/// submission outcome has not yet been persisted.
 pub(crate) async fn has_unresolved_mint_intent(
     pool: &Pool<Sqlite>,
     excluding: Option<&IssuerMintRequestId>,
@@ -179,7 +114,7 @@ impl std::str::FromStr for IssuerMintRequestId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub(crate) struct MintExternalTxId(String);
 
@@ -372,26 +307,6 @@ pub(crate) enum Mint {
     },
 }
 
-/// Groups mint submission parameters to keep `execute_mint_submission` under
-/// the clippy argument limit.
-struct MintSubmissionInput<'a> {
-    issuer_request_id: IssuerMintRequestId,
-    tokenization_request_id: &'a TokenizationRequestId,
-    quantity: &'a Quantity,
-    underlying: &'a UnderlyingSymbol,
-    network: &'a Network,
-    wallet: Address,
-    journal_confirmed_at: DateTime<Utc>,
-    receipt_note: Option<&'a str>,
-    external_tx_id: Option<String>,
-}
-
-#[derive(Debug, Clone)]
-struct KnownMintTx {
-    external_tx_id: String,
-    tx_id: TxId,
-}
-
 struct ConfirmedMint {
     tx_id: TxId,
     tx_hash: B256,
@@ -400,7 +315,6 @@ struct ConfirmedMint {
     gas_used: u64,
     block_number: u64,
 }
-
 /// Failure history preserved across a `MintRetryStarted` transition
 /// (`MintingFailed` -> `Minting`). Without it a failed retry would restart
 /// the automatic-retry schedule at attempt 1 and lose the
@@ -456,13 +370,13 @@ impl Mint {
         }
     }
 
-    fn latest_known_mint_tx(&self) -> Option<KnownMintTx> {
+    /// The `external_tx_id` of the latest persisted `FireblocksSubmitted`
+    /// predecessor, traversing any failure chain. `None` when no submission
+    /// ever reached the signing backend.
+    fn latest_known_external_tx_id(&self) -> Option<String> {
         match self.non_failed_predecessor() {
-            Self::TxSubmitted { external_tx_id, tx_id, .. } => {
-                Some(KnownMintTx {
-                    external_tx_id: external_tx_id.clone(),
-                    tx_id: tx_id.clone(),
-                })
+            Self::TxSubmitted { external_tx_id, .. } => {
+                Some(external_tx_id.clone())
             }
             _ => None,
         }
@@ -499,9 +413,9 @@ impl Mint {
     /// `external_tx_id` — is reused on the next try. The delay/exhaustion
     /// schedule uses the separate `MintingFailed::attempts` counter instead.
     fn next_retry_attempt(&self) -> u32 {
-        self.latest_known_mint_tx()
-            .and_then(|known| {
-                Self::retry_attempt_from_external_tx_id(&known.external_tx_id)
+        self.latest_known_external_tx_id()
+            .and_then(|external_tx_id| {
+                Self::retry_attempt_from_external_tx_id(&external_tx_id)
             })
             .unwrap_or(0)
             + 1
@@ -677,411 +591,6 @@ impl Mint {
         Ok(vec![MintEvent::MintingStarted {
             issuer_request_id,
             started_at: Utc::now(),
-        }])
-    }
-
-    /// Builds and signs the exact mint transaction without broadcasting it.
-    async fn handle_prepare_mint(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let Self::Minting {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            wallet,
-            journal_confirmed_at,
-            ..
-        } = self
-        else {
-            return Err(MintError::NotInMintingState {
-                current_state: self.state_name().to_string(),
-            });
-        };
-
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
-
-        let event = Self::execute_mint_preparation(
-            services,
-            MintSubmissionInput {
-                issuer_request_id,
-                tokenization_request_id,
-                quantity,
-                underlying,
-                network,
-                wallet: *wallet,
-                journal_confirmed_at: *journal_confirmed_at,
-                receipt_note: None,
-                external_tx_id: None,
-            },
-        )
-        .await?;
-
-        Ok(vec![event])
-    }
-
-    /// Shared preparation logic: vault lookup, receipt info, and signing.
-    /// Returns a persisted exact intent or a pre-broadcast failure.
-    async fn execute_mint_preparation(
-        services: &MintServices,
-        input: MintSubmissionInput<'_>,
-    ) -> Result<MintEvent, MintError> {
-        let MintSubmissionInput {
-            issuer_request_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            wallet,
-            journal_confirmed_at,
-            receipt_note,
-            external_tx_id,
-        } = input;
-        let unresolved_mint = has_unresolved_mint_intent(
-            &services.pool,
-            Some(&issuer_request_id),
-        )
-        .await
-        .map_err(|error| MintError::Database { message: error.to_string() })?;
-        let unresolved_burn =
-            has_unresolved_burn_intent(&services.pool, None).await.map_err(
-                |error| MintError::Database { message: error.to_string() },
-            )?;
-        if unresolved_mint || unresolved_burn {
-            return Err(MintError::PendingWalletIntent);
-        }
-
-        let vault_service = services.vault_for(*network)?;
-        let vault = find_vault(&services.pool, underlying, network)
-            .await?
-            .ok_or_else(|| MintError::AssetNotFound {
-                underlying: underlying.clone(),
-                network: *network,
-            })?;
-
-        let assets = quantity.to_u256_with_18_decimals().map_err(|e| {
-            MintError::QuantityConversion { message: e.to_string() }
-        })?;
-
-        let receipt_info = ReceiptInformation::new(
-            tokenization_request_id.clone(),
-            issuer_request_id.clone(),
-            underlying.clone(),
-            quantity.clone(),
-            journal_confirmed_at,
-            receipt_note.map(String::from),
-        );
-
-        let now = Utc::now();
-
-        match vault_service
-            .prepare_mint_tx(
-                vault,
-                assets,
-                services.bot,
-                wallet,
-                receipt_info,
-                external_tx_id,
-            )
-            .await
-        {
-            Ok(prepared_tx) => {
-                if let Err(err) = prepared_tx.validate() {
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        error = %err,
-                        "Mint transaction preparation returned an invalid signed envelope"
-                    );
-
-                    return Ok(MintEvent::MintingFailed {
-                        issuer_request_id,
-                        error: err.to_string(),
-                        failed_at: now,
-                    });
-                }
-
-                info!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    external_tx_id = %prepared_tx.external_tx_id,
-                    tx_hash = %prepared_tx.hash,
-                    nonce = prepared_tx.nonce,
-                    "Mint transaction intent prepared"
-                );
-
-                Ok(MintEvent::MintTxIntended {
-                    issuer_request_id,
-                    prepared_tx,
-                    intended_at: now,
-                })
-            }
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Mint transaction preparation failed"
-                );
-
-                Ok(MintEvent::MintingFailed {
-                    issuer_request_id,
-                    error: err.to_string(),
-                    failed_at: now,
-                })
-            }
-        }
-    }
-
-    /// Broadcasts only the exact signed transaction persisted by
-    /// `MintTxIntended`. A broadcast error is returned without an event so the
-    /// aggregate remains recoverable in `MintIntended`.
-    async fn handle_submit_mint(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let Self::TxIntended {
-            issuer_request_id: expected_id,
-            network,
-            prepared_tx,
-            ..
-        } = self
-        else {
-            return Err(MintError::NotInMintIntendedState {
-                current_state: self.state_name().to_string(),
-            });
-        };
-
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
-
-        let vault_service = services.vault_for(*network)?;
-        let submitted = match vault_service.submit_mint(prepared_tx).await {
-            Ok(submitted) => submitted,
-            Err(error) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    tx_hash = %prepared_tx.hash,
-                    error = %error,
-                    "Persisted mint transaction broadcast failed; keeping intent for recovery"
-                );
-                return Err(MintError::Vault { message: error.to_string() });
-            }
-        };
-
-        if submitted.tx_id != TxId::from(prepared_tx.hash)
-            || submitted.external_tx_id != prepared_tx.external_tx_id
-        {
-            return Err(MintError::SubmittedTransactionMismatch);
-        }
-
-        info!(
-            target: "mint",
-            issuer_request_id = %issuer_request_id,
-            external_tx_id = %submitted.external_tx_id,
-            tx_id = %submitted.tx_id,
-            "Persisted mint transaction broadcast"
-        );
-
-        Ok(vec![MintEvent::MintTxSubmitted {
-            issuer_request_id,
-            external_tx_id: submitted.external_tx_id,
-            tx_id: submitted.tx_id,
-            submitted_at: Utc::now(),
-        }])
-    }
-
-    /// Confirms a previously submitted mint transaction by polling the backend.
-    /// Produces `TokensMinted` on success, or `MintingFailed` on failure.
-    async fn handle_confirm_mint(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        tx_id: TxId,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let Self::TxSubmitted {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            journal_confirmed_at,
-            tx_id: stored_tx_id,
-            ..
-        } = self
-        else {
-            return Err(MintError::NotInSubmittedState {
-                current_state: self.state_name().to_string(),
-            });
-        };
-
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
-
-        if *stored_tx_id != tx_id {
-            return Err(MintError::TxIdMismatch {
-                expected: stored_tx_id.clone(),
-                provided: tx_id,
-            });
-        }
-
-        let now = Utc::now();
-
-        let vault_service = services.vault_for(*network)?;
-        // Resolved before the irreversible on-chain call: a failing lookup
-        // after `confirm_mint` would error the command and leave tokens
-        // minted with no TokensMinted event.
-        let chain_id = services.chain_id_for(*network)?;
-
-        match vault_service.confirm_mint(&tx_id).await {
-            Ok(result) => {
-                info!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    tx_hash = %result.tx_hash,
-                    receipt_id = %result.receipt_id,
-                    shares_minted = %result.shares_minted,
-                    "On-chain deposit confirmed"
-                );
-
-                // Best-effort receipt registration — vault lookup failure
-                // must not prevent TokensMinted from being emitted.
-                match find_vault(&services.pool, underlying, network).await {
-                    Ok(Some(vault)) => {
-                        let receipt_info = ReceiptInformation::new(
-                            tokenization_request_id.clone(),
-                            issuer_request_id.clone(),
-                            underlying.clone(),
-                            quantity.clone(),
-                            *journal_confirmed_at,
-                            None,
-                        );
-
-                        if let Err(err) = services
-                            .receipts
-                            .register_minted_receipt(MintedReceiptParams {
-                                chain_id,
-                                vault,
-                                receipt_id: ReceiptId::from(result.receipt_id),
-                                shares: Shares::from(result.shares_minted),
-                                block_number: result.block_number,
-                                tx_hash: result.tx_hash,
-                                receipt_info,
-                                receipt_info_bytes: result
-                                    .receipt_info_bytes
-                                    .clone(),
-                            })
-                            .await
-                        {
-                            warn!(
-                                target: "mint",
-                                issuer_request_id = %issuer_request_id,
-                                underlying = %underlying,
-                                network = %network,
-                                error = %err,
-                                "Failed to register minted receipt \
-                                 (monitor/backfill will discover it)"
-                            );
-                        }
-                    }
-                    Ok(None) => {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            underlying = %underlying,
-                            network = %network,
-                            "Vault not found for receipt registration \
-                             (monitor/backfill will discover it)"
-                        );
-                    }
-                    Err(err) => {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            underlying = %underlying,
-                            network = %network,
-                            error = %err,
-                            "Vault lookup failed for receipt registration \
-                             (monitor/backfill will discover it)"
-                        );
-                    }
-                }
-
-                Ok(vec![MintEvent::TokensMinted {
-                    issuer_request_id,
-                    tx_hash: result.tx_hash,
-                    receipt_id: result.receipt_id,
-                    shares_minted: result.shares_minted,
-                    gas_used: result.gas_used,
-                    block_number: result.block_number,
-                    minted_at: now,
-                }])
-            }
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "On-chain deposit confirmation failed"
-                );
-
-                Ok(vec![MintEvent::MintingFailed {
-                    issuer_request_id,
-                    error: err.to_string(),
-                    failed_at: now,
-                }])
-            }
-        }
-    }
-
-    async fn handle_send_callback(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let Self::CallbackPending {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            client_id,
-            wallet,
-            tx_hash,
-            network,
-            ..
-        } = self
-        else {
-            return Err(MintError::NotInCallbackPendingState {
-                current_state: self.state_name().to_string(),
-            });
-        };
-
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
-
-        let callback_request = MintCallbackRequest {
-            tokenization_request_id: tokenization_request_id.clone(),
-            client_id: *client_id,
-            wallet_address: *wallet,
-            tx_hash: *tx_hash,
-            network: *network,
-        };
-
-        services
-            .alpaca
-            .send_mint_callback(callback_request)
-            .await
-            .map_err(|e| MintError::Alpaca { message: e.to_string() })?;
-
-        info!(
-            target: "mint",
-            issuer_request_id = %issuer_request_id,
-            "Alpaca callback succeeded"
-        );
-
-        Ok(vec![MintEvent::MintCompleted {
-            issuer_request_id,
-            completed_at: Utc::now(),
         }])
     }
 
@@ -1296,485 +805,6 @@ impl Mint {
                 current_state: self.state_name().to_string(),
             }),
         }
-    }
-
-    async fn handle_recover(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        match self {
-            Self::JournalConfirmed { .. } => {
-                // Emit MintingStarted (intent). drive_recovery will call
-                // Recover again, which hits the Minting arm to submit.
-                self.handle_deposit(issuer_request_id)
-            }
-            Self::TxIntended { underlying, network, .. } => {
-                let vault = find_vault(&services.pool, underlying, network)
-                    .await?
-                    .ok_or_else(|| MintError::AssetNotFound {
-                        underlying: underlying.clone(),
-                        network: *network,
-                    })?;
-
-                if let Some(deposit_events) =
-                    Self::recover_from_existing_receipt(
-                        services,
-                        *network,
-                        &vault,
-                        &issuer_request_id,
-                    )
-                    .await?
-                {
-                    Ok(deposit_events)
-                } else {
-                    self.handle_submit_mint(services, issuer_request_id).await
-                }
-            }
-            Self::TxSubmitted { tx_id, .. } => {
-                let deposit_events = self
-                    .handle_confirm_mint(
-                        services,
-                        issuer_request_id.clone(),
-                        tx_id.clone(),
-                    )
-                    .await?;
-                Ok(deposit_events)
-            }
-            Self::MintingFailed { .. } => {
-                // Preserve the previous tx so recovery can
-                // distinguish pending/completed transactions from terminal
-                // failures that are safe to resubmit.
-                let known_tx = self.latest_known_mint_tx();
-
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        None,
-                        known_tx,
-                        mode,
-                    )
-                    .await?;
-                Ok(deposit_events)
-            }
-            Self::Minting { .. } => {
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        None,
-                        None,
-                        mode,
-                    )
-                    .await?;
-                Ok(deposit_events)
-            }
-            Self::CallbackPending { .. } => {
-                self.handle_send_callback(services, issuer_request_id).await
-            }
-            _ => Err(MintError::NotRecoverable {
-                current_state: self.state_name().to_string(),
-            }),
-        }
-    }
-
-    async fn handle_recover_wallet_step(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        if matches!(self, Self::CallbackPending { .. }) {
-            debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                "Deferring callback from wallet-locked recovery step"
-            );
-            return Ok(vec![]);
-        }
-
-        self.handle_recover(services, issuer_request_id, mode).await
-    }
-
-    /// Handles recovery triggered by receipt discovery. Only accepts
-    /// `MintingFailed` when the non-failed predecessor was `Minting`
-    /// (meaning a tx was actually submitted).
-    ///
-    /// Unlike `handle_recover`, this does NOT accept `CallbackPending`
-    /// because receipt discovery also fires during the normal mint flow
-    /// (when the deposit creates a new on-chain receipt). Handling
-    /// `CallbackPending` here would race with the normal flow's
-    /// `SendCallback` command, causing duplicate Alpaca callbacks.
-    async fn handle_recover_from_receipt(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        tx_hash: TxHash,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        match self {
-            Self::TxIntended { underlying, network, .. } => {
-                let vault = find_vault(&services.pool, underlying, network)
-                    .await?
-                    .ok_or_else(|| MintError::AssetNotFound {
-                        underlying: underlying.clone(),
-                        network: *network,
-                    })?;
-                let deposit_events = Self::recover_from_existing_receipt(
-                    services,
-                    *network,
-                    &vault,
-                    &issuer_request_id,
-                )
-                .await?
-                .ok_or_else(|| MintError::ReceiptNotFound {
-                    issuer_request_id: issuer_request_id.clone(),
-                })?;
-
-                Ok(deposit_events)
-            }
-            Self::MintingFailed { .. }
-                if matches!(
-                    self.non_failed_predecessor(),
-                    Self::Minting { .. } | Self::TxSubmitted { .. }
-                ) =>
-            {
-                let known_tx = self.latest_known_mint_tx();
-
-                let deposit_events = self
-                    .handle_recover_incomplete(
-                        services,
-                        issuer_request_id.clone(),
-                        Some(tx_hash),
-                        known_tx,
-                        MintRecoveryMode::Manual,
-                    )
-                    .await?;
-                Ok(deposit_events)
-            }
-            _ => Err(MintError::NotRecoverable {
-                current_state: self.state_name().to_string(),
-            }),
-        }
-    }
-
-    async fn handle_recover_incomplete(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        receipt_tx_hash: Option<TxHash>,
-        known_mint_tx: Option<KnownMintTx>,
-        mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let (Self::Minting {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            wallet,
-            journal_confirmed_at,
-            ..
-        }
-        | Self::MintingFailed {
-            issuer_request_id: expected_id,
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            wallet,
-            journal_confirmed_at,
-            ..
-        }) = self
-        else {
-            return Err(MintError::NotInMintingOrMintingFailedState {
-                current_state: self.state_name().to_string(),
-            });
-        };
-
-        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
-
-        let vault_service = services.vault_for(*network)?;
-        let vault = find_vault(&services.pool, underlying, network)
-            .await?
-            .ok_or_else(|| MintError::AssetNotFound {
-                underlying: underlying.clone(),
-                network: *network,
-            })?;
-
-        if let Some(events) = Self::recover_from_existing_receipt(
-            services,
-            *network,
-            &vault,
-            &issuer_request_id,
-        )
-        .await?
-        {
-            return Ok(events);
-        }
-
-        let receipt_info = ReceiptInformation::new(
-            tokenization_request_id.clone(),
-            issuer_request_id.clone(),
-            underlying.clone(),
-            quantity.clone(),
-            *journal_confirmed_at,
-            Some("Recovery mint".to_string()),
-        );
-
-        let now = Utc::now();
-        // Resolved before the irreversible on-chain call: a failing lookup
-        // after `confirm_mint` would error the command and leave tokens
-        // minted with no TokensMinted event.
-        let chain_id = services.chain_id_for(*network)?;
-
-        if let Some(known_tx) = known_mint_tx {
-            // Known tx_id from a prior submission: go straight to confirm.
-            info!(
-                target: "mint",
-                issuer_request_id = %issuer_request_id,
-                tx_id = %known_tx.tx_id,
-                "Resuming confirmation of previously submitted mint"
-            );
-
-            return match vault_service.confirm_mint(&known_tx.tx_id).await {
-                Ok(result) => {
-                    info!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        tx_hash = %result.tx_hash,
-                        "Recovery mint succeeded"
-                    );
-
-                    // Best-effort receipt registration
-                    if let Err(err) = services
-                        .receipts
-                        .register_minted_receipt(MintedReceiptParams {
-                            chain_id,
-                            vault,
-                            receipt_id: ReceiptId::from(result.receipt_id),
-                            shares: Shares::from(result.shares_minted),
-                            block_number: result.block_number,
-                            tx_hash: result.tx_hash,
-                            receipt_info: receipt_info.clone(),
-                            receipt_info_bytes: result
-                                .receipt_info_bytes
-                                .clone(),
-                        })
-                        .await
-                    {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            underlying = %underlying,
-                            network = %network,
-                            error = %err,
-                            "Failed to register recovered receipt \
-                             (monitor/backfill will discover it)"
-                        );
-                    }
-
-                    let retry_event =
-                        matches!(self, Self::MintingFailed { .. }).then(|| {
-                            MintEvent::MintRetryStarted {
-                                issuer_request_id: issuer_request_id.clone(),
-                                tx_hash: receipt_tx_hash,
-                                started_at: now,
-                            }
-                        });
-
-                    let minted = MintEvent::TokensMinted {
-                        issuer_request_id,
-                        tx_hash: result.tx_hash,
-                        receipt_id: result.receipt_id,
-                        shares_minted: result.shares_minted,
-                        gas_used: result.gas_used,
-                        block_number: result.block_number,
-                        minted_at: now,
-                    };
-
-                    Ok(retry_event
-                        .into_iter()
-                        .chain(std::iter::once(minted))
-                        .collect())
-                }
-                Err(err) => {
-                    if !matches!(err, VaultError::Reverted { .. }) {
-                        // Non-terminal error (RPC blip, pending-receipt timeout,
-                        // indexing lag, etc.) — the tx may still be in-flight.
-                        // Back off and retry confirming next pass rather than
-                        // submitting a replacement that could mine alongside the
-                        // original and create duplicate backed tokens for one journal.
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %issuer_request_id,
-                            tx_id = %known_tx.tx_id,
-                            error = %err,
-                            "Mint confirm returned transient error; \
-                             will retry confirming on next recovery pass"
-                        );
-                        return Err(MintError::RetryNotDue {
-                            retry_at: Utc::now() + ChronoDuration::minutes(1),
-                        });
-                    }
-
-                    // Confirmed on-chain revert: the tx consumed no receipts,
-                    // so it is safe to submit a fresh transaction.
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %issuer_request_id,
-                        tx_id = %known_tx.tx_id,
-                        error = %err,
-                        "Previous mint transaction reverted on-chain; submitting retry"
-                    );
-
-                    self.submit_recovery_mint(
-                        services,
-                        MintSubmissionInput {
-                            issuer_request_id,
-                            tokenization_request_id,
-                            quantity,
-                            underlying,
-                            network,
-                            wallet: *wallet,
-                            journal_confirmed_at: *journal_confirmed_at,
-                            receipt_note: Some("Recovery mint"),
-                            external_tx_id: None,
-                        },
-                        receipt_tx_hash,
-                        mode,
-                    )
-                    .await
-                }
-            };
-        }
-
-        // No prior tx_id: submit and persist TxSubmitted.
-        // Don't confirm here — let the next recovery pass handle
-        // ConfirmMint from the TxSubmitted state.
-        self.submit_recovery_mint(
-            services,
-            MintSubmissionInput {
-                issuer_request_id,
-                tokenization_request_id,
-                quantity,
-                underlying,
-                network,
-                wallet: *wallet,
-                journal_confirmed_at: *journal_confirmed_at,
-                receipt_note: Some("Recovery mint"),
-                external_tx_id: None,
-            },
-            receipt_tx_hash,
-            mode,
-        )
-        .await
-    }
-
-    async fn submit_recovery_mint(
-        &self,
-        services: &MintServices,
-        mut input: MintSubmissionInput<'_>,
-        receipt_tx_hash: Option<TxHash>,
-        mode: MintRecoveryMode,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let retrying_failed_mint = matches!(self, Self::MintingFailed { .. });
-        // The delay/cap gate uses the failure-count-based schedule
-        // (`automatic_retry_decision`); the external_tx_id uses the
-        // TxSubmitted-derived attempt so it stays stable across submission
-        // failures — the attempt counter only advances once a `TxSubmitted`
-        // event is persisted. // Double-mint protection on the alloy path relies
-        // on the receipt backfiller scanning for `Deposit` events owned by
-        // the bot wallet, decoding `issuer_request_id` from the embedded
-        // `receiptInformation`, and firing `RecoverFromReceipt` before any
-        // new submission lands.
-        if retrying_failed_mint && matches!(mode, MintRecoveryMode::Automatic) {
-            let now = Utc::now();
-            match self.automatic_retry_decision(now) {
-                AutomaticRetryDecision::Exhausted => {
-                    return Err(MintError::AutomaticRetriesExhausted {
-                        attempts: Self::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT,
-                    });
-                }
-                AutomaticRetryDecision::Wait(wait) => {
-                    let retry_at = now
-                        + ChronoDuration::from_std(wait)
-                            .map_err(|_| MintError::RetryDelayOutOfRange)?;
-                    return Err(MintError::RetryNotDue { retry_at });
-                }
-                AutomaticRetryDecision::Ready
-                | AutomaticRetryDecision::NotRecoverable => {}
-            }
-        }
-
-        let now = Utc::now();
-        let external_attempt = self.next_retry_attempt();
-        let issuer_request_id = input.issuer_request_id.clone();
-        let external_tx_id = retrying_failed_mint.then(|| {
-            Self::retry_mint_external_tx_id(
-                &issuer_request_id,
-                external_attempt,
-            )
-        });
-        input.external_tx_id = external_tx_id;
-
-        let preparation_event =
-            Self::execute_mint_preparation(services, input).await?;
-
-        // Only record MintRetryStarted alongside a successfully persisted
-        // transaction intent. Preparation failures emit MintingFailed;
-        // emitting MintRetryStarted in that case would
-        // move the aggregate MintingFailed -> Minting, discarding the
-        // TxSubmitted predecessor (its tx_id and the retry
-        // counter derived from external_tx_id). Re-emitting only the failure
-        // keeps the predecessor chain intact for the next retry.
-        let retry_event = matches!(
-            (retrying_failed_mint, &preparation_event),
-            (true, MintEvent::MintTxIntended { .. })
-        )
-        .then(|| MintEvent::MintRetryStarted {
-            issuer_request_id,
-            tx_hash: receipt_tx_hash,
-            started_at: now,
-        });
-
-        Ok(retry_event
-            .into_iter()
-            .chain(std::iter::once(preparation_event))
-            .collect())
-    }
-
-    async fn recover_from_existing_receipt(
-        services: &MintServices,
-        network: Network,
-        vault: &Address,
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Result<Option<Vec<MintEvent>>, MintError> {
-        let chain_id = services.chain_id_for(network)?;
-        let Some(receipt) = services
-            .receipts
-            .find_by_issuer_request_id(chain_id, vault, issuer_request_id)
-            .await
-            .map_err(|e| MintError::ReceiptLookup { message: e.to_string() })?
-        else {
-            debug!(target: "mint", issuer_request_id = %issuer_request_id, "No receipt found, retrying mint");
-            return Ok(None);
-        };
-
-        info!(
-            target: "mint",
-            issuer_request_id = %issuer_request_id,
-            receipt_id = %receipt.receipt_id,
-            "Found existing receipt, recording recovery"
-        );
-
-        Ok(Some(vec![MintEvent::ExistingMintRecovered {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash: receipt.tx_hash,
-            receipt_id: receipt.receipt_id,
-            shares_minted: receipt.shares,
-            block_number: receipt.block_number,
-            recovered_at: Utc::now(),
-        }]))
     }
 
     fn apply_journal_confirmed(&mut self, confirmed_at: DateTime<Utc>) {
@@ -2322,7 +1352,7 @@ impl EventSourced for Mint {
     type Event = MintEvent;
     type Command = MintCommand;
     type Error = MintError;
-    type Services = MintServices;
+    type Services = ();
     type Materialized = Table;
 
     const AGGREGATE_TYPE: &'static str = "Mint";
@@ -2408,40 +1438,25 @@ impl EventSourced for Mint {
                     current_state: "Uninitialized".to_string(),
                 })
             }
-            MintCommand::PrepareMint { .. }
-            | MintCommand::RecordTxSubmitted { .. } => {
+            MintCommand::RecordTxSubmitted { .. }
+            | MintCommand::RecordExistingMint { .. } => {
                 Err(MintError::NotInMintingState {
                     current_state: "Uninitialized".to_string(),
                 })
             }
-            MintCommand::SubmitMint { .. } => {
-                Err(MintError::NotInMintIntendedState {
-                    current_state: "Uninitialized".to_string(),
-                })
-            }
-            MintCommand::ConfirmMint { .. }
-            | MintCommand::RecordTokensMinted { .. } => {
+            MintCommand::RecordTokensMinted { .. } => {
                 Err(MintError::NotInSubmittedState {
                     current_state: "Uninitialized".to_string(),
                 })
             }
-            MintCommand::SendCallback { .. }
-            | MintCommand::RecordCallbackSent { .. } => {
+            MintCommand::RecordCallbackSent { .. } => {
                 Err(MintError::NotInCallbackPendingState {
                     current_state: "Uninitialized".to_string(),
                 })
             }
             MintCommand::RecordMintFailed { .. }
             | MintCommand::RetryMint { .. } => Ok(vec![]),
-            MintCommand::RecordExistingMint { .. } => {
-                Err(MintError::NotInMintingState {
-                    current_state: "Uninitialized".to_string(),
-                })
-            }
-            MintCommand::Recover { .. }
-            | MintCommand::RecoverWalletStep { .. }
-            | MintCommand::RecoverFromReceipt { .. }
-            | MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
+            MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
                 current_state: "Uninitialized".to_string(),
             }),
         }
@@ -2450,7 +1465,7 @@ impl EventSourced for Mint {
     async fn transition(
         &self,
         command: Self::Command,
-        services: &Self::Services,
+        _services: &Self::Services,
     ) -> Result<Vec<Self::Event>, Self::Error> {
         match command {
             MintCommand::Initiate {
@@ -2489,19 +1504,6 @@ impl EventSourced for Mint {
             }
             MintCommand::Deposit { issuer_request_id } => {
                 self.handle_deposit(issuer_request_id)
-            }
-            MintCommand::PrepareMint { issuer_request_id } => {
-                self.handle_prepare_mint(services, issuer_request_id).await
-            }
-            MintCommand::SubmitMint { issuer_request_id } => {
-                self.handle_submit_mint(services, issuer_request_id).await
-            }
-            MintCommand::ConfirmMint { issuer_request_id, tx_id } => {
-                self.handle_confirm_mint(services, issuer_request_id, tx_id)
-                    .await
-            }
-            MintCommand::SendCallback { issuer_request_id } => {
-                self.handle_send_callback(services, issuer_request_id).await
             }
             MintCommand::RecordTxSubmitted {
                 issuer_request_id,
@@ -2553,25 +1555,6 @@ impl EventSourced for Mint {
                 shares_minted,
                 block_number,
             ),
-            MintCommand::Recover { issuer_request_id, mode } => {
-                self.handle_recover(services, issuer_request_id, mode).await
-            }
-            MintCommand::RecoverWalletStep { issuer_request_id, mode } => {
-                self.handle_recover_wallet_step(
-                    services,
-                    issuer_request_id,
-                    mode,
-                )
-                .await
-            }
-            MintCommand::RecoverFromReceipt { issuer_request_id, tx_hash } => {
-                self.handle_recover_from_receipt(
-                    services,
-                    issuer_request_id,
-                    tx_hash,
-                )
-                .await
-            }
             MintCommand::CloseMint { issuer_request_id, reason } => {
                 self.handle_close_mint(issuer_request_id, reason)
             }
@@ -2771,327 +1754,34 @@ impl From<UnconfiguredNetworkError> for MintError {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, B256, U256, address, b256, uint};
-    use alloy::rpc::types::TransactionReceipt;
-    use async_trait::async_trait;
-    use chrono::{DateTime, Duration as ChronoDuration, Utc};
-    use cqrs_es::DomainEvent;
-    use event_sorcery::{
-        LifecycleError, Store, StoreBuilder, TestHarness, replay, test_store,
-    };
+    use alloy::primitives::{Address, address, b256, uint};
+    use chrono::{DateTime, Utc};
+    use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::{Pool, Sqlite};
-    use std::collections::HashMap;
-    use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
     use uuid::{Uuid, uuid};
 
     use super::{
-        AutomaticRetryDecision, ClientId, IssuerMintRequestId, Mint,
-        MintCommand, MintError, MintEvent, MintExternalTxId, MintRecoveryMode,
-        MintServices, MintView, Network, Quantity, TokenSymbol,
-        TokenizationRequestId, UnderlyingSymbol, find_by_issuer_request_id,
-        has_unresolved_mint_intent,
+        ClientId, IssuerMintRequestId, Mint, MintCommand, MintError, MintEvent,
+        MintExternalTxId, Network, Quantity, TokenSymbol,
+        TokenizationRequestId, UnderlyingSymbol,
     };
-    use crate::alpaca::mock::MockAlpacaService;
     use crate::prepare_event_sourced_startup;
-    use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
+    use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
-    use crate::vault::mock::MockVaultService;
-    use crate::vault::{
-        BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-        NetworkVaultServices, PreparedMintTx, ReceiptInformation,
-        SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
-    };
+    use crate::vault::TxId;
 
     pub(super) const VAULT: Address =
         address!("0xcccccccccccccccccccccccccccccccccccccccc");
 
     pub(super) const BOT: Address =
         address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-
-    struct TerminalFailedMintVault {
-        submitted_external_tx_id: Arc<std::sync::Mutex<Option<String>>>,
-    }
-
-    impl TerminalFailedMintVault {
-        fn new() -> Self {
-            Self {
-                submitted_external_tx_id: Arc::new(std::sync::Mutex::new(None)),
-            }
-        }
-
-        fn submitted_external_tx_id(&self) -> Option<String> {
-            self.submitted_external_tx_id.lock().unwrap().clone()
-        }
-    }
-
-    #[async_trait]
-    impl VaultService for TerminalFailedMintVault {
-        async fn prepare_mint_tx(
-            &self,
-            _vault: Address,
-            _assets: U256,
-            _bot: Address,
-            _user: Address,
-            _receipt_info: ReceiptInformation,
-            external_tx_id: Option<String>,
-        ) -> Result<PreparedMintTx, VaultError> {
-            let external_tx_id =
-                external_tx_id.unwrap_or_else(|| "mint-base".to_string());
-            *self.submitted_external_tx_id.lock().unwrap() =
-                Some(external_tx_id.clone());
-
-            Ok(PreparedMintTx::valid_for_test(1, external_tx_id))
-        }
-
-        async fn submit_mint(
-            &self,
-            prepared_tx: &PreparedMintTx,
-        ) -> Result<SubmittedTx, VaultError> {
-            Ok(SubmittedTx {
-                external_tx_id: prepared_tx.external_tx_id.clone(),
-                tx_id: prepared_tx.hash.into(),
-            })
-        }
-
-        async fn confirm_mint(
-            &self,
-            _tx_id: &TxId,
-        ) -> Result<MintResult, VaultError> {
-            Err(VaultError::Reverted { tx_hash: B256::ZERO })
-        }
-
-        async fn get_share_balance(
-            &self,
-            _vault: Address,
-            _owner: Address,
-        ) -> Result<U256, VaultError> {
-            Ok(U256::ZERO)
-        }
-
-        async fn submit_burn(
-            &self,
-            _params: MultiBurnParams,
-            _prepared_tx: SendableTxWithHash,
-        ) -> Result<SubmittedTx, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn confirm_burn(
-            &self,
-            _tx_id: &TxId,
-            _expected_dust_shares: U256,
-        ) -> Result<MultiBurnResult, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn verify_burn_tx(
-            &self,
-            _vault: Address,
-            _owner: Address,
-            _tx_hash: B256,
-        ) -> Result<BurnVerification, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn prepare_burn_tx(
-            &self,
-            _params: &MultiBurnParams,
-        ) -> Result<SendableTxWithHash, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn check_tx(
-            &self,
-            _tx_hash: &TxId,
-        ) -> Result<TransactionReceipt, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-    }
-
-    /// Vault where both confirm and retry submission fail. Exercises the
-    /// failed-resubmission path.
-    struct RetrySubmitFailsVault;
-
-    #[async_trait]
-    impl VaultService for RetrySubmitFailsVault {
-        async fn prepare_mint_tx(
-            &self,
-            _vault: Address,
-            _assets: U256,
-            _bot: Address,
-            _user: Address,
-            _receipt_info: ReceiptInformation,
-            _external_tx_id: Option<String>,
-        ) -> Result<PreparedMintTx, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn submit_mint(
-            &self,
-            _prepared_tx: &PreparedMintTx,
-        ) -> Result<SubmittedTx, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn confirm_mint(
-            &self,
-            _tx_id: &TxId,
-        ) -> Result<MintResult, VaultError> {
-            Err(VaultError::Reverted { tx_hash: B256::ZERO })
-        }
-
-        async fn get_share_balance(
-            &self,
-            _vault: Address,
-            _owner: Address,
-        ) -> Result<U256, VaultError> {
-            Ok(U256::ZERO)
-        }
-
-        async fn submit_burn(
-            &self,
-            _params: MultiBurnParams,
-            _prepared_tx: SendableTxWithHash,
-        ) -> Result<SubmittedTx, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn confirm_burn(
-            &self,
-            _tx_id: &TxId,
-            _expected_dust_shares: U256,
-        ) -> Result<MultiBurnResult, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn verify_burn_tx(
-            &self,
-            _vault: Address,
-            _owner: Address,
-            _tx_hash: B256,
-        ) -> Result<BurnVerification, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn prepare_burn_tx(
-            &self,
-            _params: &MultiBurnParams,
-        ) -> Result<SendableTxWithHash, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-
-        async fn check_tx(
-            &self,
-            _tx_hash: &TxId,
-        ) -> Result<TransactionReceipt, VaultError> {
-            Err(VaultError::InvalidReceipt)
-        }
-    }
-
-    struct MintTestFixture {
-        mint_store: Arc<Store<Mint>>,
-        pool: Pool<Sqlite>,
-    }
-
-    impl MintTestFixture {
-        async fn new_with_vault(vault: Arc<dyn VaultService>) -> Self {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect(":memory:")
-                .await
-                .unwrap();
-
-            sqlx::migrate!().run(&pool).await.unwrap();
-
-            let (asset_store, _asset_projection) =
-                StoreBuilder::<TokenizedAsset>::new(pool.clone())
-                    .build(())
-                    .await
-                    .unwrap();
-
-            let underlying = UnderlyingSymbol::new("AAPL").unwrap();
-            let asset_key = AssetKey::new(underlying.clone(), Network::Base);
-            asset_store
-                .send(
-                    &asset_key,
-                    TokenizedAssetCommand::Add {
-                        underlying: underlying.clone(),
-                        token: TokenSymbol::new("tAAPL"),
-                        network: Network::Base,
-                        vault: VAULT,
-                    },
-                )
-                .await
-                .unwrap();
-
-            let receipt_store =
-                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-            let services = MintServices::with_single_vault(
-                Network::Base,
-                ANVIL_CHAIN_ID,
-                vault,
-                Arc::new(MockAlpacaService::new_success()),
-                Arc::new(CqrsReceiptService::new(receipt_store)),
-                pool.clone(),
-                BOT,
-            );
-
-            let mint_store =
-                Arc::new(test_store::<Mint>(pool.clone(), services));
-
-            Self { mint_store, pool }
-        }
-
-        /// Seeds a pre-existing `MintEvent` history directly into the event
-        /// store so command tests can start from any lifecycle state.
-        ///
-        /// Inserts raw `MintEvent` rows — `Lifecycle<Mint>` persists the inner
-        /// `MintEvent` verbatim (`event_type = "MintEvent::<Variant>"`, payload
-        /// `{"<Variant>": {...}}`), so `mint_store.load`/`send` replay them
-        /// exactly as if they had been produced by commands.
-        async fn seed_mint_events(
-            &self,
-            aggregate_id: &str,
-            events: Vec<MintEvent>,
-        ) {
-            for (index, event) in events.into_iter().enumerate() {
-                let sequence = i64::try_from(index).unwrap() + 1;
-                let event_type = event.event_type();
-                let payload = serde_json::to_string(&event).unwrap();
-
-                sqlx::query(
-                    "
-                    INSERT INTO events (
-                        aggregate_type,
-                        aggregate_id,
-                        sequence,
-                        event_type,
-                        event_version,
-                        payload,
-                        metadata
-                    )
-                    VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
-                    ",
-                )
-                .bind(aggregate_id)
-                .bind(sequence)
-                .bind(event_type)
-                .bind(payload)
-                .execute(&self.pool)
-                .await
-                .unwrap();
-            }
-        }
-    }
 
     fn minting_events_for_retry(
         issuer_request_id: &IssuerMintRequestId,
@@ -3121,7 +1811,7 @@ pub(crate) mod tests {
             MintEvent::MintTxSubmitted {
                 issuer_request_id: issuer_request_id.clone(),
                 external_tx_id,
-                tx_id: TxId::random(),
+                tx_id: TxId::Legacy("fb-failed".to_string()),
                 submitted_at: failed_at,
             },
             MintEvent::MintingFailed {
@@ -3205,7 +1895,7 @@ pub(crate) mod tests {
     async fn record_tx_submitted_from_minting_emits_event() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_minting(&issuer_request_id))
             .when(MintCommand::RecordTxSubmitted {
                 issuer_request_id: issuer_request_id.clone(),
@@ -3264,7 +1954,7 @@ pub(crate) mod tests {
     async fn record_tx_submitted_is_idempotent_once_submitted() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_tx_submitted(&issuer_request_id))
             .when(MintCommand::RecordTxSubmitted {
                 issuer_request_id,
@@ -3289,7 +1979,7 @@ pub(crate) mod tests {
             "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
         );
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_tx_submitted(&issuer_request_id))
             .when(MintCommand::RecordTokensMinted {
                 issuer_request_id,
@@ -3327,7 +2017,7 @@ pub(crate) mod tests {
     async fn record_tokens_minted_is_idempotent_once_minted() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_tokens_minted(&issuer_request_id))
             .when(MintCommand::RecordTokensMinted {
                 issuer_request_id,
@@ -3353,7 +2043,7 @@ pub(crate) mod tests {
     async fn record_tokens_minted_rejects_mismatched_tx_id() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given(events_through_tx_submitted(&issuer_request_id))
             .when(MintCommand::RecordTokensMinted {
                 issuer_request_id,
@@ -3445,7 +2135,7 @@ pub(crate) mod tests {
     async fn record_callback_sent_from_callback_pending_completes() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_tokens_minted(&issuer_request_id))
             .when(MintCommand::RecordCallbackSent {
                 issuer_request_id: issuer_request_id.clone(),
@@ -3461,7 +2151,7 @@ pub(crate) mod tests {
     async fn record_callback_sent_is_idempotent_once_completed() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_completed(&issuer_request_id))
             .when(MintCommand::RecordCallbackSent { issuer_request_id })
             .await
@@ -3477,7 +2167,7 @@ pub(crate) mod tests {
     async fn record_mint_failed_from_minting_emits_failed() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_minting(&issuer_request_id))
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
@@ -3495,10 +2185,10 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn record_mint_failed_from_fireblocks_submitted_emits_failed() {
+    async fn record_mint_failed_from_tx_submitted_emits_failed() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_tx_submitted(&issuer_request_id))
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
@@ -3519,7 +2209,7 @@ pub(crate) mod tests {
     async fn record_mint_failed_is_ignored_once_completed() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_completed(&issuer_request_id))
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
@@ -3539,7 +2229,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let failed_at = Utc::now() - chrono::Duration::hours(2);
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(minting_events_for_retry(
                 &issuer_request_id,
                 "ext-1".to_string(),
@@ -3560,7 +2250,7 @@ pub(crate) mod tests {
     async fn retry_mint_is_idempotent_when_not_failed() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(events_through_minting(&issuer_request_id))
             .when(MintCommand::RetryMint { issuer_request_id })
             .await
@@ -3578,128 +2268,6 @@ pub(crate) mod tests {
         }
     }
 
-    /// Counts persisted `Mint` events of a given `event_type` for one mint,
-    /// reading the event store directly (recovery's audit-trail assertions
-    /// inspect emitted events, which `Store::load` collapses into state).
-    async fn count_events_of_type(
-        pool: &Pool<Sqlite>,
-        issuer_request_id: &IssuerMintRequestId,
-        event_type: &str,
-    ) -> i64 {
-        sqlx::query_scalar(
-            "
-            SELECT COUNT(*)
-            FROM events
-            WHERE aggregate_type = 'Mint'
-              AND aggregate_id = ?
-              AND event_type = ?
-            ",
-        )
-        .bind(issuer_request_id.to_string())
-        .bind(event_type)
-        .fetch_one(pool)
-        .await
-        .unwrap()
-    }
-
-    async fn test_mint_services() -> MintServices {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect(":memory:")
-            .await
-            .expect("Failed to create in-memory database");
-        sqlx::migrate!().run(&pool).await.expect("Failed to run migrations");
-
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-        let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-
-        MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            Arc::new(MockVaultService::new_success()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool,
-            bot,
-        )
-    }
-
-    /// Services whose vault map is empty, simulating a mint whose persisted
-    /// `network` has no chain registry entry.
-    fn empty_vault_services() -> MintServices {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_lazy(":memory:")
-            .expect("Failed to create in-memory database");
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        MintServices::new(
-            NetworkVaultServices::new(HashMap::new()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool,
-            BOT,
-        )
-    }
-
-    #[tokio::test]
-    async fn submit_mint_errors_when_network_not_configured() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
-        let events =
-            persisted_mint_intent_events(&issuer_request_id, prepared_tx);
-
-        let error = TestHarness::<Mint>::with(empty_vault_services())
-            .given(events)
-            .when(MintCommand::SubmitMint {
-                issuer_request_id: issuer_request_id.clone(),
-            })
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(MintError::NetworkNotConfigured { .. })
-            ),
-            "a mint submission for an unconfigured network must surface \
-             NetworkNotConfigured, got {error:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn recover_errors_when_network_not_configured() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-
-        let mut events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}"),
-            now,
-        );
-        events.truncate(4);
-
-        let error = TestHarness::<Mint>::with(empty_vault_services())
-            .given(events)
-            .when(MintCommand::Recover {
-                issuer_request_id: issuer_request_id.clone(),
-                mode: MintRecoveryMode::Manual,
-            })
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(MintError::NetworkNotConfigured { .. })
-            ),
-            "startup recovery of a mint on an unconfigured network must \
-             surface NetworkNotConfigured instead of looping, got {error:?}"
-        );
-    }
-
     #[tokio::test]
     async fn test_initiate_mint_creates_event() {
         let issuer_request_id = IssuerMintRequestId::random();
@@ -3711,7 +2279,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given_no_previous_events()
             .when(MintCommand::Initiate {
                 issuer_request_id: issuer_request_id.clone(),
@@ -3777,7 +2345,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: tokenization_request_id.clone(),
@@ -3966,7 +2534,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
@@ -3990,7 +2558,7 @@ pub(crate) mod tests {
     async fn test_confirm_journal_for_uninitialized_mint_fails() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given_no_previous_events()
             .when(MintCommand::ConfirmJournal { issuer_request_id })
             .await
@@ -4013,7 +2581,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given(vec![
                 MintEvent::Initiated {
                     issuer_request_id: issuer_request_id.clone(),
@@ -4053,7 +2621,7 @@ pub(crate) mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let reason = "Insufficient funds";
 
-        let events = TestHarness::<Mint>::with(test_mint_services().await)
+        let events = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
@@ -4087,7 +2655,7 @@ pub(crate) mod tests {
     async fn test_reject_journal_for_uninitialized_mint_fails() {
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given_no_previous_events()
             .when(MintCommand::RejectJournal {
                 issuer_request_id,
@@ -4114,7 +2682,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
@@ -4155,7 +2723,7 @@ pub(crate) mod tests {
         let client_id = ClientId::new();
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
 
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
+        let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
@@ -4553,251 +3121,6 @@ pub(crate) mod tests {
         assert_eq!(final_completed_at, completed_at);
     }
 
-    struct TestMintData {
-        issuer_request_id: super::IssuerMintRequestId,
-        tokenization_request_id: TokenizationRequestId,
-        quantity: Quantity,
-        underlying: UnderlyingSymbol,
-        token: TokenSymbol,
-        network: Network,
-        client_id: ClientId,
-        wallet: Address,
-    }
-
-    impl TestMintData {
-        fn new() -> Self {
-            Self {
-                issuer_request_id: IssuerMintRequestId::random(),
-                tokenization_request_id: TokenizationRequestId::new(
-                    "alp-integration-456",
-                ),
-                quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                token: TokenSymbol::new("tAAPL"),
-                network: Network::Base,
-                client_id: ClientId::new(),
-                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            }
-        }
-    }
-
-    /// Builds a projected `Store<Mint>` (with the `mint_view` projection wired)
-    /// plus its pool, seeded with the AAPL tokenized asset, so the split mint
-    /// flow can be driven end to end and the resulting `MintView` inspected via
-    /// the view query helpers.
-    async fn setup_projected_mint_store() -> (Arc<Store<Mint>>, Pool<Sqlite>) {
-        setup_projected_mint_store_with_vault(Arc::new(
-            MockVaultService::new_success(),
-        ))
-        .await
-    }
-
-    async fn setup_projected_mint_store_with_vault(
-        vault: Arc<dyn VaultService>,
-    ) -> (Arc<Store<Mint>>, Pool<Sqlite>) {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect(":memory:")
-            .await
-            .unwrap();
-
-        sqlx::migrate!().run(&pool).await.unwrap();
-
-        let (asset_store, _asset_projection) =
-            StoreBuilder::<TokenizedAsset>::new(pool.clone())
-                .build(())
-                .await
-                .unwrap();
-
-        asset_store
-            .send(
-                &AssetKey::new(
-                    UnderlyingSymbol::new("AAPL").unwrap(),
-                    Network::Base,
-                ),
-                TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                    token: TokenSymbol::new("tAAPL"),
-                    network: Network::Base,
-                    vault: VAULT,
-                },
-            )
-            .await
-            .unwrap();
-
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        let services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            vault,
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool.clone(),
-            BOT,
-        );
-
-        let (mint_store, _mint_projection) =
-            StoreBuilder::<Mint>::new(pool.clone())
-                .build(services)
-                .await
-                .unwrap();
-
-        (mint_store, pool)
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn prepare_mint_rejects_invalid_signed_envelope() {
-        let (store, pool) = setup_projected_mint_store_with_vault(Arc::new(
-            MockVaultService::new_invalid_prepared_mint(),
-        ))
-        .await;
-        let data = TestMintData::new();
-
-        for command in [
-            MintCommand::Initiate {
-                issuer_request_id: data.issuer_request_id.clone(),
-                tokenization_request_id: data.tokenization_request_id.clone(),
-                quantity: data.quantity.clone(),
-                underlying: data.underlying.clone(),
-                token: data.token.clone(),
-                network: data.network,
-                client_id: data.client_id,
-                wallet: data.wallet,
-            },
-            MintCommand::ConfirmJournal {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-            MintCommand::Deposit {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-            MintCommand::PrepareMint {
-                issuer_request_id: data.issuer_request_id.clone(),
-            },
-        ] {
-            store.send(&data.issuer_request_id, command).await.unwrap();
-        }
-
-        let mint = store.load(&data.issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::MintingFailed { .. }),
-            "invalid prepared envelope must fail the mint, got {}",
-            mint.state_name()
-        );
-        assert_eq!(
-            count_events_of_type(
-                &pool,
-                &data.issuer_request_id,
-                "MintEvent::MintTxIntended"
-            )
-            .await,
-            0,
-        );
-        assert!(logs_contain_at!(
-            Level::WARN,
-            &[
-                &data.issuer_request_id.to_string(),
-                "Mint transaction preparation returned an invalid signed envelope"
-            ]
-        ));
-    }
-
-    #[tokio::test]
-    async fn durable_intent_is_detected_without_a_projection_row() {
-        let (_store, pool) = setup_projected_mint_store().await;
-        let pending_id = IssuerMintRequestId::random();
-        let pending_id_string = pending_id.to_string();
-
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES ('Mint', ?, 1, 'MintEvent::MintTxIntended', '4.0', '{}', '{}')
-            ",
-        )
-        .bind(&pending_id_string)
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        assert!(
-            has_unresolved_mint_intent(
-                &pool,
-                Some(&IssuerMintRequestId::random()),
-            )
-            .await
-            .unwrap(),
-            "the event store must remain authoritative when projection writes fail"
-        );
-
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES ('Mint', ?, 2, 'MintEvent::MintClosed', '4.0', '{}', '{}')
-            ",
-        )
-        .bind(&pending_id_string)
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        assert!(
-            has_unresolved_mint_intent(
-                &pool,
-                Some(&IssuerMintRequestId::random()),
-            )
-            .await
-            .unwrap(),
-            "closing a mint must not release signed bytes that can still land"
-        );
-
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES ('Mint', ?, 3, 'MintEvent::MintTxSubmitted', '4.0', '{}', '{}')
-            ",
-        )
-        .bind(pending_id_string)
-        .execute(&pool)
-        .await
-        .unwrap();
-
-        assert!(
-            !has_unresolved_mint_intent(
-                &pool,
-                Some(&IssuerMintRequestId::random()),
-            )
-            .await
-            .unwrap(),
-            "an explicit transaction-resolution event must release the wallet-intent gate"
-        );
-    }
-
     /// Regression: pre-event-sorcery snapshot payloads (`{"Completed": ...}`)
     /// must be cleared by schema reconciliation before projection catch-up
     /// calls `load_with_context`, which deserializes into `Lifecycle<Mint>`.
@@ -4964,21 +3287,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        let services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            Arc::new(MockVaultService::new_success()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool.clone(),
-            BOT,
-        );
-
         prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
-        StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
+        StoreBuilder::<Mint>::new(pool.clone()).build(()).await.unwrap();
 
         assert!(logs_contain_at!(
             Level::INFO,
@@ -5168,21 +3478,8 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        let services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            Arc::new(MockVaultService::new_success()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool.clone(),
-            BOT,
-        );
-
         prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
-        StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
+        StoreBuilder::<Mint>::new(pool.clone()).build(()).await.unwrap();
 
         let view_payload: String = sqlx::query_scalar(
             "
@@ -5207,323 +3504,6 @@ pub(crate) mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_complete_mint_flow_via_cqrs() {
-        let (store, pool) = setup_projected_mint_store().await;
-        let data = TestMintData::new();
-
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::Initiate {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                    tokenization_request_id: data
-                        .tokenization_request_id
-                        .clone(),
-                    quantity: data.quantity.clone(),
-                    underlying: data.underlying.clone(),
-                    token: data.token.clone(),
-                    network: data.network,
-                    client_id: data.client_id,
-                    wallet: data.wallet,
-                },
-            )
-            .await
-            .unwrap();
-
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::ConfirmJournal {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                },
-            )
-            .await
-            .unwrap();
-
-        // Deposit records intent (emits MintingStarted)
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::Deposit {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                },
-            )
-            .await
-            .unwrap();
-
-        // PrepareMint signs and persists the exact transaction before any
-        // broadcast (emits MintTxIntended).
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::PrepareMint {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                },
-            )
-            .await
-            .unwrap();
-
-        let Some(Mint::TxIntended { prepared_tx, .. }) =
-            store.load(&data.issuer_request_id).await.unwrap()
-        else {
-            panic!("Expected MintIntended state after PrepareMint");
-        };
-        assert!(!prepared_tx.tx.is_empty());
-
-        // SubmitMint broadcasts only the persisted transaction.
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::SubmitMint {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                },
-            )
-            .await
-            .unwrap();
-
-        // Load the tx_id from the aggregate state
-        let Some(Mint::TxSubmitted { tx_id, .. }) =
-            store.load(&data.issuer_request_id).await.unwrap()
-        else {
-            panic!("Expected TxSubmitted state after SubmitMint");
-        };
-
-        // ConfirmMint polls the backend (emits TokensMinted)
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::ConfirmMint {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                    tx_id,
-                },
-            )
-            .await
-            .unwrap();
-
-        store
-            .send(
-                &data.issuer_request_id,
-                MintCommand::SendCallback {
-                    issuer_request_id: data.issuer_request_id.clone(),
-                },
-            )
-            .await
-            .unwrap();
-
-        assert!(
-            matches!(
-                store.load(&data.issuer_request_id).await.unwrap(),
-                Some(Mint::Completed { .. })
-            ),
-            "Expected Completed state"
-        );
-
-        // The split flow must emit exactly these seven events in order.
-        let event_types: Vec<String> = sqlx::query_scalar(
-            "
-            SELECT event_type
-            FROM events
-            WHERE aggregate_type = 'Mint' AND aggregate_id = ?
-            ORDER BY sequence
-            ",
-        )
-        .bind(data.issuer_request_id.to_string())
-        .fetch_all(&pool)
-        .await
-        .unwrap();
-
-        let event_types: Vec<&str> =
-            event_types.iter().map(String::as_str).collect();
-        assert_eq!(
-            event_types,
-            vec![
-                "MintEvent::Initiated",
-                "MintEvent::JournalConfirmed",
-                "MintEvent::MintingStarted",
-                "MintEvent::MintTxIntended",
-                "MintEvent::MintTxSubmitted",
-                "MintEvent::TokensMinted",
-                "MintEvent::MintCompleted",
-            ],
-            "Expected 7 events in the split flow, in order"
-        );
-
-        let view = find_by_issuer_request_id(&pool, &data.issuer_request_id)
-            .await
-            .unwrap()
-            .expect("MintView should exist after the flow completes");
-
-        let MintView::Completed {
-            issuer_request_id: view_issuer_id,
-            tx_hash: view_tx_hash,
-            completed_at: view_completed_at,
-            initiated_at: view_initiated_at,
-            journal_confirmed_at: view_journal_confirmed_at,
-            minted_at: view_minted_at,
-            ..
-        } = view
-        else {
-            panic!("Expected Completed view, got {view:?}");
-        };
-
-        assert_eq!(view_issuer_id, data.issuer_request_id);
-        assert!(view_tx_hash != B256::ZERO);
-        assert!(view_initiated_at.timestamp() > 0);
-        assert!(view_journal_confirmed_at.timestamp() > 0);
-        assert!(view_minted_at.timestamp() > 0);
-        assert!(view_completed_at.timestamp() > 0);
-        assert!(view_completed_at >= view_minted_at);
-        assert!(view_minted_at >= view_journal_confirmed_at);
-        assert!(view_journal_confirmed_at >= view_initiated_at);
-    }
-
-    fn persisted_mint_intent_events(
-        issuer_request_id: &IssuerMintRequestId,
-        prepared_tx: PreparedMintTx,
-    ) -> Vec<MintEvent> {
-        let now = Utc::now();
-        vec![
-            MintEvent::Initiated {
-                issuer_request_id: issuer_request_id.clone(),
-                tokenization_request_id: TokenizationRequestId::new("tok-123"),
-                quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                token: TokenSymbol::new("tAAPL"),
-                network: Network::Base,
-                client_id: ClientId::new(),
-                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-                initiated_at: now,
-            },
-            MintEvent::JournalConfirmed {
-                issuer_request_id: issuer_request_id.clone(),
-                confirmed_at: now,
-            },
-            MintEvent::MintingStarted {
-                issuer_request_id: issuer_request_id.clone(),
-                started_at: now,
-            },
-            MintEvent::MintTxIntended {
-                issuer_request_id: issuer_request_id.clone(),
-                prepared_tx,
-                intended_at: now,
-            },
-        ]
-    }
-
-    fn test_prepared_mint_tx(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> PreparedMintTx {
-        PreparedMintTx::valid_for_test(17, format!("mint-{issuer_request_id}"))
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn restart_rebroadcasts_persisted_mint_without_preparing_another_tx()
-    {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
-        let vault = Arc::new(MockVaultService::new_success());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture
-            .seed_mint_events(
-                &issuer_request_id.to_string(),
-                persisted_mint_intent_events(
-                    &issuer_request_id,
-                    prepared_tx.clone(),
-                ),
-            )
-            .await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        let Mint::TxSubmitted { prepared_tx: Some(replayed_tx), tx_id, .. } =
-            mint
-        else {
-            panic!("Expected TxSubmitted with its persisted transaction");
-        };
-        assert_eq!(replayed_tx, prepared_tx);
-        assert_eq!(tx_id, TxId::from(prepared_tx.hash));
-        assert_eq!(vault.get_call_count(), 0, "recovery must not re-prepare");
-        assert_eq!(
-            count_events_of_type(
-                &fixture.pool,
-                &issuer_request_id,
-                "MintEvent::MintTxIntended",
-            )
-            .await,
-            1,
-            "restart recovery must retain the single persisted intent"
-        );
-        assert!(logs_contain_at!(
-            Level::INFO,
-            &[
-                "Persisted mint transaction broadcast",
-                &prepared_tx.hash.to_string()
-            ]
-        ));
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn uncertain_broadcast_failure_keeps_exact_mint_intent() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
-        let vault = Arc::new(MockVaultService::new_submit_failure());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture
-            .seed_mint_events(
-                &issuer_request_id.to_string(),
-                persisted_mint_intent_events(
-                    &issuer_request_id,
-                    prepared_tx.clone(),
-                ),
-            )
-            .await;
-
-        let result = fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await;
-        assert!(result.is_err());
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(
-            mint,
-            Mint::TxIntended {
-                prepared_tx: ref stored,
-                ..
-            } if stored == &prepared_tx
-        ));
-        assert_eq!(vault.get_call_count(), 0, "failure must not re-prepare");
-        assert!(logs_contain_at!(
-            Level::WARN,
-            &[
-                "Persisted mint transaction broadcast failed",
-                &prepared_tx.hash.to_string(),
-            ]
-        ));
-    }
-
     #[test]
     fn test_issuer_request_id_display() {
         let uuid = Uuid::new_v4();
@@ -5535,562 +3515,5 @@ pub(crate) mod tests {
     fn test_tokenization_request_id_display() {
         let id = TokenizationRequestId::new("alp-456");
         assert_eq!(format!("{id}"), "alp-456");
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn automatic_recovery_retries_after_confirm_failure_with_delay() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let failed_at = Utc::now() - ChronoDuration::minutes(2);
-        let events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}"),
-            failed_at,
-        );
-        let vault = Arc::new(TerminalFailedMintVault::new());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            vault.submitted_external_tx_id(),
-            Some(format!("mint-{issuer_request_id}-retry-1"))
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let Some(Mint::TxSubmitted { external_tx_id, .. }) =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap()
-        else {
-            panic!("Expected TxSubmitted after retry");
-        };
-        assert_eq!(external_tx_id, format!("mint-{issuer_request_id}-retry-1"));
-
-        // A successful retry must record MintRetryStarted as the permanent
-        // audit-trail fact that recovery resubmitted the mint.
-        let retry_started = count_events_of_type(
-            &fixture.pool,
-            &issuer_request_id,
-            "MintEvent::MintRetryStarted",
-        )
-        .await;
-        assert_eq!(
-            retry_started, 1,
-            "Expected exactly one MintRetryStarted event after a retry"
-        );
-
-        // The retry-submission warning is the primary operational signal that
-        // recovery resubmitted after a confirm failure.
-        let test =
-            "automatic_recovery_retries_after_confirm_failure_with_delay";
-        assert_eq!(
-            log_count_at!(Level::WARN, &[test, "submitting retry"]),
-            1,
-            "Expected the retry-submission warning to be emitted once"
-        );
-    }
-
-    #[tokio::test]
-    async fn automatic_recovery_waits_until_retry_delay_elapses() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}"),
-            Utc::now(),
-        );
-        let vault = Arc::new(TerminalFailedMintVault::new());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        let result = fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await;
-
-        assert!(
-            matches!(
-                result,
-                Err(cqrs_es::AggregateError::UserError(LifecycleError::Apply(
-                    MintError::RetryNotDue { .. }
-                )))
-            ),
-            "Expected RetryNotDue, got {result:?}"
-        );
-        assert_eq!(vault.submitted_external_tx_id(), None);
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn manual_reprocess_can_bypass_automatic_retry_cap() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let failed_at = Utc::now() - ChronoDuration::hours(2);
-        let events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}-retry-4"),
-            failed_at,
-        );
-        let vault = Arc::new(TerminalFailedMintVault::new());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        let automatic_result = fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await;
-        assert!(
-            matches!(
-                automatic_result,
-                Err(cqrs_es::AggregateError::UserError(LifecycleError::Apply(
-                    MintError::AutomaticRetriesExhausted { attempts: 4 }
-                )))
-            ),
-            "Expected AutomaticRetriesExhausted, got {automatic_result:?}"
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Manual,
-                },
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            vault.submitted_external_tx_id(),
-            Some(format!("mint-{issuer_request_id}-retry-5"))
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Manual,
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint = fixture
-            .mint_store
-            .load(&issuer_request_id)
-            .await
-            .unwrap()
-            .expect("Expected a live mint after manual retry");
-        let Mint::TxSubmitted { external_tx_id, .. } = &mint else {
-            panic!(
-                "Expected TxSubmitted after manual retry, got: {}",
-                mint.state_name()
-            );
-        };
-        assert_eq!(
-            external_tx_id,
-            &format!("mint-{issuer_request_id}-retry-5")
-        );
-
-        // The manual bypass submits the next retry transaction; the automatic
-        // attempt before it was rejected by the cap and never submitted.
-        let test = "manual_reprocess_can_bypass_automatic_retry_cap";
-        let expected_external = format!("mint-{issuer_request_id}-retry-5");
-        assert_eq!(
-            log_count_at!(
-                Level::INFO,
-                &[
-                    test,
-                    "Persisted mint transaction broadcast",
-                    expected_external.as_str(),
-                ]
-            ),
-            1,
-            "Expected the manual retry-5 submission to be logged once"
-        );
-    }
-
-    /// A retry whose *submission* fails (vs. confirmation) must not advance the
-    /// aggregate past MintingFailed: emitting MintRetryStarted there would drop
-    /// the TxSubmitted predecessor and reset the retry counter to 1,
-    /// reusing a spent external_tx_id and bypassing the automatic cap.
-    #[tokio::test]
-    async fn failed_retry_submission_preserves_predecessor_and_counter() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        // Predecessor was retry attempt 1; failed 2h ago so attempt 2 is due.
-        let original_failed_at = Utc::now() - ChronoDuration::hours(2);
-        let events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}-retry-1"),
-            original_failed_at,
-        );
-        let fixture =
-            MintTestFixture::new_with_vault(Arc::new(RetrySubmitFailsVault))
-                .await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint = fixture
-            .mint_store
-            .load(&issuer_request_id)
-            .await
-            .unwrap()
-            .expect("Expected a live mint after failed resubmission");
-
-        let Mint::MintingFailed { failed_at, failed_from, .. } = &mint else {
-            panic!(
-                "Expected MintingFailed after failed resubmission, got: {}",
-                mint.state_name()
-            );
-        };
-        assert!(
-            matches!(failed_from.as_ref(), Mint::TxSubmitted { .. }),
-            "Predecessor chain must be preserved on submission failure"
-        );
-        assert_eq!(
-            mint.next_retry_attempt(),
-            2,
-            "Retry counter must not reset after a failed retry submission"
-        );
-        assert!(
-            *failed_at > original_failed_at,
-            "failed_at must advance so the backoff anchor moves forward"
-        );
-
-        let retry_started = count_events_of_type(
-            &fixture.pool,
-            &issuer_request_id,
-            "MintEvent::MintRetryStarted",
-        )
-        .await;
-        assert_eq!(
-            retry_started, 0,
-            "A failed submission must not emit MintRetryStarted"
-        );
-    }
-
-    /// Manual recovery bypasses the not-yet-elapsed retry window, not just the
-    /// attempt cap: an operator who has fixed the underlying issue can submit
-    /// the next retry immediately instead of waiting for the automatic delay.
-    #[tokio::test]
-    async fn manual_reprocess_bypasses_retry_delay() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        // Failed just now: automatic recovery would return RetryNotDue.
-        let events = minting_events_for_retry(
-            &issuer_request_id,
-            format!("mint-{issuer_request_id}"),
-            Utc::now(),
-        );
-        let vault = Arc::new(TerminalFailedMintVault::new());
-        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
-        fixture.seed_mint_events(&issuer_request_id.to_string(), events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Manual,
-                },
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(
-            vault.submitted_external_tx_id(),
-            Some(format!("mint-{issuer_request_id}-retry-1")),
-            "Manual recovery must submit immediately despite the unelapsed \
-             retry window"
-        );
-    }
-
-    /// Submission failures that produce no TxSubmitted event (pre-acceptance)
-    /// must still escalate the retry schedule and eventually exhaust, while the
-    /// external_tx_id stays at retry-1 so resubmission is idempotent.
-    #[test]
-    fn pre_acceptance_failures_escalate_attempts_but_reuse_external_id() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-        let mut mint = replay::<Mint>(vec![
-            MintEvent::Initiated {
-                issuer_request_id: issuer_request_id.clone(),
-                tokenization_request_id: TokenizationRequestId::new("tok-123"),
-                quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                token: TokenSymbol::new("tAAPL"),
-                network: Network::Base,
-                client_id: ClientId::new(),
-                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-                initiated_at: now,
-            },
-            MintEvent::JournalConfirmed {
-                issuer_request_id: issuer_request_id.clone(),
-                confirmed_at: now,
-            },
-            MintEvent::MintingStarted {
-                issuer_request_id: issuer_request_id.clone(),
-                started_at: now,
-            },
-        ])
-        .unwrap()
-        .unwrap();
-
-        // failed_at far in the past so every retry window has elapsed; the
-        // decision then turns only on the escalating attempt counter.
-        let failed_at = now - ChronoDuration::hours(3);
-
-        // First submission failure from Minting: attempts = 1, retryable.
-        mint.apply_event(MintEvent::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            error: "submission rejected".to_string(),
-            failed_at,
-        });
-        assert_eq!(
-            mint.automatic_retry_decision(Utc::now()),
-            AutomaticRetryDecision::Ready
-        );
-
-        // Three more pre-acceptance failures push attempts to 4 (still the last
-        // retryable attempt), then a fifth exhausts the automatic schedule —
-        // proving the counter escalates without a TxSubmitted record.
-        for _ in 0..3 {
-            mint.apply_event(MintEvent::MintingFailed {
-                issuer_request_id: issuer_request_id.clone(),
-                error: "submission rejected".to_string(),
-                failed_at,
-            });
-        }
-        assert_eq!(
-            mint.automatic_retry_decision(Utc::now()),
-            AutomaticRetryDecision::Ready
-        );
-
-        mint.apply_event(MintEvent::MintingFailed {
-            issuer_request_id,
-            error: "submission rejected".to_string(),
-            failed_at,
-        });
-        assert_eq!(
-            mint.automatic_retry_decision(Utc::now()),
-            AutomaticRetryDecision::Exhausted
-        );
-
-        // The external_tx_id attempt never advanced — retries reuse retry-1.
-        assert_eq!(mint.next_retry_attempt(), 1);
-    }
-
-    #[tokio::test]
-    async fn test_recover_from_receipt_rejects_journal_confirmed() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
-            .given(vec![
-                MintEvent::Initiated {
-                    issuer_request_id: issuer_request_id.clone(),
-                    tokenization_request_id: TokenizationRequestId::new(
-                        "tok-123",
-                    ),
-                    quantity: Quantity::new(Decimal::from(100)),
-                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                    token: TokenSymbol::new("tAAPL"),
-                    network: Network::Base,
-                    client_id: ClientId::new(),
-                    wallet: address!(
-                        "0x1234567890abcdef1234567890abcdef12345678"
-                    ),
-                    initiated_at: now,
-                },
-                MintEvent::JournalConfirmed {
-                    issuer_request_id: issuer_request_id.clone(),
-                    confirmed_at: now,
-                },
-            ])
-            .when(MintCommand::RecoverFromReceipt {
-                issuer_request_id,
-                tx_hash: b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            })
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(MintError::NotRecoverable { .. })
-            ),
-            "RecoverFromReceipt should reject JournalConfirmed state"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_recover_from_receipt_rejects_minting() {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-
-        let error = TestHarness::<Mint>::with(test_mint_services().await)
-            .given(vec![
-                MintEvent::Initiated {
-                    issuer_request_id: issuer_request_id.clone(),
-                    tokenization_request_id: TokenizationRequestId::new(
-                        "tok-123",
-                    ),
-                    quantity: Quantity::new(Decimal::from(100)),
-                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-                    token: TokenSymbol::new("tAAPL"),
-                    network: Network::Base,
-                    client_id: ClientId::new(),
-                    wallet: address!(
-                        "0x1234567890abcdef1234567890abcdef12345678"
-                    ),
-                    initiated_at: now,
-                },
-                MintEvent::JournalConfirmed {
-                    issuer_request_id: issuer_request_id.clone(),
-                    confirmed_at: now,
-                },
-                MintEvent::MintingStarted {
-                    issuer_request_id: issuer_request_id.clone(),
-                    started_at: now,
-                },
-            ])
-            .when(MintCommand::RecoverFromReceipt {
-                issuer_request_id,
-                tx_hash: b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            })
-            .await
-            .then_expect_error();
-
-        assert!(
-            matches!(
-                error,
-                LifecycleError::Apply(MintError::NotRecoverable { .. })
-            ),
-            "RecoverFromReceipt should reject Minting state"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_recover_from_receipt_rejects_minting_failed_with_non_minting_predecessor()
-     {
-        let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-
-        let journal_confirmed = Mint::JournalConfirmed {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: TokenizationRequestId::new("tok-123"),
-            quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-            token: TokenSymbol::new("tAAPL"),
-            network: Network::Base,
-            client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            initiated_at: now,
-            journal_confirmed_at: now,
-        };
-
-        let mint = Mint::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            tokenization_request_id: TokenizationRequestId::new("tok-123"),
-            quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
-            token: TokenSymbol::new("tAAPL"),
-            network: Network::Base,
-            client_id: ClientId::new(),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            initiated_at: now,
-            journal_confirmed_at: now,
-            error: "some error".to_string(),
-            failed_at: now,
-            attempts: 1,
-            failed_from: Box::new(journal_confirmed),
-        };
-
-        assert!(
-            matches!(
-                mint.non_failed_predecessor(),
-                Mint::JournalConfirmed { .. }
-            ),
-            "Precondition: non_failed_predecessor should be JournalConfirmed"
-        );
-
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect(":memory:")
-            .await
-            .unwrap();
-
-        sqlx::migrate!().run(&pool).await.unwrap();
-
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        let services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            Arc::new(MockVaultService::new_success()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool,
-            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        );
-
-        let result = mint
-            .handle_recover_from_receipt(
-                &services,
-                issuer_request_id,
-                b256!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-            )
-            .await;
-
-        assert!(
-            matches!(result, Err(MintError::NotRecoverable { .. })),
-            "RecoverFromReceipt should reject MintingFailed with non-Minting predecessor, got: {result:?}"
-        );
     }
 }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1772,7 +1772,7 @@ pub(crate) mod tests {
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
-    use crate::vault::TxId;
+    use crate::vault::{PreparedMintTx, TxId};
 
     pub(super) const VAULT: Address =
         address!("0xcccccccccccccccccccccccccccccccccccccccc");
@@ -1927,7 +1927,7 @@ pub(crate) mod tests {
             intended_at: Utc::now(),
         });
 
-        let recorded = TestHarness::<Mint>::with(test_mint_services().await)
+        let recorded = TestHarness::<Mint>::with(())
             .given(events)
             .when(MintCommand::RecordTxSubmitted {
                 issuer_request_id: issuer_request_id.clone(),

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1258,6 +1258,46 @@ impl Mint {
         }
     }
 
+    /// Records a mint whose on-chain transaction already succeeded (a receipt
+    /// exists), reported by the `SubmitMintJob` before it re-submitted. Pure —
+    /// emits `ExistingMintRecovered`, advancing to `CallbackPending` without
+    /// re-minting. Idempotent: a no-op once the mint is already minted.
+    fn handle_record_existing_mint(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        receipt_id: U256,
+        shares_minted: U256,
+        block_number: u64,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
+            Self::Minting { issuer_request_id: expected_id, .. }
+            | Self::TxSubmitted {
+                issuer_request_id: expected_id,
+                ..
+            }
+            | Self::MintingFailed { issuer_request_id: expected_id, .. } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+
+                Ok(vec![MintEvent::ExistingMintRecovered {
+                    issuer_request_id,
+                    tx_hash,
+                    receipt_id,
+                    shares_minted,
+                    block_number,
+                    recovered_at: Utc::now(),
+                }])
+            }
+            Self::CallbackPending { .. } | Self::Completed { .. } => Ok(vec![]),
+            _ => Err(MintError::NotInMintingState {
+                current_state: self.state_name().to_string(),
+            }),
+        }
+    }
+
     async fn handle_recover(
         &self,
         services: &MintServices,
@@ -2393,6 +2433,11 @@ impl EventSourced for Mint {
             }
             MintCommand::RecordMintFailed { .. }
             | MintCommand::RetryMint { .. } => Ok(vec![]),
+            MintCommand::RecordExistingMint { .. } => {
+                Err(MintError::NotInMintingState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
             MintCommand::Recover { .. }
             | MintCommand::RecoverWalletStep { .. }
             | MintCommand::RecoverFromReceipt { .. }
@@ -2495,6 +2540,19 @@ impl EventSourced for Mint {
             MintCommand::RetryMint { issuer_request_id } => {
                 self.handle_retry_mint(issuer_request_id)
             }
+            MintCommand::RecordExistingMint {
+                issuer_request_id,
+                tx_hash,
+                receipt_id,
+                shares_minted,
+                block_number,
+            } => self.handle_record_existing_mint(
+                issuer_request_id,
+                tx_hash,
+                receipt_id,
+                shares_minted,
+                block_number,
+            ),
             MintCommand::Recover { issuer_request_id, mode } => {
                 self.handle_recover(services, issuer_request_id, mode).await
             }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -781,10 +781,7 @@ impl Mint {
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::Minting { issuer_request_id: expected_id, .. }
-            | Self::TxSubmitted {
-                issuer_request_id: expected_id,
-                ..
-            }
+            | Self::TxSubmitted { issuer_request_id: expected_id, .. }
             | Self::MintingFailed { issuer_request_id: expected_id, .. } => {
                 Self::validate_issuer_request_id(
                     expected_id,

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -559,6 +559,8 @@ pub(crate) async fn reconcile_recoverable_mints(
 enum AbandonReason {
     /// The mint could not be loaded after the maximum load-failure backoffs.
     FailedToLoadMint,
+    /// Receipt inventory remained unreadable after transient backoffs.
+    FailedToLoadReceipt,
     /// The aggregate's automatic-retry attempts ran out.
     AutomaticRetriesExhausted,
     /// The mint stayed in the same recoverable state across the maximum number
@@ -570,6 +572,7 @@ impl fmt::Display for AbandonReason {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         let text = match self {
             Self::FailedToLoadMint => "failed to load mint",
+            Self::FailedToLoadReceipt => "failed to load receipt inventory",
             Self::AutomaticRetriesExhausted => "automatic retries exhausted",
             Self::NoProgressBudgetExhausted => "no-progress budget exhausted",
         };
@@ -590,19 +593,56 @@ enum RecoveryConclusion {
     Abandoned { reason: AbandonReason },
 }
 
+async fn minting_failed_receipt_exists_with_backoff(
+    ctx: &MintRecoveryContext,
+    mint: &Mint,
+    issuer_request_id: &IssuerMintRequestId,
+    backoff: Duration,
+    failure_backoffs: &mut usize,
+) -> Result<Option<bool>, AbandonReason> {
+    match minting_failed_receipt_exists(ctx, mint, issuer_request_id).await {
+        Ok(exists) => {
+            *failure_backoffs = 0;
+            Ok(Some(exists))
+        }
+        Err(error) => {
+            *failure_backoffs += 1;
+            if *failure_backoffs > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    error = %error,
+                    "Failed to read receipt inventory after maximum backoffs"
+                );
+                return Err(AbandonReason::FailedToLoadReceipt);
+            }
+
+            debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                backoff_ms = backoff.as_millis(),
+                "Failed to read receipt inventory; backing off"
+            );
+            tokio::time::sleep(backoff).await;
+            Ok(None)
+        }
+    }
+}
+
 async fn recover_mint_until_automatic_budget_exhausted(
     ctx: &MintRecoveryContext,
     issuer_request_id: &IssuerMintRequestId,
     backoff: Duration,
     max_no_progress_polls: usize,
 ) -> RecoveryConclusion {
-    let mut failure_backoffs = 0;
+    let mut mint_load_failure_backoffs = 0;
+    let mut receipt_load_failure_backoffs = 0;
     let mut no_progress_polls = 0;
     let mut last_state: Option<&'static str> = None;
 
     loop {
         let mint = match ctx.mint_store.load(issuer_request_id).await {
-            Ok(Some(mint)) => mint,
+            Ok(Some(mint)) => {
+                mint_load_failure_backoffs = 0;
+                mint
+            }
             Ok(None) => {
                 debug!(target: "mint", issuer_request_id = %issuer_request_id,
                     "Mint not found for scheduled recovery"
@@ -612,8 +652,10 @@ async fn recover_mint_until_automatic_budget_exhausted(
             // A load failure is transient (e.g. a SQLite blip): back off and
             // retry rather than killing the durable job over a single read error.
             Err(error) => {
-                failure_backoffs += 1;
-                if failure_backoffs > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS {
+                mint_load_failure_backoffs += 1;
+                if mint_load_failure_backoffs
+                    > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS
+                {
                     warn!(target: "mint", issuer_request_id = %issuer_request_id,
                         error = %error,
                         max_failure_backoffs = MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS,
@@ -652,12 +694,26 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 return RecoveryConclusion::Resolved;
             }
             AutomaticRetryDecision::Exhausted => {
+                let receipt_exists =
+                    match minting_failed_receipt_exists_with_backoff(
+                        ctx,
+                        &mint,
+                        issuer_request_id,
+                        backoff,
+                        &mut receipt_load_failure_backoffs,
+                    )
+                    .await
+                    {
+                        Ok(Some(exists)) => exists,
+                        Ok(None) => continue,
+                        Err(reason) => {
+                            return RecoveryConclusion::Abandoned { reason };
+                        }
+                    };
                 // A confirmed receipt outranks retry exhaustion: the mint
                 // succeeded on-chain after attempts ran out, so keep driving
                 // toward TokensMinted / callback instead of abandoning.
-                if minting_failed_receipt_exists(ctx, &mint, issuer_request_id)
-                    .await
-                {
+                if receipt_exists {
                     info!(target: "mint", issuer_request_id = %issuer_request_id,
                         "Automatic mint retries exhausted but on-chain receipt exists; continuing recovery"
                     );
@@ -693,15 +749,29 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 };
             }
             AutomaticRetryDecision::Wait(wait) => {
+                let receipt_exists =
+                    match minting_failed_receipt_exists_with_backoff(
+                        ctx,
+                        &mint,
+                        issuer_request_id,
+                        backoff,
+                        &mut receipt_load_failure_backoffs,
+                    )
+                    .await
+                    {
+                        Ok(Some(exists)) => exists,
+                        Ok(None) => continue,
+                        Err(reason) => {
+                            return RecoveryConclusion::Abandoned { reason };
+                        }
+                    };
                 // The retry backoff only spaces out re-submissions. If a receipt
                 // already exists, the mint actually succeeded on-chain, so there
                 // is nothing to wait for — drive immediately to record the
                 // existing mint (the per-state job's receipt check turns this
                 // into a record, not a re-submission). Otherwise honour the
                 // backoff so a genuinely failed mint is not hammered.
-                if minting_failed_receipt_exists(ctx, &mint, issuer_request_id)
-                    .await
-                {
+                if receipt_exists {
                     no_progress_polls += 1;
                     if no_progress_polls > max_no_progress_polls {
                         warn!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -868,25 +938,23 @@ async fn minting_failed_receipt_exists(
     ctx: &MintRecoveryContext,
     mint: &Mint,
     issuer_request_id: &IssuerMintRequestId,
-) -> bool {
+) -> Result<bool, crate::receipt_inventory::ReceiptLookupError> {
     let Mint::MintingFailed { underlying, network, .. } = mint else {
-        return false;
+        return Ok(false);
     };
 
     let Ok(vault) = resolve_vault(ctx, underlying, *network).await else {
-        return false;
+        return Ok(false);
     };
 
-    matches!(
-        ctx.receipts
-            .find_by_issuer_request_id(
-                vault.chain_id,
-                &vault.address,
-                issuer_request_id,
-            )
-            .await,
-        Ok(Some(_))
-    )
+    ctx.receipts
+        .find_by_issuer_request_id(
+            vault.chain_id,
+            &vault.address,
+            issuer_request_id,
+        )
+        .await
+        .map(|receipt| receipt.is_some())
 }
 
 /// Enqueues a per-state job for a recovering mint, first freeing the mint's
@@ -1168,14 +1236,6 @@ mod tests {
                 started_at: now,
             },
         ]
-    }
-
-    fn journal_confirmed_events(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Vec<MintEvent> {
-        let mut events = minting_events(issuer_request_id);
-        events.pop();
-        events
     }
 
     fn tx_submitted_events(
@@ -1520,10 +1580,15 @@ mod tests {
         use alloy::primitives::{B256, U256};
         use async_trait::async_trait;
 
-        struct ReceiptExists;
+        enum ReceiptLookupBehavior {
+            Present,
+            Fails,
+        }
+
+        struct ReceiptLookupStub(ReceiptLookupBehavior);
 
         #[async_trait]
-        impl ReceiptService for ReceiptExists {
+        impl ReceiptService for ReceiptLookupStub {
             async fn register_minted_receipt(
                 &self,
                 _params: MintedReceiptParams,
@@ -1590,12 +1655,22 @@ mod tests {
                 _issuer_request_id: &IssuerMintRequestId,
             ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError>
             {
-                Ok(Some(RecoveredReceipt {
-                    receipt_id: U256::from(1),
-                    tx_hash: B256::ZERO,
-                    shares: U256::from(100),
-                    block_number: 1,
-                }))
+                match self.0 {
+                    ReceiptLookupBehavior::Present => {
+                        Ok(Some(RecoveredReceipt {
+                            receipt_id: U256::from(1),
+                            tx_hash: B256::ZERO,
+                            shares: U256::from(100),
+                            block_number: 1,
+                        }))
+                    }
+                    ReceiptLookupBehavior::Fails => {
+                        Err(ReceiptLookupError::Inconsistent {
+                            issuer_request_id: _issuer_request_id.clone(),
+                            receipt_id: U256::from(1).into(),
+                        })
+                    }
+                }
             }
         }
 
@@ -1613,7 +1688,8 @@ mod tests {
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let mut ctx = fixture.context();
-        ctx.receipts = Arc::new(ReceiptExists);
+        ctx.receipts =
+            Arc::new(ReceiptLookupStub(ReceiptLookupBehavior::Present));
 
         let conclusion = recover_mint_until_automatic_budget_exhausted(
             &ctx,
@@ -1642,6 +1718,36 @@ mod tests {
             ) >= 1,
             "must log that recovery continues because a receipt exists"
         );
+
+        let lookup_failure_id = IssuerMintRequestId::random();
+        let mut lookup_failure_events = tx_submitted_events(&lookup_failure_id);
+        for _ in 0..5 {
+            lookup_failure_events.push(MintEvent::MintingFailed {
+                issuer_request_id: lookup_failure_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+            });
+        }
+        fixture
+            .seed_mint_events(&lookup_failure_id, lookup_failure_events)
+            .await;
+        ctx.receipts =
+            Arc::new(ReceiptLookupStub(ReceiptLookupBehavior::Fails));
+
+        let lookup_failure = recover_mint_until_automatic_budget_exhausted(
+            &ctx,
+            &lookup_failure_id,
+            Duration::from_millis(1),
+            3,
+        )
+        .await;
+
+        assert!(matches!(
+            lookup_failure,
+            RecoveryConclusion::Abandoned {
+                reason: AbandonReason::FailedToLoadReceipt
+            }
+        ));
     }
 
     /// `MintRecoveryJob::perform` returns `Err(AbortError)` when recovery

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, TxHash};
+use alloy::primitives::Address;
 use apalis::prelude::AbortError;
 use apalis_sqlite::SqlitePool;
 use async_trait::async_trait;
@@ -42,10 +42,11 @@ pub(crate) struct MintRecoveryContext {
 /// discovered by the receipt monitor.
 ///
 /// Enqueues the scheduled recovery job for faster pickup than the periodic
-/// reconciler. Recovery re-drives the mint via the per-state jobs; a
-/// re-submission is double-mint-safe through the deterministic `external_tx_id`
-/// (the signing backend dedups), so the discovered `tx_hash` is not needed
-/// here.
+/// reconciler. On-chain evidence (`tx_hash`, receipt id, shares) is already
+/// in inventory from the preceding `DiscoverReceipt`; the recovery /
+/// `SubmitMintJob` path loads that receipt and records it via
+/// `RecordExistingMint` (or re-submits only when no receipt exists — the
+/// signer does not dedup on `external_tx_id`).
 #[derive(Clone)]
 pub(crate) struct MintRecoveryHandler {
     pool: Pool<Sqlite>,
@@ -66,7 +67,6 @@ impl ItnReceiptHandler for MintRecoveryHandler {
     async fn on_itn_receipt_discovered(
         &self,
         issuer_request_id: IssuerMintRequestId,
-        _tx_hash: TxHash,
     ) {
         if let Err(error) = enqueue_scheduled_mint_recovery(
             &self.pool,
@@ -637,7 +637,7 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 // existing mint (the per-state job's receipt check turns this
                 // into a record, not a re-submission). Otherwise honour the
                 // backoff so a genuinely failed mint is not hammered.
-                if minting_failed_receipt_exists(ctx, &mint, &issuer_request_id)
+                if minting_failed_receipt_exists(ctx, &mint, issuer_request_id)
                     .await
                 {
                     no_progress_polls += 1;
@@ -652,7 +652,7 @@ async fn recover_mint_until_automatic_budget_exhausted(
                     }
 
                     if let Err(error) =
-                        drive_one_step(ctx, &mint, &issuer_request_id).await
+                        drive_one_step(ctx, &mint, issuer_request_id).await
                     {
                         debug!(target: "mint", issuer_request_id = %issuer_request_id,
                             error = %error,
@@ -684,7 +684,7 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 }
 
                 if let Err(error) =
-                    drive_one_step(ctx, &mint, &issuer_request_id).await
+                    drive_one_step(ctx, &mint, issuer_request_id).await
                 {
                     debug!(target: "mint", issuer_request_id = %issuer_request_id,
                         error = %error,
@@ -1121,7 +1121,7 @@ mod tests {
         events.push(MintEvent::MintTxSubmitted {
             issuer_request_id: issuer_request_id.clone(),
             external_tx_id: format!("mint-{issuer_request_id}"),
-            tx_id: "fb-tx-123".to_string(),
+            tx_id: TxId::Legacy("fb-tx-123".to_string()),
             submitted_at: now,
         });
 
@@ -1400,7 +1400,8 @@ mod tests {
             "a mint that outlasts its budget must abandon, not resolve"
         );
 
-        let test = "budget_loop_reports_abandoned_when_no_progress_budget_spent";
+        let test =
+            "budget_loop_reports_abandoned_when_no_progress_budget_spent";
         assert!(
             log_count_at!(
                 Level::WARN,

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -17,8 +17,8 @@ use super::{
     AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
     MintRecoveryMode, Network, UnderlyingSymbol, find_all_recoverable_mints,
 };
-use crate::jobs::{Job, JobQueue, QueuePushError};
-use crate::receipt_inventory::ItnReceiptHandler;
+use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
+use crate::receipt_inventory::{ItnReceiptHandler, ReceiptService};
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault,
 };
@@ -32,6 +32,7 @@ pub(crate) struct MintRecoveryContext {
     pub(crate) mint_store: Arc<Store<Mint>>,
     pub(crate) pool: Pool<Sqlite>,
     pub(crate) vault_services: NetworkVaultServices,
+    pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) submit_queue: JobQueue<SubmitMintJob>,
     pub(crate) confirm_queue: JobQueue<ConfirmMintJob>,
     pub(crate) callback_queue: JobQueue<SendCallbackJob>,
@@ -331,13 +332,14 @@ pub(crate) async fn push_mint_recovery_job(
     }
 }
 
-/// Deletes a TERMINAL recovery job for one mint so its idempotency key is free
-/// to re-enqueue, leaving any active (`Pending`/`Running`) job so the
-/// re-enqueue still dedups against it. Runs on the event-store pool (same
-/// SQLite file as the apalis pool).
-async fn release_terminal_recovery_job(
+/// Deletes a TERMINAL apalis job row for one mint and one `job_type` so its
+/// idempotency key is free to re-enqueue, leaving any active (`Pending`/
+/// `Running`) row so the re-enqueue still dedups against it. Runs on the
+/// event-store pool (same SQLite file as the apalis pool).
+async fn release_terminal_job(
     pool: &Pool<Sqlite>,
-    issuer_request_id: &IssuerMintRequestId,
+    job_type: &str,
+    idempotency_key: &str,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "
@@ -351,12 +353,26 @@ async fn release_terminal_recovery_job(
             )
         ",
     )
-    .bind(mint_recovery_job_type())
-    .bind(issuer_request_id.to_string())
+    .bind(job_type)
+    .bind(idempotency_key)
     .execute(pool)
     .await?;
 
     Ok(())
+}
+
+/// Frees a mint's [`MintRecoveryJob`] idempotency key from any terminal prior
+/// job before re-enqueuing it (see [`release_terminal_job`]).
+async fn release_terminal_recovery_job(
+    pool: &Pool<Sqlite>,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(), sqlx::Error> {
+    release_terminal_job(
+        pool,
+        mint_recovery_job_type(),
+        &issuer_request_id.to_string(),
+    )
+    .await
 }
 
 /// Deletes terminal apalis recovery jobs (`Done`/`Killed`, and `Failed` rows
@@ -432,6 +448,43 @@ pub(crate) async fn reset_orphaned_recovery_jobs(
     .bind(mint_recovery_job_type())
     .execute(pool)
     .await?;
+
+    Ok(())
+}
+
+/// Deletes terminal apalis rows for the per-state mint side-effect jobs
+/// (`SubmitMintJob` / `ConfirmMintJob` / `SendCallbackJob`), mirroring
+/// [`vacuum_terminal_recovery_jobs`] for the recovery job. Two purposes: it
+/// bounds the `Jobs` table across restarts, and it frees the per-state
+/// idempotency keys (which are scoped to the mint's `issuer_request_id`) that a
+/// completed normal-flow job would otherwise hold — so a restart-driven recovery
+/// of a rolled-back mint can re-enqueue its side-effect jobs rather than collide
+/// with the prior run's `Done` row. Only terminal rows are removed, so an
+/// orphaned `Pending`/`Running` job apalis will re-pick is left untouched. Runs
+/// on the event-store pool because both pools address the same SQLite file.
+pub(crate) async fn vacuum_terminal_mint_side_effect_jobs(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    for side_effect_job_type in [
+        job_type::<SubmitMintJob>(),
+        job_type::<ConfirmMintJob>(),
+        job_type::<SendCallbackJob>(),
+    ] {
+        sqlx::query(
+            "
+            DELETE FROM Jobs
+            WHERE
+                job_type = ?
+                AND (
+                    status IN ('Done', 'Killed')
+                    OR (status = 'Failed' AND max_attempts <= attempts)
+                )
+            ",
+        )
+        .bind(side_effect_job_type)
+        .execute(pool)
+        .await?;
+    }
 
     Ok(())
 }
@@ -631,11 +684,43 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 };
             }
             AutomaticRetryDecision::Wait(wait) => {
-                debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                    wait_ms = wait.as_millis(),
-                    "Waiting for next automatic mint retry window"
-                );
-                tokio::time::sleep(wait).await;
+                // The retry backoff only spaces out re-submissions. If a receipt
+                // already exists, the mint actually succeeded on-chain, so there
+                // is nothing to wait for — drive immediately to record the
+                // existing mint (the per-state job's receipt check turns this
+                // into a record, not a re-submission). Otherwise honour the
+                // backoff so a genuinely failed mint is not hammered.
+                if minting_failed_receipt_exists(ctx, &mint, &issuer_request_id)
+                    .await
+                {
+                    no_progress_polls += 1;
+                    if no_progress_polls > max_no_progress_polls {
+                        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                            max_no_progress_polls,
+                            "Scheduled mint recovery stopped after maximum polls without progress"
+                        );
+                        return RecoveryConclusion::Abandoned {
+                            reason: AbandonReason::NoProgressBudgetExhausted,
+                        };
+                    }
+
+                    if let Err(error) =
+                        drive_one_step(ctx, &mint, &issuer_request_id).await
+                    {
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            error = %error,
+                            "Scheduled recovery step failed; backing off"
+                        );
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                } else {
+                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                        wait_ms = wait.as_millis(),
+                        "Waiting for next automatic mint retry window"
+                    );
+                    tokio::time::sleep(wait).await;
+                }
             }
             // The state is recoverable and due: enqueue the per-state job that
             // advances it, then poll for progress on the next iteration.
@@ -675,6 +760,8 @@ enum MintRecoveryStepError {
     Store(#[from] SendError<Mint>),
     #[error(transparent)]
     Enqueue(#[from] QueuePushError),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
     #[error(transparent)]
     AssetView(#[from] TokenizedAssetViewError),
     #[error(transparent)]
@@ -910,11 +997,56 @@ async fn resolve_vault(
     Ok(ResolvedVault { address, chain_id })
 }
 
+/// Whether a `MintingFailed` mint already has a discovered receipt — i.e. its
+/// on-chain transaction actually succeeded after the mint was marked failed.
+/// When true, recovery should record the existing mint now rather than wait out
+/// the re-submission backoff. A non-`MintingFailed` state, an unresolved vault,
+/// or a lookup error is treated as "no receipt" so recovery falls back to the
+/// normal retry schedule.
+async fn minting_failed_receipt_exists(
+    ctx: &MintRecoveryContext,
+    mint: &Mint,
+    issuer_request_id: &IssuerMintRequestId,
+) -> bool {
+    let Mint::MintingFailed { underlying, network, .. } = mint else {
+        return false;
+    };
+
+    let Ok(vault) = resolve_vault(ctx, underlying, *network).await else {
+        return false;
+    };
+
+    matches!(
+        ctx.receipts
+            .find_by_issuer_request_id(
+                vault.chain_id,
+                &vault.address,
+                issuer_request_id,
+            )
+            .await,
+        Ok(Some(_))
+    )
+}
+
+/// Enqueues a per-state job for a recovering mint, first freeing the mint's
+/// idempotency key from any TERMINAL prior job of the same type (see
+/// [`release_terminal_job`]). Without the release, a normal-flow job that
+/// already ran to `Done` would hold the key and apalis's
+/// `ON CONFLICT(job_type, idempotency_key) DO NOTHING` would silently drop the
+/// re-enqueue, stranding recovery. A still-active (`Pending`/`Running`) job is
+/// left in place so the push still dedups against it.
 async fn enqueue_submit(
     ctx: &MintRecoveryContext,
     issuer_request_id: &IssuerMintRequestId,
     vault: ResolvedVault,
-) -> Result<(), QueuePushError> {
+) -> Result<(), MintRecoveryStepError> {
+    release_terminal_job(
+        &ctx.pool,
+        job_type::<SubmitMintJob>(),
+        &issuer_request_id.to_string(),
+    )
+    .await?;
+
     ctx.submit_queue
         .clone()
         .push_with_idempotency_key(
@@ -925,7 +1057,9 @@ async fn enqueue_submit(
             },
             issuer_request_id.to_string(),
         )
-        .await
+        .await?;
+
+    Ok(())
 }
 
 async fn enqueue_confirm(
@@ -933,7 +1067,14 @@ async fn enqueue_confirm(
     issuer_request_id: &IssuerMintRequestId,
     vault: ResolvedVault,
     tx_id: TxId,
-) -> Result<(), QueuePushError> {
+) -> Result<(), MintRecoveryStepError> {
+    release_terminal_job(
+        &ctx.pool,
+        job_type::<ConfirmMintJob>(),
+        &issuer_request_id.to_string(),
+    )
+    .await?;
+
     ctx.confirm_queue
         .clone()
         .push_with_idempotency_key(
@@ -945,20 +1086,31 @@ async fn enqueue_confirm(
             },
             issuer_request_id.to_string(),
         )
-        .await
+        .await?;
+
+    Ok(())
 }
 
 async fn enqueue_callback(
     ctx: &MintRecoveryContext,
     issuer_request_id: &IssuerMintRequestId,
-) -> Result<(), QueuePushError> {
+) -> Result<(), MintRecoveryStepError> {
+    release_terminal_job(
+        &ctx.pool,
+        job_type::<SendCallbackJob>(),
+        &issuer_request_id.to_string(),
+    )
+    .await?;
+
     ctx.callback_queue
         .clone()
         .push_with_idempotency_key(
             SendCallbackJob { issuer_request_id: issuer_request_id.clone() },
             issuer_request_id.to_string(),
         )
-        .await
+        .await?;
+
+    Ok(())
 }
 
 fn classify_recovery(

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -432,6 +432,39 @@ pub(crate) async fn vacuum_terminal_mint_side_effect_jobs(
     Ok(())
 }
 
+/// Flips submit/confirm/callback jobs left `Running` by a dead process back to
+/// `Pending`, clearing their lock columns. Mirrors
+/// [`reset_orphaned_recovery_jobs`] for the per-state side-effect chain so a
+/// crash mid-job does not strand recovery behind apalis's orphan timeout
+/// (re-enqueue would otherwise dedupe against the orphaned `Running` row).
+pub(crate) async fn reset_orphaned_mint_side_effect_jobs(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    for side_effect_job_type in [
+        job_type::<SubmitMintJob>(),
+        job_type::<ConfirmMintJob>(),
+        job_type::<SendCallbackJob>(),
+    ] {
+        sqlx::query(
+            "
+            UPDATE Jobs
+            SET
+                status = 'Pending',
+                lock_at = NULL,
+                lock_by = NULL
+            WHERE
+                job_type = ?
+                AND status = 'Running'
+            ",
+        )
+        .bind(side_effect_job_type)
+        .execute(pool)
+        .await?;
+    }
+
+    Ok(())
+}
+
 /// Deletes `Workers` rows for the mint-recovery worker type that no job
 /// references via `Jobs.lock_by`, so the table stays bounded across restarts.
 ///
@@ -619,6 +652,39 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 return RecoveryConclusion::Resolved;
             }
             AutomaticRetryDecision::Exhausted => {
+                // A confirmed receipt outranks retry exhaustion: the mint
+                // succeeded on-chain after attempts ran out, so keep driving
+                // toward TokensMinted / callback instead of abandoning.
+                if minting_failed_receipt_exists(ctx, &mint, issuer_request_id)
+                    .await
+                {
+                    info!(target: "mint", issuer_request_id = %issuer_request_id,
+                        "Automatic mint retries exhausted but on-chain receipt exists; continuing recovery"
+                    );
+                    no_progress_polls += 1;
+                    if no_progress_polls > max_no_progress_polls {
+                        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                            max_no_progress_polls,
+                            "Scheduled mint recovery stopped after maximum polls without progress"
+                        );
+                        return RecoveryConclusion::Abandoned {
+                            reason: AbandonReason::NoProgressBudgetExhausted,
+                        };
+                    }
+
+                    if let Err(error) =
+                        drive_one_step(ctx, &mint, issuer_request_id).await
+                    {
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            error = %error,
+                            "Scheduled recovery step failed after exhausted retries with receipt; backing off"
+                        );
+                    }
+
+                    tokio::time::sleep(backoff).await;
+                    continue;
+                }
+
                 warn!(target: "mint", issuer_request_id = %issuer_request_id,
                     "Automatic mint retries exhausted"
                 );
@@ -1436,6 +1502,145 @@ mod tests {
                 &[test, "Mint not found for scheduled recovery"]
             ) >= 1,
             "an absent mint must log the not-found path"
+        );
+    }
+
+    /// Exhausted automatic retries must not abandon a mint that already has an
+    /// on-chain receipt — recovery should keep driving toward TokensMinted /
+    /// callback instead of returning `AutomaticRetriesExhausted`.
+    #[traced_test]
+    #[tokio::test]
+    async fn exhausted_retries_with_existing_receipt_keep_driving() {
+        use crate::receipt_inventory::{
+            BurnPlan, BurnTrackingError, MintedReceiptParams,
+            ReceiptLookupError, ReceiptRegistrationError, ReceiptService,
+            RecoveredReceipt, Shares,
+        };
+        use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
+        use alloy::primitives::{B256, U256};
+        use async_trait::async_trait;
+
+        struct ReceiptExists;
+
+        #[async_trait]
+        impl ReceiptService for ReceiptExists {
+            async fn register_minted_receipt(
+                &self,
+                _params: MintedReceiptParams,
+            ) -> Result<(), ReceiptRegistrationError> {
+                Ok(())
+            }
+
+            async fn for_burn(
+                &self,
+                _chain_id: u64,
+                _vault: Address,
+                _redemption_issuer_request_id: &IssuerRedemptionRequestId,
+                _shares_to_burn: Shares,
+                _dust: Shares,
+            ) -> Result<BurnPlan, BurnTrackingError> {
+                Ok(BurnPlan {
+                    allocations: vec![],
+                    total_burn: Shares::ZERO,
+                    dust: Shares::ZERO,
+                })
+            }
+
+            async fn reserve_burn(
+                &self,
+                _chain_id: u64,
+                _vault: Address,
+                _redemption_issuer_request_id: IssuerRedemptionRequestId,
+                _burns: Vec<BurnRecord>,
+            ) -> Result<(), ReceiptRegistrationError> {
+                Ok(())
+            }
+
+            async fn release_burn(
+                &self,
+                _chain_id: u64,
+                _vault: Address,
+                _redemption_issuer_request_id: IssuerRedemptionRequestId,
+            ) -> Result<(), ReceiptRegistrationError> {
+                Ok(())
+            }
+
+            async fn settle_burn(
+                &self,
+                _chain_id: u64,
+                _vault: Address,
+                _redemption_issuer_request_id: IssuerRedemptionRequestId,
+            ) -> Result<(), ReceiptRegistrationError> {
+                Ok(())
+            }
+
+            async fn reserved_redemptions(
+                &self,
+                _chain_id: u64,
+                _vault: Address,
+            ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
+            {
+                Ok(vec![])
+            }
+
+            async fn find_by_issuer_request_id(
+                &self,
+                _chain_id: u64,
+                _vault: &Address,
+                _issuer_request_id: &IssuerMintRequestId,
+            ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError>
+            {
+                Ok(Some(RecoveredReceipt {
+                    receipt_id: U256::from(1),
+                    tx_hash: B256::ZERO,
+                    shares: U256::from(100),
+                    block_number: 1,
+                }))
+            }
+        }
+
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::hours(2);
+        let mut events = tx_submitted_events(&issuer_request_id);
+        for _ in 0..5 {
+            events.push(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+            });
+        }
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mut ctx = fixture.context();
+        ctx.receipts = Arc::new(ReceiptExists);
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &ctx,
+            &issuer_request_id,
+            Duration::from_millis(1),
+            3,
+        )
+        .await;
+
+        assert!(
+            !matches!(
+                conclusion,
+                RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::AutomaticRetriesExhausted
+                }
+            ),
+            "an exhausted mint with a confirmed receipt must not be abandoned \
+             for retry exhaustion"
+        );
+
+        let test = "exhausted_retries_with_existing_receipt_keep_driving";
+        assert!(
+            log_count_at!(
+                Level::INFO,
+                &[test, "on-chain receipt exists; continuing recovery"]
+            ) >= 1,
+            "must log that recovery continues because a receipt exists"
         );
     }
 

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -19,12 +19,8 @@ use super::{
 };
 use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{ItnReceiptHandler, ReceiptService};
-use crate::tokenized_asset::view::{
-    TokenizedAssetViewError, find_vault,
-};
-use crate::vault::{
-    NetworkVaultServices, TxId, UnconfiguredNetworkError,
-};
+use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
+use crate::vault::{NetworkVaultServices, TxId, UnconfiguredNetworkError};
 
 /// Dependencies the scheduled mint-recovery worker needs to re-drive a stuck or
 /// failed mint by enqueuing the appropriate per-state job.
@@ -922,14 +918,16 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::mint::api::test_utils::{TestAccountAndAsset, TestHarness};
+    use crate::mint::api::test_utils::{
+        TestAccountAndAsset, TestHarness, network_vault_services,
+    };
     use crate::mint::tests::VAULT;
     use crate::mint::{
         ClientId, IssuerMintRequestId, MintEvent, Network, Quantity,
         TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at};
+    use crate::test_utils::log_count_at;
     use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
 
     /// Builds a real event-sorcery [`Store<Mint>`] over a file-backed SQLite
@@ -943,6 +941,7 @@ mod tests {
         receipt_store: Arc<Store<ReceiptInventory>>,
         pool: Pool<Sqlite>,
         apalis_pool: SqlitePool,
+        vault_services: NetworkVaultServices,
     }
 
     impl MintRecoveryFixture {
@@ -971,14 +970,15 @@ mod tests {
                 (),
             ));
 
-            let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+            let TestHarness { pool, apalis_pool, mint_store, vault, .. } =
+                harness;
 
             Self {
                 mint_store,
                 receipt_store,
                 pool,
                 apalis_pool,
-                vault_services,
+                vault_services: network_vault_services(vault),
             }
         }
 

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1,10 +1,9 @@
-use alloy::primitives::TxHash;
+use alloy::primitives::{Address, TxHash};
 use apalis::prelude::AbortError;
 use apalis_sqlite::SqlitePool;
 use async_trait::async_trait;
 use chrono::Utc;
-use cqrs_es::AggregateError;
-use event_sorcery::{LifecycleError, Store};
+use event_sorcery::{AggregateError, LifecycleError, SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::fmt;
@@ -13,30 +12,51 @@ use std::time::Duration;
 use tracing::{debug, error, info, warn};
 use uuid::Uuid;
 
+use super::job::{ConfirmMintJob, SendCallbackJob, SubmitMintJob};
 use super::{
     AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
-    MintRecoveryMode, find_all_recoverable_mints,
+    MintRecoveryMode, Network, UnderlyingSymbol, find_all_recoverable_mints,
 };
-use crate::jobs::{Job, JobQueue};
+use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::ItnReceiptHandler;
-use crate::vault::VaultService;
+use crate::tokenized_asset::view::{
+    TokenizedAssetViewError, find_vault,
+};
+use crate::vault::{
+    NetworkVaultServices, TxId, UnconfiguredNetworkError, VaultService,
+};
+
+/// Dependencies the scheduled mint-recovery worker needs to re-drive a stuck or
+/// failed mint by enqueuing the appropriate per-state job.
+pub(crate) struct MintRecoveryContext {
+    pub(crate) mint_store: Arc<Store<Mint>>,
+    pub(crate) pool: Pool<Sqlite>,
+    pub(crate) vault_services: NetworkVaultServices,
+    pub(crate) submit_queue: JobQueue<SubmitMintJob>,
+    pub(crate) confirm_queue: JobQueue<ConfirmMintJob>,
+    pub(crate) callback_queue: JobQueue<SendCallbackJob>,
+}
 
 /// Production handler that triggers mint recovery when an ITN receipt is
 /// discovered by the receipt monitor.
+///
+/// Enqueues the scheduled recovery job for faster pickup than the periodic
+/// reconciler. Recovery re-drives the mint via the per-state jobs; a
+/// re-submission is double-mint-safe through the deterministic `external_tx_id`
+/// (the signing backend dedups), so the discovered `tx_hash` is not needed
+/// here.
 #[derive(Clone)]
 pub(crate) struct MintRecoveryHandler {
-    mint_store: Arc<Store<Mint>>,
     pool: Pool<Sqlite>,
     apalis_pool: SqlitePool,
 }
 
 impl MintRecoveryHandler {
     pub(crate) const fn new(
-        mint_store: Arc<Store<Mint>>,
         pool: Pool<Sqlite>,
         apalis_pool: SqlitePool,
     ) -> Self {
-        Self { mint_store, pool, apalis_pool }
+        Self { pool, apalis_pool }
     }
 }
 
@@ -45,66 +65,30 @@ impl ItnReceiptHandler for MintRecoveryHandler {
     async fn on_itn_receipt_discovered(
         &self,
         issuer_request_id: IssuerMintRequestId,
-        tx_hash: TxHash,
+        _tx_hash: TxHash,
     ) {
-        let mint_store = self.mint_store.clone();
-        let pool = self.pool.clone();
-        let apalis_pool = self.apalis_pool.clone();
-        tokio::spawn(async move {
-            let result = mint_store
-                .send(
-                    &issuer_request_id,
-                    MintCommand::RecoverFromReceipt {
-                        issuer_request_id: issuer_request_id.clone(),
-                        tx_hash,
-                    },
-                )
-                .await;
-            match result {
-                Ok(()) => {
-                    if let Err(error) = enqueue_scheduled_mint_recovery(
-                        &pool,
-                        &apalis_pool,
-                        issuer_request_id.clone(),
-                    )
-                    .await
-                    {
-                        warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                            %error,
-                            "Failed to enqueue receipt-triggered mint recovery"
-                        );
-                    }
-                }
-                Err(AggregateError::UserError(LifecycleError::Apply(
-                    MintError::NotRecoverable { current_state },
-                ))) => {
-                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                        current_state,
-                        "Receipt discovery ignored for current mint state"
-                    );
-                }
-                Err(error) => {
-                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        %error,
-                        "Receipt-triggered mint recovery failed"
-                    );
-                }
-            }
-        });
+        if let Err(error) = enqueue_scheduled_mint_recovery(
+            &self.pool,
+            &self.apalis_pool,
+            issuer_request_id.clone(),
+        )
+        .await
+        {
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Failed to enqueue recovery for a discovered receipt"
+            );
+        }
     }
 }
 
-/// Why a [`drive_recovery`] pass stopped. Lets the scheduled recovery loop
-/// decide whether to wait, back off, or give up.
+/// Why a [`drive_recovery`] pass stopped. Lets manual recovery report whether
+/// it completed, paused, exhausted its retry budget, or failed.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum DriveOutcome {
-    /// Reached a terminal or non-recoverable state — no further work.
     Done,
-    /// Paused until the next automatic retry window elapses.
     RetryNotDue,
-    /// Automatic retry budget is exhausted.
     Exhausted,
-    /// A command failed unexpectedly, or recovery did not converge.
     Failed,
 }
 
@@ -119,35 +103,6 @@ enum ClassifiedRecoveryOutcome {
     Done { current_state: &'static str },
     RetryNotDue { wait: Duration },
     Exhausted,
-}
-
-/// Drives a mint through recovery to completion using `MintCommand::Recover`.
-pub(crate) async fn recover_mint(
-    mint_store: &Store<Mint>,
-    vault_service: &Arc<dyn VaultService>,
-    issuer_request_id: IssuerMintRequestId,
-) -> DriveOutcome {
-    drive_recovery(
-        mint_store,
-        vault_service,
-        issuer_request_id,
-        RetryPolicy::Enforce,
-        recovery_step_requires_wallet,
-        |_, id, wallet_locked| {
-            if wallet_locked {
-                MintCommand::RecoverWalletStep {
-                    issuer_request_id: id,
-                    mode: MintRecoveryMode::Automatic,
-                }
-            } else {
-                MintCommand::Recover {
-                    issuer_request_id: id,
-                    mode: MintRecoveryMode::Automatic,
-                }
-            }
-        },
-    )
-    .await
 }
 
 /// Drives an operator-requested recovery, holding the shared wallet lock only
@@ -184,18 +139,17 @@ pub(crate) async fn recover_mint_manually(
 /// a transient error (e.g. RPC blip) occurred. Keeps the loop from spinning while waiting.
 const SCHEDULED_RECOVERY_BACKOFF: Duration = Duration::from_secs(60);
 
-/// Budget for retry-window wakeups (`Wait` / `RetryNotDue`). The automatic
-/// schedule already terminates healthy retries via `Exhausted` after the
-/// attempt cap; this bounds the degenerate case where a mint keeps re-failing
-/// at the same attempt (e.g. submission errors before tx acceptance),
-/// so the task gives up and the next restart re-picks it instead of looping.
-const MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS: usize =
-    (Mint::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT as usize) * 2 + 4;
-
 /// Budget for consecutive transient-failure backoffs (e.g. RPC blips) before
 /// giving up. Small: a persistent error should surface for investigation, not
 /// be hammered indefinitely. The next restart re-picks the mint.
 const MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS: usize = 8;
+
+/// Budget for recovery polls that observe no state change. A slow-but-healthy
+/// step (e.g. a submitted tx awaiting confirmation) is not something we
+/// control, so this is sized generously — ~6h at
+/// [`SCHEDULED_RECOVERY_BACKOFF`] — separate from the transient-failure
+/// budget, so slow finalization is not abandoned prematurely.
+const MAX_SCHEDULED_RECOVERY_NO_PROGRESS_POLLS: usize = 360;
 
 /// Durable apalis job that resumes one mint's automatic recovery.
 ///
@@ -217,29 +171,19 @@ pub(crate) struct MintRecoveryJob {
     issuer_request_id: IssuerMintRequestId,
 }
 
-/// Runtime dependencies injected into the [`MintRecoveryJob`] worker.
-///
-/// Bundled so the generic [`crate::jobs::work`] adapter can take a single
-/// `Data<Arc<Ctx>>` while recovery still needs both the mint store and the
-/// vault service for on-chain retry.
-pub(crate) struct MintRecoveryJobCtx {
-    pub(crate) mint_store: Arc<Store<Mint>>,
-    pub(crate) vault_service: Arc<dyn VaultService>,
-}
-
-impl Job<MintRecoveryJobCtx> for MintRecoveryJob {
+impl Job<MintRecoveryContext> for MintRecoveryJob {
     type Output = ();
     type Error = AbortError;
 
     async fn perform(
         &self,
-        ctx: &MintRecoveryJobCtx,
+        ctx: &MintRecoveryContext,
     ) -> Result<(), AbortError> {
         match recover_mint_until_automatic_budget_exhausted(
-            &ctx.mint_store,
-            &ctx.vault_service,
+            ctx,
             &self.issuer_request_id,
             SCHEDULED_RECOVERY_BACKOFF,
+            MAX_SCHEDULED_RECOVERY_NO_PROGRESS_POLLS,
         )
         .await
         {
@@ -588,10 +532,9 @@ enum AbandonReason {
     FailedToLoadMint,
     /// The aggregate's automatic-retry attempts ran out.
     AutomaticRetriesExhausted,
-    /// The transient-failure backoff budget was spent.
-    TransientFailureBudgetExhausted,
-    /// The retry-wakeup budget was spent.
-    RetryWakeupBudgetExhausted,
+    /// The mint stayed in the same recoverable state across the maximum number
+    /// of polls — the enqueued job is not making progress.
+    NoProgressBudgetExhausted,
 }
 
 impl fmt::Display for AbandonReason {
@@ -599,10 +542,7 @@ impl fmt::Display for AbandonReason {
         let text = match self {
             Self::FailedToLoadMint => "failed to load mint",
             Self::AutomaticRetriesExhausted => "automatic retries exhausted",
-            Self::TransientFailureBudgetExhausted => {
-                "transient failure budget exhausted"
-            }
-            Self::RetryWakeupBudgetExhausted => "retry wakeup budget exhausted",
+            Self::NoProgressBudgetExhausted => "no-progress budget exhausted",
         };
 
         formatter.write_str(text)
@@ -622,20 +562,18 @@ enum RecoveryConclusion {
 }
 
 async fn recover_mint_until_automatic_budget_exhausted(
-    mint_store: &Store<Mint>,
-    vault_service: &Arc<dyn VaultService>,
+    ctx: &MintRecoveryContext,
     issuer_request_id: &IssuerMintRequestId,
     backoff: Duration,
+    max_no_progress_polls: usize,
 ) -> RecoveryConclusion {
-    let mut retry_wakeups = 0;
     let mut failure_backoffs = 0;
+    let mut no_progress_polls = 0;
+    let mut last_state: Option<&'static str> = None;
 
     loop {
-        let mint = match mint_store.load(issuer_request_id).await {
+        let mint = match ctx.mint_store.load(issuer_request_id).await {
             Ok(Some(mint)) => mint,
-            // A missing mint cannot be recovered — the same outcome the old
-            // default (`Uninitialized`) aggregate produced via
-            // `AutomaticRetryDecision::NotRecoverable`.
             Ok(None) => {
                 debug!(target: "mint", issuer_request_id = %issuer_request_id,
                     "Mint not found for scheduled recovery"
@@ -643,14 +581,12 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 return RecoveryConclusion::Resolved;
             }
             // A load failure is transient (e.g. a SQLite blip): back off and
-            // retry within the same budget as `DriveOutcome::Failed` rather than
-            // abandoning the mint immediately and killing the durable job over a
-            // single read error.
-            Err(err) => {
+            // retry rather than killing the durable job over a single read error.
+            Err(error) => {
                 failure_backoffs += 1;
                 if failure_backoffs > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS {
                     warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        error = %err,
+                        error = %error,
                         max_failure_backoffs = MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS,
                         "Failed to load mint for scheduled recovery after maximum backoffs"
                     );
@@ -660,7 +596,7 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 }
 
                 debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                    error = %err,
+                    error = %error,
                     backoff_ms = backoff.as_millis(),
                     "Failed to load mint for scheduled recovery; backing off"
                 );
@@ -669,94 +605,88 @@ async fn recover_mint_until_automatic_budget_exhausted(
             }
         };
 
+        // Reset the no-progress budget whenever the mint advances to a new
+        // state, so a healthy multi-step recovery is not abandoned for taking
+        // several backoffs overall.
+        let state = mint.state_name();
+        if Some(state) != last_state {
+            no_progress_polls = 0;
+            last_state = Some(state);
+        }
+
         match mint.automatic_retry_decision(Utc::now()) {
-            AutomaticRetryDecision::Ready => {
-                match recover_mint(
-                    mint_store,
-                    vault_service,
-                    issuer_request_id.clone(),
-                )
-                .await
-                {
-                    DriveOutcome::Done => {
-                        return RecoveryConclusion::Resolved;
-                    }
-                    DriveOutcome::Exhausted => {
-                        return RecoveryConclusion::Abandoned {
-                            reason: AbandonReason::AutomaticRetriesExhausted,
-                        };
-                    }
-                    // A transient error: back off and retry a bounded number of
-                    // times so a persistent error surfaces rather than looping.
-                    DriveOutcome::Failed => {
-                        failure_backoffs += 1;
-                        if failure_backoffs
-                            > MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS
-                        {
-                            warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                                max_failure_backoffs = MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS,
-                                "Scheduled mint recovery stopped after maximum failure backoffs"
-                            );
-                            return RecoveryConclusion::Abandoned {
-                                reason: AbandonReason::TransientFailureBudgetExhausted,
-                            };
-                        }
-
-                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                            backoff_ms = backoff.as_millis(),
-                            "Scheduled recovery backing off after a transient failure"
-                        );
-                        tokio::time::sleep(backoff).await;
-                    }
-                    // The retry window passed between the decision and the
-                    // submit-time re-check; sleep so a clock race does not spin
-                    // the wakeup budget, then re-evaluate (next decision Waits).
-                    DriveOutcome::RetryNotDue => {
-                        retry_wakeups += 1;
-                        if retry_wakeups > MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS
-                        {
-                            warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                                max_retry_wakeups = MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS,
-                                "Scheduled mint recovery stopped after maximum retry wakeups"
-                            );
-                            return RecoveryConclusion::Abandoned {
-                                reason:
-                                    AbandonReason::RetryWakeupBudgetExhausted,
-                            };
-                        }
-
-                        tokio::time::sleep(backoff).await;
-                    }
-                }
+            AutomaticRetryDecision::NotRecoverable => {
+                info!(target: "mint", issuer_request_id = %issuer_request_id,
+                    current_state = state,
+                    "Mint recovery complete"
+                );
+                return RecoveryConclusion::Resolved;
+            }
+            AutomaticRetryDecision::Exhausted => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    "Automatic mint retries exhausted"
+                );
+                return RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::AutomaticRetriesExhausted,
+                };
             }
             AutomaticRetryDecision::Wait(wait) => {
-                retry_wakeups += 1;
-                if retry_wakeups > MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS {
-                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        max_retry_wakeups = MAX_SCHEDULED_RECOVERY_RETRY_WAKEUPS,
-                        "Scheduled mint recovery stopped after maximum retry wakeups"
-                    );
-                    return RecoveryConclusion::Abandoned {
-                        reason: AbandonReason::RetryWakeupBudgetExhausted,
-                    };
-                }
-
                 debug!(target: "mint", issuer_request_id = %issuer_request_id,
                     wait_ms = wait.as_millis(),
                     "Waiting for next automatic mint retry window"
                 );
                 tokio::time::sleep(wait).await;
             }
-            AutomaticRetryDecision::Exhausted => {
-                return RecoveryConclusion::Abandoned {
-                    reason: AbandonReason::AutomaticRetriesExhausted,
-                };
-            }
-            AutomaticRetryDecision::NotRecoverable => {
-                return RecoveryConclusion::Resolved;
+            // The state is recoverable and due: enqueue the per-state job that
+            // advances it, then poll for progress on the next iteration.
+            AutomaticRetryDecision::Ready => {
+                no_progress_polls += 1;
+                if no_progress_polls > max_no_progress_polls {
+                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                        max_no_progress_polls,
+                        "Scheduled mint recovery stopped after maximum polls without progress"
+                    );
+                    return RecoveryConclusion::Abandoned {
+                        reason: AbandonReason::NoProgressBudgetExhausted,
+                    };
+                }
+
+                if let Err(error) =
+                    drive_one_step(ctx, &mint, &issuer_request_id).await
+                {
+                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                        error = %error,
+                        "Scheduled recovery step failed; backing off"
+                    );
+                }
+
+                tokio::time::sleep(backoff).await;
             }
         }
     }
+}
+
+/// Why a [`drive_one_step`] call failed. Recovery treats these as transient and
+/// re-polls; the durable jobs and outcome commands are idempotent, so a retried
+/// step cannot double-apply.
+#[derive(Debug, thiserror::Error)]
+enum MintRecoveryStepError {
+    #[error(transparent)]
+    Store(#[from] SendError<Mint>),
+    #[error(transparent)]
+    Enqueue(#[from] QueuePushError),
+    #[error(transparent)]
+    AssetView(#[from] TokenizedAssetViewError),
+    #[error(transparent)]
+    UnconfiguredNetwork(#[from] UnconfiguredNetworkError),
+    #[error("no vault configured for {underlying} on {network}")]
+    VaultNotFound { underlying: UnderlyingSymbol, network: Network },
+}
+
+#[derive(Clone, Copy)]
+struct ResolvedVault {
+    address: Address,
+    chain_id: u64,
 }
 
 const MAX_RECOVERY_ATTEMPTS: usize = 10;
@@ -905,6 +835,130 @@ async fn drive_recovery(
     );
 
     DriveOutcome::Failed
+}
+
+/// Advances a recoverable mint one step by enqueuing the appropriate per-state
+/// job (or issuing the pure transition that precedes it). The durable jobs
+/// perform the actual I/O; recovery only schedules them. The deterministic
+/// `external_tx_id` keeps a re-submission double-mint-safe.
+async fn drive_one_step(
+    ctx: &MintRecoveryContext,
+    mint: &Mint,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(), MintRecoveryStepError> {
+    match mint {
+        // The deposit was never recorded: do the pure transition; the next poll
+        // enqueues the submission.
+        Mint::JournalConfirmed { .. } => {
+            ctx.mint_store
+                .send(
+                    issuer_request_id,
+                    MintCommand::Deposit {
+                        issuer_request_id: issuer_request_id.clone(),
+                    },
+                )
+                .await?;
+        }
+        Mint::Minting { underlying, network, .. }
+        | Mint::TxIntended { underlying, network, .. } => {
+            let vault = resolve_vault(ctx, underlying, *network).await?;
+            enqueue_submit(ctx, issuer_request_id, vault).await?;
+        }
+        // Retry a failed mint: transition back to Minting (advancing the attempt
+        // counter), then enqueue a fresh submission.
+        Mint::MintingFailed { underlying, network, .. } => {
+            ctx.mint_store
+                .send(
+                    issuer_request_id,
+                    MintCommand::RetryMint {
+                        issuer_request_id: issuer_request_id.clone(),
+                    },
+                )
+                .await?;
+            let vault = resolve_vault(ctx, underlying, *network).await?;
+            enqueue_submit(ctx, issuer_request_id, vault).await?;
+        }
+        Mint::TxSubmitted { underlying, network, tx_id, .. } => {
+            let vault = resolve_vault(ctx, underlying, *network).await?;
+            enqueue_confirm(ctx, issuer_request_id, vault, tx_id.clone())
+                .await?;
+        }
+        Mint::CallbackPending { .. } => {
+            enqueue_callback(ctx, issuer_request_id).await?;
+        }
+        // Initiated / JournalRejected / Completed / Closed are not driven here
+        // (NotRecoverable, or recovery doesn't start before journal confirm).
+        _ => {}
+    }
+
+    Ok(())
+}
+
+async fn resolve_vault(
+    ctx: &MintRecoveryContext,
+    underlying: &UnderlyingSymbol,
+    network: Network,
+) -> Result<ResolvedVault, MintRecoveryStepError> {
+    let address = find_vault(&ctx.pool, underlying, &network)
+        .await?
+        .ok_or_else(|| MintRecoveryStepError::VaultNotFound {
+            underlying: underlying.clone(),
+            network,
+        })?;
+    let chain_id = ctx.vault_services.chain_id(network)?;
+
+    Ok(ResolvedVault { address, chain_id })
+}
+
+async fn enqueue_submit(
+    ctx: &MintRecoveryContext,
+    issuer_request_id: &IssuerMintRequestId,
+    vault: ResolvedVault,
+) -> Result<(), QueuePushError> {
+    ctx.submit_queue
+        .clone()
+        .push_with_idempotency_key(
+            SubmitMintJob {
+                issuer_request_id: issuer_request_id.clone(),
+                vault: vault.address,
+                chain_id: vault.chain_id,
+            },
+            issuer_request_id.to_string(),
+        )
+        .await
+}
+
+async fn enqueue_confirm(
+    ctx: &MintRecoveryContext,
+    issuer_request_id: &IssuerMintRequestId,
+    vault: ResolvedVault,
+    tx_id: TxId,
+) -> Result<(), QueuePushError> {
+    ctx.confirm_queue
+        .clone()
+        .push_with_idempotency_key(
+            ConfirmMintJob {
+                issuer_request_id: issuer_request_id.clone(),
+                vault: vault.address,
+                chain_id: vault.chain_id,
+                tx_id,
+            },
+            issuer_request_id.to_string(),
+        )
+        .await
+}
+
+async fn enqueue_callback(
+    ctx: &MintRecoveryContext,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(), QueuePushError> {
+    ctx.callback_queue
+        .clone()
+        .push_with_idempotency_key(
+            SendCallbackJob { issuer_request_id: issuer_request_id.clone() },
+            issuer_request_id.to_string(),
+        )
+        .await
 }
 
 fn classify_recovery(

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -3,7 +3,7 @@ use apalis::prelude::AbortError;
 use apalis_sqlite::SqlitePool;
 use async_trait::async_trait;
 use chrono::Utc;
-use event_sorcery::{AggregateError, LifecycleError, SendError, Store};
+use event_sorcery::{SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::fmt;
@@ -14,8 +14,8 @@ use uuid::Uuid;
 
 use super::job::{ConfirmMintJob, SendCallbackJob, SubmitMintJob};
 use super::{
-    AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, MintError,
-    MintRecoveryMode, Network, UnderlyingSymbol, find_all_recoverable_mints,
+    AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, Network,
+    UnderlyingSymbol, find_all_recoverable_mints,
 };
 use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{ItnReceiptHandler, ReceiptService};
@@ -23,7 +23,7 @@ use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault,
 };
 use crate::vault::{
-    NetworkVaultServices, TxId, UnconfiguredNetworkError, VaultService,
+    NetworkVaultServices, TxId, UnconfiguredNetworkError,
 };
 
 /// Dependencies the scheduled mint-recovery worker needs to re-drive a stuck or
@@ -81,59 +81,6 @@ impl ItnReceiptHandler for MintRecoveryHandler {
             );
         }
     }
-}
-
-/// Why a [`drive_recovery`] pass stopped. Lets manual recovery report whether
-/// it completed, paused, exhausted its retry budget, or failed.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum DriveOutcome {
-    Done,
-    RetryNotDue,
-    Exhausted,
-    Failed,
-}
-
-#[derive(Clone, Copy)]
-enum RetryPolicy {
-    Enforce,
-    Bypass,
-}
-
-#[derive(Clone, Copy)]
-enum ClassifiedRecoveryOutcome {
-    Done { current_state: &'static str },
-    RetryNotDue { wait: Duration },
-    Exhausted,
-}
-
-/// Drives an operator-requested recovery, holding the shared wallet lock only
-/// for transitions that may prepare or broadcast a transaction.
-pub(crate) async fn recover_mint_manually(
-    mint_store: &Store<Mint>,
-    vault_service: &Arc<dyn VaultService>,
-    issuer_request_id: IssuerMintRequestId,
-) -> DriveOutcome {
-    drive_recovery(
-        mint_store,
-        vault_service,
-        issuer_request_id,
-        RetryPolicy::Bypass,
-        recovery_step_requires_wallet,
-        |_, id, wallet_locked| {
-            if wallet_locked {
-                MintCommand::RecoverWalletStep {
-                    issuer_request_id: id,
-                    mode: MintRecoveryMode::Manual,
-                }
-            } else {
-                MintCommand::Recover {
-                    issuer_request_id: id,
-                    mode: MintRecoveryMode::Manual,
-                }
-            }
-        },
-    )
-    .await
 }
 
 /// Fixed backoff applied when a scheduled recovery pass cannot make progress —
@@ -776,154 +723,6 @@ struct ResolvedVault {
     chain_id: u64,
 }
 
-const MAX_RECOVERY_ATTEMPTS: usize = 10;
-
-/// Drives a mint through recovery to completion by repeatedly sending
-/// commands built by `make_command` until the mint reaches a terminal state.
-///
-/// A single recovery command advances the mint by one step (e.g.,
-/// `MintingFailed` -> `CallbackPending`). The aggregate state is classified
-/// before each command and after every successful step so terminal states and
-/// retry windows do not need to be discovered through expected command errors.
-///
-/// Bounded to [`MAX_RECOVERY_ATTEMPTS`] iterations to prevent infinite
-/// spinning if a command returns `Ok(())` without advancing state.
-async fn drive_recovery(
-    mint_store: &Store<Mint>,
-    vault_service: &Arc<dyn VaultService>,
-    issuer_request_id: IssuerMintRequestId,
-    retry_policy: RetryPolicy,
-    requires_wallet: impl Fn(&Mint) -> bool,
-    make_command: impl Fn(Option<&Mint>, IssuerMintRequestId, bool) -> MintCommand,
-) -> DriveOutcome {
-    for attempt in 1..=MAX_RECOVERY_ATTEMPTS {
-        let mut loaded_mint = match mint_store.load(&issuer_request_id).await {
-            Ok(Some(mint)) => mint,
-            Ok(None) => {
-                debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                    "Mint not found for recovery"
-                );
-                return DriveOutcome::Done;
-            }
-            Err(err) => {
-                warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Failed to load mint before recovery step"
-                );
-                return DriveOutcome::Failed;
-            }
-        };
-
-        if let Some(outcome) = classify_recovery(&loaded_mint, retry_policy) {
-            return finish_classified_recovery(&issuer_request_id, outcome);
-        }
-
-        let mut wallet_guard = None;
-        if requires_wallet(&loaded_mint) {
-            wallet_guard = vault_service.lock_wallet().await;
-            loaded_mint = match mint_store.load(&issuer_request_id).await {
-                Ok(Some(mint)) => mint,
-                Ok(None) => {
-                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                        "Mint not found after acquiring wallet lock for recovery"
-                    );
-                    return DriveOutcome::Done;
-                }
-                Err(err) => {
-                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        error = %err,
-                        "Failed to reload mint under wallet lock before recovery step"
-                    );
-                    return DriveOutcome::Failed;
-                }
-            };
-
-            if let Some(outcome) = classify_recovery(&loaded_mint, retry_policy)
-            {
-                drop(wallet_guard);
-                return finish_classified_recovery(&issuer_request_id, outcome);
-            }
-
-            if !requires_wallet(&loaded_mint) {
-                drop(wallet_guard.take());
-            }
-        }
-
-        let result = mint_store
-            .send(
-                &issuer_request_id,
-                make_command(
-                    Some(&loaded_mint),
-                    issuer_request_id.clone(),
-                    wallet_guard.is_some(),
-                ),
-            )
-            .await;
-        drop(wallet_guard);
-
-        match result {
-            Ok(()) => {
-                debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                    attempt,
-                    "Recovery step succeeded, continuing"
-                );
-
-                if let Some(outcome) = recovery_outcome_after_step(
-                    mint_store,
-                    &issuer_request_id,
-                    retry_policy,
-                )
-                .await
-                {
-                    return outcome;
-                }
-            }
-            Err(AggregateError::UserError(LifecycleError::Apply(
-                MintError::NotRecoverable { current_state },
-            ))) => {
-                info!(target: "mint", issuer_request_id = %issuer_request_id,
-                    current_state,
-                    "Mint recovery complete"
-                );
-                return DriveOutcome::Done;
-            }
-            Err(AggregateError::UserError(LifecycleError::Apply(
-                MintError::RetryNotDue { retry_at },
-            ))) => {
-                info!(target: "mint", issuer_request_id = %issuer_request_id,
-                    %retry_at,
-                    "Mint recovery paused until retry window"
-                );
-                return DriveOutcome::RetryNotDue;
-            }
-            Err(AggregateError::UserError(LifecycleError::Apply(
-                MintError::AutomaticRetriesExhausted { attempts },
-            ))) => {
-                warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                    attempts,
-                    "Automatic mint retries exhausted"
-                );
-                return DriveOutcome::Exhausted;
-            }
-            Err(err) => {
-                warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Mint recovery failed"
-                );
-                return DriveOutcome::Failed;
-            }
-        }
-    }
-
-    error!(target: "mint", issuer_request_id = %issuer_request_id,
-        aggregate_id = %issuer_request_id,
-        max_attempts = MAX_RECOVERY_ATTEMPTS,
-        "Mint recovery exceeded maximum attempts without reaching terminal state"
-    );
-
-    DriveOutcome::Failed
-}
-
 /// Advances a recoverable mint one step by enqueuing the appropriate per-state
 /// job (or issuing the pure transition that precedes it). The durable jobs
 /// perform the actual I/O; recovery only schedules them. The deterministic
@@ -1113,175 +912,45 @@ async fn enqueue_callback(
     Ok(())
 }
 
-fn classify_recovery(
-    mint: &Mint,
-    retry_policy: RetryPolicy,
-) -> Option<ClassifiedRecoveryOutcome> {
-    match mint.automatic_retry_decision(Utc::now()) {
-        AutomaticRetryDecision::Ready => None,
-        AutomaticRetryDecision::Wait(wait)
-            if matches!(retry_policy, RetryPolicy::Enforce) =>
-        {
-            Some(ClassifiedRecoveryOutcome::RetryNotDue { wait })
-        }
-        AutomaticRetryDecision::Exhausted
-            if matches!(retry_policy, RetryPolicy::Enforce) =>
-        {
-            Some(ClassifiedRecoveryOutcome::Exhausted)
-        }
-        AutomaticRetryDecision::NotRecoverable => {
-            Some(ClassifiedRecoveryOutcome::Done {
-                current_state: mint.state_name(),
-            })
-        }
-        AutomaticRetryDecision::Wait(_) | AutomaticRetryDecision::Exhausted => {
-            None
-        }
-    }
-}
-
-fn finish_classified_recovery(
-    issuer_request_id: &IssuerMintRequestId,
-    outcome: ClassifiedRecoveryOutcome,
-) -> DriveOutcome {
-    match outcome {
-        ClassifiedRecoveryOutcome::Done { current_state } => {
-            info!(target: "mint", issuer_request_id = %issuer_request_id,
-                current_state,
-                "Mint recovery complete"
-            );
-            DriveOutcome::Done
-        }
-        ClassifiedRecoveryOutcome::RetryNotDue { wait } => {
-            info!(target: "mint", issuer_request_id = %issuer_request_id,
-                wait_ms = wait.as_millis(),
-                "Mint recovery paused until retry window"
-            );
-            DriveOutcome::RetryNotDue
-        }
-        ClassifiedRecoveryOutcome::Exhausted => {
-            warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                "Automatic mint retries exhausted"
-            );
-            DriveOutcome::Exhausted
-        }
-    }
-}
-
-async fn recovery_outcome_after_step(
-    mint_store: &Store<Mint>,
-    issuer_request_id: &IssuerMintRequestId,
-    retry_policy: RetryPolicy,
-) -> Option<DriveOutcome> {
-    let mint = match mint_store.load(issuer_request_id).await {
-        Ok(Some(mint)) => mint,
-        Ok(None) => {
-            warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                "Mint disappeared during recovery"
-            );
-            return Some(DriveOutcome::Failed);
-        }
-        Err(err) => {
-            warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Failed to load mint after recovery step"
-            );
-            return Some(DriveOutcome::Failed);
-        }
-    };
-
-    classify_recovery(&mint, retry_policy)
-        .map(|outcome| finish_classified_recovery(issuer_request_id, outcome))
-}
-
-const fn recovery_step_requires_wallet(mint: &Mint) -> bool {
-    !matches!(
-        mint,
-        Mint::JournalRejected { .. }
-            | Mint::CallbackPending { .. }
-            | Mint::Completed { .. }
-            | Mint::Closed { .. }
-    )
-}
-
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, b256, uint};
-    use chrono::{Duration as ChronoDuration, Utc};
-    use event_sorcery::{StoreBuilder, test_store};
+    use alloy::primitives::address;
+    use chrono::Utc;
+    use event_sorcery::test_store;
     use rust_decimal::Decimal;
-    use sqlx::sqlite::SqlitePoolOptions;
-    use std::sync::atomic::{AtomicUsize, Ordering};
     use tracing::Level;
     use tracing_test::traced_test;
 
     use super::*;
-    use crate::alpaca::AlpacaService;
-    use crate::alpaca::mock::MockAlpacaService;
     use crate::mint::api::test_utils::{TestAccountAndAsset, TestHarness};
-    use crate::mint::tests::{BOT, VAULT};
+    use crate::mint::tests::VAULT;
     use crate::mint::{
-        ClientId, IssuerMintRequestId, MintEvent, MintServices, Network,
-        Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        ClientId, IssuerMintRequestId, MintEvent, Network, Quantity,
+        TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
-    use crate::receipt_inventory::{
-        CqrsReceiptService, ReceiptId, ReceiptInventory,
-        ReceiptInventoryCommand, ReceiptSource, ReceiptVaultKey, Shares,
-    };
-    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
-    use crate::tokenized_asset::{
-        AssetKey, TokenizedAsset, TokenizedAssetCommand,
-    };
-    use crate::vault::mock::MockVaultService;
-    use crate::vault::{
-        PreparedMintTx, ReceiptInformation, TxId, VaultService,
-    };
+    use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at};
+    use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
 
-    /// Builds a real event-sorcery [`Store<Mint>`] backed by an in-memory
-    /// SQLite pool, wired with the same services the production recovery flow
-    /// uses (vault, Alpaca, receipt inventory). The [`TokenizedAsset`]
-    /// projection is populated with the AAPL -> [`VAULT`] mapping so the
-    /// recovery vault lookup (`find_vault`) resolves.
+    /// Builds a real event-sorcery [`Store<Mint>`] over a file-backed SQLite
+    /// pool shared with an apalis-sqlite pool (so the durable per-state queues
+    /// see the `Jobs` table), seeding the AAPL -> [`VAULT`] mapping so the
+    /// recovery vault lookup (`find_vault_by_underlying`) resolves. The `Mint`
+    /// aggregate is pure (`Services = ()`); the recovery worker's I/O
+    /// dependencies are assembled on demand via [`Self::context`].
     struct MintRecoveryFixture {
         mint_store: Arc<Store<Mint>>,
         receipt_store: Arc<Store<ReceiptInventory>>,
-        pool: sqlx::SqlitePool,
-        vault: Arc<dyn VaultService>,
+        pool: Pool<Sqlite>,
+        apalis_pool: SqlitePool,
     }
 
     impl MintRecoveryFixture {
         async fn new() -> Self {
-            Self::new_with_vault(Arc::new(MockVaultService::new_success()))
-                .await
-        }
+            let harness = TestHarness::new().await;
 
-        async fn new_with_vault(vault: Arc<dyn VaultService>) -> Self {
-            Self::new_with_services(
-                vault,
-                Arc::new(MockAlpacaService::new_success()),
-            )
-            .await
-        }
-
-        async fn new_with_services(
-            vault: Arc<dyn VaultService>,
-            alpaca: Arc<dyn AlpacaService>,
-        ) -> Self {
-            let pool = SqlitePoolOptions::new()
-                .max_connections(1)
-                .connect(":memory:")
-                .await
-                .unwrap();
-
-            sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-
-            let (asset_store, _asset_projection) =
-                StoreBuilder::<TokenizedAsset>::new(pool.clone())
-                    .build(())
-                    .await
-                    .unwrap();
-
-            asset_store
+            harness
+                .asset_store
                 .send(
                     &AssetKey::new(
                         UnderlyingSymbol::new("AAPL").unwrap(),
@@ -1297,23 +966,38 @@ mod tests {
                 .await
                 .unwrap();
 
-            let receipt_store =
-                Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+            let receipt_store = Arc::new(test_store::<ReceiptInventory>(
+                harness.pool.clone(),
+                (),
+            ));
 
-            let services = MintServices::with_single_vault(
-                Network::Base,
-                ANVIL_CHAIN_ID,
-                vault.clone(),
-                alpaca,
-                Arc::new(CqrsReceiptService::new(receipt_store.clone())),
-                pool.clone(),
-                BOT,
-            );
+            let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
 
-            let mint_store =
-                Arc::new(test_store::<Mint>(pool.clone(), services));
+            Self {
+                mint_store,
+                receipt_store,
+                pool,
+                apalis_pool,
+                vault_services,
+            }
+        }
 
-            Self { mint_store, receipt_store, pool, vault }
+        /// Assembles the recovery worker's I/O dependencies against the shared
+        /// pools: the event-store pool, a [`CqrsReceiptService`] over the
+        /// fixture's receipt inventory, and the three per-state job queues on
+        /// the apalis pool.
+        fn context(&self) -> MintRecoveryContext {
+            MintRecoveryContext {
+                mint_store: self.mint_store.clone(),
+                pool: self.pool.clone(),
+                vault_services: self.vault_services.clone(),
+                receipts: Arc::new(CqrsReceiptService::new(
+                    self.receipt_store.clone(),
+                )),
+                submit_queue: JobQueue::new(&self.apalis_pool),
+                confirm_queue: JobQueue::new(&self.apalis_pool),
+                callback_queue: JobQueue::new(&self.apalis_pool),
+            }
         }
 
         /// Seeds the event store with raw `Mint` events, putting the aggregate
@@ -1371,6 +1055,20 @@ mod tests {
         }
     }
 
+    fn tx_failed_events(
+        issuer_request_id: &IssuerMintRequestId,
+        failed_at: chrono::DateTime<Utc>,
+    ) -> Vec<MintEvent> {
+        let mut events = tx_submitted_events(issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "terminal signer failure".to_string(),
+            failed_at,
+        });
+
+        events
+    }
+
     fn test_issuer_request_id() -> IssuerMintRequestId {
         IssuerMintRequestId::new(
             uuid::Uuid::parse_str("00000000-0000-0000-0000-000000000001")
@@ -1423,1127 +1121,74 @@ mod tests {
         events.push(MintEvent::MintTxSubmitted {
             issuer_request_id: issuer_request_id.clone(),
             external_tx_id: format!("mint-{issuer_request_id}"),
-            tx_id: TxId::random(),
+            tx_id: "fb-tx-123".to_string(),
             submitted_at: now,
         });
 
         events
     }
 
-    fn mint_intended_events(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Vec<MintEvent> {
-        let mut events = minting_events(issuer_request_id);
-        events.push(MintEvent::MintTxIntended {
-            issuer_request_id: issuer_request_id.clone(),
-            prepared_tx: PreparedMintTx::valid_for_test(
-                1,
-                format!("mint-{issuer_request_id}"),
-            ),
-            intended_at: Utc::now(),
-        });
-
-        events
-    }
-
-    fn minting_failed_events(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Vec<MintEvent> {
-        let now = Utc::now();
-        let mut events = minting_events(issuer_request_id);
-
-        events.push(MintEvent::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            error: "timeout".to_string(),
-            failed_at: now,
-        });
-
-        events
-    }
-
-    fn callback_pending_events(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Vec<MintEvent> {
-        let now = Utc::now();
-        let mut events = minting_failed_events(issuer_request_id);
-
-        events.push(MintEvent::ExistingMintRecovered {
-            issuer_request_id: issuer_request_id.clone(),
-            tx_hash: b256!(
-                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-            ),
-            receipt_id: uint!(42_U256),
-            shares_minted: uint!(100_000000000000000000_U256),
-            block_number: 1000,
-            recovered_at: now,
-        });
-
-        events
-    }
-
-    fn completed_events(
-        issuer_request_id: &IssuerMintRequestId,
-    ) -> Vec<MintEvent> {
-        let now = Utc::now();
-        let mut events = callback_pending_events(issuer_request_id);
-
-        events.push(MintEvent::MintCompleted {
-            issuer_request_id: issuer_request_id.clone(),
-            completed_at: now,
-        });
-
-        events
-    }
-
-    async fn setup_with_receipt_and_events(
-        events: Vec<MintEvent>,
-    ) -> MintRecoveryFixture {
-        setup_with_receipt_and_events_and_vault(
-            events,
-            Arc::new(MockVaultService::new_success()),
-        )
-        .await
-    }
-
-    async fn setup_with_receipt_and_events_and_vault(
-        events: Vec<MintEvent>,
-        vault: Arc<dyn VaultService>,
-    ) -> MintRecoveryFixture {
-        let fixture = MintRecoveryFixture::new_with_vault(vault).await;
-        setup_fixture_with_receipt_and_events(fixture, events).await
-    }
-
-    async fn setup_fixture_with_receipt_and_events(
-        fixture: MintRecoveryFixture,
-        events: Vec<MintEvent>,
-    ) -> MintRecoveryFixture {
-        let issuer_request_id = test_issuer_request_id();
-
-        let receipt_info = ReceiptInformation::new(
-            TokenizationRequestId::new("tok-123"),
-            issuer_request_id.clone(),
-            UnderlyingSymbol::new("AAPL").unwrap(),
-            Quantity::new(Decimal::from(100)),
-            Utc::now(),
-            None,
-        );
-
-        fixture
-            .receipt_store
-            .send(
-                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, VAULT),
-                ReceiptInventoryCommand::DiscoverReceipt {
-                    receipt_id: ReceiptId::from(uint!(42_U256)),
-                    balance: Shares::from(
-                        uint!(100_000000000000000000_U256),
-                    ),
-                    block_number: 1000,
-                    tx_hash: b256!(
-                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    ),
-                    source: ReceiptSource::Itn {
-                        issuer_request_id: issuer_request_id.clone(),
-                    },
-                    receipt_info: Some(Box::new(receipt_info)),
-                    receipt_info_bytes: None,
-                },
-            )
-            .await
-            .unwrap();
-
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        fixture
-    }
-
+    /// The budget loop must sleep the backoff on every no-progress poll rather
+    /// than spinning through its budget instantly, so total elapsed time is at
+    /// least one backoff per poll — a spinning loop would finish in
+    /// microseconds. Here a `MintingFailed` mint whose re-submission never
+    /// completes (no worker drains the enqueued `SubmitMintJob`) keeps the loop
+    /// driving until the no-progress budget is spent.
     #[traced_test]
     #[tokio::test]
-    async fn receipt_scan_bypasses_retry_window_and_recovers_to_completed() {
+    async fn scheduled_recovery_backs_off_without_progress() {
         let issuer_request_id = test_issuer_request_id();
-        let events = minting_failed_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-
-        drive_recovery(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-            RetryPolicy::Bypass,
-            recovery_step_requires_wallet,
-            |_, id, _wallet_locked| MintCommand::Recover {
-                issuer_request_id: id,
-                mode: MintRecoveryMode::Automatic,
-            },
-        )
-        .await;
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
-        assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state, got: {}",
-            mint.state_name()
-        );
-        let test =
-            "receipt_scan_bypasses_retry_window_and_recovers_to_completed";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
-            1,
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-        );
-        // Receipt recovery and callback delivery are separate durable steps,
-        // so the wallet guard is released before the Alpaca request.
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            2,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn mint_intended_with_receipt_recovers_without_rebroadcast() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = mint_intended_events(&issuer_request_id);
-        let vault = Arc::new(MockVaultService::new_submit_failure());
-        let fixture =
-            setup_with_receipt_and_events_and_vault(events, vault.clone())
-                .await;
-
-        recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-        )
-        .await;
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "receipt proof must complete MintIntended, got {}",
-            mint.state_name()
-        );
-        assert_eq!(
-            vault.get_call_count(),
-            0,
-            "receipt-first recovery must not prepare a replacement transaction"
-        );
-        assert!(
-            log_count_at!(
-                Level::INFO,
-                &["Found existing receipt, recording recovery"]
-            ) > 0
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn callback_pending_recovers_to_completed() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = callback_pending_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-        let wallet_guard = fixture.vault.lock_wallet().await;
-
-        tokio::time::timeout(
-            Duration::from_secs(1),
-            recover_mint(
-                fixture.mint_store.as_ref(),
-                &fixture.vault,
-                issuer_request_id.clone(),
-            ),
-        )
-        .await
-        .expect("callback-only recovery must not wait for the wallet lock");
-        drop(wallet_guard);
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
-        assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state, got: {}",
-            mint.state_name()
-        );
-        let test = "callback_pending_recovers_to_completed";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
-            1,
-        );
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            1,
-        );
-    }
-
-    /// Recovery from `Minting` persists the receipt proof before delivering
-    /// the callback in a second command.
-    #[traced_test]
-    #[tokio::test]
-    async fn minting_receipt_recovery_persists_before_callback() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = minting_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
-        assert!(
-            matches!(mint, Mint::CallbackPending { .. }),
-            "Expected CallbackPending after receipt recovery, got: {}",
-            mint.state_name()
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let completed =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(completed, Mint::Completed { .. }));
-        let test = "minting_receipt_recovery_persists_before_callback";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
-            1,
-        );
-    }
-
-    /// The same durable boundary applies from `MintingFailed`.
-    #[traced_test]
-    #[tokio::test]
-    async fn failed_mint_receipt_recovery_persists_before_callback() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = minting_failed_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
-        assert!(
-            matches!(mint, Mint::CallbackPending { .. }),
-            "Expected CallbackPending after receipt recovery, got: {}",
-            mint.state_name()
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let completed =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(completed, Mint::Completed { .. }));
-        let test = "failed_mint_receipt_recovery_persists_before_callback";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
-            1,
-        );
-    }
-
-    /// Same invariant for the `TxSubmitted` starting state.
-    #[traced_test]
-    #[tokio::test]
-    async fn tx_submitted_recovery_persists_before_callback() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = tx_submitted_events(&issuer_request_id);
-        // No pre-existing receipt — the mock confirm path produces TokensMinted.
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_events(&issuer_request_id, failed_at);
         let fixture = MintRecoveryFixture::new().await;
         fixture.seed_mint_events(&issuer_request_id, events).await;
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
 
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
-        assert!(
-            matches!(mint, Mint::CallbackPending { .. }),
-            "Expected CallbackPending after one Recover, got: {}",
-            mint.state_name()
-        );
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .unwrap();
-
-        let completed =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(completed, Mint::Completed { .. }));
-        let test = "tx_submitted_recovery_persists_before_callback";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
-            1,
-        );
-    }
-
-    /// Receipt-monitor recovery must durably record the receipt before making
-    /// the Alpaca callback.
-    #[traced_test]
-    #[tokio::test]
-    async fn receipt_command_persists_recovery_before_callback() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = minting_failed_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::RecoverFromReceipt {
-                    issuer_request_id: issuer_request_id.clone(),
-                    tx_hash: b256!(
-                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                    ),
-                },
-            )
-            .await
-            .unwrap();
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::CallbackPending { .. }),
-            "Expected CallbackPending after receipt command, got: {}",
-            mint.state_name()
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::INFO,
-                &[
-                    "receipt_command_persists_recovery_before_callback",
-                    "Alpaca callback succeeded"
-                ]
-            ),
-            0,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn receipt_discovery_does_not_send_callback_from_callback_pending() {
-        let issuer_request_id = test_issuer_request_id();
-        let harness = TestHarness::new().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
-        seed_mint_events(
-            &pool,
+        let backoff = Duration::from_millis(5);
+        let max_no_progress_polls = 8;
+        let start = tokio::time::Instant::now();
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
             &issuer_request_id,
-            callback_pending_events(&issuer_request_id),
+            backoff,
+            max_no_progress_polls,
         )
         .await;
-        let handler = MintRecoveryHandler::new(
-            mint_store.clone(),
-            pool.clone(),
-            apalis_pool,
-        );
-
-        handler
-            .on_itn_receipt_discovered(
-                issuer_request_id.clone(),
-                b256!(
-                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                ),
-            )
-            .await;
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while !logs_contain_at!(
-                Level::DEBUG,
-                &[
-                    "receipt_discovery_does_not_send_callback_from_callback_pending",
-                    "Receipt discovery ignored for current mint state",
-                ]
-            ) {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("receipt-triggered recovery should finish");
-
-        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(mint, Mint::CallbackPending { .. }));
-        let queued: i64 = sqlx::query_scalar(
-            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key = ?",
-        )
-        .bind(issuer_request_id.to_string())
-        .fetch_one(&pool)
-        .await
-        .unwrap();
-        assert_eq!(queued, 0);
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn completed_mint_returns_cleanly() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = completed_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-
-        recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-        )
-        .await;
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        let elapsed = start.elapsed();
 
         assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state, got: {}",
-            mint.state_name()
-        );
-
-        let test = "completed_mint_returns_cleanly";
-        assert_eq!(
-            log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
-            1,
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn journal_confirmed_recovery_waits_for_wallet_lock() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = journal_confirmed_events(&issuer_request_id);
-        let fixture = setup_with_receipt_and_events(events).await;
-        let wallet_guard = fixture.vault.lock_wallet().await;
-
-        let blocked = tokio::time::timeout(
-            Duration::from_millis(100),
-            recover_mint(
-                fixture.mint_store.as_ref(),
-                &fixture.vault,
-                issuer_request_id.clone(),
-            ),
-        )
-        .await;
-
-        assert!(blocked.is_err(), "recovery must wait for the wallet lock");
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::JournalConfirmed { .. }),
-            "recovery must not advance toward signing without the wallet lock"
-        );
-
-        drop(wallet_guard);
-        recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-        )
-        .await;
-
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(mint, Mint::Completed { .. }));
-        assert_eq!(
-            log_count_at!(
-                Level::INFO,
-                &[
-                    "journal_confirmed_recovery_waits_for_wallet_lock",
-                    "Mint recovery complete",
-                ]
-            ),
-            1,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn recovery_reloads_state_and_releases_obsolete_wallet_lock() {
-        let issuer_request_id = test_issuer_request_id();
-        let vault = Arc::new(MockVaultService::new_success());
-        let alpaca =
-            Arc::new(MockAlpacaService::new_success().with_callback_delay(500));
-        let fixture = MintRecoveryFixture::new_with_services(
-            vault.clone(),
-            alpaca.clone(),
-        )
-        .await;
-        let fixture = setup_fixture_with_receipt_and_events(
-            fixture,
-            minting_events(&issuer_request_id),
-        )
-        .await;
-        let wallet_guard = fixture.vault.lock_wallet().await;
-        let mint_store = fixture.mint_store.clone();
-        let recovery_vault = fixture.vault.clone();
-        let recovery_id = issuer_request_id.clone();
-        let recovery = tokio::spawn(async move {
-            recover_mint(mint_store.as_ref(), &recovery_vault, recovery_id)
-                .await
-        });
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while vault.get_wallet_lock_call_count() < 2 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("recovery must begin waiting for the wallet lock");
-
-        fixture
-            .mint_store
-            .send(
-                &issuer_request_id,
-                MintCommand::Recover {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            )
-            .await
-            .expect("concurrent receipt recovery should advance the mint");
-        drop(wallet_guard);
-
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while alpaca.get_call_count() == 0 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("callback must start after the aggregate reload");
-
-        let available_guard = tokio::time::timeout(
-            Duration::from_millis(100),
-            fixture.vault.lock_wallet(),
-        )
-        .await
-        .expect("callback delivery must not retain the obsolete wallet lock");
-        drop(available_guard);
-
-        assert_eq!(
-            tokio::time::timeout(Duration::from_secs(1), recovery)
-                .await
-                .expect("recovery should finish after callback delivery")
-                .expect("recovery task should not panic"),
-            DriveOutcome::Done,
-        );
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(mint, Mint::Completed { .. }));
-        assert_eq!(
-            log_count_at!(
-                Level::INFO,
-                &[
-                    "recovery_reloads_state_and_releases_obsolete_wallet_lock",
-                    "Mint recovery complete",
-                ]
-            ),
-            1,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn wallet_recovery_step_defers_concurrent_callback_state() {
-        let issuer_request_id = test_issuer_request_id();
-        let vault = Arc::new(MockVaultService::new_success());
-        let alpaca =
-            Arc::new(MockAlpacaService::new_success().with_callback_delay(500));
-        let fixture =
-            MintRecoveryFixture::new_with_services(vault, alpaca.clone()).await;
-        fixture
-            .seed_mint_events(
-                &issuer_request_id,
-                callback_pending_events(&issuer_request_id),
-            )
-            .await;
-
-        tokio::time::timeout(
-            Duration::from_millis(100),
-            fixture.mint_store.send(
-                &issuer_request_id,
-                MintCommand::RecoverWalletStep {
-                    issuer_request_id: issuer_request_id.clone(),
-                    mode: MintRecoveryMode::Automatic,
-                },
-            ),
-        )
-        .await
-        .expect("wallet recovery step must not call Alpaca")
-        .expect("callback deferral should be a successful no-op");
-
-        assert_eq!(alpaca.get_call_count(), 0);
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(mint, Mint::CallbackPending { .. }));
-        assert_eq!(
-            log_count_at!(
-                Level::DEBUG,
-                &[
-                    "wallet_recovery_step_defers_concurrent_callback_state",
-                    "Deferring callback from wallet-locked recovery step",
-                ]
-            ),
-            1,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn wallet_recovery_noop_converges_on_next_unlocked_iteration() {
-        let issuer_request_id = test_issuer_request_id();
-        let vault = Arc::new(MockVaultService::new_success());
-        let alpaca = Arc::new(MockAlpacaService::new_success());
-        let fixture =
-            MintRecoveryFixture::new_with_services(vault, alpaca.clone()).await;
-        fixture
-            .seed_mint_events(
-                &issuer_request_id,
-                callback_pending_events(&issuer_request_id),
-            )
-            .await;
-        let classifications = Arc::new(AtomicUsize::new(0));
-        let classifier_calls = classifications.clone();
-
-        let outcome = drive_recovery(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-            RetryPolicy::Bypass,
-            move |_| classifier_calls.fetch_add(1, Ordering::Relaxed) < 2,
-            |_, id, wallet_locked| {
-                if wallet_locked {
-                    MintCommand::RecoverWalletStep {
-                        issuer_request_id: id,
-                        mode: MintRecoveryMode::Automatic,
-                    }
-                } else {
-                    MintCommand::Recover {
-                        issuer_request_id: id,
-                        mode: MintRecoveryMode::Automatic,
-                    }
+            matches!(
+                conclusion,
+                RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::NoProgressBudgetExhausted
                 }
-            },
-        )
-        .await;
-
-        assert_eq!(outcome, DriveOutcome::Done);
-        assert_eq!(alpaca.get_call_count(), 1);
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(matches!(mint, Mint::Completed { .. }));
-        assert_eq!(
-            log_count_at!(
-                Level::DEBUG,
-                &[
-                    "wallet_recovery_noop_converges_on_next_unlocked_iteration",
-                    "Deferring callback from wallet-locked recovery step",
-                ]
             ),
-            1,
+            "No-progress budget exhaustion must report Abandoned, not Resolved"
         );
-        assert_eq!(
-            log_count_at!(
-                Level::INFO,
-                &[
-                    "wallet_recovery_noop_converges_on_next_unlocked_iteration",
-                    "Mint recovery complete",
-                ]
-            ),
-            1,
+
+        assert!(
+            elapsed
+                >= backoff
+                    * (u32::try_from(max_no_progress_polls).unwrap() - 1),
+            "Scheduled recovery must sleep the backoff on each no-progress \
+             poll, elapsed={elapsed:?}"
         );
-    }
-
-    /// When a mint is in `TxSubmitted` and `confirm_mint` fails, the recovery
-    /// pass emits `MintingFailed` (attempts=1) and succeeds. Post-step
-    /// classification observes the 1-minute backoff window and returns
-    /// `RetryNotDue` without sending another command.
-    #[traced_test]
-    #[tokio::test]
-    async fn tx_submitted_confirm_failure_transitions_to_minting_failed_then_retry_not_due()
-     {
-        let issuer_request_id = test_issuer_request_id();
-        let events = tx_submitted_events(&issuer_request_id);
-        let fixture = MintRecoveryFixture::new_with_vault(Arc::new(
-            MockVaultService::new_failure(),
-        ))
-        .await;
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        // First pass: confirm_mint fails → MintingFailed emitted. The step
-        // succeeds, then classification observes that the retry is not due.
-        let outcome = recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-        )
-        .await;
 
         let mint =
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-
         assert!(
-            matches!(mint, Mint::MintingFailed { .. }),
-            "Expected MintingFailed after confirm failure, got: {}",
-            mint.state_name()
-        );
-        assert_eq!(
-            outcome,
-            DriveOutcome::RetryNotDue,
-            "Expected RetryNotDue after immediate re-check of fresh failure"
-        );
-        assert!(
-            log_count_at!(
-                Level::WARN,
-                &["On-chain deposit confirmation failed"]
-            ) > 0,
-            "Expected confirmation-failure warning"
-        );
-        let test = "tx_submitted_confirm_failure_transitions_to_minting_failed_then_retry_not_due";
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            1,
-            "post-step classification must stop without a second command"
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-            "RetryNotDue is expected control flow, not a command error"
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn initial_retry_wait_returns_without_sending_command() {
-        let issuer_request_id = test_issuer_request_id();
-        let events = minting_failed_events(&issuer_request_id);
-        let fixture = MintRecoveryFixture::new().await;
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        let outcome = recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id,
-        )
-        .await;
-
-        assert_eq!(outcome, DriveOutcome::RetryNotDue);
-        let test = "initial_retry_wait_returns_without_sending_command";
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            0,
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn initial_retry_exhaustion_returns_without_sending_command() {
-        let issuer_request_id = test_issuer_request_id();
-        let failed_at = Utc::now() - ChronoDuration::hours(24);
-        let mut events = minting_events(&issuer_request_id);
-        for _ in 0..=Mint::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT {
-            events.push(MintEvent::MintingFailed {
-                issuer_request_id: issuer_request_id.clone(),
-                error: "timeout".to_string(),
-                failed_at,
-            });
-        }
-        let fixture = MintRecoveryFixture::new().await;
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        let outcome = recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id,
-        )
-        .await;
-
-        assert_eq!(outcome, DriveOutcome::Exhausted);
-        let test = "initial_retry_exhaustion_returns_without_sending_command";
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            0,
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-        );
-    }
-
-    #[traced_test]
-    #[tokio::test]
-    async fn failed_final_attempt_returns_exhausted_without_extra_command() {
-        let issuer_request_id = test_issuer_request_id();
-        let failed_at = Utc::now() - ChronoDuration::hours(24);
-        let mut events = minting_events(&issuer_request_id);
-        for _ in 0..Mint::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT {
-            events.push(MintEvent::MintingFailed {
-                issuer_request_id: issuer_request_id.clone(),
-                error: "timeout".to_string(),
-                failed_at,
-            });
-        }
-        let fixture = MintRecoveryFixture::new_with_vault(Arc::new(
-            MockVaultService::new_prepare_tx_failure(),
-        ))
-        .await;
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        let outcome = recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id,
-        )
-        .await;
-
-        assert_eq!(outcome, DriveOutcome::Exhausted);
-        let test =
-            "failed_final_attempt_returns_exhausted_without_extra_command";
-        assert_eq!(
-            log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            1,
-        );
-        assert_eq!(
-            log_count_at!(
-                Level::ERROR,
-                &[test, "Command handler returned domain error"]
-            ),
-            0,
-        );
-    }
-
-    /// When a known `tx_id` is in the `MintingFailed` predecessor and the retry
-    /// window has elapsed (`failed_at` old enough for `Ready`), a transient
-    /// `confirm_mint` failure must NOT trigger a new submission — it must return
-    /// `RetryNotDue` so the next recovery pass retries confirming the same tx.
-    ///
-    /// Without the fix, the old code called `submit_recovery_mint` unconditionally
-    /// on any confirm error, which would submit a fresh tx while the original was
-    /// still pending, creating duplicate backed tokens for one journal.
-    #[traced_test]
-    #[tokio::test]
-    async fn minting_failed_with_known_tx_transient_confirm_error_does_not_resubmit()
-     {
-        let issuer_request_id = test_issuer_request_id();
-        // new_failure() makes confirm_mint return Err(VaultError::InvalidReceipt),
-        // a non-terminal error.
-        let fixture = MintRecoveryFixture::new_with_vault(Arc::new(
-            MockVaultService::new_failure(),
-        ))
-        .await;
-
-        // Seed: Initiated → JournalConfirmed → MintingStarted → MintTxSubmitted
-        //       → MintingFailed with failed_at 24h ago (retry window: Ready).
-        let failed_at = Utc::now() - ChronoDuration::hours(24);
-        let mut events = tx_submitted_events(&issuer_request_id);
-        events.push(MintEvent::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            error: "timeout".to_string(),
-            failed_at,
-        });
-        fixture.seed_mint_events(&issuer_request_id, events).await;
-
-        let outcome = recover_mint(
-            fixture.mint_store.as_ref(),
-            &fixture.vault,
-            issuer_request_id.clone(),
-        )
-        .await;
-
-        // Must back off, not submit a new tx.
-        assert_eq!(
-            outcome,
-            DriveOutcome::RetryNotDue,
-            "transient confirm error must not submit a replacement tx"
-        );
-
-        // No new mint transaction was submitted.
-        let mint =
-            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::MintingFailed { .. }),
-            "Aggregate must stay in MintingFailed, got: {}",
+            matches!(mint, Mint::Minting { .. }),
+            "drive_one_step retries MintingFailed into Minting and re-enqueues \
+             the submission, got: {}",
             mint.state_name()
         );
 
+        let test = "scheduled_recovery_backs_off_without_progress";
         assert!(
             log_count_at!(
                 Level::WARN,
-                &["Mint confirm returned transient error"]
-            ) > 0,
-            "Expected transient-error warning"
-        );
-    }
-
-    /// `recover_mint_until_automatic_budget_exhausted` stops and logs a warning
-    /// after exceeding `MAX_SCHEDULED_RECOVERY_FAILURE_BACKOFFS` consecutive
-    /// `DriveOutcome::Failed` outcomes. This uses a mint whose underlying asset
-    /// is not registered in the `TokenizedAsset` projection, causing every
-    /// `Recover` command to fail with `AssetNotFound` (surfacing as `Failed`).
-    #[traced_test]
-    #[tokio::test]
-    async fn scheduled_recovery_stops_after_max_failure_backoffs() {
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect(":memory:")
-            .await
-            .unwrap();
-        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
-
-        // Intentionally skip TokenizedAsset registration so that every
-        // Recover command fails with AssetNotFound → DriveOutcome::Failed.
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-        let vault: Arc<dyn VaultService> =
-            Arc::new(MockVaultService::new_success());
-        let services = MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            vault.clone(),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool.clone(),
-            BOT,
-        );
-        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), services));
-
-        let issuer_request_id = test_issuer_request_id();
-
-        // Seed a MintingFailed with failed_at 24h in the past so the retry
-        // window is always Ready, and attempts=0 so exhaustion is not hit.
-        let failed_at = Utc::now() - ChronoDuration::hours(24);
-        let mut events = minting_events(&issuer_request_id);
-        events.push(MintEvent::MintingFailed {
-            issuer_request_id: issuer_request_id.clone(),
-            error: "timeout".to_string(),
-            failed_at,
-        });
-
-        let aggregate_id = issuer_request_id.to_string();
-        for (offset, event) in events.into_iter().enumerate() {
-            let sequence = i64::try_from(offset).unwrap() + 1;
-            let payload = serde_json::to_value(&event).unwrap();
-            let variant = payload
-                .as_object()
-                .and_then(|map| map.keys().next())
-                .expect("MintEvent serializes as an externally-tagged enum")
-                .clone();
-            let event_type = format!("MintEvent::{variant}");
-            let payload_str = payload.to_string();
-
-            sqlx::query(
-                "
-                INSERT INTO events (
-                    aggregate_type,
-                    aggregate_id,
-                    sequence,
-                    event_type,
-                    event_version,
-                    payload,
-                    metadata
-                )
-                VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
-                ",
-            )
-            .bind(&aggregate_id)
-            .bind(sequence)
-            .bind(&event_type)
-            .bind(&payload_str)
-            .execute(&pool)
-            .await
-            .unwrap();
-        }
-
-        // Zero backoff so the test does not sleep.
-        recover_mint_until_automatic_budget_exhausted(
-            mint_store.as_ref(),
-            &vault,
-            &issuer_request_id,
-            Duration::ZERO,
-        )
-        .await;
-
-        assert!(
-            log_count_at!(
-                Level::WARN,
-                &[
-                    "Scheduled mint recovery stopped after maximum failure backoffs"
-                ]
-            ) > 0,
-            "Expected exhaustion warning after max failure backoffs"
+                &[test, "stopped after maximum polls without progress"]
+            ) >= 1,
+            "Loop must stop with a warning once the no-progress budget is spent"
         );
     }
 
@@ -2724,6 +1369,47 @@ mod tests {
         );
     }
 
+    /// The budget loop must report `Abandoned` — not a clean conclusion — when
+    /// it gives up on a still-incomplete mint (here a re-submission that never
+    /// completes, outlasting the no-progress budget), so the job is recorded as
+    /// Killed rather than a success that hides a stuck mint.
+    #[traced_test]
+    #[tokio::test]
+    async fn budget_loop_reports_abandoned_when_no_progress_budget_spent() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_events(&issuer_request_id, failed_at);
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
+            &issuer_request_id,
+            Duration::from_millis(1),
+            2,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                conclusion,
+                RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::NoProgressBudgetExhausted
+                }
+            ),
+            "a mint that outlasts its budget must abandon, not resolve"
+        );
+
+        let test = "budget_loop_reports_abandoned_when_no_progress_budget_spent";
+        assert!(
+            log_count_at!(
+                Level::WARN,
+                &[test, "stopped after maximum polls without progress"]
+            ) >= 1,
+            "abandoning on the no-progress budget must log the WARN"
+        );
+    }
+
     /// `MintRecoveryJob::perform` resolves cleanly (`Ok`) when there is nothing
     /// to recover — an absent mint — so apalis records the job as Done. Also
     /// exercises the job's dispatch into the budget loop.
@@ -2734,10 +1420,7 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
 
         let result = MintRecoveryJob { issuer_request_id }
-            .perform(&MintRecoveryJobCtx {
-                mint_store: fixture.mint_store.clone(),
-                vault_service: fixture.vault.clone(),
-            })
+            .perform(&fixture.context())
             .await;
 
         assert!(
@@ -2780,10 +1463,7 @@ mod tests {
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let error = MintRecoveryJob { issuer_request_id }
-            .perform(&MintRecoveryJobCtx {
-                mint_store: fixture.mint_store.clone(),
-                vault_service: fixture.vault.clone(),
-            })
+            .perform(&fixture.context())
             .await
             .expect_err("an exhausted mint must abort, not resolve");
 

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -272,17 +272,12 @@ pub(crate) async fn find_stuck(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, b256, uint};
-    use event_sorcery::{StoreBuilder, test_store};
+    use event_sorcery::StoreBuilder;
     use rust_decimal::Decimal;
     use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
-    use std::sync::Arc;
 
     use super::*;
-    use crate::alpaca::mock::MockAlpacaService;
-    use crate::mint::{Mint, MintCommand, MintServices};
-    use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::ANVIL_CHAIN_ID;
-    use crate::vault::mock::MockVaultService;
+    use crate::mint::{Mint, MintCommand};
 
     /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given
     /// query view. The adjusted variants reproduce the production `Mint`
@@ -341,21 +336,6 @@ mod tests {
         .unwrap();
     }
 
-    fn mint_services(pool: Pool<Sqlite>) -> MintServices {
-        let receipt_store =
-            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
-
-        MintServices::with_single_vault(
-            Network::Base,
-            ANVIL_CHAIN_ID,
-            Arc::new(MockVaultService::new_success()),
-            Arc::new(MockAlpacaService::new_success()),
-            Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool,
-            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        )
-    }
-
     struct TestMintFields {
         issuer_request_id: IssuerMintRequestId,
         tokenization_request_id: TokenizationRequestId,
@@ -388,7 +368,7 @@ mod tests {
         let pool = setup_test_db().await;
 
         let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
-            .build(mint_services(pool.clone()))
+            .build(())
             .await
             .expect("Failed to build mint store");
 

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -519,9 +519,7 @@ where
         );
 
         if let ReceiptSource::Itn { issuer_request_id } = source {
-            self.handler
-                .on_itn_receipt_discovered(issuer_request_id, discovery.tx_hash)
-                .await;
+            self.handler.on_itn_receipt_discovered(issuer_request_id).await;
         }
 
         Ok(ProcessOutcome::Processed)
@@ -580,15 +578,16 @@ enum ProcessOutcome {
 /// Called when the receipt backfiller discovers an ITN receipt (a receipt
 /// with a valid `issuer_request_id` in its receiptInformation).
 ///
-/// Production implementation triggers mint recovery for the associated mint.
-/// The `tx_hash` is the on-chain transaction that created the receipt,
-/// serving as compiler-enforced evidence that the mint succeeded on-chain.
+/// Invoked only after `DiscoverReceipt` has already persisted the receipt
+/// (including `tx_hash`) to inventory. On-chain evidence therefore lives in
+/// the inventory aggregate; this callback only needs the mint id so recovery
+/// can re-drive via the per-state jobs, which load the receipt (and its
+/// `tx_hash`) from inventory before recording or re-submitting.
 #[async_trait]
 pub(crate) trait ItnReceiptHandler: Send + Sync {
     async fn on_itn_receipt_discovered(
         &self,
         issuer_request_id: IssuerMintRequestId,
-        tx_hash: TxHash,
     );
 }
 
@@ -597,9 +596,8 @@ impl<T: ItnReceiptHandler + Sync> ItnReceiptHandler for &T {
     async fn on_itn_receipt_discovered(
         &self,
         issuer_request_id: IssuerMintRequestId,
-        tx_hash: TxHash,
     ) {
-        (*self).on_itn_receipt_discovered(issuer_request_id, tx_hash).await;
+        (*self).on_itn_receipt_discovered(issuer_request_id).await;
     }
 }
 
@@ -613,7 +611,6 @@ impl ItnReceiptHandler for NoOpItnHandler {
     async fn on_itn_receipt_discovered(
         &self,
         _issuer_request_id: IssuerMintRequestId,
-        _tx_hash: TxHash,
     ) {
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -19,7 +19,6 @@ use std::sync::Arc;
 use url::Url;
 
 use crate::account::Account;
-use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
 use crate::auth::{FailedAuthRateLimiter, test_auth_config};
 use crate::bindings::{
@@ -27,15 +26,12 @@ use crate::bindings::{
     OffchainAssetReceiptVaultAuthorizerV1, Receipt,
 };
 use crate::config::{Config, Environment, LogLevel};
-use crate::mint::{Mint, MintServices};
-use crate::receipt_inventory::{
-    CqrsReceiptService, ReceiptInventory, view::ReceiptInventoryViewReactor,
-};
+use crate::mint::Mint;
+use crate::receipt_inventory::view::ReceiptInventoryViewReactor;
 use crate::tokenized_asset::{
     AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol,
 };
-use crate::vault::mock::MockVaultService;
 use crate::wallet::SignerConfig;
 
 /// Builds Anvil with startup output enabled when stdout is piped by Alloy.
@@ -139,28 +135,12 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
     let (tokenized_asset_store, _tokenized_asset_projection) =
         StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
 
-    // Setup ReceiptInventory (needed by MintServices for receipt lookups and registration)
-    let receipt_inventory_store =
-        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
-
-    // Create mock services for Mint aggregate
-    let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-    let mint_services = MintServices::with_single_vault(
-        Network::Base,
-        ANVIL_CHAIN_ID,
-        Arc::new(MockVaultService::new_success()),
-        Arc::new(MockAlpacaService::new_success()),
-        Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
-        pool.clone(),
-        bot,
-    );
-
     // Setup Mint store (event-sorcery), mirroring the production wiring: the
     // reactor keeps receipt_inventory_view in sync with Mint events.
     let (mint_store, _mint_projection) =
         StoreBuilder::<Mint>::new(pool.clone())
             .with(Arc::new(ReceiptInventoryViewReactor::new(pool.clone())))
-            .build(mint_services)
+            .build(())
             .await?;
 
     // Seed initial assets

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -10,13 +10,20 @@ use alloy::providers::{PendingTransactionError, Provider, ProviderBuilder};
 use alloy::signers::local::PrivateKeySigner;
 use alloy::sol_types::SolValue;
 use alloy::transports::{RpcError, TransportErrorKind};
+use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
 use event_sorcery::{Store, StoreBuilder};
 use rocket::routes;
-use sqlx::sqlite::SqlitePoolOptions;
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePoolOptions,
+};
+use std::env::temp_dir;
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use url::Url;
+use uuid::Uuid;
 
 use crate::account::Account;
 use crate::alpaca::service::AlpacaConfig;
@@ -32,6 +39,8 @@ use crate::tokenized_asset::{
     AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol,
 };
+use crate::vault::mock::MockVaultService;
+use crate::vault::{NetworkVaultServices, VaultService};
 use crate::wallet::SignerConfig;
 
 /// Builds Anvil with startup output enabled when stdout is piped by Alloy.
@@ -120,12 +129,28 @@ fn test_config() -> Result<Config, anyhow::Error> {
 /// - Rate limiter initialization fails
 pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>>
 {
-    // Create in-memory database
-    let pool =
-        SqlitePoolOptions::new().max_connections(5).connect(":memory:").await?;
+    // Both sqlx major versions must address the same file: private in-memory
+    // databases do not share the Jobs table used by the confirmation route.
+    let database_path =
+        temp_dir().join(format!("st0x-issuance-test-{}.db", Uuid::new_v4()));
+    let database_url = format!("sqlite:{}", database_path.display());
 
-    // Run migrations
+    let options = SqliteConnectOptions::from_str(&database_url)?
+        .create_if_missing(true)
+        .journal_mode(SqliteJournalMode::Wal)
+        .busy_timeout(Duration::from_secs(5));
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect_with(options)
+        .await?;
+
     sqlx::migrate!("./migrations").run(&pool).await?;
+
+    let apalis_options =
+        apalis_sqlite::SqliteConnectOptions::from_str(&database_url)?
+            .pragma("journal_mode", "WAL")
+            .busy_timeout(Duration::from_secs(5));
+    let apalis_pool = ApalisSqlitePool::connect_with(apalis_options).await?;
 
     // Setup Account store (event-sorcery)
     let (account_store, _account_projection) =
@@ -147,6 +172,13 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
     seed_test_assets(&tokenized_asset_store).await?;
 
     let rate_limiter = FailedAuthRateLimiter::new()?;
+    let vault: Arc<dyn VaultService> =
+        Arc::new(MockVaultService::new_success());
+    let vault_services = NetworkVaultServices::with_single_vault(
+        Network::Base,
+        ANVIL_CHAIN_ID,
+        vault,
+    );
 
     // Build rocket
     Ok(rocket::build()
@@ -156,6 +188,8 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
         .manage(mint_store)
         .manage(rate_limiter)
         .manage(pool)
+        .manage(apalis_pool)
+        .manage(vault_services)
         .mount(
             "/",
             routes![

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -75,8 +75,6 @@ enum MockBehavior {
     /// where signed-tx preparation fails before the tx is stored in the event.
     #[cfg(test)]
     PrepareTxFails,
-    #[cfg(test)]
-    InvalidPreparedMint,
 }
 
 /// Configured outcome for `verify_burn_tx` in tests.
@@ -443,13 +441,6 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
-    pub(crate) fn new_invalid_prepared_mint() -> Self {
-        let mut service = Self::new_success();
-        service.behavior = MockBehavior::InvalidPreparedMint;
-        service
-    }
-
-    #[cfg(test)]
     #[must_use]
     pub(crate) const fn with_delay(mut self, delay_ms: u64) -> Self {
         self.mint_delay_ms = delay_ms;
@@ -760,19 +751,9 @@ impl VaultService for MockVaultService {
             receipt_info_bytes,
         });
 
-        #[cfg(test)]
-        let persisted_hash =
-            if matches!(self.behavior, MockBehavior::InvalidPreparedMint) {
-                B256::ZERO
-            } else {
-                tx_hash
-            };
-        #[cfg(not(test))]
-        let persisted_hash = tx_hash;
-
         Ok(PreparedMintTx {
             tx: envelope.encoded_2718(),
-            hash: persisted_hash,
+            hash: tx_hash,
             nonce: envelope.nonce(),
             signed_at: chrono::Utc::now(),
             external_tx_id: external_tx_id
@@ -844,10 +825,7 @@ impl VaultService for MockVaultService {
             | MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::ConfirmPendingBlocked { .. }
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails
-            | MockBehavior::InvalidPreparedMint => {
-                Err(VaultError::InvalidReceipt)
-            }
+            | MockBehavior::PrepareTxFails => Err(VaultError::InvalidReceipt),
         }
     }
 
@@ -975,8 +953,7 @@ impl VaultService for MockVaultService {
             #[cfg(test)]
             MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails
-            | MockBehavior::InvalidPreparedMint => {
+            | MockBehavior::PrepareTxFails => {
                 let result = self
                     .pending_burn_result
                     .lock()

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -25,6 +25,7 @@ use crate::mint::{
 };
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
+#[cfg(test)]
 pub(crate) mod mock;
 pub(crate) mod network_services;
 pub(crate) mod rain_meta;

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -25,7 +25,6 @@ use crate::mint::{
 };
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
-#[cfg(test)]
 pub(crate) mod mock;
 pub(crate) mod network_services;
 pub(crate) mod rain_meta;

--- a/src/vault/network_services.rs
+++ b/src/vault/network_services.rs
@@ -60,6 +60,8 @@ impl NetworkVaultServices {
         self.get(network).map(|entry| entry.chain_id)
     }
 
+    /// Test-only convenience wrapping one mock vault the way production
+    /// Rocket state wires the real per-network map.
     pub(crate) fn with_single_vault(
         network: Network,
         chain_id: u64,


### PR DESCRIPTION
## Motivation

PR #207 moved the **normal** mint flow's side effects into durable apalis jobs.
Recovery still drove stuck mints through the old inline-I/O `Recover` /
`RecoverFromReceipt` command handlers — re-opening the lost-effect window
ADR-0001 closes, on the recovery path. RAI-935 finishes the extraction: the
scheduled-recovery budget loop now enqueues the same per-state jobs the normal
flow uses, and the inline recovery commands/handlers are removed.

Implements RAI-935 (recovery). Stacked on #207.

## Solution

- **Recovery enqueues jobs.** `MintRecoveryJob`'s budget loop keeps its
  `automatic_retry_decision` schedule but, for a recoverable mint, `drive_one_step`
  enqueues the per-state job (`SubmitMintJob` / `ConfirmMintJob` / `SendCallbackJob`)
  or issues the pure transition that precedes it (`Deposit` / `RetryMint`). The
  receipt monitor's `on_itn_receipt_discovered` and the admin reprocess endpoint
  both route through the same `enqueue_scheduled_mint_recovery`.
- **`SubmitMintJob` is double-mint-safe.** Before submitting, it checks the
  receipt inventory; if the mint already succeeded on-chain it records the
  existing mint (`RecordExistingMint` → `ExistingMintRecovered`) instead of
  re-submitting — the only guard that holds when the signer does not dedup on a
  deterministic `external_tx_id`.
- **Two correctness fixes the recovery e2e surfaced** (their own commit):
  - The per-state jobs share a per-mint idempotency key with the normal-flow
    jobs, so a completed run's terminal `Done` row blocked recovery's re-enqueue
    via apalis's `ON CONFLICT DO NOTHING`. Recovery now frees the terminal row
    before pushing, and a startup vacuum releases the keys across restarts.
  - A `MintingFailed` mint whose transaction actually succeeded sat behind the
    re-submission backoff; the budget loop now drives immediately when a receipt
    exists, recording the mint rather than waiting out the retry window.
- **Removes the superseded inline recovery.** Deletes the `SubmitMint` /
  `ConfirmMint` / `SendCallback` / `Recover` / `RecoverFromReceipt` commands and
  their handlers, `MintRecoveryMode`, and the `external_tx_id` retry-construction
  helpers. The Mint aggregate's command handlers are now pure, so its `Services`
  associated type is `()` (`MintServices` is gone).

### How #239 builds on this

[#239](https://github.com/ST0x-Technology/st0x.issuance/pull/239) applies the
same durable-job foundation to scheduled freeze/unfreeze windows. It reuses the
apalis queue conventions established here: typed jobs perform side effects,
domain command handlers stay pure, scheduled work survives restarts, terminal
rows release their idempotency keys before re-arming, and startup recovery
resets or vacuums only the relevant job type. Mint recovery and freeze
scheduling keep separate payloads, job types, and idempotency namespaces, so
#239 builds on #208's execution model without coupling the two domains.

### Behaviour change

Manual admin reprocess (`POST /admin/reprocess/mint`) now enqueues a recovery
job that honours the automatic-retry schedule, instead of the old `Recover`
command's manual mode that could force a retry **past** the exhaustion cap. An
already-exhausted mint with no on-chain receipt is no longer retried by a manual
reprocess (close it instead). If forcing a retry past the cap is still wanted,
it should be a follow-up (a `force` flag on recovery).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Full workspace suite green — `tests/recovery.rs` drives the whole job-based
recovery end-to-end (startup re-scan, receipt-monitor trigger, double-mint
prevention); the new recovery infrastructure (idempotency release, startup
vacuum, budget-loop abandon/resolve) is unit-tested in `src/mint/recovery.rs`.
Clippy clean, fmt applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable mint recovery jobs that resume mint processing across mint states.
  * Introduced outcome-recording mint commands (including recording existing on-chain mints) and a terminal mint-closed path.
  * Updated admin reprocessing to enqueue the scheduled recovery workflow.

* **Bug Fixes**
  * Prevent duplicate on-chain mint submissions by detecting already-recorded receipts before submitting again.
  * Improved callback enqueuing to align with the new durable mint outcome flow.

* **Documentation**
  * Refreshed the mint flow, recovery behavior, command mappings, and state diagrams to match the durable job workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
