### PR TITLE
feat: crash-safe burn idempotency via pre-signed tx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -4191,9 +4191,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5785,7 +5785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.60.2",
@@ -5860,9 +5860,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -5881,9 +5881,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/SPEC.md
+++ b/SPEC.md
@@ -377,6 +377,13 @@ on-chain transfer through calling Alpaca to burning tokens.
   balance fails to reserve and never submits an unbacked burn. On confirmation
   the reservation is settled (mirror balance reduced); on a definitive
   terminal/reverted failure it is released.
+- `BurnIntended` - For a locally signed burn, persists the exact signed raw
+  transaction and its hash before any broadcast attempt. A prepared
+  transaction is immutable: live execution and recovery may only broadcast
+  those persisted bytes, never sign a replacement while its outcome is
+  unknown. Recovery re-broadcasts the same bytes before confirming the stored
+  hash. If the broadcast outcome remains ambiguous, the redemption stays in
+  `BurnIntended` with its receipt reservation held for operator resolution.
 - `TokensBurned` - On-chain burn succeeded, redemption complete (terminal
   success). Payload contains `burns: Vec<BurnRecord>` where each `BurnRecord`
   has `receipt_id` and `shares_burned`, supporting multi-receipt burns when a
@@ -409,6 +416,7 @@ on-chain transfer through calling Alpaca to burning tokens.
 | `RecordAlpacaCall`      | `AlpacaCalled`            | Alpaca API called                             |
 | `RecordAlpacaFailure`   | `AlpacaCallFailed`        | Terminal failure                              |
 | `ConfirmAlpacaComplete` | `AlpacaJournalCompleted`  | Journal complete                              |
+| `IntendBurn`            | `BurnIntended`            | Persist exact signed tx before broadcasting   |
 | `BurnTokens`            | `BurnFireblocksSubmitted` | Submits to signing backend                    |
 | `ConfirmBurn`           | `TokensBurned`            | Confirms burn, terminal success               |
 | `RecordBurnFailure`     | `BurningFailed`           | Records failure with optional tx metadata     |

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -252,7 +252,9 @@ async fn load_reprocess_context(
                 ..
             } => {
                 burning_failed = Some(BurningFailedData {
-                    fireblocks_tx_id: fireblocks_tx_id.clone(),
+                    fireblocks_tx_id: fireblocks_tx_id
+                        .as_ref()
+                        .map(ToString::to_string),
                     planned_burns: planned_burns.clone(),
                 });
             }
@@ -644,7 +646,9 @@ async fn inspect_prior_fireblocks_burn(
                     issuer_request_id,
                     RedemptionCommand::RecordExistingBurn {
                         issuer_request_id: issuer_request_id.clone(),
-                        fireblocks_tx_id: fb_tx_id.clone(),
+                        fireblocks_tx_id: crate::vault::TxId::Legacy(
+                            fb_tx_id.clone(),
+                        ),
                         tx_hash,
                         planned_burns: bf_data.planned_burns.clone(),
                         block_number,
@@ -1612,7 +1616,7 @@ fn redemption_history_summary_from_events(
                 fireblocks_tx_id: Some(fireblocks_tx_id),
                 ..
             } => {
-                summary.fireblocks_tx_id = Some(fireblocks_tx_id);
+                summary.fireblocks_tx_id = Some(fireblocks_tx_id.to_string());
             }
             _ => {}
         }
@@ -1934,7 +1938,9 @@ mod tests {
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{FireblocksTxStatus, MultiBurnEntry, VaultService};
+    use crate::vault::{
+        FireblocksTxStatus, MultiBurnEntry, SendableTxWithHash, VaultService,
+    };
 
     use super::{AggregateKind, StuckAggregate};
 
@@ -2356,6 +2362,30 @@ mod tests {
         store
             .send(
                 &metadata.issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    vault: address!(
+                        "0xcccccccccccccccccccccccccccccccccccccccc"
+                    ),
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: U256::from(99),
+                        burn_shares: U256::from(100),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: Address::ZERO,
+                    external_tx_id: Some(BurnExternalTxId::base(
+                        &metadata.detected_tx_hash,
+                    )),
+                },
+            )
+            .await
+            .expect("IntendBurn failed");
+
+        store
+            .send(
+                &metadata.issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     vault: address!(
@@ -2383,7 +2413,9 @@ mod tests {
                 RedemptionCommand::RecordBurnFailure {
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     error: "burn terminally failed".to_string(),
-                    fireblocks_tx_id: Some("mock-fb-burn".to_string()),
+                    fireblocks_tx_id: Some(crate::vault::TxId::Legacy(
+                        "mock-fb-burn".to_string(),
+                    )),
                     planned_burns: vec![],
                 },
             )
@@ -3483,14 +3515,20 @@ mod tests {
         async fn submit_burn(
             &self,
             _params: crate::vault::MultiBurnParams,
-        ) -> Result<crate::vault::SubmittedTx, crate::vault::VaultError>
-        {
+            _prepared_tx: Option<SendableTxWithHash>,
+        ) -> Result<
+            crate::vault::SubmittedTx<
+                crate::redemption::BurnExternalTxId,
+                crate::vault::TxId,
+            >,
+            crate::vault::VaultError,
+        > {
             unimplemented!("not used in enrichment tests")
         }
 
         async fn confirm_burn(
             &self,
-            _fireblocks_tx_id: &str,
+            _fireblocks_tx_id: &crate::vault::TxId,
             _dust_shares: alloy::primitives::U256,
         ) -> Result<crate::vault::MultiBurnResult, crate::vault::VaultError>
         {
@@ -4171,7 +4209,9 @@ mod tests {
                 external_tx_id: BurnExternalTxId::from_string(format!(
                     "burn-{tx_hash}"
                 )),
-                fireblocks_tx_id: "fb-old-attempt".to_string(),
+                fireblocks_tx_id: crate::vault::TxId::Legacy(
+                    "fb-old-attempt".to_string(),
+                ),
                 planned_burns: vec![],
                 submitted_at: now,
             },
@@ -4179,7 +4219,9 @@ mod tests {
                 issuer_request_id: issuer.clone(),
                 error: "fireblocks failed".to_string(),
                 failed_at: now,
-                fireblocks_tx_id: Some("fb-old-attempt".to_string()),
+                fireblocks_tx_id: Some(crate::vault::TxId::Legacy(
+                    "fb-old-attempt".to_string(),
+                )),
                 planned_burns: vec![],
             },
             RedemptionEvent::RedemptionFailed {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use alloy::providers::fillers::BlobGasFiller;
 use alloy::providers::{Provider, ProviderBuilder};
 use alloy::transports::{RpcError, TransportErrorKind};
 use clap::{Args, Parser};
@@ -97,6 +98,11 @@ impl Config {
                     .map_err(|err| ConfigError::SignerResolve(Box::new(err)))?;
 
                 let signing_provider = ProviderBuilder::new()
+                    .disable_recommended_fillers()
+                    .with_gas_estimation()
+                    .filler(BlobGasFiller)
+                    .with_simple_nonce_management()
+                    .with_chain_id(self.chain_id)
                     .wallet(resolved.wallet)
                     .connect_http(wss_to_http(&self.rpc_url)?);
 

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -25,8 +25,8 @@ use crate::redemption::BurnExternalTxId;
 use crate::vault::rain_meta::OaSchemaCache;
 use crate::vault::{
     BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-    MultiBurnResultEntry, ReceiptInformation, SubmittedTx, VaultError,
-    VaultService, verify_burn_in_receipt,
+    MultiBurnResultEntry, ReceiptInformation, SendableTxWithHash, SubmittedTx,
+    TxId, VaultError, VaultService, verify_burn_in_receipt,
 };
 
 /// Fireblocks-specific errors that can occur during vault operations.
@@ -732,12 +732,13 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
     async fn submit_burn(
         &self,
         params: MultiBurnParams,
-    ) -> Result<SubmittedTx, VaultError> {
+        _prepared_tx: Option<SendableTxWithHash>,
+    ) -> Result<SubmittedTx<BurnExternalTxId, TxId>, VaultError> {
         let vault_contract =
             OffchainAssetReceiptVault::new(params.vault, &self.read_provider);
 
-        let needs_encoding = params.burns.iter().any(|b| {
-            b.receipt_info_bytes.is_none() && b.receipt_info.is_some()
+        let needs_encoding = params.burns.iter().any(|burn| {
+            burn.receipt_info_bytes.is_none() && burn.receipt_info.is_some()
         });
 
         let oa_schema = if needs_encoding {
@@ -792,7 +793,8 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             vault_contract.multicall(calls).calldata().clone();
 
         // Submit CONTRACT_CALL to Fireblocks
-        let total_burn: U256 = params.burns.iter().map(|b| b.burn_shares).sum();
+        let total_burn: U256 =
+            params.burns.iter().map(|burn| burn.burn_shares).sum();
 
         let note = format!(
             "Burn {total_burn} shares from {} receipts (issuer_request_id: {})",
@@ -819,16 +821,19 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
             .await?;
 
         Ok(SubmittedTx {
-            external_tx_id: external_tx_id.into_string(),
-            fireblocks_tx_id,
+            external_tx_id,
+            fireblocks_tx_id: TxId::Legacy(fireblocks_tx_id),
         })
     }
 
     async fn confirm_burn(
         &self,
-        fireblocks_tx_id: &str,
+        fireblocks_tx_id: &TxId,
         dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError> {
+        let TxId::Legacy(fireblocks_tx_id) = fireblocks_tx_id else {
+            return Err(VaultError::InvalidReceipt);
+        };
         let tx_hash = self.wait_for_completion(fireblocks_tx_id).await?;
 
         self.parse_burn_receipt(tx_hash, dust_shares).await

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -2158,8 +2158,8 @@ pub(crate) mod tests {
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
-        MultiBurnResult, ReceiptInformation, SubmittedTx, VaultError,
-        VaultService,
+        MultiBurnResult, ReceiptInformation, SendableTxWithHash, SubmittedTx,
+        VaultError, VaultService,
     };
 
     pub(super) const VAULT: Address =
@@ -2235,13 +2235,20 @@ pub(crate) mod tests {
         async fn submit_burn(
             &self,
             _params: MultiBurnParams,
-        ) -> Result<SubmittedTx, VaultError> {
+            _prepared_tx: Option<SendableTxWithHash>,
+        ) -> Result<
+            SubmittedTx<
+                crate::redemption::BurnExternalTxId,
+                crate::vault::TxId,
+            >,
+            VaultError,
+        > {
             Err(VaultError::InvalidReceipt)
         }
 
         async fn confirm_burn(
             &self,
-            _fireblocks_tx_id: &str,
+            _fireblocks_tx_id: &crate::vault::TxId,
             _expected_dust_shares: U256,
         ) -> Result<MultiBurnResult, VaultError> {
             Err(VaultError::InvalidReceipt)
@@ -2304,13 +2311,20 @@ pub(crate) mod tests {
         async fn submit_burn(
             &self,
             _params: MultiBurnParams,
-        ) -> Result<SubmittedTx, VaultError> {
+            _prepared_tx: Option<SendableTxWithHash>,
+        ) -> Result<
+            SubmittedTx<
+                crate::redemption::BurnExternalTxId,
+                crate::vault::TxId,
+            >,
+            VaultError,
+        > {
             Err(VaultError::InvalidReceipt)
         }
 
         async fn confirm_burn(
             &self,
-            _fireblocks_tx_id: &str,
+            _fireblocks_tx_id: &crate::vault::TxId,
             _expected_dust_shares: U256,
         ) -> Result<MultiBurnResult, VaultError> {
             Err(VaultError::InvalidReceipt)

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -349,8 +349,8 @@ mod tests {
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
-        MultiBurnResult, ReceiptInformation, SubmittedTx, VaultError,
-        VaultService,
+        MultiBurnResult, ReceiptInformation, SendableTxWithHash, SubmittedTx,
+        VaultError, VaultService,
     };
 
     /// Builds a real event-sorcery [`Store<Mint>`] backed by an in-memory
@@ -507,13 +507,20 @@ mod tests {
         async fn submit_burn(
             &self,
             _params: MultiBurnParams,
-        ) -> Result<SubmittedTx, VaultError> {
+            _prepared_tx: Option<SendableTxWithHash>,
+        ) -> Result<
+            SubmittedTx<
+                crate::redemption::BurnExternalTxId,
+                crate::vault::TxId,
+            >,
+            VaultError,
+        > {
             Err(VaultError::InvalidReceipt)
         }
 
         async fn confirm_burn(
             &self,
-            _fireblocks_tx_id: &str,
+            _fireblocks_tx_id: &crate::vault::TxId,
             _expected_dust_shares: U256,
         ) -> Result<MultiBurnResult, VaultError> {
             Err(VaultError::InvalidReceipt)

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -477,7 +477,9 @@ mod tests {
                 issuer_request_id.clone(),
                 RedemptionEvent::ExistingBurnRecovered {
                     issuer_request_id: issuer_request_id.clone(),
-                    fireblocks_tx_id: "fb-tx-123".to_string(),
+                    fireblocks_tx_id: crate::vault::TxId::Legacy(
+                        "fb-tx-123".to_string(),
+                    ),
                     tx_hash: b256!(
                         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
                     ),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -19,12 +19,13 @@ use crate::receipt_inventory::{
     BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
     Shares,
 };
+use crate::redemption::{BurnRecord, RedemptionMetadata};
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
 use crate::vault::{
-    BurnVerification, FireblocksTxStatus, MultiBurnEntry, VaultError,
+    BurnVerification, FireblocksTxStatus, MultiBurnEntry, TxId, VaultError,
     VaultService,
 };
 
@@ -161,7 +162,8 @@ impl BurnManager {
         self.recover_single_burning(issuer_request_id).await
     }
 
-    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
+    /// Admin-terminalizes a redemption stuck in
+    /// `Burning`/`BurnIntended`/`BurnSubmitted` whose
     /// burn already landed on-chain but was never recorded (e.g. a crash
     /// between the burn and `TokensBurned`).
     ///
@@ -191,6 +193,7 @@ impl BurnManager {
 
         let underlying = match &redemption {
             Redemption::Burning { metadata, .. }
+            | Redemption::BurnIntended { metadata, .. }
             | Redemption::BurnSubmitted { metadata, .. } => {
                 metadata.underlying.clone()
             }
@@ -533,7 +536,10 @@ impl BurnManager {
 
         match self
             .vault_service
-            .confirm_burn(fireblocks_tx_id, dust_shares)
+            .confirm_burn(
+                &TxId::Legacy(fireblocks_tx_id.to_string()),
+                dust_shares,
+            )
             .await
         {
             Ok(result) => {
@@ -561,7 +567,9 @@ impl BurnManager {
                         issuer_request_id,
                         RedemptionCommand::RecordExistingBurn {
                             issuer_request_id: issuer_request_id.clone(),
-                            fireblocks_tx_id: fireblocks_tx_id.to_string(),
+                            fireblocks_tx_id: TxId::Legacy(
+                                fireblocks_tx_id.to_string(),
+                            ),
                             tx_hash: result.tx_hash,
                             planned_burns: actual_burns,
                             block_number: result.block_number,
@@ -607,6 +615,107 @@ impl BurnManager {
         }
     }
 
+    async fn recover_single_burning_shared_inner(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        metadata: &RedemptionMetadata,
+        tx_id: &TxId,
+        dust_shares: U256,
+        planned_burns: &[BurnRecord],
+        recovery_state: BurnRecoveryState,
+    ) -> Result<RecoveryOutcome, BurnManagerError> {
+        let vault =
+            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+                .await?
+                .ok_or_else(|| BurnManagerError::AssetNotFound {
+                    underlying: metadata.underlying.clone(),
+                })?;
+
+        if recovery_state == BurnRecoveryState::Submitted {
+            info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                fireblocks_tx_id = %tx_id,
+                "Recovering BurnSubmitted redemption - confirming existing transaction"
+            );
+        } else {
+            info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                fireblocks_tx_id = %tx_id,
+                "Recovering BurnIntended redemption - checking existing transaction"
+            );
+        }
+
+        let confirm_result = self
+            .store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::ConfirmBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    fireblocks_tx_id: tx_id.clone(),
+                    dust_shares,
+                },
+            )
+            .await;
+
+        match confirm_result {
+            Ok(()) => {
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "Burn confirmed successfully during recovery"
+                );
+
+                self.settle_reserved_burn(vault, issuer_request_id).await;
+
+                Ok(RecoveryOutcome::ExistingBurnRecorded)
+            }
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                RedemptionError::Vault {
+                    message: err,
+                    release_reservation,
+                    ..
+                },
+            ))) => {
+                if recovery_state == BurnRecoveryState::Submitted {
+                    warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Burn confirmation failed during recovery"
+                    );
+                } else {
+                    warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "BurnIntended confirmation failed during recovery"
+                    );
+                }
+
+                if release_reservation {
+                    // Release before terminalizing the redemption. A crash
+                    // after this idempotent release leaves the aggregate in
+                    // its recoverable state, so the same transaction is
+                    // checked again. Recording failure first could strand a
+                    // reservation because burning-state recovery would no
+                    // longer revisit the aggregate.
+                    self.release_reserved_burn(vault, issuer_request_id).await;
+                }
+
+                self.store
+                    .send(
+                        issuer_request_id,
+                        RedemptionCommand::RecordBurnFailure {
+                            issuer_request_id: issuer_request_id.clone(),
+                            error: err.clone(),
+                            fireblocks_tx_id: Some(tx_id.clone()),
+                            planned_burns: planned_burns.to_vec(),
+                        },
+                    )
+                    .await?;
+
+                Err(BurnManagerError::Redemption(RedemptionError::Vault {
+                    message: err,
+                    release_reservation,
+                    fireblocks_tx_id: None,
+                }))
+            }
+            Err(err) => Err(err.into()),
+        }
+    }
+
     async fn recover_single_burning(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
@@ -628,7 +737,24 @@ impl BurnManager {
                 ..
             } => {
                 let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
+                self.recover_single_burning_shared_inner(
+                    issuer_request_id,
+                    metadata,
+                    fireblocks_tx_id,
+                    dust_shares,
+                    planned_burns,
+                    BurnRecoveryState::Submitted,
+                )
+                .await
+            }
 
+            Redemption::BurnIntended {
+                metadata,
+                planned_burns,
+                sendable_tx: Some(sendable_tx),
+                external_tx_id,
+                ..
+            } => {
                 let vault = find_vault_by_underlying(
                     &self.view_pool,
                     &metadata.underlying,
@@ -639,88 +765,76 @@ impl BurnManager {
                         underlying: metadata.underlying.clone(),
                     }
                 })?;
+                let dust_shares = sendable_tx.dust_shares;
+                let tx_id = TxId::Hash(sendable_tx.hash);
 
-                info!(target: "redemption", issuer_request_id = %issuer_request_id,
-                    fireblocks_tx_id = %fireblocks_tx_id,
-                    "Recovering BurnSubmitted redemption - confirming existing transaction"
+                info!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %sendable_tx.hash,
+                    "Recovering BurnIntended redemption - re-broadcasting persisted transaction"
                 );
 
-                let confirm_result = self
+                let burns = planned_burns
+                    .iter()
+                    .map(|burn| MultiBurnEntry {
+                        receipt_id: burn.receipt_id,
+                        burn_shares: burn.shares_burned,
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    })
+                    .collect();
+                let wallet_guard = self.vault_service.lock_wallet().await;
+                let submit_result = self
                     .store
                     .send(
                         issuer_request_id,
-                        RedemptionCommand::ConfirmBurn {
+                        RedemptionCommand::BurnTokens {
                             issuer_request_id: issuer_request_id.clone(),
-                            fireblocks_tx_id: fireblocks_tx_id.clone(),
+                            vault,
+                            burns,
                             dust_shares,
+                            owner: self.bot_wallet,
+                            external_tx_id: external_tx_id.clone(),
                         },
                     )
                     .await;
+                drop(wallet_guard);
 
-                match confirm_result {
-                    Ok(()) => {
-                        info!(target: "redemption", issuer_request_id = %issuer_request_id,
-                            "Burn confirmed successfully during recovery"
-                        );
-
-                        self.settle_reserved_burn(vault, issuer_request_id)
-                            .await;
-
-                        Ok(RecoveryOutcome::ExistingBurnRecorded)
-                    }
-                    Err(AggregateError::UserError(LifecycleError::Apply(
-                        RedemptionError::Vault {
-                            message: err,
-                            release_reservation,
-                            ..
-                        },
-                    ))) => {
-                        warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                            error = %err,
-                            "Burn confirmation failed during recovery"
-                        );
-
-                        if release_reservation {
-                            self.release_reserved_burn(
-                                vault,
-                                issuer_request_id,
-                            )
-                            .await;
-                        }
-
-                        self.store
-                            .send(
-                                issuer_request_id,
-                                RedemptionCommand::RecordBurnFailure {
-                                    issuer_request_id: issuer_request_id
-                                        .clone(),
-                                    error: err.clone(),
-                                    fireblocks_tx_id: Some(
-                                        fireblocks_tx_id.clone(),
-                                    ),
-                                    planned_burns: planned_burns.clone(),
-                                },
-                            )
-                            .await?;
-
-                        Err(BurnManagerError::Redemption(
-                            RedemptionError::Vault {
-                                message: err,
-                                release_reservation,
-                                fireblocks_tx_id: None,
-                            },
-                        ))
-                    }
-                    Err(err) => Err(err.into()),
+                if let Err(error) = submit_result {
+                    warn!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tx_hash = %sendable_tx.hash,
+                        error = %error,
+                        "Persisted burn transaction re-broadcast failed; keeping BurnIntended for recovery"
+                    );
+                    return Err(error.into());
                 }
+
+                self.recover_single_burning_shared_inner(
+                    issuer_request_id,
+                    metadata,
+                    &tx_id,
+                    dust_shares,
+                    planned_burns,
+                    BurnRecoveryState::Intended,
+                )
+                .await
             }
 
-            // Still in Burning state — needs full submit + confirm flow
+            // Still in Burning/BurnIntended(with no prepared tx - mean fireblocks path) state — needs full submit + confirm flow
             Redemption::Burning {
                 metadata,
                 alpaca_quantity,
                 dust_quantity,
                 external_tx_id,
+                ..
+            }
+            | Redemption::BurnIntended {
+                metadata,
+                alpaca_quantity,
+                dust_quantity,
+                external_tx_id,
+                sendable_tx: None,
                 ..
             } => {
                 let vault = find_vault_by_underlying(
@@ -825,13 +939,21 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
         aggregate: &Redemption,
     ) -> Result<(), BurnManagerError> {
-        let Redemption::Burning {
+        let (Redemption::Burning {
             metadata,
             alpaca_quantity,
             dust_quantity,
             external_tx_id,
             ..
-        } = aggregate
+        }
+        | Redemption::BurnIntended {
+            metadata,
+            alpaca_quantity,
+            dust_quantity,
+            external_tx_id,
+            sendable_tx: None,
+            ..
+        }) = aggregate
         else {
             return Err(BurnManagerError::InvalidAggregateState {
                 current_state: aggregate_state_name(aggregate).to_string(),
@@ -1025,110 +1147,213 @@ impl BurnManager {
         plan: BurnPlan,
         external_tx_id: Option<BurnExternalTxId>,
     ) -> Result<(), BurnManagerError> {
-        let burns: Vec<MultiBurnEntry> = plan
-            .allocations
-            .into_iter()
-            .map(|alloc| MultiBurnEntry {
-                receipt_id: alloc.receipt.receipt_id.inner(),
-                burn_shares: alloc.burn_amount.inner(),
-                receipt_info: alloc.receipt.receipt_info,
-                receipt_info_bytes: alloc.receipt.receipt_info_bytes,
-            })
-            .collect();
-
-        // Capture planned burns before they are consumed by the command,
-        // so we can include them in the BurningFailed event if the burn fails.
-        let planned_burns: Vec<super::BurnRecord> = burns
-            .iter()
-            .map(|entry| super::BurnRecord {
-                receipt_id: entry.receipt_id,
-                shares_burned: entry.burn_shares,
-            })
-            .collect();
-
-        let dust_shares = plan.dust.inner();
-
-        // Reserve the planned receipts BEFORE submitting to the signing
-        // backend. The vault inventory is a single serialized aggregate, so a
-        // concurrent redemption that already committed the same balance makes
-        // this reservation fail — and we must not submit an unbacked burn that
-        // would later revert on-chain with ERC1155InsufficientBalance.
-        if let Err(err) = self
-            .reserve_with_conflict_retry(
-                vault,
-                issuer_request_id,
-                planned_burns.clone(),
-            )
-            .await
-        {
-            error!(target: "redemption", issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Failed to reserve receipts before burn submission; aborting to avoid double-spend"
-            );
-
-            self.store
-                .send(
-                    issuer_request_id,
-                    RedemptionCommand::RecordBurnFailure {
-                        issuer_request_id: issuer_request_id.clone(),
-                        error: err.to_string(),
-                        fireblocks_tx_id: None,
-                        planned_burns,
-                    },
-                )
-                .await?;
-
-            return Err(err.into());
+        let execution = BurnExecutionPlan::new(vault, &plan, external_tx_id);
+        let wallet_guard = self.vault_service.lock_wallet().await;
+        if !self.is_burn_execution_current(issuer_request_id).await? {
+            return Ok(());
         }
 
-        // Step 1: Submit the burn transaction (emits BurnFireblocksSubmitted)
-        let submit_result = self
+        self.reserve_execution(issuer_request_id, &execution).await?;
+        self.persist_burn_intention(issuer_request_id, &execution).await?;
+        let tx_id =
+            self.submit_intended_burn(issuer_request_id, &execution).await;
+        drop(wallet_guard);
+        let tx_id = tx_id?;
+
+        self.confirm_submitted_burn(issuer_request_id, &execution, tx_id).await
+    }
+
+    async fn is_burn_execution_current(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<bool, BurnManagerError> {
+        let Some(current) = self.store.load(issuer_request_id).await? else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: "Uninitialized".to_string(),
+            });
+        };
+        if matches!(
+            &current,
+            Redemption::Burning { .. }
+                | Redemption::BurnIntended { sendable_tx: None, .. }
+        ) {
+            return Ok(true);
+        }
+
+        debug!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            state = aggregate_state_name(&current),
+            "Skipping stale burn execution after acquiring wallet lock"
+        );
+        Ok(false)
+    }
+
+    async fn reserve_execution(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        execution: &BurnExecutionPlan,
+    ) -> Result<(), BurnManagerError> {
+        let result = self
+            .reserve_with_conflict_retry(
+                execution.vault,
+                issuer_request_id,
+                execution.planned_burns.clone(),
+            )
+            .await;
+        let Err(error) = result else {
+            return Ok(());
+        };
+
+        error!(target: "redemption", issuer_request_id = %issuer_request_id,
+            error = %error,
+            "Failed to reserve receipts before burn submission; aborting to avoid double-spend"
+        );
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::RecordBurnFailure {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: error.to_string(),
+                    fireblocks_tx_id: None,
+                    planned_burns: execution.planned_burns.clone(),
+                },
+            )
+            .await?;
+
+        Err(error.into())
+    }
+
+    async fn persist_burn_intention(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        execution: &BurnExecutionPlan,
+    ) -> Result<(), BurnManagerError> {
+        let result = self
+            .store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault: execution.vault,
+                    burns: execution.burns.clone(),
+                    dust_shares: execution.dust_shares,
+                    owner: self.bot_wallet,
+                    external_tx_id: execution.external_tx_id.clone(),
+                },
+            )
+            .await;
+
+        match result {
+            Ok(()) => {
+                debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    "IntendBurn succeeded, submitting..."
+                );
+                Ok(())
+            }
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                RedemptionError::PreparingBurnTxFailed { message },
+            ))) => {
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    error = %message,
+                    "Preparing signed burn tx failed"
+                );
+                self.release_reserved_burn(execution.vault, issuer_request_id)
+                    .await;
+                self.store
+                    .send(
+                        issuer_request_id,
+                        RedemptionCommand::RecordBurnFailure {
+                            issuer_request_id: issuer_request_id.clone(),
+                            error: message.clone(),
+                            fireblocks_tx_id: None,
+                            planned_burns: execution.planned_burns.clone(),
+                        },
+                    )
+                    .await?;
+
+                Err(BurnManagerError::Redemption(
+                    RedemptionError::PreparingBurnTxFailed { message },
+                ))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    async fn submit_intended_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        execution: &BurnExecutionPlan,
+    ) -> Result<TxId, BurnManagerError> {
+        let aggregate =
+            self.store.load(issuer_request_id).await?.ok_or_else(|| {
+                BurnManagerError::InvalidAggregateState {
+                    current_state: "Uninitialized".to_string(),
+                }
+            })?;
+        let Redemption::BurnIntended { sendable_tx, .. } = &aggregate else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: aggregate_state_name(&aggregate).to_string(),
+            });
+        };
+        let submission_kind = match sendable_tx {
+            Some(_) => BurnSubmissionKind::PersistedTransaction,
+            None => BurnSubmissionKind::ExternalBackend,
+        };
+
+        let result = self
             .store
             .send(
                 issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns,
-                    dust_shares,
+                    vault: execution.vault,
+                    burns: execution.burns.clone(),
+                    dust_shares: execution.dust_shares,
                     owner: self.bot_wallet,
-                    external_tx_id,
+                    external_tx_id: execution.external_tx_id.clone(),
                 },
             )
             .await;
 
-        match submit_result {
+        match result {
             Ok(()) => {
                 debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "BurnTokens submitted, confirming..."
                 );
+                self.load_submitted_tx_id(issuer_request_id).await
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
                 RedemptionError::Vault {
-                    message: err,
+                    message,
                     release_reservation,
                     fireblocks_tx_id,
                 },
             ))) => {
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                    error = %err,
+                    error = %message,
                     fireblocks_tx_id = ?fireblocks_tx_id,
                     "Burn submission failed"
                 );
-
-                // Release only on a DEFINITIVE failure that proves no shares
-                // were consumed — a terminal Fireblocks status or an EVM revert
-                // (the local backend submits synchronously, so a revert can
-                // surface here). Otherwise RETAIN: a submit error does not prove
-                // no transaction was created (a duplicate `externalTxId` whose
-                // lookup failed, a missing transaction id, or an SDK/RPC error
-                // after the request was sent all leave a possibly-in-flight
-                // burn), and releasing could let a concurrent redemption reuse
-                // the balance and double-submit. Recovery (via the preserved
-                // `fireblocks_tx_id`) or manual intervention resolves retained
-                // reservations.
                 if release_reservation {
-                    self.release_reserved_burn(vault, issuer_request_id).await;
+                    self.release_before_terminal_failure(
+                        execution.vault,
+                        issuer_request_id,
+                    )
+                    .await;
+                }
+
+                if submission_kind == BurnSubmissionKind::PersistedTransaction {
+                    warn!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        "Burn broadcast outcome is ambiguous; keeping persisted transaction for recovery"
+                    );
+                    return Err(BurnManagerError::Redemption(
+                        RedemptionError::Vault {
+                            message,
+                            release_reservation: false,
+                            fireblocks_tx_id,
+                        },
+                    ));
                 }
 
                 self.store
@@ -1136,105 +1361,114 @@ impl BurnManager {
                         issuer_request_id,
                         RedemptionCommand::RecordBurnFailure {
                             issuer_request_id: issuer_request_id.clone(),
-                            error: err.clone(),
+                            error: message.clone(),
                             fireblocks_tx_id: fireblocks_tx_id.clone(),
-                            planned_burns,
+                            planned_burns: execution.planned_burns.clone(),
                         },
                     )
                     .await?;
-
-                return Err(BurnManagerError::Redemption(
-                    RedemptionError::Vault {
-                        message: err,
-                        release_reservation,
-                        fireblocks_tx_id,
-                    },
-                ));
+                Err(BurnManagerError::Redemption(RedemptionError::Vault {
+                    message,
+                    release_reservation,
+                    fireblocks_tx_id,
+                }))
             }
-            // Submission outcome is unknown (non-vault error): keep the
-            // reservation so a concurrent redemption cannot reuse the balance.
-            // A retry's atomic clear-and-reserve (ReserveBurn) replaces this
-            // redemption's reservation in one step.
-            Err(err) => return Err(err.into()),
+            Err(error) => Err(error.into()),
         }
+    }
 
-        // Step 2: Load aggregate to get the fireblocks_tx_id from BurnSubmitted state
-        let Some(aggregate) = self.store.load(issuer_request_id).await? else {
-            return Err(BurnManagerError::InvalidAggregateState {
-                current_state: "Uninitialized".to_string(),
-            });
-        };
-
-        let Redemption::BurnSubmitted { fireblocks_tx_id, .. } = &aggregate
+    async fn load_submitted_tx_id(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<TxId, BurnManagerError> {
+        let aggregate =
+            self.store.load(issuer_request_id).await?.ok_or_else(|| {
+                BurnManagerError::InvalidAggregateState {
+                    current_state: "Uninitialized".to_string(),
+                }
+            })?;
+        let Redemption::BurnSubmitted { fireblocks_tx_id, .. } = aggregate
         else {
             return Err(BurnManagerError::InvalidAggregateState {
                 current_state: aggregate_state_name(&aggregate).to_string(),
             });
         };
+        Ok(fireblocks_tx_id)
+    }
 
-        let fireblocks_tx_id = fireblocks_tx_id.clone();
-
-        // Step 3: Confirm the burn (emits TokensBurned or error)
-        let confirm_result = self
+    async fn confirm_submitted_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        execution: &BurnExecutionPlan,
+        tx_id: TxId,
+    ) -> Result<(), BurnManagerError> {
+        let result = self
             .store
             .send(
                 issuer_request_id,
                 RedemptionCommand::ConfirmBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    fireblocks_tx_id: fireblocks_tx_id.clone(),
-                    dust_shares,
+                    fireblocks_tx_id: tx_id.clone(),
+                    dust_shares: execution.dust_shares,
                 },
             )
             .await;
 
-        match confirm_result {
+        match result {
             Ok(()) => {
                 info!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "Burn confirmed successfully"
                 );
-
-                // The burn landed on-chain: consume the reservation so the
-                // mirror balance drops to match.
-                self.settle_reserved_burn(vault, issuer_request_id).await;
-
+                self.settle_reserved_burn(execution.vault, issuer_request_id)
+                    .await;
                 Ok(())
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
-                RedemptionError::Vault {
-                    message: err,
-                    release_reservation,
-                    ..
-                },
+                RedemptionError::Vault { message, release_reservation, .. },
             ))) => {
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                    error = %err,
+                    error = %message,
                     "Burn confirmation failed"
                 );
-
                 if release_reservation {
-                    self.release_reserved_burn(vault, issuer_request_id).await;
+                    self.release_before_terminal_failure(
+                        execution.vault,
+                        issuer_request_id,
+                    )
+                    .await;
                 }
-
                 self.store
                     .send(
                         issuer_request_id,
                         RedemptionCommand::RecordBurnFailure {
                             issuer_request_id: issuer_request_id.clone(),
-                            error: err.clone(),
-                            fireblocks_tx_id: Some(fireblocks_tx_id),
-                            planned_burns,
+                            error: message.clone(),
+                            fireblocks_tx_id: Some(tx_id),
+                            planned_burns: execution.planned_burns.clone(),
                         },
                     )
                     .await?;
 
                 Err(BurnManagerError::Redemption(RedemptionError::Vault {
-                    message: err,
+                    message,
                     release_reservation,
                     fireblocks_tx_id: None,
                 }))
             }
-            Err(err) => Err(err.into()),
+            Err(error) => Err(error.into()),
         }
+    }
+
+    async fn release_before_terminal_failure(
+        &self,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) {
+        // A crash after this idempotent release leaves the redemption in its
+        // recoverable state, so the same transaction is checked again.
+        // Recording failure first could strand the reservation because
+        // burning-state recovery would no longer revisit the aggregate.
+        self.release_reserved_burn(vault, issuer_request_id).await;
     }
 
     /// Reserves planned burns, retrying a bounded number of times on an
@@ -1325,6 +1559,63 @@ impl BurnManager {
     }
 }
 
+struct BurnExecutionPlan {
+    vault: Address,
+    burns: Vec<MultiBurnEntry>,
+    planned_burns: Vec<BurnRecord>,
+    dust_shares: U256,
+    external_tx_id: Option<BurnExternalTxId>,
+}
+
+impl BurnExecutionPlan {
+    fn new(
+        vault: Address,
+        plan: &BurnPlan,
+        external_tx_id: Option<BurnExternalTxId>,
+    ) -> Self {
+        let burns: Vec<MultiBurnEntry> = plan
+            .allocations
+            .iter()
+            .map(|allocation| MultiBurnEntry {
+                receipt_id: allocation.receipt.receipt_id.inner(),
+                burn_shares: allocation.burn_amount.inner(),
+                receipt_info: allocation.receipt.receipt_info.clone(),
+                receipt_info_bytes: allocation
+                    .receipt
+                    .receipt_info_bytes
+                    .clone(),
+            })
+            .collect();
+        let planned_burns = burns
+            .iter()
+            .map(|entry| BurnRecord {
+                receipt_id: entry.receipt_id,
+                shares_burned: entry.burn_shares,
+            })
+            .collect();
+
+        Self {
+            vault,
+            burns,
+            planned_burns,
+            dust_shares: plan.dust.inner(),
+            external_tx_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BurnSubmissionKind {
+    PersistedTransaction,
+    ExternalBackend,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BurnRecoveryState {
+    Intended,
+    Submitted,
+}
+
 const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
     match aggregate {
         Redemption::Detected { .. } => "Detected",
@@ -1334,12 +1625,13 @@ const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
         Redemption::Failed { .. } => "Failed",
         Redemption::Completed { .. } => "Completed",
         Redemption::Closed { .. } => "Closed",
+        Redemption::BurnIntended { .. } => "BurnIntended",
     }
 }
 
 /// Extracts the Fireblocks transaction ID from a `VaultError`, if the error
 /// originated from a Fireblocks error that carries a transaction ID.
-pub(crate) fn extract_fireblocks_tx_id(error: &VaultError) -> Option<String> {
+pub(crate) fn extract_fireblocks_tx_id(error: &VaultError) -> Option<TxId> {
     match error {
         VaultError::Fireblocks(
             crate::fireblocks::FireblocksVaultError::TransactionFailed {
@@ -1347,7 +1639,7 @@ pub(crate) fn extract_fireblocks_tx_id(error: &VaultError) -> Option<String> {
                 ..
             }
             | crate::fireblocks::FireblocksVaultError::MissingTxHash { tx_id },
-        ) => Some(tx_id.clone()),
+        ) => Some(TxId::Legacy(tx_id.clone())),
         _ => None,
     }
 }
@@ -1362,6 +1654,19 @@ pub(crate) const fn should_release_reserved_burn(error: &VaultError) -> bool {
             ..
         }) => !vault_service::is_still_pending(*status),
         VaultError::Reverted { .. } => true,
+        _ => false,
+    }
+}
+
+pub(crate) const fn is_pending_burn_confirmation(error: &VaultError) -> bool {
+    match error {
+        VaultError::ConfirmationPending { .. }
+        | VaultError::PendingTransaction(_)
+        | VaultError::Rpc(_) => true,
+        VaultError::Fireblocks(FireblocksVaultError::TransactionFailed {
+            status,
+            ..
+        }) => vault_service::is_still_pending(*status),
         _ => false,
     }
 }
@@ -1410,8 +1715,8 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        BurnManager, BurnManagerError, Redemption, RedemptionCommand,
-        should_release_reserved_burn,
+        BurnManager, BurnManagerError, RecoveryOutcome, Redemption,
+        RedemptionCommand, should_release_reserved_burn,
     };
     use crate::fireblocks::FireblocksVaultError;
     use crate::mint::IssuerMintRequestId;
@@ -1431,8 +1736,8 @@ mod tests {
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        FireblocksTxStatus, MultiBurnEntry, ReceiptInformation, VaultError,
-        VaultService,
+        FireblocksTxStatus, MultiBurnEntry, ReceiptInformation,
+        SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
     const TEST_WALLET: Address =
@@ -3187,7 +3492,9 @@ mod tests {
                 RedemptionCommand::RecordBurnFailure {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Terminal Fireblocks failure".to_string(),
-                    fireblocks_tx_id: Some("fb-failed-123".to_string()),
+                    fireblocks_tx_id: Some(TxId::Legacy(
+                        "fb-failed-123".to_string(),
+                    )),
                     planned_burns: vec![],
                 },
             )
@@ -3285,6 +3592,26 @@ mod tests {
         store
             .send(
                 &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: uint!(0_U256),
+                    owner: TEST_WALLET,
+                    external_tx_id: Some(prior_retry_id.clone()),
+                },
+            )
+            .await
+            .expect("Failed to intend prior burn submission");
+
+        store
+            .send(
+                &issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: issuer_request_id.clone(),
                     vault,
@@ -3308,7 +3635,9 @@ mod tests {
                 RedemptionCommand::RecordBurnFailure {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Replacement burn terminally failed".to_string(),
-                    fireblocks_tx_id: Some("mock-fb-burn".to_string()),
+                    fireblocks_tx_id: Some(TxId::Legacy(
+                        "mock-fb-burn".to_string(),
+                    )),
                     planned_burns: vec![],
                 },
             )
@@ -3382,7 +3711,9 @@ mod tests {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Recorded failure while tx still pending"
                         .to_string(),
-                    fireblocks_tx_id: Some("fb-pending-123".to_string()),
+                    fireblocks_tx_id: Some(TxId::Legacy(
+                        "fb-pending-123".to_string(),
+                    )),
                     planned_burns: vec![],
                 },
             )
@@ -3460,7 +3791,9 @@ mod tests {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Recorded failure though tx actually completed"
                         .to_string(),
-                    fireblocks_tx_id: Some("fb-completed-123".to_string()),
+                    fireblocks_tx_id: Some(TxId::Legacy(
+                        "fb-completed-123".to_string(),
+                    )),
                     planned_burns: vec![],
                 },
             )
@@ -3630,6 +3963,461 @@ mod tests {
         ));
     }
 
+    /// Recovery must re-broadcast the exact persisted transaction before
+    /// confirming it, covering a crash after persistence but before broadcast.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_intended_rebroadcasts_persisted_transaction() {
+        let prepared_hash = b256!(
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+        let vault_mock =
+            Arc::new(MockVaultService::new_success().with_prepared_tx(
+                SendableTxWithHash {
+                    tx: vec![],
+                    hash: prepared_hash,
+                    nonce: 0,
+                    signed_at: Utc::now(),
+                    dust_shares: U256::ZERO,
+                },
+            ));
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+
+        // Seed a reservation so the test verifies it is settled on confirm.
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(99_U256),
+                    shares_burned: uint!(100_000000000000000000_U256),
+                }],
+            )
+            .await
+            .expect("seeding reservation should succeed");
+
+        // Drive to BurnIntended { sendable_tx: Some(...) } by sending IntendBurn;
+        // the mock returns the configured prepared tx from prepare_tx.
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: TEST_WALLET,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn should succeed");
+
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(
+                aggregate,
+                Redemption::BurnIntended { sendable_tx: Some(_), .. }
+            ),
+            "Expected BurnIntended with sendable_tx, got {aggregate:?}"
+        );
+
+        let result = manager.recover_single_burning(&issuer_request_id).await;
+
+        assert!(
+            matches!(result, Ok(RecoveryOutcome::ExistingBurnRecorded)),
+            "Expected ExistingBurnRecorded, got {result:?}"
+        );
+
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "recovery must broadcast the persisted transaction exactly once"
+        );
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Completed { .. }),
+            "Expected Completed after recovery, got {updated:?}"
+        );
+
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "reservation must be settled after confirmed burn"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &[
+                "Recovering BurnIntended redemption",
+                "re-broadcasting persisted transaction",
+            ]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Burn confirmed successfully during recovery"]
+        ));
+    }
+
+    /// An ambiguous local broadcast failure must retain both the persisted
+    /// transaction and its receipt reservation. Signing a replacement could
+    /// burn twice if the first broadcast actually reached the node.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_ambiguous_broadcast_failure_keeps_burn_intended() {
+        let prepared_hash = b256!(
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+        let vault_mock =
+            Arc::new(MockVaultService::new_submit_failure().with_prepared_tx(
+                SendableTxWithHash {
+                    tx: vec![1, 2, 3],
+                    hash: prepared_hash,
+                    nonce: 7,
+                    signed_at: Utc::now(),
+                    dust_shares: U256::ZERO,
+                },
+            ));
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        assert!(
+            manager
+                .handle_burning_started(&issuer_request_id, &aggregate)
+                .await
+                .is_err(),
+            "ambiguous broadcast failure must be reported"
+        );
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(
+                updated,
+                Redemption::BurnIntended {
+                    sendable_tx: Some(SendableTxWithHash { hash, .. }),
+                    ..
+                } if hash == prepared_hash
+            ),
+            "the exact persisted transaction must remain recoverable: {updated:?}"
+        );
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![issuer_request_id],
+            "ambiguous broadcast must retain the receipt reservation"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &[
+                "Burn broadcast outcome is ambiguous",
+                "keeping persisted transaction for recovery",
+            ]
+        ));
+    }
+
+    /// A receipt timeout does not prove that a broadcast transaction failed.
+    /// The submitted identity and reservation must remain recoverable so a
+    /// later pass confirms the same transaction instead of signing a replacement.
+    #[tokio::test]
+    async fn test_confirmation_timeout_keeps_submitted_burn_and_reservation() {
+        let prepared_hash = b256!(
+            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+        );
+        let vault_mock =
+            Arc::new(MockVaultService::new_confirm_pending().with_prepared_tx(
+                SendableTxWithHash {
+                    tx: vec![1, 2, 3],
+                    hash: prepared_hash,
+                    nonce: 7,
+                    signed_at: Utc::now(),
+                    dust_shares: U256::ZERO,
+                },
+            ));
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        assert!(
+            manager
+                .handle_burning_started(&issuer_request_id, &aggregate)
+                .await
+                .is_err(),
+            "an unresolved confirmation must remain visible to the caller"
+        );
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(
+                updated,
+                Redemption::BurnSubmitted {
+                    fireblocks_tx_id: TxId::Hash(hash),
+                    ..
+                } if hash == prepared_hash
+            ),
+            "the submitted transaction must remain recoverable: {updated:?}"
+        );
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![issuer_request_id],
+            "ambiguous confirmation must retain the receipt reservation"
+        );
+    }
+
+    /// Tests recovery from `BurnIntended { sendable_tx: None }` (lines 825-831):
+    /// when no pre-signed tx exists, the manager re-runs the full burn flow
+    /// (reserve → BurnTokens → ConfirmBurn) from the existing BurnIntended state.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_intended_without_sendable_tx_executes_full_burn_flow()
+     {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+
+        // Drive to BurnIntended { sendable_tx: None }: default mock prepare_tx
+        // returns None (Fireblocks backend), so no pre-signed tx is stored.
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: TEST_WALLET,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn should succeed");
+
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(
+                aggregate,
+                Redemption::BurnIntended { sendable_tx: None, .. }
+            ),
+            "Expected BurnIntended without sendable_tx, got {aggregate:?}"
+        );
+
+        let result = manager.recover_single_burning(&issuer_request_id).await;
+
+        assert!(
+            matches!(result, Ok(RecoveryOutcome::Executed)),
+            "Expected Executed, got {result:?}"
+        );
+
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "full burn flow must submit exactly one burn"
+        );
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Completed { .. }),
+            "Expected Completed after recovery, got {updated:?}"
+        );
+
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "reservation must be settled after completed burn"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Burn confirmed successfully"]
+        ));
+    }
+
+    /// Tests the `PreparingBurnTxFailed` path in `execute_burn_and_record_result`
+    /// (lines 1195-1266): when `prepare_tx` fails, the manager releases the receipt
+    /// reservation and records a burn failure before returning an error.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_prepare_tx_failure_releases_reservation_and_records_burn_failure()
+     {
+        let vault_mock = Arc::new(MockVaultService::new_prepare_tx_failure());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(
+                result.unwrap_err(),
+                BurnManagerError::Redemption(
+                    RedemptionError::PreparingBurnTxFailed { .. }
+                )
+            ),
+            "Expected PreparingBurnTxFailed error"
+        );
+
+        // No burn was submitted on-chain.
+        assert_eq!(vault_mock.get_multi_burn_call_count(), 0);
+
+        // Reservation must be released since nothing landed on-chain.
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "reservation must be released when prepare_tx fails"
+        );
+
+        // Aggregate must be in Failed state (RecordBurnFailure was called).
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Failed { .. }),
+            "Expected Failed state after prepare_tx failure, got {updated:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Preparing signed burn tx failed"]
+        ));
+    }
+
     /// Tests that recovery from `BurnSubmitted` state (crash between submit
     /// and confirm) successfully confirms the existing transaction without
     /// submitting a new one.
@@ -3667,9 +4455,29 @@ mod tests {
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
 
-        // Issue BurnTokens directly to stop at BurnSubmitted (simulating
-        // a crash between submit and confirm). This calls submit_burn on
-        // the mock and emits BurnFireblocksSubmitted without confirming.
+        // Issue IntendBurn then BurnTokens directly to stop at BurnSubmitted
+        // (simulating a crash between submit and confirm). This calls submit_burn
+        // on the mock and emits BurnFireblocksSubmitted without confirming.
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![crate::vault::MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: TEST_WALLET,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn should succeed");
+
         store
             .send(
                 &issuer_request_id,

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -5,7 +5,7 @@ use super::{BurnExternalTxId, IssuerRedemptionRequestId};
 use crate::Quantity;
 use crate::mint::TokenizationRequestId;
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
-use crate::vault::MultiBurnEntry;
+use crate::vault::{MultiBurnEntry, TxId};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum RedemptionCommand {
@@ -58,14 +58,14 @@ pub(crate) enum RedemptionCommand {
     /// Polls the signing backend and produces `TokensBurned` or error.
     ConfirmBurn {
         issuer_request_id: IssuerRedemptionRequestId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         dust_shares: U256,
     },
     RecordBurnFailure {
         issuer_request_id: IssuerRedemptionRequestId,
         error: String,
         /// Fireblocks transaction ID, if the burn was submitted via Fireblocks.
-        fireblocks_tx_id: Option<String>,
+        fireblocks_tx_id: Option<TxId>,
         /// Planned burns at the time of failure.
         planned_burns: Vec<super::BurnRecord>,
     },
@@ -83,7 +83,7 @@ pub(crate) enum RedemptionCommand {
     /// succeeded on-chain but the bot timed out before recording it.
     RecordExistingBurn {
         issuer_request_id: IssuerRedemptionRequestId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         tx_hash: B256,
         planned_burns: Vec<super::BurnRecord>,
         block_number: u64,
@@ -95,10 +95,11 @@ pub(crate) enum RedemptionCommand {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
     },
-    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
-    /// burn already landed on-chain. The admin layer verifies `burn_tx_hash`
-    /// on-chain before issuing this command; the aggregate records it as the
-    /// proving tx hash and transitions to `Completed`.
+    /// Admin-terminalizes a redemption stuck in
+    /// `Burning`/`BurnIntended`/`BurnSubmitted` whose burn already landed
+    /// on-chain. The admin layer verifies `burn_tx_hash` before issuing this
+    /// command; the aggregate records it as proof and transitions to
+    /// `Completed`.
     ForceCompleteBurn {
         issuer_request_id: IssuerRedemptionRequestId,
         burn_tx_hash: B256,
@@ -121,6 +122,18 @@ pub(crate) enum RedemptionCommand {
         /// Optional deterministic Fireblocks `externalTxId` for the next burn
         /// submission. Persisted through `BurnResumed` so a retry submission
         /// that fails before Fireblocks accepts it can be retried idempotently.
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
+    },
+    IntendBurn {
+        issuer_request_id: IssuerRedemptionRequestId,
+        vault: Address,
+        /// Burns to execute (receipt_id + amount for each)
+        burns: Vec<MultiBurnEntry>,
+        /// Dust to return to user
+        dust_shares: U256,
+        owner: Address,
+        /// Optional deterministic `externalTxId` override.
         #[serde(default)]
         external_tx_id: Option<BurnExternalTxId>,
     },

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use super::{BurnExternalTxId, IssuerRedemptionRequestId};
 use crate::mint::{Quantity, TokenizationRequestId};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
+use crate::vault::{SendableTxWithHash, TxId};
 
 /// A single burn operation within a multi-receipt burn.
 ///
@@ -146,7 +147,7 @@ pub(crate) enum RedemptionEvent {
         /// Fireblocks transaction ID, if the burn was submitted via Fireblocks.
         /// Absent for non-Fireblocks backends or pre-enrichment events.
         #[serde(default)]
-        fireblocks_tx_id: Option<String>,
+        fireblocks_tx_id: Option<TxId>,
         /// Planned burns at the time of failure.
         /// Absent for pre-enrichment events.
         #[serde(default)]
@@ -171,7 +172,7 @@ pub(crate) enum RedemptionEvent {
     BurnFireblocksSubmitted {
         issuer_request_id: IssuerRedemptionRequestId,
         external_tx_id: BurnExternalTxId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         /// Planned burns at the time of submission (for recovery use).
         planned_burns: Vec<BurnRecord>,
         submitted_at: DateTime<Utc>,
@@ -182,7 +183,7 @@ pub(crate) enum RedemptionEvent {
     /// but the bot failed to record it (e.g., Fireblocks polling timeout).
     ExistingBurnRecovered {
         issuer_request_id: IssuerRedemptionRequestId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         tx_hash: B256,
         burns: Vec<BurnRecord>,
         block_number: u64,
@@ -234,6 +235,11 @@ pub(crate) enum RedemptionEvent {
         external_tx_id: Option<BurnExternalTxId>,
         resumed_at: DateTime<Utc>,
     },
+    BurnIntended {
+        issuer_request_id: IssuerRedemptionRequestId,
+        sendable_tx: Option<SendableTxWithHash>,
+        planned_burns: Vec<BurnRecord>,
+    },
 }
 
 impl DomainEvent for RedemptionEvent {
@@ -275,6 +281,9 @@ impl DomainEvent for RedemptionEvent {
             }
             Self::BurnForceCompleted { .. } => {
                 "RedemptionEvent::BurnForceCompleted".to_string()
+            }
+            Self::BurnIntended { .. } => {
+                "RedemptionEvent::BurnIntended".to_string()
             }
         }
     }
@@ -394,7 +403,7 @@ mod tests {
             issuer_request_id: test_redemption_id(),
             error: "Network timeout".to_string(),
             failed_at: Utc::now(),
-            fireblocks_tx_id: Some("fb-tx-123".to_string()),
+            fireblocks_tx_id: Some(TxId::Legacy("fb-tx-123".to_string())),
             planned_burns: vec![BurnRecord {
                 receipt_id: uint!(7_U256),
                 shares_burned: uint!(100_000000000000000000_U256),

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -22,7 +22,8 @@ use tracing::warn;
 use crate::Quantity;
 use crate::mint::TokenizationRequestId;
 use crate::redemption::burn_manager::{
-    extract_fireblocks_tx_id, should_release_reserved_burn,
+    extract_fireblocks_tx_id, is_pending_burn_confirmation,
+    should_release_reserved_burn,
 };
 
 /// Issuer request ID for redemption operations.
@@ -137,10 +138,6 @@ impl BurnExternalTxId {
             .rsplit_once(Redemption::BURN_RETRY_EXTERNAL_TX_MARKER)
             .and_then(|(_, attempt)| attempt.parse().ok())
     }
-
-    pub(crate) fn into_string(self) -> String {
-        self.0
-    }
 }
 
 impl std::fmt::Display for BurnExternalTxId {
@@ -149,8 +146,8 @@ impl std::fmt::Display for BurnExternalTxId {
     }
 }
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
-use crate::vault::VaultError;
 use crate::vault::{MultiBurnEntry, MultiBurnParams, VaultService};
+use crate::vault::{SendableTxWithHash, TxId, VaultError};
 
 pub(crate) use cmd::RedemptionCommand;
 pub(crate) use event::{BurnRecord, RedemptionEvent, TokensBurnedData};
@@ -206,7 +203,7 @@ pub(crate) enum Redemption {
         called_at: DateTime<Utc>,
         alpaca_journal_completed_at: DateTime<Utc>,
         external_tx_id: BurnExternalTxId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         planned_burns: Vec<event::BurnRecord>,
     },
     Completed {
@@ -223,6 +220,21 @@ pub(crate) enum Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
         closed_at: DateTime<Utc>,
+    },
+    BurnIntended {
+        metadata: RedemptionMetadata,
+        tokenization_request_id: TokenizationRequestId,
+        /// Quantity to burn (what Alpaca processed, 9 decimals)
+        alpaca_quantity: Quantity,
+        /// Dust quantity to return to user
+        dust_quantity: Quantity,
+        called_at: DateTime<Utc>,
+        alpaca_journal_completed_at: DateTime<Utc>,
+        planned_burns: Vec<event::BurnRecord>,
+        #[serde(default)]
+        external_tx_id: Option<BurnExternalTxId>,
+        #[serde(default)]
+        sendable_tx: Option<SendableTxWithHash>,
     },
 }
 
@@ -311,6 +323,7 @@ impl Redemption {
             Self::Completed { .. } => "Completed",
             Self::Failed { .. } => "Failed",
             Self::Closed { .. } => "Closed",
+            Self::BurnIntended { .. } => "BurnIntended",
         }
     }
 
@@ -391,9 +404,9 @@ impl Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         input: BurnInput,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let Self::Burning { metadata, .. } = self else {
+        let Self::BurnIntended { metadata, sendable_tx, .. } = self else {
             return Err(RedemptionError::InvalidState {
-                expected: "Burning".to_string(),
+                expected: "BurnIntended".to_string(),
                 found: self.state_name().to_string(),
             });
         };
@@ -409,17 +422,19 @@ impl Redemption {
             })
             .collect();
 
+        let params = MultiBurnParams {
+            vault: input.vault,
+            burns: input.burns,
+            dust_shares: input.dust_shares,
+            owner: input.owner,
+            user: user_wallet,
+            issuer_request_id: issuer_request_id.clone(),
+            detected_tx_hash: metadata.detected_tx_hash,
+            external_tx_id: input.external_tx_id,
+        };
+
         let submitted = services
-            .submit_burn(MultiBurnParams {
-                vault: input.vault,
-                burns: input.burns,
-                dust_shares: input.dust_shares,
-                owner: input.owner,
-                user: user_wallet,
-                issuer_request_id: issuer_request_id.clone(),
-                detected_tx_hash: metadata.detected_tx_hash,
-                external_tx_id: input.external_tx_id,
-            })
+            .submit_burn(params, sendable_tx.clone())
             .await
             .map_err(|error: VaultError| RedemptionError::Vault {
                 release_reservation: should_release_reserved_burn(&error),
@@ -429,9 +444,7 @@ impl Redemption {
 
         Ok(vec![RedemptionEvent::BurnFireblocksSubmitted {
             issuer_request_id,
-            external_tx_id: BurnExternalTxId::from_string(
-                submitted.external_tx_id,
-            ),
+            external_tx_id: submitted.external_tx_id,
             fireblocks_tx_id: submitted.fireblocks_tx_id,
             planned_burns,
             submitted_at: Utc::now(),
@@ -443,39 +456,55 @@ impl Redemption {
         &self,
         services: &Arc<dyn VaultService>,
         issuer_request_id: IssuerRedemptionRequestId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         dust_shares: U256,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let Self::BurnSubmitted { fireblocks_tx_id: stored_tx_id, .. } = self
-        else {
-            return Err(RedemptionError::InvalidState {
-                expected: "BurnSubmitted".to_string(),
-                found: self.state_name().to_string(),
-            });
+        let stored_tx_id = match self {
+            Self::BurnSubmitted { fireblocks_tx_id, .. } => {
+                fireblocks_tx_id.clone()
+            }
+            Self::BurnIntended { sendable_tx: Some(tx), .. } => {
+                TxId::Hash(tx.hash)
+            }
+            _ => {
+                return Err(RedemptionError::InvalidState {
+                    expected: "BurnSubmitted or BurnIntended".to_string(),
+                    found: self.state_name().to_string(),
+                });
+            }
         };
 
-        if *stored_tx_id != fireblocks_tx_id {
+        if stored_tx_id != fireblocks_tx_id {
             return Err(RedemptionError::FireblocksTxIdMismatch {
-                expected: stored_tx_id.clone(),
-                provided: fireblocks_tx_id,
+                expected: stored_tx_id.to_string(),
+                provided: fireblocks_tx_id.to_string(),
             });
         }
 
         let result = services
             .confirm_burn(&fireblocks_tx_id, dust_shares)
             .await
-            .map_err(|error: VaultError| RedemptionError::Vault {
-                release_reservation: should_release_reserved_burn(&error),
-                fireblocks_tx_id: extract_fireblocks_tx_id(&error),
-                message: error.to_string(),
+            .map_err(|error| {
+                if is_pending_burn_confirmation(&error) {
+                    return RedemptionError::BurnConfirmationPending {
+                        tx_id: fireblocks_tx_id.clone(),
+                        message: error.to_string(),
+                    };
+                }
+
+                RedemptionError::Vault {
+                    release_reservation: should_release_reserved_burn(&error),
+                    fireblocks_tx_id: extract_fireblocks_tx_id(&error),
+                    message: error.to_string(),
+                }
             })?;
 
         let burns = result
             .burns
             .into_iter()
-            .map(|b| BurnRecord {
-                receipt_id: b.receipt_id,
-                shares_burned: b.shares_burned,
+            .map(|burn| BurnRecord {
+                receipt_id: burn.receipt_id,
+                shares_burned: burn.shares_burned,
             })
             .collect();
 
@@ -494,12 +523,17 @@ impl Redemption {
         &self,
         issuer_request_id: IssuerRedemptionRequestId,
         error: String,
-        fireblocks_tx_id: Option<String>,
+        fireblocks_tx_id: Option<TxId>,
         planned_burns: Vec<BurnRecord>,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
+        if !matches!(
+            self,
+            Self::Burning { .. }
+                | Self::BurnIntended { .. }
+                | Self::BurnSubmitted { .. }
+        ) {
             return Err(RedemptionError::InvalidState {
-                expected: "Burning or BurnSubmitted".to_string(),
+                expected: "Burning, BurnIntended, or BurnSubmitted".to_string(),
                 found: self.state_name().to_string(),
             });
         }
@@ -591,7 +625,7 @@ impl Redemption {
     fn handle_record_existing_burn(
         &self,
         issuer_request_id: IssuerRedemptionRequestId,
-        fireblocks_tx_id: String,
+        fireblocks_tx_id: TxId,
         tx_hash: B256,
         planned_burns: Vec<BurnRecord>,
         block_number: u64,
@@ -653,7 +687,8 @@ impl Redemption {
         }])
     }
 
-    /// Admin-terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose
+    /// Admin-terminalizes a redemption stuck in
+    /// `Burning`/`BurnIntended`/`BurnSubmitted` whose
     /// burn already landed on-chain but was never recorded. The admin layer
     /// verifies `burn_tx_hash` on-chain before issuing this command, so the
     /// aggregate trusts the supplied tx hash and block number and records the
@@ -665,13 +700,19 @@ impl Redemption {
         block_number: u64,
         reason: String,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        if !matches!(self, Self::Burning { .. } | Self::BurnSubmitted { .. }) {
+        if !matches!(
+            self,
+            Self::Burning { .. }
+                | Self::BurnIntended { .. }
+                | Self::BurnSubmitted { .. }
+        ) {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
                     RedemptionError::AlreadyCompleted { issuer_request_id }
                 }
                 _ => RedemptionError::InvalidState {
-                    expected: "Burning or BurnSubmitted".to_string(),
+                    expected: "Burning, BurnIntended, or BurnSubmitted"
+                        .to_string(),
                     found: self.state_name().to_string(),
                 },
             });
@@ -760,6 +801,60 @@ impl Redemption {
             external_tx_id: None,
         };
     }
+
+    /// Prepares a signed tx and precomputed tx hash ready for broadcasting onchain
+    /// Produces `BurnIntended` on success; failure is propagated to caller.
+    async fn handle_intend_burn(
+        &self,
+        services: &Arc<dyn VaultService>,
+        issuer_request_id: IssuerRedemptionRequestId,
+        input: BurnInput,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        let (Self::Burning { metadata, .. }
+        | Self::BurnIntended { metadata, sendable_tx: None, .. }) = self
+        else {
+            return Err(RedemptionError::InvalidState {
+                expected:
+                    "Burning or BurnIntended without a signed transaction"
+                        .to_string(),
+                found: self.state_name().to_string(),
+            });
+        };
+
+        let user_wallet = metadata.wallet;
+
+        let planned_burns: Vec<BurnRecord> = input
+            .burns
+            .iter()
+            .map(|entry| BurnRecord {
+                receipt_id: entry.receipt_id,
+                shares_burned: entry.burn_shares,
+            })
+            .collect();
+
+        let params = MultiBurnParams {
+            vault: input.vault,
+            burns: input.burns,
+            dust_shares: input.dust_shares,
+            owner: input.owner,
+            user: user_wallet,
+            issuer_request_id: issuer_request_id.clone(),
+            detected_tx_hash: metadata.detected_tx_hash,
+            external_tx_id: input.external_tx_id,
+        };
+
+        let sendable_tx = services.prepare_burn_tx(&params).await.map_err(
+            |error: VaultError| RedemptionError::PreparingBurnTxFailed {
+                message: error.to_string(),
+            },
+        )?;
+
+        Ok(vec![RedemptionEvent::BurnIntended {
+            issuer_request_id,
+            sendable_tx,
+            planned_burns,
+        }])
+    }
 }
 
 pub(crate) fn next_burn_retry_external_tx_id_from_history<'a>(
@@ -805,16 +900,20 @@ pub(crate) enum RedemptionError {
         release_reservation: bool,
         /// Fireblocks transaction id pulled from the `VaultError`, if any, so a
         /// possibly-in-flight burn stays recoverable after the type is erased.
-        fireblocks_tx_id: Option<String>,
+        fireblocks_tx_id: Option<TxId>,
     },
     #[error(
         "Fireblocks tx ID mismatch. Expected: {expected}, provided: {provided}"
     )]
     FireblocksTxIdMismatch { expected: String, provided: String },
+    #[error("Burn confirmation remains pending for {tx_id}: {message}")]
+    BurnConfirmationPending { tx_id: TxId, message: String },
     #[error(
         "Burn retry attempt counter overflowed for external tx id: {latest_external_tx_id}"
     )]
     RetryAttemptOverflow { latest_external_tx_id: BurnExternalTxId },
+    #[error("Failed to prepare sendable signed tx: {message}")]
+    PreparingBurnTxFailed { message: String },
 }
 
 #[async_trait]
@@ -909,6 +1008,14 @@ impl EventSourced for Redemption {
                     found: "Uninitialized".to_string(),
                 })
             }
+            RedemptionCommand::IntendBurn { .. } => {
+                Err(RedemptionError::InvalidState {
+                    expected:
+                        "Burning or BurnIntended without a signed transaction"
+                            .to_string(),
+                    found: "Uninitialized".to_string(),
+                })
+            }
             RedemptionCommand::BurnTokens { .. } => {
                 Err(RedemptionError::InvalidState {
                     expected: "Burning".to_string(),
@@ -924,7 +1031,8 @@ impl EventSourced for Redemption {
             RedemptionCommand::RecordBurnFailure { .. }
             | RedemptionCommand::ForceCompleteBurn { .. } => {
                 Err(RedemptionError::InvalidState {
-                    expected: "Burning or BurnSubmitted".to_string(),
+                    expected: "Burning, BurnIntended, or BurnSubmitted"
+                        .to_string(),
                     found: "Uninitialized".to_string(),
                 })
             }
@@ -1065,46 +1173,37 @@ impl EventSourced for Redemption {
                 alpaca_journal_completed_at,
                 external_tx_id,
             }),
+            RedemptionCommand::IntendBurn {
+                issuer_request_id,
+                vault,
+                burns,
+                dust_shares,
+                owner,
+                external_tx_id,
+            } => {
+                self.handle_intend_burn(
+                    services,
+                    issuer_request_id,
+                    BurnInput {
+                        vault,
+                        burns,
+                        dust_shares,
+                        owner,
+                        external_tx_id,
+                    },
+                )
+                .await
+            }
         }
     }
 }
 
 impl Redemption {
     fn apply_event(&mut self, event: RedemptionEvent) {
-        match event {
-            RedemptionEvent::Detected {
-                issuer_request_id,
-                underlying,
-                token,
-                wallet,
-                quantity,
-                tx_hash,
-                block_number,
-                detected_at,
-            }
-            | RedemptionEvent::Reprocessed {
-                issuer_request_id,
-                underlying,
-                token,
-                wallet,
-                quantity,
-                tx_hash,
-                block_number,
-                detected_at,
-                ..
-            } => {
-                *self = Self::Detected {
-                    metadata: RedemptionMetadata {
-                        issuer_request_id,
-                        underlying,
-                        token,
-                        wallet,
-                        quantity,
-                        detected_tx_hash: tx_hash,
-                        block_number,
-                        detected_at,
-                    },
-                };
+        match &event {
+            RedemptionEvent::Detected { .. }
+            | RedemptionEvent::Reprocessed { .. } => {
+                self.apply_detection_event(event);
             }
             RedemptionEvent::AlpacaCalled {
                 issuer_request_id,
@@ -1112,23 +1211,88 @@ impl Redemption {
                 alpaca_quantity,
                 dust_quantity,
                 called_at,
-            } => {
-                self.apply_alpaca_called(
-                    &issuer_request_id,
-                    tokenization_request_id,
-                    alpaca_quantity,
-                    dust_quantity,
-                    called_at,
-                );
+            } => self.apply_alpaca_called(
+                issuer_request_id,
+                tokenization_request_id.clone(),
+                alpaca_quantity.clone(),
+                dust_quantity.clone(),
+                *called_at,
+            ),
+            RedemptionEvent::AlpacaCallFailed { .. }
+            | RedemptionEvent::RedemptionFailed { .. }
+            | RedemptionEvent::BurningFailed { .. } => {
+                self.apply_failure_event(event);
             }
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id,
+                alpaca_journal_completed_at,
+            } => self.apply_alpaca_journal_completed(
+                issuer_request_id,
+                *alpaca_journal_completed_at,
+            ),
+            RedemptionEvent::BurnFireblocksSubmitted { .. } => {
+                self.apply_burn_submitted_event(event);
+            }
+            RedemptionEvent::BurnResumed { .. } => {
+                self.apply_burn_resumed_event(event);
+            }
+            RedemptionEvent::TokensBurned(_)
+            | RedemptionEvent::ExistingBurnRecovered { .. }
+            | RedemptionEvent::RedemptionClosed { .. }
+            | RedemptionEvent::BurnForceCompleted { .. } => {
+                self.apply_terminal_event(event);
+            }
+            RedemptionEvent::BurnIntended { .. } => {
+                self.apply_burn_intended_event(event);
+            }
+        }
+    }
+
+    fn apply_detection_event(&mut self, event: RedemptionEvent) {
+        let (RedemptionEvent::Detected {
+            issuer_request_id,
+            underlying,
+            token,
+            wallet,
+            quantity,
+            tx_hash,
+            block_number,
+            detected_at,
+        }
+        | RedemptionEvent::Reprocessed {
+            issuer_request_id,
+            underlying,
+            token,
+            wallet,
+            quantity,
+            tx_hash,
+            block_number,
+            detected_at,
+            ..
+        }) = event
+        else {
+            return;
+        };
+
+        *self = Self::Detected {
+            metadata: RedemptionMetadata {
+                issuer_request_id,
+                underlying,
+                token,
+                wallet,
+                quantity,
+                detected_tx_hash: tx_hash,
+                block_number,
+                detected_at,
+            },
+        };
+    }
+
+    fn apply_failure_event(&mut self, event: RedemptionEvent) {
+        let (issuer_request_id, reason, failed_at) = match event {
             RedemptionEvent::AlpacaCallFailed {
                 issuer_request_id,
                 error,
-                failed_at,
-            }
-            | RedemptionEvent::RedemptionFailed {
-                issuer_request_id,
-                reason: error,
                 failed_at,
             }
             | RedemptionEvent::BurningFailed {
@@ -1136,90 +1300,108 @@ impl Redemption {
                 error,
                 failed_at,
                 ..
-            } => {
-                *self = Self::Failed {
-                    issuer_request_id,
-                    reason: error,
-                    failed_at,
-                };
-            }
-            RedemptionEvent::AlpacaJournalCompleted {
+            } => (issuer_request_id, error, failed_at),
+            RedemptionEvent::RedemptionFailed {
                 issuer_request_id,
-                alpaca_journal_completed_at,
-            } => {
-                self.apply_alpaca_journal_completed(
-                    &issuer_request_id,
-                    alpaca_journal_completed_at,
-                );
-            }
-            RedemptionEvent::BurnFireblocksSubmitted {
-                issuer_request_id: _,
-                external_tx_id,
-                fireblocks_tx_id,
-                planned_burns,
-                submitted_at: _,
-            } => {
-                let Self::Burning {
-                    metadata,
-                    tokenization_request_id,
-                    alpaca_quantity,
-                    dust_quantity,
-                    called_at,
-                    alpaca_journal_completed_at,
-                    external_tx_id: _,
-                } = self.clone()
-                else {
-                    return;
-                };
+                reason,
+                failed_at,
+            } => (issuer_request_id, reason, failed_at),
+            _ => return,
+        };
 
-                *self = Self::BurnSubmitted {
-                    metadata,
-                    tokenization_request_id,
-                    alpaca_quantity,
-                    dust_quantity,
-                    called_at,
-                    alpaca_journal_completed_at,
-                    external_tx_id,
-                    fireblocks_tx_id,
-                    planned_burns,
-                };
-            }
-            RedemptionEvent::BurnResumed {
+        *self = Self::Failed { issuer_request_id, reason, failed_at };
+    }
+
+    fn apply_burn_submitted_event(&mut self, event: RedemptionEvent) {
+        let RedemptionEvent::BurnFireblocksSubmitted {
+            external_tx_id,
+            fireblocks_tx_id,
+            planned_burns,
+            ..
+        } = event
+        else {
+            return;
+        };
+
+        let (Self::Burning {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            ..
+        }
+        | Self::BurnIntended {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            ..
+        }) = self.clone()
+        else {
+            return;
+        };
+
+        *self = Self::BurnSubmitted {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+            fireblocks_tx_id,
+            planned_burns,
+        };
+    }
+
+    fn apply_burn_resumed_event(&mut self, event: RedemptionEvent) {
+        let RedemptionEvent::BurnResumed {
+            issuer_request_id,
+            underlying,
+            token,
+            wallet,
+            quantity,
+            tx_hash,
+            block_number,
+            detected_at,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+            ..
+        } = event
+        else {
+            return;
+        };
+
+        *self = Self::Burning {
+            metadata: RedemptionMetadata {
                 issuer_request_id,
                 underlying,
                 token,
                 wallet,
                 quantity,
-                tx_hash,
+                detected_tx_hash: tx_hash,
                 block_number,
                 detected_at,
-                tokenization_request_id,
-                alpaca_quantity,
-                dust_quantity,
-                called_at,
-                alpaca_journal_completed_at,
-                external_tx_id,
-                ..
-            } => {
-                *self = Self::Burning {
-                    metadata: RedemptionMetadata {
-                        issuer_request_id,
-                        underlying,
-                        token,
-                        wallet,
-                        quantity,
-                        detected_tx_hash: tx_hash,
-                        block_number,
-                        detected_at,
-                    },
-                    tokenization_request_id,
-                    alpaca_quantity,
-                    dust_quantity,
-                    called_at,
-                    alpaca_journal_completed_at,
-                    external_tx_id,
-                };
-            }
+            },
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+        };
+    }
+
+    fn apply_terminal_event(&mut self, event: RedemptionEvent) {
+        match event {
             RedemptionEvent::TokensBurned(TokensBurnedData {
                 issuer_request_id,
                 tx_hash,
@@ -1263,13 +1445,58 @@ impl Redemption {
                     completed_at,
                 };
             }
+            _ => {}
         }
+    }
+
+    fn apply_burn_intended_event(&mut self, event: RedemptionEvent) {
+        let RedemptionEvent::BurnIntended {
+            sendable_tx, planned_burns, ..
+        } = event
+        else {
+            return;
+        };
+
+        let (Self::Burning {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+        }
+        | Self::BurnIntended {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+            ..
+        }) = self.clone()
+        else {
+            return;
+        };
+
+        *self = Self::BurnIntended {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            planned_burns,
+            external_tx_id,
+            sendable_tx,
+        };
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{TxHash, U256, address, b256, uint};
+    use alloy::primitives::{B256, TxHash, U256, address, b256, uint};
     use chrono::Utc;
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
@@ -1280,14 +1507,14 @@ mod tests {
     use super::{
         BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, Redemption,
         RedemptionCommand, RedemptionError, RedemptionEvent,
-        RedemptionMetadata, TokensBurnedData,
+        RedemptionMetadata, TokensBurnedData, TxId,
         next_burn_retry_external_tx_id_from_history,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::prepare_event_sourced_startup;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{MultiBurnEntry, VaultService};
+    use crate::vault::{MultiBurnEntry, SendableTxWithHash, VaultService};
 
     fn mock_services() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
@@ -1301,7 +1528,7 @@ mod tests {
         let events = [RedemptionEvent::BurnFireblocksSubmitted {
             issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
             external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
-            fireblocks_tx_id: "fb-1".to_string(),
+            fireblocks_tx_id: TxId::Legacy("fb-1".to_string()),
             planned_burns: vec![],
             submitted_at: Utc::now(),
         }];
@@ -1334,7 +1561,7 @@ mod tests {
                     detected_tx_hash,
                 ),
                 external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
-                fireblocks_tx_id: "fb-1".to_string(),
+                fireblocks_tx_id: TxId::Legacy("fb-1".to_string()),
                 planned_burns: vec![],
                 submitted_at: Utc::now(),
             },
@@ -1852,6 +2079,207 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_intend_burn_from_burning_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let receipt_id = uint!(42_U256);
+        let burn_shares = uint!(100_000000000000000000_U256);
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let owner = address!("0x1111111111111111111111111111111111111111");
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(vec![
+                RedemptionEvent::Detected {
+                    issuer_request_id: issuer_request_id.clone(),
+                    underlying: UnderlyingSymbol::new("AAPL"),
+                    token: TokenSymbol::new("tAAPL"),
+                    wallet: address!(
+                        "0x1234567890abcdef1234567890abcdef12345678"
+                    ),
+                    quantity: Quantity::new(Decimal::from(100)),
+                    tx_hash: b256!(
+                        "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    ),
+                    block_number: 12345,
+                    detected_at: Utc::now(),
+                },
+                RedemptionEvent::AlpacaCalled {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: TokenizationRequestId::new(
+                        "alp-intend-456",
+                    ),
+                    alpaca_quantity: Quantity::new(Decimal::from(100)),
+                    dust_quantity: Quantity::new(Decimal::ZERO),
+                    called_at: Utc::now(),
+                },
+                RedemptionEvent::AlpacaJournalCompleted {
+                    issuer_request_id: issuer_request_id.clone(),
+                    alpaca_journal_completed_at: Utc::now(),
+                },
+            ])
+            .when(RedemptionCommand::IntendBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                vault,
+                burns: vec![MultiBurnEntry {
+                    receipt_id,
+                    burn_shares,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
+                dust_shares: U256::ZERO,
+                owner,
+                external_tx_id: None,
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+
+        let RedemptionEvent::BurnIntended {
+            issuer_request_id: event_id,
+            planned_burns,
+            sendable_tx,
+        } = &events[0]
+        else {
+            panic!("Expected BurnIntended event, got {:?}", &events[0]);
+        };
+
+        assert_eq!(event_id, &issuer_request_id);
+        assert_eq!(planned_burns.len(), 1);
+        assert_eq!(planned_burns[0].receipt_id, receipt_id);
+        assert_eq!(planned_burns[0].shares_burned, burn_shares);
+        // Default mock prepare_tx returns None (local signing not configured)
+        assert!(sendable_tx.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_intend_burn_from_wrong_state_fails() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(vec![RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("NVDA"),
+                token: TokenSymbol::new("tNVDA"),
+                wallet: address!(
+                    "0xfedcbafedcbafedcbafedcbafedcbafedcbafedc"
+                ),
+                quantity: Quantity::new(Decimal::from(25)),
+                tx_hash: b256!(
+                    "0x2222222222222222222222222222222222222222222222222222222222222222"
+                ),
+                block_number: 15000,
+                detected_at: Utc::now(),
+            }])
+            .when(RedemptionCommand::IntendBurn {
+                issuer_request_id,
+                vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                burns: vec![MultiBurnEntry {
+                    receipt_id: uint!(1_U256),
+                    burn_shares: uint!(25_000000000000000000_U256),
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                }],
+                dust_shares: U256::ZERO,
+                owner: address!("0x1111111111111111111111111111111111111111"),
+                external_tx_id: None,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::InvalidState {
+                expected:
+                    "Burning or BurnIntended without a signed transaction"
+                        .to_string(),
+                found: "Detected".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_apply_burn_intended_event_transitions_to_burn_intended_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tokenization_request_id =
+            TokenizationRequestId::new("alp-intended-456");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let quantity = Quantity::new(Decimal::from(100));
+        let tx_hash = b256!(
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+        let block_number = 12345;
+        let detected_at = Utc::now();
+        let alpaca_quantity = Quantity::new(Decimal::from(100));
+        let dust_quantity = Quantity::new(Decimal::ZERO);
+        let called_at = Utc::now();
+        let alpaca_journal_completed_at = Utc::now();
+        let receipt_id = uint!(7_U256);
+        let burn_shares = uint!(100_000000000000000000_U256);
+        let planned_burns =
+            vec![BurnRecord { receipt_id, shares_burned: burn_shares }];
+
+        let redemption = replay::<Redemption>(vec![
+            RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: underlying.clone(),
+                token: token.clone(),
+                wallet,
+                quantity: quantity.clone(),
+                tx_hash,
+                block_number,
+                detected_at,
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: tokenization_request_id.clone(),
+                alpaca_quantity: alpaca_quantity.clone(),
+                dust_quantity: dust_quantity.clone(),
+                called_at,
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id: issuer_request_id.clone(),
+                alpaca_journal_completed_at,
+            },
+            RedemptionEvent::BurnIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                sendable_tx: None,
+                planned_burns: planned_burns.clone(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            redemption,
+            Redemption::BurnIntended {
+                metadata: RedemptionMetadata {
+                    issuer_request_id,
+                    underlying,
+                    token,
+                    wallet,
+                    quantity,
+                    detected_tx_hash: tx_hash,
+                    block_number,
+                    detected_at,
+                },
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                planned_burns,
+                external_tx_id: None,
+                sendable_tx: None,
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn test_burn_tokens_from_burning_state() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let receipt_id = uint!(42_U256);
@@ -1885,6 +2313,14 @@ mod tests {
                 RedemptionEvent::AlpacaJournalCompleted {
                     issuer_request_id: issuer_request_id.clone(),
                     alpaca_journal_completed_at: Utc::now(),
+                },
+                RedemptionEvent::BurnIntended {
+                    issuer_request_id: issuer_request_id.clone(),
+                    sendable_tx: None,
+                    planned_burns: vec![BurnRecord {
+                        receipt_id,
+                        shares_burned: burn_shares,
+                    }],
                 },
             ])
             .when(RedemptionCommand::BurnTokens {
@@ -1964,7 +2400,7 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "Burning".to_string(),
+                expected: "BurnIntended".to_string(),
                 found: "Detected".to_string(),
             }
         );
@@ -2050,7 +2486,7 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "Burning or BurnSubmitted".to_string(),
+                expected: "Burning, BurnIntended, or BurnSubmitted".to_string(),
                 found: "Uninitialized".to_string(),
             }
         );
@@ -2099,11 +2535,133 @@ mod tests {
             external_tx_id: BurnExternalTxId::base(&b256!(
                 "0x4444444444444444444444444444444444444444444444444444444444444444"
             )),
-            fireblocks_tx_id: "fb-799".to_string(),
+            fireblocks_tx_id: TxId::Legacy("fb-799".to_string()),
             planned_burns: vec![],
             submitted_at: Utc::now(),
         });
         events
+    }
+
+    fn burn_intended_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+        tx_hash: B256,
+    ) -> Vec<RedemptionEvent> {
+        let mut events = burning_given_events(issuer_request_id);
+        events.push(RedemptionEvent::BurnIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            sendable_tx: Some(SendableTxWithHash {
+                tx: vec![1, 2, 3],
+                hash: tx_hash,
+                nonce: 7,
+                signed_at: Utc::now(),
+                dust_shares: U256::ZERO,
+            }),
+            planned_burns: vec![],
+        });
+        events
+    }
+
+    #[tokio::test]
+    async fn test_confirm_burn_from_burn_intended_with_matching_hash() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, tx_hash))
+            .when(RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                fireblocks_tx_id: TxId::Hash(tx_hash),
+                dust_shares: U256::ZERO,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::TokensBurned(_)]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_confirm_burn_from_burn_intended_rejects_mismatched_hash() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let stored_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let provided_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, stored_hash))
+            .when(RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                fireblocks_tx_id: TxId::Hash(provided_hash),
+                dust_shares: U256::ZERO,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::FireblocksTxIdMismatch {
+                expected: TxId::Hash(stored_hash).to_string(),
+                provided: TxId::Hash(provided_hash).to_string(),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_burn_failure_from_burn_intended_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, tx_hash))
+            .when(RedemptionCommand::RecordBurnFailure {
+                issuer_request_id,
+                error: "receipt reverted".to_string(),
+                fireblocks_tx_id: Some(TxId::Hash(tx_hash)),
+                planned_burns: vec![],
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurningFailed { .. }]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_from_burn_intended_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, burn_tx_hash))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash,
+                block_number: 45_989_009,
+                reason: "persisted burn confirmed on-chain".to_string(),
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted { .. }]
+        ));
     }
 
     #[tokio::test]
@@ -2354,7 +2912,7 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "Burning or BurnSubmitted".to_string(),
+                expected: "Burning, BurnIntended, or BurnSubmitted".to_string(),
                 found: "Uninitialized".to_string(),
             }
         );

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -11,6 +11,7 @@ use super::IssuerRedemptionRequestId;
 use crate::mint::{Quantity, TokenizationRequestId};
 use crate::redemption::{Redemption, RedemptionEvent, TokensBurnedData};
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
+use crate::vault::TxId;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub(crate) enum RedemptionView {
@@ -193,7 +194,7 @@ impl RedemptionView {
         self,
         error: &str,
         failed_at: DateTime<Utc>,
-        fireblocks_tx_id: Option<&String>,
+        fireblocks_tx_id: Option<&TxId>,
         planned_burns: &[super::BurnRecord],
     ) -> Self {
         let Self::Burning {
@@ -232,7 +233,7 @@ impl RedemptionView {
             alpaca_journal_completed_at,
             error: error.to_string(),
             failed_at,
-            fireblocks_tx_id: fireblocks_tx_id.cloned(),
+            fireblocks_tx_id: fireblocks_tx_id.map(ToString::to_string),
             planned_burns: planned_burns.to_vec(),
         }
     }
@@ -387,9 +388,10 @@ impl RedemptionView {
                 block_number: *block_number,
                 completed_at: *recovered_at,
             },
-            // View stays in Burning — BurnFireblocksSubmitted is an internal
+            // View stays in Burning — BurnFireblocksSubmitted and BurnIntended is an internal
             // detail that doesn't change the query-facing state.
-            RedemptionEvent::BurnFireblocksSubmitted { .. } => self,
+            RedemptionEvent::BurnIntended { .. }
+            | RedemptionEvent::BurnFireblocksSubmitted { .. } => self,
             RedemptionEvent::RedemptionClosed {
                 issuer_request_id,
                 reason,
@@ -732,6 +734,7 @@ mod tests {
         TokensBurnedData,
     };
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
+    use crate::vault::TxId;
 
     async fn migrated_pool() -> SqlitePool {
         let pool = SqlitePoolOptions::new()
@@ -2236,7 +2239,9 @@ mod tests {
                 issuer_request_id.clone(),
                 RedemptionEvent::ExistingBurnRecovered {
                     issuer_request_id: issuer_request_id.clone(),
-                    fireblocks_tx_id: "fb-recovered-123".to_string(),
+                    fireblocks_tx_id: TxId::Legacy(
+                        "fb-recovered-123".to_string(),
+                    ),
                     tx_hash,
                     burns: vec![],
                     block_number,

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -7,9 +7,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use super::{
     BurnVerification, FireblocksTxStatus, MintResult, MultiBurnParams,
     MultiBurnResult, MultiBurnResultEntry, ReceiptInformation, SubmittedTx,
-    VaultError, VaultService,
+    TxId, VaultError, VaultService,
 };
 use crate::redemption::BurnExternalTxId;
+use crate::vault::SendableTxWithHash;
 
 #[cfg(test)]
 #[derive(Debug, Clone)]
@@ -35,11 +36,19 @@ enum MockBehavior {
     /// (`VaultError::Reverted`) — exercises the terminal-failure release path.
     #[cfg(test)]
     ConfirmRevert,
+    /// Confirmation timed out without proving whether the submitted
+    /// transaction landed on-chain.
+    #[cfg(test)]
+    ConfirmPending,
     /// `submit_burn` fails with a definitive on-chain revert
     /// (`VaultError::Reverted`), as the synchronous local backend does when a
     /// burn mines but reverts — exercises the submit-failure release path.
     #[cfg(test)]
     SubmitRevert,
+    /// `prepare_tx` returns an error, testing the crash-safe idempotency path
+    /// where signed-tx preparation fails before the tx is stored in the event.
+    #[cfg(test)]
+    PrepareTxFails,
 }
 
 /// Configured outcome for `verify_burn_tx` in tests, exercising the admin
@@ -95,6 +104,10 @@ pub(crate) struct MockVaultService {
     /// verification, exercising the admin force-complete happy path.
     #[cfg(test)]
     verify_burn: Arc<Mutex<MockVerifyBurn>>,
+    /// Signed tx returned by `prepare_tx` when local signing is configured.
+    /// `None` simulates the Fireblocks backend (prepare_tx returns nothing).
+    #[cfg(test)]
+    prepared_tx: Arc<Mutex<Option<SendableTxWithHash>>>,
 }
 
 impl MockVaultService {
@@ -117,6 +130,8 @@ impl MockVaultService {
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            prepared_tx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -134,6 +149,7 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            prepared_tx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -151,6 +167,7 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            prepared_tx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -168,7 +185,15 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            prepared_tx: Arc::new(Mutex::new(None)),
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_confirm_pending() -> Self {
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::ConfirmPending;
+        service
     }
 
     #[cfg(test)]
@@ -185,6 +210,25 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             fireblocks_tx_status: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            prepared_tx: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_prepare_tx_failure() -> Self {
+        Self {
+            behavior: MockBehavior::PrepareTxFails,
+            mint_delay_ms: 0,
+            call_count: Arc::new(AtomicUsize::new(0)),
+            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            pending_mint_result: Arc::new(Mutex::new(None)),
+            pending_burn_result: Arc::new(Mutex::new(None)),
+            last_call: Arc::new(Mutex::new(None)),
+            share_balance: Arc::new(Mutex::new(U256::MAX)),
+            last_multi_burn_params: Arc::new(Mutex::new(None)),
+            fireblocks_tx_status: Arc::new(Mutex::new(None)),
+            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            prepared_tx: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -267,6 +311,17 @@ impl MockVaultService {
         *self.fireblocks_tx_status.lock().unwrap() = Some(status);
         self
     }
+
+    /// Configures `prepare_tx` to return the given [`SendableTxWithHash`],
+    /// simulating the local signing backend pre-signing the burn transaction.
+    #[cfg(test)]
+    pub(crate) fn with_prepared_tx(
+        self,
+        sendable_tx: SendableTxWithHash,
+    ) -> Self {
+        *self.prepared_tx.lock().unwrap() = Some(sendable_tx);
+        self
+    }
 }
 
 const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
@@ -274,6 +329,19 @@ const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
 
 const MOCK_BURN_TX_HASH: alloy::primitives::B256 =
     b256!("0x4545454545454545454545454545454545454545454545454545454545454545");
+
+fn default_multi_burn_result(dust_shares: U256) -> MultiBurnResult {
+    MultiBurnResult {
+        tx_hash: MOCK_BURN_TX_HASH,
+        burns: vec![MultiBurnResultEntry {
+            receipt_id: U256::from(99u64),
+            shares_burned: U256::from(100_000_000_000_000_000_000u128),
+        }],
+        dust_returned: dust_shares,
+        gas_used: 50000,
+        block_number: 5000,
+    }
+}
 
 #[async_trait]
 impl VaultService for MockVaultService {
@@ -384,9 +452,10 @@ impl VaultService for MockVaultService {
                 Ok(result)
             }
             #[cfg(test)]
-            MockBehavior::ConfirmRevert | MockBehavior::SubmitRevert => {
-                Err(VaultError::InvalidReceipt)
-            }
+            MockBehavior::ConfirmRevert
+            | MockBehavior::ConfirmPending
+            | MockBehavior::SubmitRevert
+            | MockBehavior::PrepareTxFails => Err(VaultError::InvalidReceipt),
         }
     }
 
@@ -422,7 +491,8 @@ impl VaultService for MockVaultService {
     async fn submit_burn(
         &self,
         params: MultiBurnParams,
-    ) -> Result<SubmittedTx, VaultError> {
+        prepared_tx: Option<SendableTxWithHash>,
+    ) -> Result<SubmittedTx<BurnExternalTxId, TxId>, VaultError> {
         #[cfg(test)]
         if matches!(self.behavior, MockBehavior::SubmitFailure) {
             return Err(VaultError::InvalidReceipt);
@@ -463,17 +533,19 @@ impl VaultService for MockVaultService {
             });
 
         Ok(SubmittedTx {
-            external_tx_id: params.external_tx_id.map_or_else(
-                || "mock-burn".to_string(),
-                BurnExternalTxId::into_string,
+            external_tx_id: params.external_tx_id.unwrap_or_else(|| {
+                BurnExternalTxId::from_string("mock-burn".to_string())
+            }),
+            fireblocks_tx_id: prepared_tx.map_or_else(
+                || TxId::Legacy("mock-fb-burn".to_string()),
+                |sendable_tx| TxId::Hash(sendable_tx.hash),
             ),
-            fireblocks_tx_id: "mock-fb-burn".to_string(),
         })
     }
 
     async fn confirm_burn(
         &self,
-        _fireblocks_tx_id: &str,
+        _fireblocks_tx_id: &TxId,
         dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError> {
         match &self.behavior {
@@ -483,13 +555,7 @@ impl VaultService for MockVaultService {
                     .lock()
                     .expect("pending_burn_result mutex poisoned")
                     .take()
-                    .unwrap_or_else(|| MultiBurnResult {
-                        tx_hash: MOCK_BURN_TX_HASH,
-                        burns: vec![],
-                        dust_returned: dust_shares,
-                        gas_used: 50000,
-                        block_number: 5000,
-                    });
+                    .unwrap_or_else(|| default_multi_burn_result(dust_shares));
 
                 Ok(result)
             }
@@ -502,35 +568,32 @@ impl VaultService for MockVaultService {
                     .lock()
                     .expect("pending_burn_result mutex poisoned")
                     .take()
-                    .unwrap_or_else(|| MultiBurnResult {
-                        tx_hash: MOCK_BURN_TX_HASH,
-                        burns: vec![],
-                        dust_returned: dust_shares,
-                        gas_used: 50000,
-                        block_number: 5000,
-                    });
+                    .unwrap_or_else(|| default_multi_burn_result(dust_shares));
                 Ok(result)
             }
             #[cfg(test)]
             MockBehavior::ConfirmRevert => {
                 Err(VaultError::Reverted { tx_hash: MOCK_BURN_TX_HASH })
             }
+            #[cfg(test)]
+            MockBehavior::ConfirmPending => {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _fireblocks_tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
             // SubmitRevert fails at submit; if confirm is somehow reached,
             // return the cached result like the other submit-* behaviors.
+            // PrepareTxFails never reaches confirm (fails before submit);
+            // if somehow called, return the cached result.
             #[cfg(test)]
-            MockBehavior::SubmitRevert => {
+            MockBehavior::SubmitRevert | MockBehavior::PrepareTxFails => {
                 let result = self
                     .pending_burn_result
                     .lock()
                     .expect("pending_burn_result mutex poisoned")
                     .take()
-                    .unwrap_or_else(|| MultiBurnResult {
-                        tx_hash: MOCK_BURN_TX_HASH,
-                        burns: vec![],
-                        dust_returned: dust_shares,
-                        gas_used: 50000,
-                        block_number: 5000,
-                    });
+                    .unwrap_or_else(|| default_multi_burn_result(dust_shares));
                 Ok(result)
             }
         }
@@ -564,6 +627,23 @@ impl VaultService for MockVaultService {
             })
         }
     }
+
+    async fn prepare_burn_tx(
+        &self,
+        _params: &MultiBurnParams,
+    ) -> Result<Option<SendableTxWithHash>, VaultError> {
+        #[cfg(test)]
+        {
+            if matches!(self.behavior, MockBehavior::PrepareTxFails) {
+                return Err(VaultError::InvalidReceipt);
+            }
+            let prepared = self.prepared_tx.lock().unwrap().take();
+            if prepared.is_some() {
+                return Ok(prepared);
+            }
+        }
+        Ok(None)
+    }
 }
 
 #[cfg(test)]
@@ -576,7 +656,7 @@ mod tests {
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
-    use crate::redemption::IssuerRedemptionRequestId;
+    use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
     use crate::vault::{
         MultiBurnEntry, MultiBurnParams, ReceiptInformation, VaultError,
         VaultService,
@@ -806,8 +886,11 @@ mod tests {
         let params = test_multi_burn_params();
         let dust = params.dust_shares;
 
-        let submitted = mock.submit_burn(params).await.unwrap();
-        assert_eq!(submitted.external_tx_id, "mock-burn");
+        let submitted = mock.submit_burn(params, None).await.unwrap();
+        assert_eq!(
+            submitted.external_tx_id,
+            BurnExternalTxId::from_string("mock-burn".to_string())
+        );
 
         let result =
             mock.confirm_burn(&submitted.fireblocks_tx_id, dust).await.unwrap();
@@ -822,10 +905,10 @@ mod tests {
 
         assert_eq!(mock.get_multi_burn_call_count(), 0);
 
-        mock.submit_burn(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params(), None).await.unwrap();
         assert_eq!(mock.get_multi_burn_call_count(), 1);
 
-        mock.submit_burn(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params(), None).await.unwrap();
         assert_eq!(mock.get_multi_burn_call_count(), 2);
     }
 
@@ -833,8 +916,8 @@ mod tests {
     async fn test_reset_clears_multi_burn_state() {
         let mock = MockVaultService::new_success();
 
-        mock.submit_burn(test_multi_burn_params()).await.unwrap();
-        mock.submit_burn(test_multi_burn_params()).await.unwrap();
+        mock.submit_burn(test_multi_burn_params(), None).await.unwrap();
+        mock.submit_burn(test_multi_burn_params(), None).await.unwrap();
 
         assert_eq!(mock.get_multi_burn_call_count(), 2);
 
@@ -866,7 +949,7 @@ mod tests {
     #[tokio::test]
     async fn test_submit_burn_failure() {
         let mock = MockVaultService::new_submit_failure();
-        let result = mock.submit_burn(test_multi_burn_params()).await;
+        let result = mock.submit_burn(test_multi_burn_params(), None).await;
 
         assert!(
             matches!(result, Err(VaultError::InvalidReceipt)),

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,5 +1,7 @@
+use alloy::hex::decode;
 use alloy::primitives::{Address, B256, Bytes, U256};
-use alloy::rpc::types::TransactionReceipt;
+use alloy::providers::SendableTxErr;
+use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -94,7 +96,8 @@ pub(crate) trait VaultService: Send + Sync {
     async fn submit_burn(
         &self,
         params: MultiBurnParams,
-    ) -> Result<SubmittedTx, VaultError>;
+        prepared_tx: Option<SendableTxWithHash>,
+    ) -> Result<SubmittedTx<BurnExternalTxId, TxId>, VaultError>;
 
     /// Confirms a previously submitted burn transaction.
     ///
@@ -107,7 +110,7 @@ pub(crate) trait VaultService: Send + Sync {
     ///   from the original request since it cannot be derived from on-chain events)
     async fn confirm_burn(
         &self,
-        fireblocks_tx_id: &str,
+        fireblocks_tx_id: &TxId,
         dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError>;
 
@@ -124,6 +127,33 @@ pub(crate) trait VaultService: Send + Sync {
         owner: Address,
         tx_hash: B256,
     ) -> Result<BurnVerification, VaultError>;
+
+    /// Prepares asigned raw tx that is sendable via eth_sendRawTransaction
+    ///
+    /// Currently returns Option<>, since fireblocks path doesnt use this,
+    /// but options return will be removed once fireblocks is completely removed
+    async fn prepare_burn_tx(
+        &self,
+        _params: &MultiBurnParams,
+    ) -> Result<Option<SendableTxWithHash>, VaultError> {
+        Ok(None)
+    }
+
+    /// Serializes the local wallet's nonce assignment through broadcast.
+    async fn lock_wallet(&self) -> WalletNonceGuard {
+        None
+    }
+}
+
+pub(crate) type WalletNonceGuard = Option<tokio::sync::OwnedMutexGuard<()>>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct SendableTxWithHash {
+    pub(crate) tx: Vec<u8>,
+    pub(crate) hash: B256,
+    pub(crate) nonce: u64,
+    pub(crate) signed_at: DateTime<Utc>,
+    pub(crate) dust_shares: U256,
 }
 
 /// Proof that a burn transaction landed on-chain, returned by
@@ -367,14 +397,68 @@ impl ReceiptInformation {
 /// persisted in an intermediate CQRS event so that `confirm_mint`/`confirm_burn`
 /// can resume polling after a restart.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct SubmittedTx {
+pub(crate) struct SubmittedTx<ExternalTxId = String, TransactionId = String> {
     /// Deterministic ID used for Fireblocks idempotency (`externalTxId`).
     /// Format: `{operation}-{issuer_request_id}`.
-    pub(crate) external_tx_id: String,
+    pub(crate) external_tx_id: ExternalTxId,
     /// Backend-specific transaction identifier.
     /// For Fireblocks: the Fireblocks transaction ID.
     /// For local backends: the on-chain transaction hash.
-    pub(crate) fireblocks_tx_id: String,
+    pub(crate) fireblocks_tx_id: TransactionId,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TxId {
+    Hash(B256),
+    Legacy(String),
+}
+
+impl From<B256> for TxId {
+    fn from(value: B256) -> Self {
+        Self::Hash(value)
+    }
+}
+
+impl std::fmt::Display for TxId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Hash(tx_hash) => write!(f, "{tx_hash:#x}"),
+            Self::Legacy(id) => f.write_str(id),
+        }
+    }
+}
+
+impl std::str::FromStr for TxId {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Ok(bytes) = decode(value)
+            && bytes.len() == B256::len_bytes()
+        {
+            return Ok(Self::Hash(B256::from_slice(&bytes)));
+        }
+
+        Ok(Self::Legacy(value.to_string()))
+    }
+}
+
+impl Serialize for TxId {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for TxId {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(serde::de::Error::custom)
+    }
 }
 
 /// Errors that can occur when encoding receipt information.
@@ -415,6 +499,11 @@ pub(crate) enum VaultError {
     /// Failed to get transaction receipt
     #[error(transparent)]
     PendingTransaction(#[from] alloy::providers::PendingTransactionError),
+    /// The transaction may still be pending after receipt confirmation ended.
+    /// Retrying with a newly signed transaction is unsafe until this exact
+    /// transaction reaches a definitive terminal state.
+    #[error("Transaction confirmation remains pending for {tx_id}: {message}")]
+    ConfirmationPending { tx_id: TxId, message: String },
     /// RPC transport error (e.g., fetching receipt by tx hash during recovery)
     #[error(transparent)]
     Rpc(
@@ -424,6 +513,10 @@ pub(crate) enum VaultError {
     /// Fireblocks vault service error
     #[error(transparent)]
     Fireblocks(#[from] crate::fireblocks::FireblocksVaultError),
+    #[error(transparent)]
+    SendableTxErr(#[from] Box<SendableTxErr<TransactionRequest>>),
+    #[error("Expected a prepared signed tx but got none")]
+    ExpectedPreparedTx,
 }
 
 #[cfg(test)]
@@ -647,5 +740,27 @@ mod tests {
             .unwrap_err();
 
         assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn tx_id_deserializes_hashes_without_changing_wire_format() {
+        let hash = B256::repeat_byte(0x42);
+        let json = serde_json::to_string(&TxId::Hash(hash)).unwrap();
+
+        assert_eq!(json, format!("\"{hash:#x}\""));
+        assert_eq!(
+            serde_json::from_str::<TxId>(&json).unwrap(),
+            TxId::Hash(hash)
+        );
+    }
+
+    #[test]
+    fn tx_id_preserves_legacy_backend_identifiers() {
+        let json = r#""fireblocks-transaction-id""#;
+
+        assert_eq!(
+            serde_json::from_str::<TxId>(json).unwrap(),
+            TxId::Legacy("fireblocks-transaction-id".to_string())
+        );
     }
 }

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -1,20 +1,44 @@
+use alloy::consensus::Transaction;
+use alloy::eips::Encodable2718;
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::fillers::{
+    BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill,
+    NonceFiller, SimpleNonceManager, WalletFiller,
+};
+use alloy::providers::{
+    Identity, PendingTransactionBuilder, Provider, RootProvider,
+};
+use async_trait::async_trait;
+use chrono::Utc;
 use std::collections::HashMap;
 use std::sync::Arc;
-
-use alloy::primitives::{Address, B256, Bytes, U256};
-use alloy::providers::Provider;
-use async_trait::async_trait;
+use std::time::Duration;
 use tokio::sync::Mutex;
 use tracing::debug;
 
 use super::rain_meta::OaSchemaCache;
 use super::{
     BurnVerification, MintResult, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, SubmittedTx, VaultError, VaultService,
-    verify_burn_in_receipt,
+    ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId, VaultError,
+    VaultService, WalletNonceGuard, verify_burn_in_receipt,
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
+
+pub type RealBlockchainServiceProvider = FillProvider<
+    JoinFill<
+        JoinFill<
+            JoinFill<
+                JoinFill<JoinFill<Identity, GasFiller>, BlobGasFiller>,
+                NonceFiller<SimpleNonceManager>,
+            >,
+            ChainIdFiller,
+        >,
+        WalletFiller<EthereumWallet>,
+    >,
+    RootProvider,
+>;
 
 /// Alloy-based blockchain service that interacts with the Rain OffchainAssetReceiptVault
 /// contract.
@@ -22,26 +46,35 @@ use crate::redemption::BurnExternalTxId;
 /// Generic over the provider type to support both production RPC providers and mock providers
 /// for testing.
 ///
-/// Since this backend submits and confirms transactions synchronously (no Fireblocks),
-/// `submit_mint`/`submit_burn` execute the full operation and cache the result for
-/// `confirm_mint`/`confirm_burn` to return. Results are keyed by tx hash to prevent
+/// Since this backend submits and confirms mint transactions synchronously (no Fireblocks),
+/// `submit_mint` executes the full operation and caches the result for
+/// `confirm_mint` to return. Results are keyed by tx hash to prevent
 /// concurrent operations from overwriting each other.
+/// Burns use a different flow: the signed transaction and its precomputed hash
+/// are persisted before the transaction is broadcast.
 ///
-/// **Dev/test only.** This backend does not provide crash-safe idempotency:
-/// if the process crashes after the on-chain transaction completes but before
-/// the CQRS event is persisted, recovery will re-submit a new transaction
-/// (no `externalTxId` deduplication). The Fireblocks backend handles this
-/// via deterministic `externalTxId` and duplicate detection.
-pub(crate) struct RealBlockchainService<P> {
-    provider: P,
+/// **Crash-safe idempotency:**
+/// - **Mints**: handled at the application layer — the receipt backfiller runs at
+///   startup before recovery, scans the chain for `Deposit` events, and populates
+///   the receipt inventory by `issuer_request_id`. `recover_from_existing_receipt`
+///   finds the existing deposit and emits `ExistingMintRecovered`, preventing a
+///   double-mint. `submit_mint` also scans for an existing deposit before sending
+///   as defense-in-depth (covers periodic-backfill gaps during live operation).
+/// - **Burns**: through `prepare_burn_tx()` which prepares a signed transaction
+///   whose hash commits to the complete encoded transaction, including its
+///   assigned nonce. On startup recovery, the exact persisted transaction is
+///   re-broadcast before `confirm_burn` polls for its receipt, so a crash
+///   between persistence, submission, and confirmation cannot cause a
+///   replacement transaction to double-burn.
+pub(crate) struct RealBlockchainService {
+    provider: RealBlockchainServiceProvider,
     oa_schema_cache: Arc<OaSchemaCache>,
     /// Cached results from `submit_mint`, keyed by tx hash string.
     cached_mints: Arc<Mutex<HashMap<String, MintResult>>>,
-    /// Cached results from `submit_burn`, keyed by tx hash string.
-    cached_burns: Arc<Mutex<HashMap<String, MultiBurnResult>>>,
+    wallet_nonce_lock: Arc<Mutex<()>>,
 }
 
-impl<P: Provider + Clone> RealBlockchainService<P> {
+impl RealBlockchainService {
     /// Creates a new blockchain service instance.
     ///
     /// # Arguments
@@ -49,22 +82,20 @@ impl<P: Provider + Clone> RealBlockchainService<P> {
     /// * `provider` - Alloy provider for blockchain communication
     /// * `oa_schema_cache` - Cache for querying OA schema hashes from the subgraph
     pub(crate) fn new(
-        provider: P,
+        provider: RealBlockchainServiceProvider,
         oa_schema_cache: Arc<OaSchemaCache>,
     ) -> Self {
         Self {
             provider,
             oa_schema_cache,
             cached_mints: Arc::new(Mutex::new(HashMap::new())),
-            cached_burns: Arc::new(Mutex::new(HashMap::new())),
+            wallet_nonce_lock: Arc::new(Mutex::new(())),
         }
     }
 }
 
 #[async_trait]
-impl<P: Provider + Clone + Send + Sync + 'static> VaultService
-    for RealBlockchainService<P>
-{
+impl VaultService for RealBlockchainService {
     async fn submit_mint(
         &self,
         vault: Address,
@@ -96,13 +127,13 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
         let transfer_call =
             vault_contract.transfer(user, shares).calldata().clone();
 
-        // Execute both operations atomically via multicall
-        let receipt = vault_contract
+        let wallet_guard = self.wallet_nonce_lock.clone().lock_owned().await;
+        let pending = vault_contract
             .multicall(vec![deposit_call, transfer_call])
             .send()
-            .await?
-            .get_receipt()
             .await?;
+        drop(wallet_guard);
+        let receipt = pending.get_receipt().await?;
 
         let (receipt_id, shares_minted) = receipt
             .inner
@@ -213,150 +244,62 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
     async fn submit_burn(
         &self,
         params: super::MultiBurnParams,
-    ) -> Result<SubmittedTx, VaultError> {
-        let vault_contract =
-            OffchainAssetReceiptVault::new(params.vault, &self.provider);
-
-        let needs_encoding = params.burns.iter().any(|b| {
-            b.receipt_info_bytes.is_none() && b.receipt_info.is_some()
-        });
-
-        let oa_schema = if needs_encoding {
-            self.oa_schema_cache.get(params.vault).await
-        } else {
-            None
-        };
-
-        let redeem_calls: Vec<Bytes> = params
-            .burns
-            .iter()
-            .map(|burn| {
-                let receipt_bytes = if let Some(raw) = &burn.receipt_info_bytes
+        prepared_tx: Option<SendableTxWithHash>,
+    ) -> Result<SubmittedTx<BurnExternalTxId, TxId>, VaultError> {
+        if let Some(sendable_tx) = prepared_tx {
+            if let Err(error) =
+                self.provider.send_raw_transaction(&sendable_tx.tx).await
+            {
+                if self
+                    .provider
+                    .get_transaction_by_hash(sendable_tx.hash)
+                    .await?
+                    .is_none()
                 {
-                    raw.clone()
-                } else {
-                    burn.receipt_info
-                        .as_ref()
-                        .map(|info| info.encode(oa_schema.as_deref()))
-                        .transpose()?
-                        .unwrap_or_default()
-                };
+                    return Err(error.into());
+                }
 
-                Ok(vault_contract
-                    .redeem(
-                        burn.burn_shares,
-                        params.user,
-                        params.owner,
-                        burn.receipt_id,
-                        receipt_bytes,
-                    )
-                    .calldata()
-                    .clone())
-            })
-            .collect::<Result<Vec<_>, VaultError>>()?;
+                debug!(target: "vault", tx_hash = %sendable_tx.hash,
+                    "Burn broadcast errored but the node holds the persisted transaction"
+                );
+            }
 
-        // Build multicall: all redeems, plus optional dust transfer
-        let calls = if params.dust_shares > U256::ZERO {
-            let transfer_call = vault_contract
-                .transfer(params.user, params.dust_shares)
-                .calldata()
-                .clone();
-            redeem_calls
-                .into_iter()
-                .chain(std::iter::once(transfer_call))
-                .collect()
-        } else {
-            redeem_calls
-        };
-
-        let receipt =
-            vault_contract.multicall(calls).send().await?.get_receipt().await?;
-
-        // The local backend executes the burn synchronously, so a mined-but-
-        // reverted transaction is a definitive no-consumption outcome here (the
-        // Fireblocks backend, which submits asynchronously, catches reverts at
-        // confirm time instead). Surface it as a definitive failure so the
-        // reservation is released rather than retained as ambiguous.
-        if !receipt.status() {
-            return Err(VaultError::Reverted {
-                tx_hash: receipt.transaction_hash,
-            });
-        }
-
-        // Parse all Withdraw events from the receipt
-        let burns: Vec<super::MultiBurnResultEntry> = receipt
-            .inner
-            .logs()
-            .iter()
-            .filter_map(|log| {
-                log.log_decode::<OffchainAssetReceiptVault::Withdraw>()
-                    .ok()
-                    .map(|decoded| {
-                        let event_data = decoded.data();
-                        super::MultiBurnResultEntry {
-                            receipt_id: event_data.id,
-                            shares_burned: event_data.shares,
-                        }
-                    })
-            })
-            .collect();
-
-        if burns.is_empty() {
-            return Err(VaultError::EventNotFound {
-                tx_hash: receipt.transaction_hash,
-            });
-        }
-
-        let gas_used = receipt.gas_used;
-        let block_number =
-            receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
-
-        let tx_hash_str = receipt.transaction_hash.to_string();
-        let result = super::MultiBurnResult {
-            tx_hash: receipt.transaction_hash,
-            burns,
-            dust_returned: params.dust_shares,
-            gas_used,
-            block_number,
-        };
-
-        self.cached_burns.lock().await.insert(tx_hash_str.clone(), result);
-
-        Ok(SubmittedTx {
-            external_tx_id: params
-                .external_tx_id
-                .unwrap_or_else(|| {
+            return Ok(SubmittedTx {
+                external_tx_id: params.external_tx_id.unwrap_or_else(|| {
                     BurnExternalTxId::base(&params.detected_tx_hash)
-                })
-                .into_string(),
-            fireblocks_tx_id: tx_hash_str,
-        })
+                }),
+                fireblocks_tx_id: TxId::Hash(sendable_tx.hash),
+            });
+        }
+        Err(VaultError::ExpectedPreparedTx)
     }
 
     async fn confirm_burn(
         &self,
-        fireblocks_tx_id: &str,
+        fireblocks_tx_id: &TxId,
         dust_shares: U256,
     ) -> Result<MultiBurnResult, VaultError> {
-        // Try cache first (normal path when submit and confirm happen in same process)
-        let cached = self.cached_burns.lock().await.remove(fireblocks_tx_id);
-        if let Some(result) = cached {
-            return Ok(result);
-        }
-
-        // Cache empty (process restarted) — re-fetch receipt from chain using tx hash
+        // Fetch receipt from chain using tx hash
         debug!(target: "vault", tx_hash = %fireblocks_tx_id,
-            "Burn cache empty, recovering from chain"
+            "Getting burn tx data from chain"
         );
 
-        let tx_hash: B256 =
-            fireblocks_tx_id.parse().map_err(|_| VaultError::InvalidReceipt)?;
+        let TxId::Hash(tx_hash) = fireblocks_tx_id else {
+            return Err(VaultError::InvalidReceipt);
+        };
+        let tx_hash = *tx_hash;
 
-        let receipt = self
-            .provider
-            .get_transaction_receipt(tx_hash)
-            .await?
-            .ok_or(VaultError::InvalidReceipt)?;
+        let receipt = PendingTransactionBuilder::new(
+            self.provider.root().clone(),
+            tx_hash,
+        )
+        .with_timeout(Some(Duration::from_secs(120)))
+        .get_receipt()
+        .await
+        .map_err(|error| VaultError::ConfirmationPending {
+            tx_id: TxId::Hash(tx_hash),
+            message: error.to_string(),
+        })?;
 
         // A mined-but-reverted burn consumes no receipts, so it is a definitive
         // failure distinct from an anomalous missing-Withdraw parse error.
@@ -410,6 +353,92 @@ impl<P: Provider + Clone + Send + Sync + 'static> VaultService
 
         verify_burn_in_receipt(&receipt, vault, owner, tx_hash)
     }
+
+    /// Prepares a signed tx that can be sent on-chain via eth_sendRawTransaction
+    async fn prepare_burn_tx(
+        &self,
+        params: &super::MultiBurnParams,
+    ) -> Result<Option<SendableTxWithHash>, VaultError> {
+        let vault_contract =
+            OffchainAssetReceiptVault::new(params.vault, &self.provider);
+
+        let needs_encoding = params.burns.iter().any(|burn| {
+            burn.receipt_info_bytes.is_none() && burn.receipt_info.is_some()
+        });
+
+        let oa_schema = if needs_encoding {
+            self.oa_schema_cache.get(params.vault).await
+        } else {
+            None
+        };
+
+        let redeem_calls: Vec<Bytes> = params
+            .burns
+            .iter()
+            .map(|burn| {
+                let receipt_bytes = if let Some(raw) = &burn.receipt_info_bytes
+                {
+                    raw.clone()
+                } else {
+                    burn.receipt_info
+                        .as_ref()
+                        .map(|info| info.encode(oa_schema.as_deref()))
+                        .transpose()?
+                        .unwrap_or_default()
+                };
+
+                Ok(vault_contract
+                    .redeem(
+                        burn.burn_shares,
+                        params.user,
+                        params.owner,
+                        burn.receipt_id,
+                        receipt_bytes,
+                    )
+                    .calldata()
+                    .clone())
+            })
+            .collect::<Result<Vec<_>, VaultError>>()?;
+
+        // Build multicall: all redeems, plus optional dust transfer
+        let calls = if params.dust_shares > U256::ZERO {
+            let transfer_call = vault_contract
+                .transfer(params.user, params.dust_shares)
+                .calldata()
+                .clone();
+            redeem_calls
+                .into_iter()
+                .chain(std::iter::once(transfer_call))
+                .collect()
+        } else {
+            redeem_calls
+        };
+
+        let tx = vault_contract.multicall(calls).into_transaction_request();
+
+        // Fill nonce, gas price, gas limit, chain_id from the provider
+        let envelop = self
+            .provider
+            .fill(tx)
+            .await?
+            .try_into_envelope()
+            .map_err(Box::new)?;
+        let nonce = envelop.nonce();
+        let hash = *envelop.tx_hash();
+        let tx = envelop.encoded_2718();
+
+        Ok(Some(SendableTxWithHash {
+            tx,
+            hash,
+            nonce,
+            signed_at: Utc::now(),
+            dust_shares: params.dust_shares,
+        }))
+    }
+
+    async fn lock_wallet(&self) -> WalletNonceGuard {
+        Some(self.wallet_nonce_lock.clone().lock_owned().await)
+    }
 }
 
 #[cfg(test)]
@@ -423,6 +452,7 @@ mod tests {
         fixed_bytes,
     };
     use alloy::providers::ProviderBuilder;
+    use alloy::providers::fillers::{BlobGasFiller, ChainIdFiller};
     use alloy::providers::mock::Asserter;
     use alloy::rpc::types::{Block, FeeHistory, TransactionReceipt};
     use alloy::signers::local::PrivateKeySigner;
@@ -438,8 +468,8 @@ mod tests {
     use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
-        MultiBurnEntry, MultiBurnParams, ReceiptInformation, VaultError,
-        VaultService,
+        MultiBurnEntry, MultiBurnParams, ReceiptInformation,
+        SendableTxWithHash, VaultError, VaultService,
     };
 
     const TEST_OA_SCHEMA: &str =
@@ -486,22 +516,35 @@ mod tests {
         tx_hash: alloy::primitives::B256,
         receipt: &TransactionReceipt,
     ) {
-        let block: Block<alloy::rpc::types::Transaction> = Block::default();
-        asserter.push_success(&0u64); // eth_getTransactionCount
-        asserter.push_success(&test_fee_history()); // eth_feeHistory
-        asserter.push_success(&block); // eth_getBlockByNumber
-        asserter.push_success(&1u64); // eth_chainId
-        asserter.push_success(&100_000_u64); // eth_estimateGas
-        asserter.push_success(&1_000_000_000_u64); // eth_maxPriorityFeePerGas
-        asserter.push_success(&0u64); // eth_getTransactionCount again
         asserter.push_success(&tx_hash); // eth_sendRawTransaction
         asserter.push_success(receipt); // eth_getTransactionReceipt
         asserter.push_success(receipt); // eth_getTransactionReceipt (polling)
     }
 
+    /// Sets up mock responses for `provider.fill(tx)`:
+    /// ChainIdFiller → eth_chainId,
+    /// GasFiller → eth_feeHistory / eth_getBlockByNumber / eth_estimateGas / eth_maxPriorityFeePerGas,
+    /// NonceFiller → eth_getTransactionCount,
+    /// WalletFiller → eth_chainId (signing uses chain_id for replay protection).
+    fn setup_asserter_for_fill(asserter: &Asserter, nonce: u64) {
+        let block: Block<alloy::rpc::types::Transaction> = Block::default();
+        asserter.push_success(&1u64); // eth_chainId (ChainIdFiller)
+        asserter.push_success(&test_fee_history()); // eth_feeHistory (GasFiller)
+        asserter.push_success(&block); // eth_getBlockByNumber (GasFiller)
+        asserter.push_success(&100_000_u64); // eth_estimateGas (GasFiller)
+        asserter.push_success(&1_000_000_000_u64); // eth_maxPriorityFeePerGas (GasFiller)
+        asserter.push_success(&nonce); // eth_getTransactionCount (NonceFiller)
+        asserter.push_success(&1u64); // eth_chainId (WalletFiller, for EIP-155 signing)
+    }
+
     fn create_service_with_asserter(asserter: Asserter) -> impl VaultService {
         let signer = PrivateKeySigner::random();
         let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .filler(BlobGasFiller)
+            .with_simple_nonce_management()
+            .filler(ChainIdFiller::default())
             .wallet(EthereumWallet::from(signer))
             .connect_mocked_client(asserter);
         RealBlockchainService::new(
@@ -605,6 +648,11 @@ mod tests {
 
         let signer = PrivateKeySigner::random();
         let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .filler(BlobGasFiller)
+            .with_simple_nonce_management()
+            .filler(ChainIdFiller::default())
             .wallet(EthereumWallet::from(signer))
             .connect_mocked_client(asserter);
         let service = RealBlockchainService::new(
@@ -702,6 +750,11 @@ mod tests {
 
         let signer = PrivateKeySigner::random();
         let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .filler(BlobGasFiller)
+            .with_simple_nonce_management()
+            .filler(ChainIdFiller::default())
             .wallet(EthereumWallet::from(signer))
             .connect_mocked_client(asserter);
         let service = RealBlockchainService::new(
@@ -856,25 +909,35 @@ mod tests {
         let detected_tx_hash = b256!(
             "0xabababababababababababababababababababababababababababababababab"
         );
+        let prepared_tx = SendableTxWithHash {
+            tx: vec![],
+            hash: tx_hash,
+            nonce: 0,
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        };
         let submitted = service
-            .submit_burn(MultiBurnParams {
-                vault: vault_address,
-                burns: burns
-                    .iter()
-                    .map(|(receipt_id, burn_shares)| MultiBurnEntry {
-                        receipt_id: *receipt_id,
-                        burn_shares: *burn_shares,
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    })
-                    .collect(),
-                dust_shares: U256::ZERO,
-                owner,
-                user,
-                issuer_request_id: test_issuer_redemption_id(),
-                detected_tx_hash,
-                external_tx_id: None,
-            })
+            .submit_burn(
+                MultiBurnParams {
+                    vault: vault_address,
+                    burns: burns
+                        .iter()
+                        .map(|(receipt_id, burn_shares)| MultiBurnEntry {
+                            receipt_id: *receipt_id,
+                            burn_shares: *burn_shares,
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        })
+                        .collect(),
+                    dust_shares: U256::ZERO,
+                    owner,
+                    user,
+                    issuer_request_id: test_issuer_redemption_id(),
+                    detected_tx_hash,
+                    external_tx_id: None,
+                },
+                Some(prepared_tx),
+            )
             .await;
 
         assert!(submitted.is_ok(), "Expected Ok but got: {submitted:?}");
@@ -924,33 +987,46 @@ mod tests {
         );
         let override_id = "burn-0xabab-retry-2".to_string();
 
+        let prepared_tx = SendableTxWithHash {
+            tx: vec![],
+            hash: tx_hash,
+            nonce: 0,
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        };
         let submitted = service
-            .submit_burn(MultiBurnParams {
-                vault: vault_address,
-                burns: burns
-                    .iter()
-                    .map(|(receipt_id, burn_shares)| MultiBurnEntry {
-                        receipt_id: *receipt_id,
-                        burn_shares: *burn_shares,
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    })
-                    .collect(),
-                dust_shares: U256::ZERO,
-                owner,
-                user,
-                issuer_request_id: test_issuer_redemption_id(),
-                detected_tx_hash,
-                external_tx_id: Some(BurnExternalTxId::from_string(
-                    override_id.clone(),
-                )),
-            })
+            .submit_burn(
+                MultiBurnParams {
+                    vault: vault_address,
+                    burns: burns
+                        .iter()
+                        .map(|(receipt_id, burn_shares)| MultiBurnEntry {
+                            receipt_id: *receipt_id,
+                            burn_shares: *burn_shares,
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        })
+                        .collect(),
+                    dust_shares: U256::ZERO,
+                    owner,
+                    user,
+                    issuer_request_id: test_issuer_redemption_id(),
+                    detected_tx_hash,
+                    external_tx_id: Some(BurnExternalTxId::from_string(
+                        override_id.clone(),
+                    )),
+                },
+                Some(prepared_tx),
+            )
             .await
             .expect("submit_burn should succeed");
 
         // A caller-provided externalTxId (used for replacement burn retries)
         // must propagate verbatim rather than be replaced by the local default.
-        assert_eq!(submitted.external_tx_id, override_id);
+        assert_eq!(
+            submitted.external_tx_id,
+            BurnExternalTxId::from_string(override_id)
+        );
     }
 
     #[tokio::test]
@@ -970,7 +1046,14 @@ mod tests {
 
         let service = create_service_with_asserter(asserter);
 
-        let result = service
+        let prepared_tx = SendableTxWithHash {
+            tx: vec![],
+            hash: tx_hash,
+            nonce: 0,
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        };
+        let submit_result = service
             .submit_burn(MultiBurnParams {
                 vault: vault_address,
                 burns: vec![MultiBurnEntry {
@@ -987,7 +1070,11 @@ mod tests {
                     "0xabababababababababababababababababababababababababababababababab"
                 ),
                 external_tx_id: None,
-            })
+            }, Some(prepared_tx))
+            .await
+            .expect("Expected a successfull tx submit, but failed1");
+        let result = service
+            .confirm_burn(&submit_result.fireblocks_tx_id, U256::ZERO)
             .await;
 
         assert!(result.is_err(), "Expected Err but got Ok: {result:?}");
@@ -995,5 +1082,87 @@ mod tests {
             result.unwrap_err(),
             VaultError::EventNotFound { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn prepare_tx_returns_signed_tx_with_correct_nonce_and_dust_shares() {
+        let vault_address = test_vault_address();
+        let owner = test_receiver();
+        let user = address!("0x3333333333333333333333333333333333333333");
+        let detected_tx_hash = b256!(
+            "0xabababababababababababababababababababababababababababababababab"
+        );
+        let expected_nonce = 7u64;
+        let dust_shares = U256::from(500);
+
+        let asserter = Asserter::new();
+        setup_asserter_for_fill(&asserter, expected_nonce);
+
+        let service = create_service_with_asserter(asserter);
+
+        let params = MultiBurnParams {
+            vault: vault_address,
+            burns: vec![MultiBurnEntry {
+                receipt_id: U256::from(1),
+                burn_shares: U256::from(100),
+                receipt_info: None,
+                receipt_info_bytes: Some(Bytes::from(b"test".to_vec())),
+            }],
+            dust_shares,
+            owner,
+            user,
+            issuer_request_id: test_issuer_redemption_id(),
+            detected_tx_hash,
+            external_tx_id: None,
+        };
+
+        let result = service.prepare_burn_tx(&params).await.unwrap();
+
+        let sendable = result.expect("expected Some(SendableTxWithHash)");
+        assert_eq!(sendable.nonce, expected_nonce, "nonce must match mock");
+        assert_eq!(
+            sendable.dust_shares, dust_shares,
+            "dust_shares must be propagated from params"
+        );
+        assert!(!sendable.tx.is_empty(), "encoded tx must be non-empty");
+        assert_ne!(sendable.hash, B256::ZERO, "tx hash must be non-zero");
+        assert!(sendable.signed_at.timestamp() > 0, "signed_at must be set");
+    }
+
+    #[tokio::test]
+    async fn prepare_tx_zero_dust_shares_when_params_has_no_dust() {
+        let vault_address = test_vault_address();
+        let owner = test_receiver();
+        let user = address!("0x3333333333333333333333333333333333333333");
+        let detected_tx_hash = b256!(
+            "0xabababababababababababababababababababababababababababababababab"
+        );
+
+        let asserter = Asserter::new();
+        setup_asserter_for_fill(&asserter, 0);
+
+        let service = create_service_with_asserter(asserter);
+
+        let params = MultiBurnParams {
+            vault: vault_address,
+            burns: vec![MultiBurnEntry {
+                receipt_id: U256::from(42),
+                burn_shares: U256::from(200),
+                receipt_info: None,
+                receipt_info_bytes: Some(Bytes::from(b"receipt".to_vec())),
+            }],
+            dust_shares: U256::ZERO,
+            owner,
+            user,
+            issuer_request_id: test_issuer_redemption_id(),
+            detected_tx_hash,
+            external_tx_id: None,
+        };
+
+        let result = service.prepare_burn_tx(&params).await.unwrap();
+
+        let sendable = result.expect("expected Some(SendableTxWithHash)");
+        assert_eq!(sendable.dust_shares, U256::ZERO);
+        assert!(!sendable.tx.is_empty());
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -9,6 +9,11 @@ pub mod alpaca_mocks;
 
 use alloy::hex;
 use alloy::primitives::{Address, U256};
+use alloy::providers::fillers::{
+    BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller,
+    SimpleNonceManager,
+};
+use alloy::providers::{Identity, ProviderBuilder};
 use chrono::Utc;
 use httpmock::Mock;
 use httpmock::prelude::*;
@@ -30,6 +35,17 @@ use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
     LogLevel, SignerConfig,
 };
+
+pub type TestProviderBuilder = ProviderBuilder<
+    Identity,
+    JoinFill<
+        JoinFill<
+            JoinFill<JoinFill<Identity, GasFiller>, BlobGasFiller>,
+            NonceFiller<SimpleNonceManager>,
+        >,
+        ChainIdFiller,
+    >,
+>;
 
 pub async fn wait_for_shares<T>(
     vault: &OffchainAssetReceiptVaultInstance<T>,
@@ -777,4 +793,13 @@ pub async fn seed_pre_lifecycle_view_row(
         .await?;
 
     Ok(())
+}
+
+pub fn create_provider() -> TestProviderBuilder {
+    ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .filler(BlobGasFiller)
+        .with_simple_nonce_management()
+        .filler(ChainIdFiller::default())
 }

--- a/tests/mint.rs
+++ b/tests/mint.rs
@@ -5,6 +5,7 @@ mod harness;
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, U256, b256};
 use alloy::providers::ProviderBuilder;
+use alloy::providers::fillers::{BlobGasFiller, ChainIdFiller};
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use rocket::local::asynchronous::Client;
@@ -76,6 +77,11 @@ async fn perform_mint_flow(
     let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
     let user_wallet_instance = EthereumWallet::from(user_signer);
     let user_provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .filler(BlobGasFiller)
+        .with_simple_nonce_management()
+        .filler(ChainIdFiller::default())
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/multi_vault_redemption.rs
+++ b/tests/multi_vault_redemption.rs
@@ -4,13 +4,14 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+
+use crate::harness::create_provider;
 
 /// Tests that redemptions are detected and completed on ALL vaults, not just one.
 ///
@@ -107,7 +108,7 @@ async fn test_multi_vault_redemption_detects_on_all_vaults()
 
     // Setup user provider for transfers
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -259,7 +260,7 @@ async fn test_transfer_backfill_detects_transfers_while_down()
     .await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -4,7 +4,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use rocket::local::asynchronous::Client;
@@ -21,6 +20,8 @@ use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
     LogLevel, SignerConfig, initialize_rocket,
 };
+
+use crate::harness::create_provider;
 
 async fn wait_for_receipt_depleted(
     db_url: &str,
@@ -448,7 +449,7 @@ async fn test_startup_reconciliation_detects_stale_receipts()
     let client = Client::tracked(rocket).await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -557,7 +558,7 @@ async fn test_external_burn_detected_by_withdraw_monitor()
     tokio::time::sleep(Duration::from_secs(1)).await;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/receipt_transfer.rs
+++ b/tests/receipt_transfer.rs
@@ -4,7 +4,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, Bytes, U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use rocket::local::asynchronous::Client;
@@ -15,6 +14,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::bindings::Receipt::ReceiptInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+
+use crate::harness::create_provider;
 
 /// Helper: set up a second wallet from Anvil's test accounts (account index 1).
 fn second_wallet() -> (PrivateKeySigner, Address) {
@@ -82,7 +83,7 @@ async fn test_inbound_receipt_transfer_discovered_by_monitor()
 
     // We need to mint as other_wallet, so use their provider
     let other_evm_wallet = EthereumWallet::from(other_signer.clone());
-    let other_provider = ProviderBuilder::new()
+    let other_provider = create_provider()
         .wallet(other_evm_wallet.clone())
         .connect(&evm.endpoint)
         .await?;
@@ -257,10 +258,8 @@ async fn test_outbound_receipt_transfer_reconciles_balance()
     // Bot transfers the receipt out to other_wallet
     let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
     let bot_evm_wallet = EthereumWallet::from(bot_signer);
-    let bot_provider = ProviderBuilder::new()
-        .wallet(bot_evm_wallet)
-        .connect(&evm.endpoint)
-        .await?;
+    let bot_provider =
+        create_provider().wallet(bot_evm_wallet).connect(&evm.endpoint).await?;
 
     let receipt_contract_addr = {
         let vault = OffchainAssetReceiptVaultInstance::new(
@@ -386,7 +385,7 @@ async fn test_mint_transfer_not_double_counted()
     );
 
     // Verify on-chain: bot holds the minted receipt with expected balance
-    let provider = ProviderBuilder::new().connect(&evm.endpoint).await?;
+    let provider = create_provider().connect(&evm.endpoint).await?;
     let vault_contract =
         OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
     let receipt_contract_addr =
@@ -425,7 +424,7 @@ async fn test_inbound_transfer_discovered_by_backfill()
 
     // Mint as other_wallet
     let other_evm_wallet = EthereumWallet::from(other_signer.clone());
-    let other_provider = ProviderBuilder::new()
+    let other_provider = create_provider()
         .wallet(other_evm_wallet)
         .connect(&evm.endpoint)
         .await?;
@@ -622,10 +621,8 @@ async fn test_unrelated_transfer_ignored()
 
     // Mint receipt to wallet_a
     let wallet_a_evm = EthereumWallet::from(wallet_a_signer.clone());
-    let wallet_a_provider = ProviderBuilder::new()
-        .wallet(wallet_a_evm)
-        .connect(&evm.endpoint)
-        .await?;
+    let wallet_a_provider =
+        create_provider().wallet(wallet_a_evm).connect(&evm.endpoint).await?;
 
     let vault = OffchainAssetReceiptVaultInstance::new(
         evm.vault_address,
@@ -748,7 +745,7 @@ async fn test_inbound_transfer_with_zero_balance_skipped()
 
     // Step 1: Other wallet mints receipt
     let other_evm_wallet = EthereumWallet::from(other_signer.clone());
-    let other_provider = ProviderBuilder::new()
+    let other_provider = create_provider()
         .wallet(other_evm_wallet)
         .connect(&evm.endpoint)
         .await?;
@@ -810,7 +807,7 @@ async fn test_inbound_transfer_with_zero_balance_skipped()
     evm.withdraw_directly(receipt_id, shares, bot_wallet).await?;
 
     // Verify on-chain: bot has 0 receipt balance
-    let bot_provider = ProviderBuilder::new()
+    let bot_provider = create_provider()
         .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
             &evm.private_key,
         )?))

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -4,7 +4,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, Bytes, U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use serde_json::json;
@@ -17,6 +16,8 @@ use harness::alpaca_mocks::{setup_mint_mocks, setup_redemption_mocks};
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+
+use crate::harness::create_provider;
 
 static RECOVERY_TEST_LOCK: Mutex<()> = Mutex::const_new(());
 
@@ -223,7 +224,7 @@ async fn test_mint_recovery_after_view_deletion()
 
     // Wait for mint to complete
     let user_wallet_instance = EthereumWallet::from(user_signer.clone());
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -386,7 +387,7 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
     .await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer.clone());
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -551,7 +552,7 @@ async fn test_mint_recovery_from_minting_state_when_no_receipt()
 
     // Wait for recovery and mint to complete
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -660,7 +661,7 @@ async fn test_mint_recovery_prevents_double_mint()
 
     // Get initial share balance of bot_wallet (which received shares from the manual mint)
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -939,7 +940,7 @@ async fn test_mint_recovery_from_minting_failed_state()
 
     // Wait for recovery and mint to complete
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -1197,7 +1198,7 @@ async fn test_detected_redemption_auto_failed_when_no_account()
 
     // Assert: service still works — can process a new mint
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/redemption.rs
+++ b/tests/redemption.rs
@@ -4,7 +4,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, TxHash, U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::Mock;
 use httpmock::prelude::*;
@@ -18,6 +17,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::mint::MintResponse;
 use st0x_issuance::test_utils::{LocalEvm, test_alpaca_legacy_auth};
+
+use crate::harness::create_provider;
 
 async fn perform_mint_flow(
     client: &Client,
@@ -77,7 +78,7 @@ async fn perform_mint_flow(
     );
     let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -308,7 +309,7 @@ async fn test_burn_tracking_computes_available_balance_correctly()
 
     // Setup user provider
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -466,7 +467,7 @@ async fn test_redemption_recovery_after_restart()
 
     // Setup user provider for transfer
     let user_wallet_instance = EthereumWallet::from(user_signer.clone());
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/redemption_dust.rs
+++ b/tests/redemption_dust.rs
@@ -16,7 +16,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::Mock;
 use httpmock::prelude::*;
@@ -29,6 +28,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::mint::MintResponse;
 use st0x_issuance::test_utils::{LocalEvm, test_alpaca_legacy_auth};
+
+use crate::harness::create_provider;
 
 /// Quantity with >9 decimal precision (18 decimals on-chain).
 /// Represents: 0.450574852280275235 shares
@@ -134,7 +135,7 @@ async fn perform_mint_flow(
     );
     let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -318,7 +319,7 @@ async fn test_redemption_returns_dust_to_user()
     mint_callback_mock.assert();
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;
@@ -417,7 +418,7 @@ async fn test_redemption_no_dust_when_9_decimals()
     mint_callback_mock.assert();
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -4,13 +4,15 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, U256, b256};
-use alloy::providers::{Provider, ProviderBuilder};
+use alloy::providers::Provider;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+
+use crate::harness::create_provider;
 
 const UNDERLYING: &str = "TSLA";
 const TOKEN: &str = "tTSLA";
@@ -90,7 +92,7 @@ async fn test_three_round_trips() -> Result<(), Box<dyn std::error::Error>> {
     let client_id = link_body.client_id.to_string();
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -4,7 +4,6 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{U256, b256};
-use alloy::providers::ProviderBuilder;
 use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 use serde_json::json;
@@ -17,6 +16,8 @@ use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
     LogLevel, SignerConfig, initialize_rocket,
 };
+
+use crate::harness::create_provider;
 
 #[tokio::test]
 async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
@@ -94,7 +95,7 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
     .await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
-    let user_provider = ProviderBuilder::new()
+    let user_provider = create_provider()
         .wallet(user_wallet_instance)
         .connect(&evm.endpoint)
         .await?;


### PR DESCRIPTION
## Motivation

- The alloy (local signer) burn path had no crash safety. `submit_burn` signed, sent, and waited for the receipt in one go, so if the process died after the tx landed on-chain but before `BurnFireblocksSubmitted` was persisted, startup recovery would sign and send a brand new burn: double-burn.
- Fireblocks got this for free through deterministic `externalTxId` dedup. Alloy had nothing equivalent, and alloy is the path we're keeping now that Fireblocks is on its way out.
- Same bug class as [RAI-374](https://linear.app/makeitrain/issue/RAI-374/idempotent-mintburn-recovery-split-submitconfirm-events-phase-2), which fixed the Fireblocks side.

## Solution

- New `IntendBurn` command / `BurnIntended` event. `prepare_burn_tx()` builds and signs the multicall (redeems + optional dust transfer) and we persist the raw signed bytes, tx hash, nonce, and dust **before** any broadcast.
- **State machine change:** `BurnTokens` is now only valid from `BurnIntended`, not from `Burning`. Every burn goes through `IntendBurn` first.
- Local `submit_burn` now only broadcasts the persisted bytes via `eth_sendRawTransaction` and errors with `ExpectedPreparedTx` if nothing was prepared. A prepared tx is immutable: we never sign a replacement while its outcome is unknown. Fireblocks `submit_burn` ignores the prepared tx and behaves as before.
- Recovery from `BurnIntended { sendable_tx: Some(_) }` re-broadcasts the exact same bytes, then confirms against the stored hash. If the broadcast errors but `eth_getTransactionByHash` shows the node already has it, we treat it as sent.
- An ambiguous broadcast failure keeps the redemption in `BurnIntended` with its receipt reservation held, instead of releasing and re-signing. Operator resolves.
- `BurnIntended { sendable_tx: None }` is any backend whose `prepare_burn_tx` returns `None` (today, Fireblocks, via the trait default). It falls through to the existing submit + confirm flow.
- `RealBlockchainService` is no longer generic over `P`, it's pinned to one concrete filler stack so the tx we sign is the tx we hashed. Same stack now in `config.rs`, `tests/harness::create_provider()`, and the service unit tests, which is most of the test churn.
- New wallet nonce lock (`VaultService::lock_wallet()` → `WalletNonceGuard`) serializing nonce assignment through broadcast, plus a stale-state check after acquiring it so a queued burn doesn't re-execute. `submit_mint` takes the same lock around its send, so mints and burns can't race on the nonce.
- `confirm_burn` drops the in-process burn cache and always reads the receipt from chain via `PendingTransactionBuilder` (120s timeout). `MultiBurnParams` gains `detected_block_number`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

## Anything else

New unit tests in `burn_manager.rs` cover recovery re-broadcasting the persisted tx, an ambiguous broadcast keeping `BurnIntended` + its reservation, `sendable_tx: None` recovery running the full flow, and `prepare_tx` failure releasing the reservation and recording `BurningFailed`. `redemption/mod.rs` covers `IntendBurn` from `Burning`, from a wrong state, and the `BurnIntended` apply. Mock gets `with_prepared_tx` and `new_prepare_tx_failure`. No new e2e: the crash window itself isn't exercised end to end, the existing e2e suites just moved to `create_provider()` for the new filler stack.

`BurnIntended` is a new permanent event and there's no migration. Redemptions already sitting in `Burning`/`BurnSubmitted` still recover through their old paths.

I added two `#[allow(clippy::too_many_lines)]` (`execute_burn_and_record_result` and `Redemption::apply_event`). Can split those functions instead if you'd rather not carry the allows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new burn “intention” phase that records the signed burn details before any broadcast.
  * Added support for deterministic, typed transaction identifiers to improve tracking across events and reporting.
* **Bug Fixes**
  * Improved burn execution/recovery to avoid duplicate processing and to re-use persisted signed burn bytes when outcomes are unclear.
  * Standardized transaction-id handling in admin stuck history and redemption history summaries.
* **Documentation**
  * Updated the redemption lifecycle and admin terminalization spec to include the new burn-intention step.
* **Tests**
  * Updated and extended coverage for the new burn-intention state and typed transaction identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->