### PR TITLE
feat: route mint vault calls through ChainRegistry

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -112,11 +112,8 @@ impl std::fmt::Display for TokenSymbol {
 
 /// Blockchain network a tokenized asset lives on.
 ///
-/// A closed set -- only `base` is supported today. Serialized as the lowercase
-/// wire string (`"base"`) it has always used, so the JSON contract and the
-/// values already persisted in the event store are unchanged. Modeling it as an
-/// enum (rather than an opaque `String`) means an unsupported network is now a
-/// deserialization error instead of a value that silently flows through.
+/// Supported ITN networks. Serialized as the lowercase wire string (`"base"`,
+/// `"ethereum"`, ...) used in JSON and the event store.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, TS,
 )]
@@ -124,6 +121,8 @@ impl std::fmt::Display for TokenSymbol {
 #[serde(rename_all = "snake_case")]
 pub enum Network {
     Base,
+    /// Ethereum L1.
+    Ethereum,
 }
 
 impl Network {
@@ -132,6 +131,7 @@ impl Network {
     pub const fn as_str(&self) -> &'static str {
         match self {
             Self::Base => "base",
+            Self::Ethereum => "ethereum",
         }
     }
 }
@@ -154,6 +154,7 @@ impl FromStr for Network {
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "base" => Ok(Self::Base),
+            "ethereum" => Ok(Self::Ethereum),
             other => {
                 Err(NetworkParseError::Unsupported { value: other.to_string() })
             }
@@ -436,6 +437,10 @@ mod tests {
             json!("tSGOV")
         );
         assert_eq!(serde_json::to_value(Network::Base).unwrap(), json!("base"));
+        assert_eq!(
+            serde_json::to_value(Network::Ethereum).unwrap(),
+            json!("ethereum")
+        );
     }
 
     #[test]
@@ -452,6 +457,10 @@ mod tests {
             serde_json::from_value::<Network>(json!("base")).unwrap(),
             Network::Base
         );
+        assert_eq!(
+            serde_json::from_value::<Network>(json!("ethereum")).unwrap(),
+            Network::Ethereum
+        );
     }
 
     // `Network` is a closed enum, so an unsupported or wrong-cased network must
@@ -460,7 +469,7 @@ mod tests {
     #[test]
     fn network_rejects_unknown_and_non_snake_case_variants() {
         for invalid in
-            [json!("ethereum"), json!("Base"), json!("BASE"), json!("")]
+            [json!("arbitrum"), json!("Base"), json!("BASE"), json!("")]
         {
             assert!(
                 serde_json::from_value::<Network>(invalid.clone()).is_err(),
@@ -482,12 +491,13 @@ mod tests {
         assert_eq!(UnderlyingSymbol::new("SGOV").unwrap().to_string(), "SGOV");
         assert_eq!(TokenSymbol::new("tSGOV").to_string(), "tSGOV");
         assert_eq!(Network::Base.to_string(), "base");
+        assert_eq!(Network::Ethereum.to_string(), "ethereum");
     }
 
     #[test]
     fn network_from_str_parses_wire_values() {
         assert_eq!("base".parse::<Network>().unwrap(), Network::Base);
-        assert!("ethereum".parse::<Network>().is_err());
+        assert_eq!("ethereum".parse::<Network>().unwrap(), Network::Ethereum);
     }
 
     #[test]
@@ -622,6 +632,13 @@ mod tests {
         assert_eq!(key.to_string(), "SGOV:base");
         assert_eq!(serde_json::to_value(&key).unwrap(), json!("SGOV:base"));
         assert_eq!("SGOV:base".parse::<AssetKey>().unwrap(), key);
+
+        let eth_key = AssetKey::new(
+            valid_underlying_symbol("TSLA"),
+            Network::Ethereum,
+        );
+        assert_eq!(eth_key.to_string(), "TSLA:ethereum");
+        assert_eq!("TSLA:ethereum".parse::<AssetKey>().unwrap(), eth_key);
     }
 
     #[test]
@@ -639,7 +656,7 @@ mod tests {
             AssetKeyParseError::Network(NetworkParseError::Unsupported { .. })
         ));
         assert!(matches!(
-            "SGOV:ethereum".parse::<AssetKey>().unwrap_err(),
+            "SGOV:solana".parse::<AssetKey>().unwrap_err(),
             AssetKeyParseError::Network(NetworkParseError::Unsupported { .. })
         ));
     }

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -634,7 +634,7 @@ mod tests {
         assert_eq!("SGOV:base".parse::<AssetKey>().unwrap(), key);
 
         let eth_key = AssetKey::new(
-            valid_underlying_symbol("TSLA"),
+            UnderlyingSymbol::new("TSLA").unwrap(),
             Network::Ethereum,
         );
         assert_eq!(eth_key.to_string(), "TSLA:ethereum");

--- a/migrations/20260710155219_rekey_receipt_inventory_aggregate_id.sql
+++ b/migrations/20260710155219_rekey_receipt_inventory_aggregate_id.sql
@@ -1,0 +1,47 @@
+-- Rekey ReceiptInventory aggregate ids from bare vault addresses to
+-- `{chain_id}:{vault_lowercase}`. Pre-multichain deployments were Base-only,
+-- so every legacy id belongs to chain 8453.
+--
+-- Legacy ids were written via `Address::to_string()` (EIP-55 mixed case) while
+-- the multichain `ReceiptVaultKey` formats the vault with `{:#x}` (lowercase
+-- hex), so `lower()` here both rekeys and normalizes the casing. Without this
+-- migration a chain-qualified lookup finds no stream and pre-upgrade receipts
+-- silently vanish from burn planning.
+--
+-- Guard the shape assumption instead of trusting it: any id that is neither a
+-- bare `0x…` address (legacy) nor an already-rekeyed `{chain_id}:0x…` key
+-- would be silently skipped by the update below and left permanently
+-- unreadable. Inserting such an id into this CHECK-violating temp table
+-- aborts the migration transaction before any row is touched.
+CREATE TEMP TABLE receipt_rekey_precondition (
+    unexpected_aggregate_id TEXT CHECK (unexpected_aggregate_id IS NULL)
+);
+INSERT INTO receipt_rekey_precondition (unexpected_aggregate_id)
+SELECT aggregate_id
+FROM events
+WHERE aggregate_type = 'ReceiptInventory'
+  AND NOT (
+    (
+      aggregate_id GLOB '0x*'
+      AND aggregate_id NOT GLOB '*:*'
+    )
+    OR (
+      instr(aggregate_id, ':') > 1
+      AND substr(aggregate_id, 1, instr(aggregate_id, ':') - 1)
+          NOT GLOB '*[^0-9]*'
+      AND substr(aggregate_id, instr(aggregate_id, ':') + 1) GLOB '0x*'
+    )
+  );
+DROP TABLE receipt_rekey_precondition;
+
+UPDATE events
+SET aggregate_id = '8453:' || lower(aggregate_id)
+WHERE aggregate_type = 'ReceiptInventory'
+  AND aggregate_id GLOB '0x*'
+  AND aggregate_id NOT GLOB '*:*';
+
+UPDATE snapshots
+SET aggregate_id = '8453:' || lower(aggregate_id)
+WHERE aggregate_type = 'ReceiptInventory'
+  AND aggregate_id GLOB '0x*'
+  AND aggregate_id NOT GLOB '*:*';

--- a/src/account/api.rs
+++ b/src/account/api.rs
@@ -345,6 +345,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
+            chains: Vec::new(),
         }
     }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2793,6 +2793,7 @@ mod tests {
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
+            chains: Vec::new(),
         };
 
         let pool = setup_pool().await;
@@ -3087,6 +3088,7 @@ mod tests {
             hyperdx: None,
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
+            chains: Vec::new(),
         };
 
         rocket::build()
@@ -3936,6 +3938,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
+            chains: Vec::new(),
         }
     }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1885,7 +1885,8 @@ mod tests {
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
         CqrsReceiptService, ReceiptId, ReceiptInventory,
-        ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
+        ReceiptInventoryCommand, ReceiptService, ReceiptSource,
+        ReceiptVaultKey, Shares,
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::{
@@ -2018,7 +2019,10 @@ mod tests {
             self.calls.fetch_add(1, Ordering::Relaxed);
             self.receipt_inventory_store
                 .send(
-                    &self.vault,
+                    &ReceiptVaultKey::new(
+                        crate::test_utils::ANVIL_CHAIN_ID,
+                        self.vault,
+                    ),
                     ReceiptInventoryCommand::ReleaseBurn {
                         redemption_issuer_request_id: issuer_request_id.clone(),
                     },
@@ -2980,7 +2984,7 @@ mod tests {
 
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(crate::test_utils::ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(U256::from(99)),
                     balance: Shares::from(U256::from(100)),
@@ -2998,7 +3002,7 @@ mod tests {
 
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(crate::test_utils::ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::ReserveBurn {
                     redemption_issuer_request_id: issuer_request_id.clone(),
                     burns: vec![BurnRecord {
@@ -3011,7 +3015,10 @@ mod tests {
             .expect("receipt reservation should succeed");
 
         let inventory = store
-            .load(&vault)
+            .load(&ReceiptVaultKey::new(
+                crate::test_utils::ANVIL_CHAIN_ID,
+                vault,
+            ))
             .await
             .expect("receipt inventory should load")
             .expect("receipt inventory should exist");
@@ -3367,8 +3374,14 @@ mod tests {
             let planned_burn = planned_burns.first().unwrap();
             assert_eq!(planned_burn.receipt_id, U256::from(99));
             assert_eq!(planned_burn.shares_burned, U256::from(100));
-            let receipt_inventory =
-                receipt_inventory_store.load(&vault).await.unwrap().unwrap();
+            let receipt_inventory = receipt_inventory_store
+                .load(&ReceiptVaultKey::new(
+                    crate::test_utils::ANVIL_CHAIN_ID,
+                    vault,
+                ))
+                .await
+                .unwrap()
+                .unwrap();
             assert_eq!(
                 receipt_inventory.reserved_redemptions(),
                 vec![metadata.issuer_request_id.clone()],
@@ -3583,8 +3596,14 @@ mod tests {
                 1,
             ))
         );
-        let receipt_inventory =
-            receipt_inventory_store.load(&vault).await.unwrap().unwrap();
+        let receipt_inventory = receipt_inventory_store
+            .load(&ReceiptVaultKey::new(
+                crate::test_utils::ANVIL_CHAIN_ID,
+                vault,
+            ))
+            .await
+            .unwrap()
+            .unwrap();
         assert!(receipt_inventory.reserved_redemptions().is_empty());
         let resumed_events: i64 = sqlx::query_scalar(
             "
@@ -4039,7 +4058,7 @@ mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         receipt_store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(crate::test_utils::ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(U256::from(42)),
                     balance: Shares::new(U256::from(17)),
@@ -4055,6 +4074,7 @@ mod tests {
         let receipt_service = CqrsReceiptService::new(receipt_store);
         receipt_service
             .reserve_burn(
+                crate::test_utils::ANVIL_CHAIN_ID,
                 vault,
                 metadata.issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -4087,7 +4107,10 @@ mod tests {
             Some(Redemption::Closed { .. })
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![metadata.issuer_request_id.clone()],
             "acknowledged close must retain the unresolved reservation"
         );
@@ -4146,7 +4169,7 @@ mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         receipt_store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(crate::test_utils::ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(U256::from(42)),
                     balance: Shares::new(U256::from(17)),
@@ -4162,6 +4185,7 @@ mod tests {
         let receipt_service = Arc::new(CqrsReceiptService::new(receipt_store));
         receipt_service
             .reserve_burn(
+                crate::test_utils::ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -4178,6 +4202,7 @@ mod tests {
                 store,
                 receipt_service.clone(),
                 owner,
+                crate::test_utils::ANVIL_CHAIN_ID,
             ));
 
         (burn_recovery, receipt_service)
@@ -4344,7 +4369,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty()
@@ -4417,7 +4442,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty()
@@ -4501,7 +4526,10 @@ mod tests {
             Some(Redemption::BurnIntended { .. })
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![metadata.issuer_request_id]
         );
         let proving_hash = format!("{proving_burn_tx_hash:?}");
@@ -4577,7 +4605,10 @@ mod tests {
             Some(Redemption::BurnIntended { .. })
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![metadata.issuer_request_id]
         );
         assert!(logs_contain_at!(
@@ -4649,7 +4680,10 @@ mod tests {
             Some(Redemption::BurnIntended { .. })
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![metadata.issuer_request_id]
         );
         let persisted_hash = format!("{:?}", persisted_tx.hash);
@@ -4720,7 +4754,10 @@ mod tests {
             Some(Redemption::BurnIntended { .. })
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(crate::test_utils::ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![metadata.issuer_request_id]
         );
         let persisted_hash = format!("{:?}", persisted_tx.hash);

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -1496,6 +1496,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_poll_request_status_parses_ethereum_network_wire_string() {
+        let target_id = "00000000-0000-0000-0000-000000000002";
+        let ethereum_json = r#"{"tokenization_request_id":"00000000-0000-0000-0000-000000000002","issuer_request_id":"0x2222222222222222222222222222222222222222222222222222222222222222","type":"mint","status":"completed","underlying_symbol":"AAPL","token_symbol":"tAAPL","qty":"1","client_external_account_id":"00000000-0000-0000-0000-000000000003","created_at":"2026-06-11T00:02:27.467568Z","updated_at":"2026-06-11T04:02:33.530523Z","wallet_address":"0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","network":"ethereum","issuer":"st0x","fees":"0","tx_hash":"0x2222222222222222222222222222222222222222222222222222222222222222"}"#;
+
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path(format!(
+                "/v1/accounts/test-account/tokenization/requests/{target_id}"
+            ));
+            then.status(200).body(ethereum_json);
+        });
+
+        let service = RealAlpacaService::new(
+            server.base_url(),
+            "test-account".to_string(),
+            "test-key".to_string(),
+            "test-secret".to_string(),
+            10,
+            30,
+        )
+        .unwrap();
+
+        let result = service
+            .poll_request_status(&TokenizationRequestId::new(target_id))
+            .await;
+
+        let request = result.unwrap();
+        assert!(
+            matches!(request, TokenizationRequest::Mint {}),
+            "ethereum mint payload must parse through the real poll path, \
+             got {request:?}"
+        );
+        mock.assert();
+    }
+
+    #[tokio::test]
     async fn test_200_with_invalid_json_returns_non_retryable_error() {
         let server = MockServer::start();
 

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -355,6 +355,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
+            chains: Vec::new(),
         }
     }
 

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -10,7 +10,7 @@ use alloy::transports::{RpcError, TransportErrorKind};
 use futures::stream::{self, StreamExt, TryStreamExt};
 use itertools::Itertools;
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 use url::Url;
@@ -29,12 +29,14 @@ use crate::wallet::{
 
 const MAX_CHAIN_RUNTIME_BUILD_CONCURRENCY: usize = 4;
 
-pub(crate) struct ChainConfig {
-    pub(crate) network: Network,
-    pub(crate) chain_id: u64,
-    pub(crate) rpc_url: Url,
-    pub(crate) subgraph_url: Url,
-    pub(crate) backfill_start_block: u64,
+/// Per-chain RPC, vault, and subgraph settings for [`ChainRegistry`].
+#[derive(Clone)]
+pub struct ChainConfig {
+    pub network: Network,
+    pub chain_id: u64,
+    pub rpc_url: Url,
+    pub subgraph_url: Url,
+    pub backfill_start_block: u64,
 }
 
 pub(crate) struct ChainRuntime<P> {
@@ -48,6 +50,24 @@ pub(crate) struct ChainRuntime<P> {
 
 pub(crate) struct ChainRegistry<P> {
     runtimes: HashMap<Network, ChainRuntime<P>>,
+}
+
+/// Networks that have a chain configuration, extracted from
+/// [`ChainRegistry`] so HTTP handlers can reject asset registrations for
+/// unconfigured networks without holding the provider-generic registry.
+#[derive(Debug, Clone)]
+pub(crate) struct ConfiguredNetworks(HashSet<Network>);
+
+impl ConfiguredNetworks {
+    pub(crate) fn contains(&self, network: Network) -> bool {
+        self.0.contains(&network)
+    }
+}
+
+impl FromIterator<Network> for ConfiguredNetworks {
+    fn from_iter<I: IntoIterator<Item = Network>>(iter: I) -> Self {
+        Self(iter.into_iter().collect())
+    }
 }
 
 pub(crate) async fn validate_configured_asset_networks<P: Sync>(
@@ -129,6 +149,19 @@ impl<P> ChainRegistry<P> {
 
     pub(crate) fn base(&self) -> Result<&ChainRuntime<P>, ChainRegistryError> {
         self.get_required(Network::Base)
+    }
+
+    pub(crate) fn configured_networks(&self) -> ConfiguredNetworks {
+        self.runtimes.keys().copied().collect()
+    }
+
+    pub(crate) fn clone_vault_services(
+        &self,
+    ) -> HashMap<Network, Arc<dyn VaultService>> {
+        self.runtimes
+            .iter()
+            .map(|(network, runtime)| (*network, runtime.vault_service.clone()))
+            .collect()
     }
 }
 
@@ -267,6 +300,26 @@ mod tests {
     }
 
     #[traced_test]
+    #[test]
+    fn validate_rejects_duplicate_chain_id_across_networks() {
+        let configs = vec![
+            base_config(8453),
+            ChainConfig {
+                network: Network::Ethereum,
+                chain_id: 8453,
+                rpc_url: Url::parse("wss://localhost:8546").unwrap(),
+                subgraph_url: Url::parse("http://localhost:0/subgraph")
+                    .unwrap(),
+                backfill_start_block: 1,
+            },
+        ];
+
+        assert!(matches!(
+            validate_chain_configs(&configs),
+            Err(ChainRegistryError::DuplicateChainId { .. })
+        ));
+    }
+
     #[test]
     fn validate_rejects_duplicate_network() {
         let configs = vec![base_config(8453), base_config(8453)];

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -163,6 +163,12 @@ impl<P> ChainRegistry<P> {
             .map(|(network, runtime)| (*network, runtime.vault_service.clone()))
             .collect()
     }
+
+    pub(crate) fn runtimes(
+        &self,
+    ) -> impl Iterator<Item = (&Network, &ChainRuntime<P>)> {
+        self.runtimes.iter()
+    }
 }
 
 pub(crate) fn validate_chain_configs(

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,11 @@ pub struct Config {
     pub hyperdx: Option<HyperDxConfig>,
     pub alpaca: AlpacaConfig,
     pub subgraph_url: Url,
+    /// All chain runtimes the registry is built from, Base first. The legacy
+    /// flat env vars populate the single Base entry today; the multichain
+    /// `CHAIN_<NETWORK>_*` config format extends this list (see the SPEC.md
+    /// Multi-chain section, which also specifies the legacy-var sunset).
+    pub chains: Vec<ChainConfig>,
 }
 
 impl Config {
@@ -56,27 +61,16 @@ impl Config {
         env.into_config()
     }
 
-    /// Builds a [`ChainRegistry`] from legacy single-chain env vars, producing
-    /// a registry with a single `base` entry.
+    /// Builds a [`ChainRegistry`] from `chains`. Consumers route per-chain
+    /// side effects through `registry.get(network)`; anything not yet
+    /// migrated to network-aware routing pins itself to `registry.base()`
+    /// at its own call site.
     pub(crate) async fn create_chain_registry(
         &self,
     ) -> Result<ChainRegistry<impl Provider + Clone + use<>>, ConfigError> {
-        build_chain_registry(
-            vec![self.legacy_base_chain_config()],
-            &self.signer,
-        )
-        .await
-        .map_err(|error| ConfigError::ChainRegistry(Box::new(error)))
-    }
-
-    fn legacy_base_chain_config(&self) -> ChainConfig {
-        ChainConfig {
-            network: Network::Base,
-            chain_id: self.chain_id,
-            rpc_url: self.rpc_url.clone(),
-            subgraph_url: self.subgraph_url.clone(),
-            backfill_start_block: self.backfill_start_block,
-        }
+        build_chain_registry(self.chains.clone(), &self.signer)
+            .await
+            .map_err(|error| ConfigError::ChainRegistry(Box::new(error)))
     }
 }
 
@@ -170,6 +164,14 @@ impl Env {
             }
         }
 
+        let chains = vec![ChainConfig {
+            network: Network::Base,
+            chain_id: self.chain_id,
+            rpc_url: self.rpc_url.clone(),
+            subgraph_url: self.subgraph_url.clone(),
+            backfill_start_block: self.backfill_start_block,
+        }];
+
         Ok(Config {
             database_url: self.database_url,
             database_max_connections: self.database_max_connections,
@@ -184,6 +186,7 @@ impl Env {
             hyperdx,
             alpaca: self.alpaca,
             subgraph_url: self.subgraph_url,
+            chains,
         })
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -369,6 +369,20 @@ mod tests {
     }
 
     #[test]
+    fn into_config_populates_base_chain_entry_from_legacy_env_vars() {
+        let env = Env::try_parse_from(minimal_args()).unwrap();
+        let config = env.into_config().unwrap();
+
+        assert_eq!(config.chains.len(), 1);
+        let chain = &config.chains[0];
+        assert_eq!(chain.network, Network::Base);
+        assert_eq!(chain.chain_id, DEFAULT_CHAIN_ID);
+        assert_eq!(chain.rpc_url, config.rpc_url);
+        assert_eq!(chain.subgraph_url, config.subgraph_url);
+        assert_eq!(chain.backfill_start_block, config.backfill_start_block);
+    }
+
+    #[test]
     fn test_empty_ip_ranges_default() {
         let args = minimal_args();
         let env = Env::try_parse_from(args).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ use tracing::{debug, error, info, trace, warn};
 use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
+use crate::chain::{ChainRegistry, ConfiguredNetworks};
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
@@ -74,9 +75,11 @@ pub mod bindings;
 
 pub use alpaca::AlpacaConfig;
 pub use auth::{AuthConfig, InternalIpWhitelist, IpWhitelist, IssuerApiKey};
+pub use chain::ChainConfig;
 pub use config::{Config, Environment, LogLevel, setup_tracing};
+pub use st0x_issuance_dto::Network;
 pub use telemetry::TelemetryGuard;
-pub use test_utils::ANVIL_CHAIN_ID;
+pub use test_utils::{ANVIL_CHAIN_ID, ETHEREUM_TEST_CHAIN_ID};
 pub use tokenized_asset::cli::run_issuer_cli;
 pub use wallet::SignerConfig;
 
@@ -271,12 +274,13 @@ pub async fn initialize_rocket(
     info!(target: "startup", "Bot wallet address: {bot_wallet}");
 
     let vault_service_for_rocket = base.vault_service.clone();
+    let configured_networks = chain_registry.configured_networks();
 
     let AggregateCqrsSetup { mint_store, redemption_store } =
         setup_aggregate_cqrs(
             &pool,
             &receipt_inventory_store,
-            base.vault_service.clone(),
+            &chain_registry,
             alpaca_service.clone(),
             bot_wallet,
         )
@@ -429,6 +433,7 @@ pub async fn initialize_rocket(
         burn_recovery: managers.burn.clone()
             as Arc<dyn admin::RedemptionBurnRecovery>,
         vault_service: vault_service_for_rocket,
+        configured_networks,
     }))
 }
 
@@ -444,6 +449,7 @@ struct RocketState {
     alpaca_service: Arc<dyn AlpacaService>,
     burn_recovery: Arc<dyn admin::RedemptionBurnRecovery>,
     vault_service: Arc<dyn vault::VaultService>,
+    configured_networks: ConfiguredNetworks,
 }
 
 fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
@@ -469,6 +475,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .manage(state.alpaca_service)
         .manage(state.burn_recovery)
         .manage(state.vault_service)
+        .manage(state.configured_networks)
         .manage(state.pool)
         .manage(state.apalis_pool)
         .mount(
@@ -519,23 +526,26 @@ fn mount_api_docs(
     )
 }
 
-async fn setup_aggregate_cqrs(
+async fn setup_aggregate_cqrs<P>(
     pool: &Pool<Sqlite>,
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
-    vault_service: Arc<dyn vault::VaultService>,
+    chain_registry: &ChainRegistry<P>,
     alpaca_service: Arc<dyn AlpacaService>,
     bot_wallet: Address,
-) -> Result<AggregateCqrsSetup, anyhow::Error> {
+) -> Result<AggregateCqrsSetup, anyhow::Error>
+where
+    P: Provider + Clone,
+{
     // Create MintServices with all dependencies
     let receipt_service =
         Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
-    let mint_services = MintServices {
-        vault: vault_service.clone(),
-        alpaca: alpaca_service,
-        pool: pool.clone(),
-        bot: bot_wallet,
-        receipts: receipt_service,
-    };
+    let mint_services = MintServices::new(
+        chain_registry.clone_vault_services(),
+        alpaca_service.clone(),
+        receipt_service,
+        pool.clone(),
+        bot_wallet,
+    );
 
     // Mint's canonical `mint_view` projection is auto-wired by StoreBuilder; the
     // secondary `receipt_inventory_view` (formerly a View<Mint> GenericQuery) is
@@ -563,7 +573,7 @@ async fn setup_aggregate_cqrs(
     let redemption_store = StoreBuilder::<Redemption>::new(pool.clone())
         .with(Arc::new(RedemptionViewReactor::new(pool.clone())))
         .with(Arc::new(ReceiptBurnsViewReactor::new(pool.clone())))
-        .build(vault_service)
+        .build(chain_registry.base()?.vault_service.clone())
         .await?;
 
     Ok(AggregateCqrsSetup { mint_store, redemption_store })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,9 @@ use tracing::{debug, error, info, trace, warn};
 use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
-use crate::chain::{ChainRegistry, ConfiguredNetworks};
+use crate::chain::{
+    ChainRegistry, ConfiguredNetworks, validate_configured_asset_networks,
+};
 use crate::mint::{
     Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
@@ -33,7 +35,9 @@ use crate::mint::{
         vacuum_terminal_recovery_jobs,
     },
 };
-use crate::receipt_inventory::backfill::{NoOpItnHandler, ReceiptBackfiller};
+use crate::receipt_inventory::backfill::{
+    NoOpItnHandler, ReceiptBackfillDeps, ReceiptBackfiller,
+};
 use crate::receipt_inventory::reconcile::run_startup_reconciliation;
 use crate::receipt_inventory::{
     CqrsReceiptService, ItnReceiptHandler, ReceiptInventory,
@@ -49,8 +53,10 @@ use crate::redemption::{
     view::{RedemptionViewReactor, rebuild_redemption_view},
 };
 use crate::tokenized_asset::{
-    TokenizedAsset, TokenizedAssetView, view::list_enabled_assets,
+    TokenizedAsset, TokenizedAssetView, UnderlyingSymbol,
+    view::list_enabled_assets,
 };
+use poll_checkpoint::load_receipt_backfill;
 
 pub mod account;
 pub mod mint;
@@ -79,7 +85,9 @@ pub use chain::ChainConfig;
 pub use config::{Config, Environment, LogLevel, setup_tracing};
 pub use st0x_issuance_dto::Network;
 pub use telemetry::TelemetryGuard;
-pub use test_utils::{ANVIL_CHAIN_ID, ETHEREUM_TEST_CHAIN_ID};
+pub use test_utils::{
+    ANVIL_CHAIN_ID, ETHEREUM_TEST_CHAIN_ID, receipt_inventory_aggregate_id,
+};
 pub use tokenized_asset::cli::run_issuer_cli;
 pub use wallet::SignerConfig;
 
@@ -263,6 +271,7 @@ pub async fn initialize_rocket(
     let chain_registry = config.create_chain_registry().await?;
     let base = chain_registry.base()?;
     let alpaca_service = config.alpaca.service()?;
+    let rocket_alpaca = alpaca_service.clone();
     let bot_wallet = config.signer.address()?;
     info!(
         target: "startup",
@@ -281,7 +290,7 @@ pub async fn initialize_rocket(
             &pool,
             &receipt_inventory_store,
             &chain_registry,
-            alpaca_service.clone(),
+            alpaca_service,
             bot_wallet,
         )
         .await?;
@@ -293,6 +302,7 @@ pub async fn initialize_rocket(
         &receipt_inventory_store,
         &pool,
         bot_wallet,
+        base.chain_id,
     )?;
 
     // Reprojections must complete BEFORE recovery runs, so recovery queries
@@ -303,30 +313,21 @@ pub async fn initialize_rocket(
     rebuild_redemption_view(&pool).await?;
     rebuild_receipt_burns_view(&pool).await?;
 
-    crate::chain::validate_configured_asset_networks(&pool, &chain_registry)
-        .await?;
+    validate_configured_asset_networks(&pool, &chain_registry).await?;
 
     // Receipt backfill must run before recovery so that recovery can check
     // receipt inventory to detect already-minted receipts (prevents double-mints).
     let vault_configs = run_all_receipt_backfills(
         &pool,
-        base.http_provider.clone(),
+        &chain_registry,
         &receipt_inventory_store,
         bot_wallet,
-        base.backfill_start_block,
     )
     .await?;
 
-    // Reconcile receipt balances with on-chain state after backfill. This detects
-    // external burns (manual burns by stakeholders) that the service didn't track.
-    let vault_receipt_pairs: Vec<_> = vault_configs
-        .iter()
-        .map(|config| (config.vault, config.receipt_contract))
-        .collect();
-
-    if let Err(error) = run_startup_reconciliation(
-        base.http_provider.clone(),
-        &vault_receipt_pairs,
+    if let Err(error) = run_startup_reconciliation_for_vaults(
+        &chain_registry,
+        &vault_configs,
         &receipt_inventory_store,
         bot_wallet,
     )
@@ -383,19 +384,23 @@ pub async fn initialize_rocket(
     spawn_mint_recovery_reconciler(pool.clone(), apalis_pool.clone());
     spawn_burn_recovery_reconciler(managers.burn.clone());
 
-    spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
-        pool: pool.clone(),
-        provider: base.http_provider.clone(),
-        receipt_inventory_store: receipt_inventory_store.clone(),
-        bot_wallet,
-        backfill_start_block: base.backfill_start_block,
-        receipt_poll_interval: config.receipt_poll_interval,
-        handler: MintRecoveryHandler::new(
-            mint_store.clone(),
-            pool.clone(),
-            apalis_pool.clone(),
-        ),
-    });
+    for (network, runtime) in chain_registry.runtimes() {
+        spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
+            pool: pool.clone(),
+            provider: runtime.http_provider.clone(),
+            network: *network,
+            chain_id: runtime.chain_id,
+            receipt_inventory_store: receipt_inventory_store.clone(),
+            bot_wallet,
+            backfill_start_block: runtime.backfill_start_block,
+            receipt_poll_interval: config.receipt_poll_interval,
+            handler: MintRecoveryHandler::new(
+                mint_store.clone(),
+                pool.clone(),
+                apalis_pool.clone(),
+            ),
+        });
+    }
 
     {
         info!(
@@ -429,7 +434,7 @@ pub async fn initialize_rocket(
         tokenized_asset_store,
         mint_store,
         redemption_store,
-        alpaca_service,
+        alpaca_service: rocket_alpaca,
         burn_recovery: managers.burn.clone()
             as Arc<dyn admin::RedemptionBurnRecovery>,
         vault_service: vault_service_for_rocket,
@@ -539,9 +544,14 @@ where
     // Create MintServices with all dependencies
     let receipt_service =
         Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
+    let chain_ids = chain_registry
+        .runtimes()
+        .map(|(network, runtime)| (*network, runtime.chain_id))
+        .collect();
     let mint_services = MintServices::new(
         chain_registry.clone_vault_services(),
-        alpaca_service.clone(),
+        chain_ids,
+        alpaca_service,
         receipt_service,
         pool.clone(),
         bot_wallet,
@@ -678,6 +688,7 @@ fn setup_redemption_managers(
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     pool: &Pool<Sqlite>,
     bot_wallet: Address,
+    receipt_chain_id: u64,
 ) -> Result<RedemptionManagers, anyhow::Error> {
     let alpaca_service = config.alpaca.service()?;
     let redeem_call = Arc::new(RedeemCallManager::new(
@@ -700,6 +711,7 @@ fn setup_redemption_managers(
         redemption_store.clone(),
         receipt_service,
         bot_wallet,
+        receipt_chain_id,
     ));
 
     Ok(RedemptionManagers { redeem_call, journal, burn })
@@ -917,22 +929,39 @@ async fn run_recovery_with_timeout(
     }
 }
 
+/// Shared inputs for a single-vault startup receipt backfill.
+struct VaultBackfillCtx<'a, P> {
+    pool: &'a Pool<Sqlite>,
+    provider: &'a P,
+    receipt_inventory_store: &'a Arc<Store<ReceiptInventory>>,
+    bot_wallet: Address,
+}
+
+/// Per-vault startup receipt backfill parameters.
+struct VaultBackfillRequest {
+    network: Network,
+    vault: Address,
+    underlying: UnderlyingSymbol,
+    backfill_start_block: u64,
+    chain_id: u64,
+}
+
 /// Configuration for a single vault, extracted from TokenizedAssetView.
 #[derive(Clone, Copy)]
 struct VaultBackfillConfig {
+    chain_id: u64,
+    network: Network,
     vault: Address,
     receipt_contract: Address,
 }
 
-/// Runs receipt backfill for ALL enabled tokenized assets.
-///
-/// Returns the vault configurations needed for live monitoring.
+/// Runs receipt backfill for ALL enabled tokenized assets, using each asset's
+/// configured network runtime for RPC and backfill start block.
 async fn run_all_receipt_backfills<P: Provider + Clone>(
     pool: &Pool<Sqlite>,
-    provider: P,
+    chain_registry: &ChainRegistry<P>,
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
-    backfill_start_block: u64,
 ) -> Result<Vec<VaultBackfillConfig>, anyhow::Error> {
     let assets = list_enabled_assets(pool).await?;
 
@@ -948,81 +977,140 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
     );
 
     stream::iter(assets)
-        .then(|TokenizedAssetView { vault, underlying, .. }| {
-            let provider = provider.clone();
-            async move {
+        .then(
+            |TokenizedAssetView { vault, underlying, network, .. }| async move {
+                let runtime = chain_registry.get_required(network)?;
                 run_single_vault_backfill(
-                    pool,
-                    &provider,
-                    vault,
-                    backfill_start_block,
-                    underlying.as_str(),
-                    receipt_inventory_store,
-                    bot_wallet,
+                    &VaultBackfillCtx {
+                        pool,
+                        provider: &runtime.http_provider,
+                        receipt_inventory_store,
+                        bot_wallet,
+                    },
+                    VaultBackfillRequest {
+                        network,
+                        vault,
+                        underlying,
+                        backfill_start_block: runtime.backfill_start_block,
+                        chain_id: runtime.chain_id,
+                    },
                 )
                 .await
-            }
-        })
+            },
+        )
         .try_collect()
         .await
 }
 
 /// Runs receipt backfill for a single vault.
 async fn run_single_vault_backfill<P: Provider + Clone>(
-    pool: &Pool<Sqlite>,
-    provider: &P,
-    vault: Address,
-    backfill_start_block: u64,
-    underlying: &str,
-    receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
-    bot_wallet: Address,
+    ctx: &VaultBackfillCtx<'_, P>,
+    request: VaultBackfillRequest,
 ) -> Result<VaultBackfillConfig, anyhow::Error> {
+    let VaultBackfillRequest {
+        network,
+        vault,
+        underlying,
+        backfill_start_block,
+        chain_id,
+    } = request;
+
     let vault_contract =
-        bindings::OffchainAssetReceiptVault::new(vault, provider);
+        bindings::OffchainAssetReceiptVault::new(vault, ctx.provider);
     let receipt_contract =
         Address::from(vault_contract.receipt().call().await?.0);
 
-    let last_block = crate::poll_checkpoint::load(
-        pool,
-        &crate::poll_checkpoint::receipt_backfill_name(vault),
-    )
-    .await?;
+    let last_block = load_receipt_backfill(ctx.pool, network, vault).await?;
     let from_block =
         next_receipt_backfill_block(last_block, backfill_start_block)?;
 
     info!(
         target: "receipt",
-        underlying,
+        network = %network,
+        underlying = %underlying,
         vault = %vault,
         receipt_contract = %receipt_contract,
-        bot_wallet = %bot_wallet,
+        bot_wallet = %ctx.bot_wallet,
         from_block,
         "Running receipt backfill for vault"
     );
 
-    let backfiller = ReceiptBackfiller::new(
-        provider.clone(),
+    let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
+        provider: ctx.provider.clone(),
         receipt_contract,
-        bot_wallet,
+        bot_wallet: ctx.bot_wallet,
+        chain_id,
+        network,
         vault,
-        receipt_inventory_store.clone(),
-        pool.clone(),
-        NoOpItnHandler,
-    );
+        store: ctx.receipt_inventory_store.clone(),
+        pool: ctx.pool.clone(),
+        handler: NoOpItnHandler,
+    });
 
-    let head_block = provider.get_block_number().await?;
+    let head_block = ctx.provider.get_block_number().await?;
     let result = backfiller.backfill_receipts(from_block, head_block).await?;
 
     info!(
         target: "receipt",
-        underlying,
+        network = %network,
+        underlying = %underlying,
         vault = %vault,
         processed = result.processed_count,
         skipped_zero_balance = result.skipped_zero_balance,
         "Receipt backfill complete for vault"
     );
 
-    Ok(VaultBackfillConfig { vault, receipt_contract })
+    Ok(VaultBackfillConfig { chain_id, network, vault, receipt_contract })
+}
+
+/// Attempts reconciliation for every vault even when earlier vaults fail —
+/// a transient RPC failure on one network must not leave the remaining
+/// networks' receipt inventories unreconciled at boot.
+async fn run_startup_reconciliation_for_vaults<P: Provider + Clone>(
+    chain_registry: &ChainRegistry<P>,
+    vault_configs: &[VaultBackfillConfig],
+    store: &Arc<Store<ReceiptInventory>>,
+    bot_wallet: Address,
+) -> Result<(), anyhow::Error> {
+    let mut failed_vaults = 0_usize;
+
+    for &VaultBackfillConfig { chain_id, network, vault, receipt_contract } in
+        vault_configs
+    {
+        let outcome: Result<(), anyhow::Error> = async {
+            let runtime = chain_registry.get_required(network)?;
+            run_startup_reconciliation(
+                runtime.http_provider.clone(),
+                &[(chain_id, vault, receipt_contract)],
+                store,
+                bot_wallet,
+            )
+            .await?;
+            Ok(())
+        }
+        .await;
+
+        if let Err(error) = outcome {
+            failed_vaults += 1;
+            warn!(
+                target: "receipt",
+                %network,
+                %vault,
+                error = %error,
+                "Startup reconciliation failed for vault; continuing with \
+                 the remaining vaults"
+            );
+        }
+    }
+
+    if failed_vaults > 0 {
+        return Err(anyhow::anyhow!(
+            "startup reconciliation failed for {failed_vaults} of {} vaults",
+            vault_configs.len()
+        ));
+    }
+
+    Ok(())
 }
 
 fn next_receipt_backfill_block(
@@ -1058,11 +1146,8 @@ where
     P: Provider + Clone,
     H: ItnReceiptHandler,
 {
-    let last_block = crate::poll_checkpoint::load(
-        ctx.pool,
-        &crate::poll_checkpoint::receipt_backfill_name(config.vault),
-    )
-    .await?;
+    let last_block =
+        load_receipt_backfill(ctx.pool, config.network, config.vault).await?;
     let from_block =
         next_receipt_backfill_block(last_block, ctx.backfill_start_block)?;
 
@@ -1074,15 +1159,17 @@ where
         "Running periodic receipt backfill for vault"
     );
 
-    let backfiller = ReceiptBackfiller::new(
-        ctx.provider.clone(),
-        config.receipt_contract,
-        ctx.bot_wallet,
-        config.vault,
-        ctx.receipt_inventory_store.clone(),
-        ctx.pool.clone(),
-        ctx.handler,
-    );
+    let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
+        provider: ctx.provider.clone(),
+        receipt_contract: config.receipt_contract,
+        bot_wallet: ctx.bot_wallet,
+        chain_id: config.chain_id,
+        network: config.network,
+        vault: config.vault,
+        store: ctx.receipt_inventory_store.clone(),
+        pool: ctx.pool.clone(),
+        handler: ctx.handler,
+    });
 
     let result = backfiller.backfill_receipts(from_block, head_block).await?;
 
@@ -1104,6 +1191,8 @@ where
 struct PeriodicBackfillSpawn<P, H> {
     pool: Pool<Sqlite>,
     provider: P,
+    network: Network,
+    chain_id: u64,
     receipt_inventory_store: Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
     backfill_start_block: u64,
@@ -1124,6 +1213,8 @@ where
     let PeriodicBackfillSpawn {
         pool,
         provider,
+        network,
+        chain_id,
         receipt_inventory_store,
         bot_wallet,
         backfill_start_block,
@@ -1159,7 +1250,10 @@ where
             // Re-read the enabled vault set each pass so runtime-added assets
             // are reconciled without a restart.
             let assets = match list_enabled_assets(&pool).await {
-                Ok(assets) => assets,
+                Ok(assets) => assets
+                    .into_iter()
+                    .filter(|asset| asset.network == network)
+                    .collect::<Vec<_>>(),
                 Err(error) => {
                     warn!(
                         target: "receipt",
@@ -1221,6 +1315,8 @@ where
                 };
 
                 let config = VaultBackfillConfig {
+                    chain_id,
+                    network,
                     vault: asset.vault,
                     receipt_contract: receipt_contract.0,
                 };

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -863,6 +863,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_initiate_mint_rejects_unknown_network() {
+        let harness = TestHarness::new().await;
+        let TestAccountAndAsset { client_id, underlying, token, .. } =
+            harness.setup_account_and_asset().await;
+        let TestHarness {
+            pool,
+            account_store,
+            asset_store: tokenized_asset_store,
+            mint_store,
+            ..
+        } = harness;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(mint_store)
+            .manage(account_store)
+            .manage(tokenized_asset_store)
+            .manage(pool)
+            .mount("/", routes![initiate_mint]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "tokenization_request_id": "alp-123",
+            "qty": "100.5",
+            "underlying_symbol": underlying.as_str(),
+            "token_symbol": token.0,
+            "network": "arbitrum",
+            "client_id": client_id,
+            "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
+        });
+
+        let response = client
+            .post("/inkind/issuance")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    #[tokio::test]
     async fn test_initiate_mint_rejects_wrong_network() {
         let harness = TestHarness::new().await;
         let TestAccountAndAsset { client_id, underlying, token, .. } =
@@ -910,12 +961,14 @@ mod tests {
             .dispatch()
             .await;
 
-        // `Network` is a closed enum, so an unsupported network is
-        // unrepresentable: the request is rejected at JSON deserialization
-        // (Rocket's data guard -> 422) before the handler's asset-availability
-        // check runs. A mismatched-but-parseable network can no longer be
-        // expressed, so the old handler-level 400 path is unreachable here.
-        assert_eq!(response.status(), Status::UnprocessableEntity);
+        assert_eq!(response.status(), Status::BadRequest);
+        assert!(
+            response
+                .into_string()
+                .await
+                .unwrap()
+                .contains("Token not available on the network")
+        );
     }
 
     #[tokio::test]

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -863,57 +863,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_initiate_mint_rejects_unknown_network() {
-        let harness = TestHarness::new().await;
-        let TestAccountAndAsset { client_id, underlying, token, .. } =
-            harness.setup_account_and_asset().await;
-        let TestHarness {
-            pool,
-            account_store,
-            asset_store: tokenized_asset_store,
-            mint_store,
-            ..
-        } = harness;
-
-        let rocket = rocket::build()
-            .manage(test_config())
-            .manage(FailedAuthRateLimiter::new().unwrap())
-            .manage(mint_store)
-            .manage(account_store)
-            .manage(tokenized_asset_store)
-            .manage(pool)
-            .mount("/", routes![initiate_mint]);
-
-        let client = rocket::local::asynchronous::Client::tracked(rocket)
-            .await
-            .expect("valid rocket instance");
-
-        let request_body = serde_json::json!({
-            "tokenization_request_id": "alp-123",
-            "qty": "100.5",
-            "underlying_symbol": underlying.as_str(),
-            "token_symbol": token.0,
-            "network": "arbitrum",
-            "client_id": client_id,
-            "wallet_address": "0x1234567890abcdef1234567890abcdef12345678"
-        });
-
-        let response = client
-            .post("/inkind/issuance")
-            .header(ContentType::JSON)
-            .header(Header::new(
-                "X-API-KEY",
-                "test-key-12345678901234567890123456",
-            ))
-            .remote("127.0.0.1:8000".parse().unwrap())
-            .body(request_body.to_string())
-            .dispatch()
-            .await;
-
-        assert_eq!(response.status(), Status::UnprocessableEntity);
-    }
-
-    #[tokio::test]
     async fn test_initiate_mint_rejects_wrong_network() {
         let harness = TestHarness::new().await;
         let TestAccountAndAsset { client_id, underlying, token, .. } =

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -16,6 +16,7 @@ use crate::auth::test_auth_config;
 use crate::config::{Config, Environment, LogLevel};
 use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
 use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+use crate::test_utils::ANVIL_CHAIN_ID;
 use crate::tokenized_asset::{AssetKey, TokenizedAsset, TokenizedAssetCommand};
 use crate::vault::VaultService;
 use crate::vault::mock::MockVaultService;
@@ -26,7 +27,7 @@ pub(crate) fn test_config() -> Config {
         database_url: "sqlite::memory:".to_string(),
         database_max_connections: 5,
         rpc_url: Url::parse("wss://localhost:8545").expect("Valid URL"),
-        chain_id: crate::test_utils::ANVIL_CHAIN_ID,
+        chain_id: ANVIL_CHAIN_ID,
         signer: SignerConfig::Local(B256::ZERO),
         backfill_start_block: 0,
         receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
@@ -117,6 +118,7 @@ impl TestHarness {
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
         let mint_services = MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             vault.clone(),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_inventory_store)),

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -37,6 +37,7 @@ pub(crate) fn test_config() -> Config {
         alpaca: AlpacaConfig::test_default(),
         subgraph_url: Url::parse("http://localhost:0/subgraph")
             .expect("valid test URL"),
+        chains: Vec::new(),
     }
 }
 
@@ -114,15 +115,14 @@ impl TestHarness {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-        let mint_services = MintServices {
-            vault: vault.clone(),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            pool: pool.clone(),
+        let mint_services = MintServices::with_single_vault(
+            Network::Base,
+            vault.clone(),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
+            pool.clone(),
             bot,
-            receipts: Arc::new(CqrsReceiptService::new(
-                receipt_inventory_store,
-            )),
-        };
+        );
 
         let (mint_store, _mint_projection) =
             StoreBuilder::<Mint>::new(pool.clone())

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -10,6 +10,7 @@ use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
+use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -37,12 +38,53 @@ pub(crate) use view::{
 };
 
 /// Services required by the Mint aggregate for command handling.
+///
+/// Mint side effects resolve [`VaultService`] per aggregate `network` via
+/// [`Self::vault_for`] ([RAI-1206]).
 pub(crate) struct MintServices {
-    pub(crate) vault: Arc<dyn VaultService>,
+    vaults: HashMap<Network, Arc<dyn VaultService>>,
     pub(crate) alpaca: Arc<dyn AlpacaService>,
     pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) pool: Pool<Sqlite>,
     pub(crate) bot: Address,
+}
+
+impl MintServices {
+    pub(crate) fn new(
+        vaults: HashMap<Network, Arc<dyn VaultService>>,
+        alpaca: Arc<dyn AlpacaService>,
+        receipts: Arc<dyn ReceiptService>,
+        pool: Pool<Sqlite>,
+        bot: Address,
+    ) -> Self {
+        Self { vaults, alpaca, receipts, pool, bot }
+    }
+
+    pub(crate) fn with_single_vault(
+        network: Network,
+        vault: Arc<dyn VaultService>,
+        alpaca: Arc<dyn AlpacaService>,
+        receipts: Arc<dyn ReceiptService>,
+        pool: Pool<Sqlite>,
+        bot: Address,
+    ) -> Self {
+        Self::new(
+            HashMap::from([(network, vault)]),
+            alpaca,
+            receipts,
+            pool,
+            bot,
+        )
+    }
+
+    fn vault_for(
+        &self,
+        network: Network,
+    ) -> Result<&Arc<dyn VaultService>, MintError> {
+        self.vaults
+            .get(&network)
+            .ok_or(MintError::NetworkNotConfigured { network })
+    }
 }
 
 pub(crate) async fn has_unresolved_mint_intent(
@@ -76,7 +118,6 @@ pub(crate) async fn has_unresolved_mint_intent(
     .bind(excluding)
     .fetch_one(pool)
     .await?;
-
     Ok(exists)
 }
 
@@ -626,6 +667,7 @@ impl Mint {
             return Err(MintError::PendingWalletIntent);
         }
 
+        let vault_service = services.vault_for(*network)?;
         let vault = find_vault(&services.pool, underlying, network)
             .await?
             .ok_or_else(|| MintError::AssetNotFound {
@@ -648,8 +690,7 @@ impl Mint {
 
         let now = Utc::now();
 
-        match services
-            .vault
+        match vault_service
             .prepare_mint_tx(
                 vault,
                 assets,
@@ -718,6 +759,7 @@ impl Mint {
     ) -> Result<Vec<MintEvent>, MintError> {
         let Self::TxIntended {
             issuer_request_id: expected_id,
+            network,
             prepared_tx,
             ..
         } = self
@@ -729,7 +771,8 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        let submitted = match services.vault.submit_mint(prepared_tx).await {
+        let vault_service = services.vault_for(*network)?;
+        let submitted = match vault_service.submit_mint(prepared_tx).await {
             Ok(submitted) => submitted,
             Err(error) => {
                 warn!(
@@ -800,7 +843,9 @@ impl Mint {
 
         let now = Utc::now();
 
-        match services.vault.confirm_mint(&tx_id).await {
+        let vault_service = services.vault_for(*network)?;
+
+        match vault_service.confirm_mint(&tx_id).await {
             Ok(result) => {
                 info!(
                     target: "mint",
@@ -1141,6 +1186,7 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
+        let vault_service = services.vault_for(*network)?;
         let vault = find_vault(&services.pool, underlying, network)
             .await?
             .ok_or_else(|| MintError::AssetNotFound {
@@ -1178,7 +1224,7 @@ impl Mint {
                 "Resuming confirmation of previously submitted mint"
             );
 
-            return match services.vault.confirm_mint(&known_tx.tx_id).await {
+            return match vault_service.confirm_mint(&known_tx.tx_id).await {
                 Ok(result) => {
                     info!(
                         target: "mint",
@@ -2296,6 +2342,8 @@ pub(crate) enum MintError {
         "Transaction ID mismatch. Expected: {expected}, provided: {provided}"
     )]
     TxIdMismatch { expected: TxId, provided: TxId },
+    #[error("Network {network} is not configured for mint")]
+    NetworkNotConfigured { network: Network },
     #[error(
         "Vault returned transaction metadata that differs from mint intent"
     )]
@@ -2342,6 +2390,7 @@ pub(crate) mod tests {
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
     use sqlx::{Pool, Sqlite};
+    use std::collections::HashMap;
     use std::sync::Arc;
     use tracing::Level;
     use tracing_test::traced_test;
@@ -2593,13 +2642,14 @@ pub(crate) mod tests {
             let receipt_store =
                 Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-            let services = MintServices {
+            let services = MintServices::with_single_vault(
+                Network::Base,
                 vault,
-                alpaca: Arc::new(MockAlpacaService::new_success()),
-                receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-                pool: pool.clone(),
-                bot: BOT,
-            };
+                Arc::new(MockAlpacaService::new_success()),
+                Arc::new(CqrsReceiptService::new(receipt_store)),
+                pool.clone(),
+                BOT,
+            );
 
             let mint_store =
                 Arc::new(test_store::<Mint>(pool.clone(), services));
@@ -2730,13 +2780,91 @@ pub(crate) mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
 
-        MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+        MintServices::with_single_vault(
+            Network::Base,
+            Arc::new(MockVaultService::new_success()),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
             bot,
-        }
+        )
+    }
+
+    /// Services whose vault map is empty, simulating a mint whose persisted
+    /// `network` has no chain registry entry.
+    fn empty_vault_services() -> MintServices {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_lazy(":memory:")
+            .expect("Failed to create in-memory database");
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+
+        MintServices::new(
+            HashMap::new(),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool,
+            BOT,
+        )
+    }
+
+    #[tokio::test]
+    async fn submit_mint_errors_when_network_not_configured() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let now = Utc::now();
+
+        let mut events =
+            minting_events_for_retry(&issuer_request_id, String::new(), now);
+        events.truncate(3);
+
+        let error = TestHarness::<Mint>::with(empty_vault_services())
+            .given(events)
+            .when(MintCommand::SubmitMint {
+                issuer_request_id: issuer_request_id.clone(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::NetworkNotConfigured { .. })
+            ),
+            "a mint submission for an unconfigured network must surface \
+             NetworkNotConfigured, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recover_errors_when_network_not_configured() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let now = Utc::now();
+
+        let mut events = minting_events_for_retry(
+            &issuer_request_id,
+            format!("mint-{issuer_request_id}"),
+            now,
+        );
+        events.truncate(4);
+
+        let error = TestHarness::<Mint>::with(empty_vault_services())
+            .given(events)
+            .when(MintCommand::Recover {
+                issuer_request_id: issuer_request_id.clone(),
+                mode: MintRecoveryMode::Manual,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::NetworkNotConfigured { .. })
+            ),
+            "startup recovery of a mint on an unconfigured network must \
+             surface NetworkNotConfigured instead of looping, got {error:?}"
+        );
     }
 
     #[tokio::test]
@@ -3660,13 +3788,14 @@ pub(crate) mod tests {
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-        let services = MintServices {
+        let services = MintServices::with_single_vault(
+            Network::Base,
             vault,
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool: pool.clone(),
-            bot: BOT,
-        };
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool.clone(),
+            BOT,
+        );
 
         let (mint_store, _mint_projection) =
             StoreBuilder::<Mint>::new(pool.clone())
@@ -3997,13 +4126,14 @@ pub(crate) mod tests {
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-        let services = MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool: pool.clone(),
-            bot: BOT,
-        };
+        let services = MintServices::with_single_vault(
+            Network::Base,
+            Arc::new(MockVaultService::new_success()),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool.clone(),
+            BOT,
+        );
 
         prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
         StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
@@ -4199,13 +4329,14 @@ pub(crate) mod tests {
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-        let services = MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool: pool.clone(),
-            bot: BOT,
-        };
+        let services = MintServices::with_single_vault(
+            Network::Base,
+            Arc::new(MockVaultService::new_success()),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool.clone(),
+            BOT,
+        );
 
         prepare_event_sourced_startup::<Mint>(&pool).await.unwrap();
         StoreBuilder::<Mint>::new(pool.clone()).build(services).await.unwrap();
@@ -5096,13 +5227,14 @@ pub(crate) mod tests {
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-        let services = MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+        let services = MintServices::with_single_vault(
+            Network::Base,
+            Arc::new(MockVaultService::new_success()),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
-            bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        };
+            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        );
 
         let result = mint
             .handle_recover_from_receipt(

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -43,6 +43,7 @@ pub(crate) use view::{
 /// [`Self::vault_for`] ([RAI-1206]).
 pub(crate) struct MintServices {
     vaults: HashMap<Network, Arc<dyn VaultService>>,
+    chain_ids: HashMap<Network, u64>,
     pub(crate) alpaca: Arc<dyn AlpacaService>,
     pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) pool: Pool<Sqlite>,
@@ -52,16 +53,18 @@ pub(crate) struct MintServices {
 impl MintServices {
     pub(crate) fn new(
         vaults: HashMap<Network, Arc<dyn VaultService>>,
+        chain_ids: HashMap<Network, u64>,
         alpaca: Arc<dyn AlpacaService>,
         receipts: Arc<dyn ReceiptService>,
         pool: Pool<Sqlite>,
         bot: Address,
     ) -> Self {
-        Self { vaults, alpaca, receipts, pool, bot }
+        Self { vaults, chain_ids, alpaca, receipts, pool, bot }
     }
 
     pub(crate) fn with_single_vault(
         network: Network,
+        chain_id: u64,
         vault: Arc<dyn VaultService>,
         alpaca: Arc<dyn AlpacaService>,
         receipts: Arc<dyn ReceiptService>,
@@ -70,11 +73,22 @@ impl MintServices {
     ) -> Self {
         Self::new(
             HashMap::from([(network, vault)]),
+            HashMap::from([(network, chain_id)]),
             alpaca,
             receipts,
             pool,
             bot,
         )
+    }
+
+    pub(crate) fn chain_id_for(
+        &self,
+        network: Network,
+    ) -> Result<u64, MintError> {
+        self.chain_ids
+            .get(&network)
+            .copied()
+            .ok_or(MintError::NetworkNotConfigured { network })
     }
 
     fn vault_for(
@@ -651,18 +665,11 @@ impl Mint {
             Some(&issuer_request_id),
         )
         .await
-        .map_err(|error| {
-            MintError::AssetView(TokenizedAssetViewFailure::Database {
-                message: error.to_string(),
-            })
-        })?;
-        let unresolved_burn = has_unresolved_burn_intent(&services.pool, None)
-            .await
-            .map_err(|error| {
-                MintError::AssetView(TokenizedAssetViewFailure::Database {
-                    message: error.to_string(),
-                })
-            })?;
+        .map_err(|error| MintError::Database { message: error.to_string() })?;
+        let unresolved_burn =
+            has_unresolved_burn_intent(&services.pool, None).await.map_err(
+                |error| MintError::Database { message: error.to_string() },
+            )?;
         if unresolved_mint || unresolved_burn {
             return Err(MintError::PendingWalletIntent);
         }
@@ -844,6 +851,10 @@ impl Mint {
         let now = Utc::now();
 
         let vault_service = services.vault_for(*network)?;
+        // Resolved before the irreversible on-chain call: a failing lookup
+        // after `confirm_mint` would error the command and leave tokens
+        // minted with no TokensMinted event.
+        let chain_id = services.chain_id_for(*network)?;
 
         match vault_service.confirm_mint(&tx_id).await {
             Ok(result) => {
@@ -872,6 +883,7 @@ impl Mint {
                         if let Err(err) = services
                             .receipts
                             .register_minted_receipt(MintedReceiptParams {
+                                chain_id,
                                 vault,
                                 receipt_id: ReceiptId::from(result.receipt_id),
                                 shares: Shares::from(result.shares_minted),
@@ -1016,6 +1028,7 @@ impl Mint {
                 if let Some(deposit_events) =
                     Self::recover_from_existing_receipt(
                         services,
+                        *network,
                         &vault,
                         &issuer_request_id,
                     )
@@ -1115,6 +1128,7 @@ impl Mint {
                     })?;
                 let deposit_events = Self::recover_from_existing_receipt(
                     services,
+                    *network,
                     &vault,
                     &issuer_request_id,
                 )
@@ -1196,6 +1210,7 @@ impl Mint {
 
         if let Some(events) = Self::recover_from_existing_receipt(
             services,
+            *network,
             &vault,
             &issuer_request_id,
         )
@@ -1214,6 +1229,10 @@ impl Mint {
         );
 
         let now = Utc::now();
+        // Resolved before the irreversible on-chain call: a failing lookup
+        // after `confirm_mint` would error the command and leave tokens
+        // minted with no TokensMinted event.
+        let chain_id = services.chain_id_for(*network)?;
 
         if let Some(known_tx) = known_mint_tx {
             // Known tx_id from a prior submission: go straight to confirm.
@@ -1237,6 +1256,7 @@ impl Mint {
                     if let Err(err) = services
                         .receipts
                         .register_minted_receipt(MintedReceiptParams {
+                            chain_id,
                             vault,
                             receipt_id: ReceiptId::from(result.receipt_id),
                             shares: Shares::from(result.shares_minted),
@@ -1432,12 +1452,14 @@ impl Mint {
 
     async fn recover_from_existing_receipt(
         services: &MintServices,
+        network: Network,
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
     ) -> Result<Option<Vec<MintEvent>>, MintError> {
+        let chain_id = services.chain_id_for(network)?;
         let Some(receipt) = services
             .receipts
-            .find_by_issuer_request_id(vault, issuer_request_id)
+            .find_by_issuer_request_id(chain_id, vault, issuer_request_id)
             .await
             .map_err(|e| MintError::ReceiptLookup { message: e.to_string() })?
         else {
@@ -2356,6 +2378,8 @@ pub(crate) enum MintError {
     QuantityConversion { message: String },
     #[error(transparent)]
     AssetView(#[from] TokenizedAssetViewFailure),
+    #[error("database query failed: {message}")]
+    Database { message: String },
     #[error("Alpaca: {message}")]
     Alpaca { message: String },
     #[error("Receipt lookup: {message}")]
@@ -2406,7 +2430,7 @@ pub(crate) mod tests {
     use crate::alpaca::mock::MockAlpacaService;
     use crate::prepare_event_sourced_startup;
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::{log_count_at, logs_contain_at};
+    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
@@ -2644,6 +2668,7 @@ pub(crate) mod tests {
 
             let services = MintServices::with_single_vault(
                 Network::Base,
+                ANVIL_CHAIN_ID,
                 vault,
                 Arc::new(MockAlpacaService::new_success()),
                 Arc::new(CqrsReceiptService::new(receipt_store)),
@@ -2782,6 +2807,7 @@ pub(crate) mod tests {
 
         MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             Arc::new(MockVaultService::new_success()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
@@ -2802,6 +2828,7 @@ pub(crate) mod tests {
 
         MintServices::new(
             HashMap::new(),
+            HashMap::new(),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
@@ -2812,11 +2839,9 @@ pub(crate) mod tests {
     #[tokio::test]
     async fn submit_mint_errors_when_network_not_configured() {
         let issuer_request_id = IssuerMintRequestId::random();
-        let now = Utc::now();
-
-        let mut events =
-            minting_events_for_retry(&issuer_request_id, String::new(), now);
-        events.truncate(3);
+        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
+        let events =
+            persisted_mint_intent_events(&issuer_request_id, prepared_tx);
 
         let error = TestHarness::<Mint>::with(empty_vault_services())
             .given(events)
@@ -3790,6 +3815,7 @@ pub(crate) mod tests {
 
         let services = MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             vault,
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
@@ -4128,6 +4154,7 @@ pub(crate) mod tests {
 
         let services = MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             Arc::new(MockVaultService::new_success()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
@@ -4331,6 +4358,7 @@ pub(crate) mod tests {
 
         let services = MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             Arc::new(MockVaultService::new_success()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
@@ -5229,6 +5257,7 @@ pub(crate) mod tests {
 
         let services = MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             Arc::new(MockVaultService::new_success()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1084,15 +1084,14 @@ mod tests {
             let receipt_store =
                 Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-            let services = MintServices {
-                vault: vault.clone(),
+            let services = MintServices::with_single_vault(
+                Network::Base,
+                vault.clone(),
                 alpaca,
-                receipts: Arc::new(CqrsReceiptService::new(
-                    receipt_store.clone(),
-                )),
-                pool: pool.clone(),
-                bot: BOT,
-            };
+                Arc::new(CqrsReceiptService::new(receipt_store.clone())),
+                pool.clone(),
+                BOT,
+            );
 
             let mint_store =
                 Arc::new(test_store::<Mint>(pool.clone(), services));

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1010,9 +1010,9 @@ mod tests {
     };
     use crate::receipt_inventory::{
         CqrsReceiptService, ReceiptId, ReceiptInventory,
-        ReceiptInventoryCommand, ReceiptSource, Shares,
+        ReceiptInventoryCommand, ReceiptSource, ReceiptVaultKey, Shares,
     };
-    use crate::test_utils::{log_count_at, logs_contain_at};
+    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
@@ -1086,6 +1086,7 @@ mod tests {
 
             let services = MintServices::with_single_vault(
                 Network::Base,
+                ANVIL_CHAIN_ID,
                 vault.clone(),
                 alpaca,
                 Arc::new(CqrsReceiptService::new(receipt_store.clone())),
@@ -1314,7 +1315,7 @@ mod tests {
         fixture
             .receipt_store
             .send(
-                &VAULT,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, VAULT),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(42_U256)),
                     balance: Shares::from(
@@ -2252,13 +2253,15 @@ mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
         let vault: Arc<dyn VaultService> =
             Arc::new(MockVaultService::new_success());
-        let services = MintServices {
-            vault: vault.clone(),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
-            pool: pool.clone(),
-            bot: BOT,
-        };
+        let services = MintServices::with_single_vault(
+            Network::Base,
+            ANVIL_CHAIN_ID,
+            vault.clone(),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
+            pool.clone(),
+            BOT,
+        );
         let mint_store = Arc::new(test_store::<Mint>(pool.clone(), services));
 
         let issuer_request_id = test_issuer_request_id();

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -344,13 +344,14 @@ mod tests {
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
-        MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
-            alpaca: Arc::new(MockAlpacaService::new_success()),
-            receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
+        MintServices::with_single_vault(
+            Network::Base,
+            Arc::new(MockVaultService::new_success()),
+            Arc::new(MockAlpacaService::new_success()),
+            Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,
-            bot: address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
-        }
+            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        )
     }
 
     struct TestMintFields {

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -281,6 +281,7 @@ mod tests {
     use crate::alpaca::mock::MockAlpacaService;
     use crate::mint::{Mint, MintCommand, MintServices};
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
+    use crate::test_utils::ANVIL_CHAIN_ID;
     use crate::vault::mock::MockVaultService;
 
     /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given
@@ -346,6 +347,7 @@ mod tests {
 
         MintServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             Arc::new(MockVaultService::new_success()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -182,7 +182,10 @@ mod tests {
         // must be a string enum over the exact lowercase wire values clients
         // switch on, not an open string or a struct.
         assert_eq!(schemas["Network"]["type"], "string");
-        assert_eq!(schemas["Network"]["enum"], serde_json::json!(["base"]));
+        assert_eq!(
+            schemas["Network"]["enum"],
+            serde_json::json!(["base", "ethereum"])
+        );
         assert_eq!(schemas["TokenizedAssetStatus"]["type"], "string");
         assert_eq!(
             schemas["TokenizedAssetStatus"]["enum"],

--- a/src/poll_checkpoint.rs
+++ b/src/poll_checkpoint.rs
@@ -8,6 +8,7 @@
 //! Checkpoints are not domain entities — there is no audit history to keep
 //! and no state machine to enforce — so they live in a plain SQL table.
 
+use crate::tokenized_asset::Network;
 use alloy::primitives::Address;
 use sqlx::{Pool, Sqlite};
 
@@ -27,14 +28,59 @@ pub(crate) fn transfer_poll_name(vault: Address) -> String {
     format!("transfer_poll:{vault:#x}")
 }
 
-/// Checkpoint name for the receipt backfiller for a given vault.
-pub(crate) fn receipt_backfill_name(vault: Address) -> String {
+/// Per-network receipt backfill checkpoint name.
+pub(crate) fn receipt_backfill_name(
+    network: Network,
+    vault: Address,
+) -> String {
+    format!("receipt_backfill:{network}:{vault:#x}")
+}
+
+/// Legacy single-chain (Base only) checkpoint name, seeded by the migration
+/// from event-sourced BackfillCheckpoint events.
+fn legacy_receipt_backfill_name(vault: Address) -> String {
     format!("receipt_backfill:{vault:#x}")
+}
+
+/// Loads the receipt backfill checkpoint for `network`/`vault`, falling back
+/// to the legacy vault-only name when polling Base.
+pub(crate) async fn load_receipt_backfill(
+    pool: &Pool<Sqlite>,
+    network: Network,
+    vault: Address,
+) -> Result<Option<u64>, CheckpointError> {
+    if let Some(block) =
+        load_checkpoint_block(pool, &receipt_backfill_name(network, vault))
+            .await?
+    {
+        return Ok(Some(block));
+    }
+
+    if network == Network::Base {
+        load_checkpoint_block(pool, &legacy_receipt_backfill_name(vault)).await
+    } else {
+        Ok(None)
+    }
+}
+
+/// Advances the receipt backfill checkpoint for `network`/`vault`.
+pub(crate) async fn advance_receipt_backfill(
+    pool: &Pool<Sqlite>,
+    network: Network,
+    vault: Address,
+    block_number: u64,
+) -> Result<(), CheckpointError> {
+    advance_checkpoint_block(
+        pool,
+        &receipt_backfill_name(network, vault),
+        block_number,
+    )
+    .await
 }
 
 /// Returns the highest block number recorded for `name`, or `None` if no
 /// checkpoint has been written yet.
-pub(crate) async fn load(
+pub(crate) async fn load_checkpoint_block(
     pool: &Pool<Sqlite>,
     name: &str,
 ) -> Result<Option<u64>, CheckpointError> {
@@ -51,7 +97,7 @@ pub(crate) async fn load(
 /// Advances `name` to `block_number`, but only if the new value is strictly
 /// greater than the existing one. Older or equal values are ignored, matching
 /// the monotonic semantics of the aggregates this replaces.
-pub(crate) async fn advance(
+pub(crate) async fn advance_checkpoint_block(
     pool: &Pool<Sqlite>,
     name: &str,
     block_number: u64,
@@ -107,6 +153,8 @@ mod tests {
     use alloy::primitives::address;
     use sqlx::sqlite::SqlitePoolOptions;
 
+    use crate::tokenized_asset::Network;
+
     use super::*;
 
     async fn setup_pool() -> Pool<Sqlite> {
@@ -122,39 +170,54 @@ mod tests {
     #[tokio::test]
     async fn load_returns_none_when_unset() {
         let pool = setup_pool().await;
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), None);
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            None
+        );
     }
 
     #[tokio::test]
     async fn advance_sets_the_value() {
         let pool = setup_pool().await;
-        advance(&pool, TRANSFER_POLL, 100).await.unwrap();
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), Some(100));
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 100).await.unwrap();
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            Some(100)
+        );
     }
 
     #[tokio::test]
     async fn advance_is_monotonic() {
         let pool = setup_pool().await;
-        advance(&pool, TRANSFER_POLL, 100).await.unwrap();
-        advance(&pool, TRANSFER_POLL, 80).await.unwrap();
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), Some(100));
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 100).await.unwrap();
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 80).await.unwrap();
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            Some(100)
+        );
     }
 
     #[tokio::test]
     async fn advance_to_same_block_is_noop() {
         let pool = setup_pool().await;
-        advance(&pool, TRANSFER_POLL, 100).await.unwrap();
-        advance(&pool, TRANSFER_POLL, 100).await.unwrap();
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), Some(100));
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 100).await.unwrap();
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 100).await.unwrap();
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            Some(100)
+        );
     }
 
     #[tokio::test]
     async fn sequential_advances_grow_monotonically() {
         let pool = setup_pool().await;
-        advance(&pool, TRANSFER_POLL, 100).await.unwrap();
-        advance(&pool, TRANSFER_POLL, 200).await.unwrap();
-        advance(&pool, TRANSFER_POLL, 350).await.unwrap();
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), Some(350));
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 100).await.unwrap();
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 200).await.unwrap();
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 350).await.unwrap();
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            Some(350)
+        );
     }
 
     #[tokio::test]
@@ -162,27 +225,70 @@ mod tests {
         let pool = setup_pool().await;
         let vault_a = address!("00000000000000000000000000000000000000aa");
         let vault_b = address!("00000000000000000000000000000000000000bb");
-        advance(&pool, &receipt_backfill_name(vault_a), 100).await.unwrap();
-        advance(&pool, &receipt_backfill_name(vault_b), 500).await.unwrap();
-        advance(&pool, TRANSFER_POLL, 999).await.unwrap();
+        advance_checkpoint_block(
+            &pool,
+            &receipt_backfill_name(Network::Base, vault_a),
+            100,
+        )
+        .await
+        .unwrap();
+        advance_checkpoint_block(
+            &pool,
+            &receipt_backfill_name(Network::Base, vault_b),
+            500,
+        )
+        .await
+        .unwrap();
+        advance_checkpoint_block(&pool, TRANSFER_POLL, 999).await.unwrap();
 
         assert_eq!(
-            load(&pool, &receipt_backfill_name(vault_a)).await.unwrap(),
+            load_checkpoint_block(
+                &pool,
+                &receipt_backfill_name(Network::Base, vault_a),
+            )
+            .await
+            .unwrap(),
             Some(100)
         );
         assert_eq!(
-            load(&pool, &receipt_backfill_name(vault_b)).await.unwrap(),
+            load_checkpoint_block(
+                &pool,
+                &receipt_backfill_name(Network::Base, vault_b),
+            )
+            .await
+            .unwrap(),
             Some(500)
         );
-        assert_eq!(load(&pool, TRANSFER_POLL).await.unwrap(), Some(999));
+        assert_eq!(
+            load_checkpoint_block(&pool, TRANSFER_POLL).await.unwrap(),
+            Some(999)
+        );
     }
 
     #[tokio::test]
     async fn receipt_backfill_name_uses_lowercase_hex() {
         let vault = address!("AaBbCcDdEeFf00112233445566778899aAbBcCdD");
         assert_eq!(
-            receipt_backfill_name(vault),
-            "receipt_backfill:0xaabbccddeeff00112233445566778899aabbccdd"
+            receipt_backfill_name(Network::Base, vault),
+            "receipt_backfill:base:0xaabbccddeeff00112233445566778899aabbccdd"
+        );
+    }
+
+    #[tokio::test]
+    async fn load_receipt_backfill_falls_back_to_legacy_base_checkpoint() {
+        let pool = setup_pool().await;
+        let vault = address!("00000000000000000000000000000000000000aa");
+        advance_checkpoint_block(
+            &pool,
+            &legacy_receipt_backfill_name(vault),
+            42,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            load_receipt_backfill(&pool, Network::Base, vault).await.unwrap(),
+            Some(42)
         );
     }
 
@@ -259,7 +365,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(
-            load(&pool, &receipt_backfill_name(vault)).await.unwrap(),
+            load_receipt_backfill(&pool, Network::Base, vault).await.unwrap(),
             Some(12345),
             "seeded checkpoint must be readable via the runtime key"
         );

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -18,7 +18,8 @@ use super::{
 };
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::mint::IssuerMintRequestId;
-use crate::poll_checkpoint::{self, CheckpointError, receipt_backfill_name};
+use crate::poll_checkpoint::{CheckpointError, advance_receipt_backfill};
+use crate::tokenized_asset::Network;
 
 /// Maximum number of blocks to query in a single get_logs call.
 /// RPCs typically limit response sizes, so we chunk large ranges.
@@ -53,10 +54,26 @@ where
     provider: ProviderType,
     receipt_contract: Address,
     bot_wallet: Address,
+    chain_id: u64,
+    network: Network,
     vault: Address,
     store: Arc<Store<ReceiptInventory>>,
     pool: Pool<Sqlite>,
     handler: Handler,
+}
+
+/// Bundles [`ReceiptBackfiller`] construction inputs to stay within clippy's
+/// argument limit.
+pub(crate) struct ReceiptBackfillDeps<ProviderType, Handler> {
+    pub(crate) provider: ProviderType,
+    pub(crate) receipt_contract: Address,
+    pub(crate) bot_wallet: Address,
+    pub(crate) chain_id: u64,
+    pub(crate) network: Network,
+    pub(crate) vault: Address,
+    pub(crate) store: Arc<Store<ReceiptInventory>>,
+    pub(crate) pool: Pool<Sqlite>,
+    pub(crate) handler: Handler,
 }
 
 #[derive(Debug)]
@@ -90,19 +107,27 @@ impl<ProviderType, Handler> ReceiptBackfiller<ProviderType, Handler>
 where
     Handler: ItnReceiptHandler,
 {
-    pub(crate) const fn new(
-        provider: ProviderType,
-        receipt_contract: Address,
-        bot_wallet: Address,
-        vault: Address,
-        store: Arc<Store<ReceiptInventory>>,
-        pool: Pool<Sqlite>,
-        handler: Handler,
+    pub(crate) fn new(
+        deps: ReceiptBackfillDeps<ProviderType, Handler>,
     ) -> Self {
+        let ReceiptBackfillDeps {
+            provider,
+            receipt_contract,
+            bot_wallet,
+            chain_id,
+            network,
+            vault,
+            store,
+            pool,
+            handler,
+        } = deps;
+
         Self {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id,
+            network,
             vault,
             store,
             pool,
@@ -127,7 +152,7 @@ where
     /// `from_block` is the block to start scanning from. On first run, pass
     /// the configured backfill start block. On subsequent runs, read the
     /// previous checkpoint via
-    /// `poll_checkpoint::load(pool, &receipt_backfill_name(vault))`.
+    /// `load_receipt_backfill(pool, network, vault)`.
     ///
     /// `head_block` is the chain head to scan up to. The caller fetches it so
     /// a single `eth_blockNumber` can be shared across every vault in one
@@ -217,9 +242,10 @@ where
             self.reconcile_receipt(receipt_id).await?;
         }
 
-        poll_checkpoint::advance(
+        advance_receipt_backfill(
             &self.pool,
-            &receipt_backfill_name(self.vault),
+            self.network,
+            self.vault,
             current_block,
         )
         .await?;
@@ -459,6 +485,7 @@ where
 
         send_receipt_inventory_command(
             &self.store,
+            self.chain_id,
             &self.vault,
             ReceiptInventoryCommand::DiscoverReceipt {
                 receipt_id: discovery.receipt_id,
@@ -477,6 +504,7 @@ where
         // after an inbound transfer increases the balance).
         send_receipt_inventory_command(
             &self.store,
+            self.chain_id,
             &self.vault,
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id: discovery.receipt_id,
@@ -514,6 +542,7 @@ where
 
         send_receipt_inventory_command(
             &self.store,
+            self.chain_id,
             &self.vault,
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id,
@@ -651,14 +680,17 @@ mod tests {
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    use super::{NoOpItnHandler, ReceiptBackfiller};
+    use super::{NoOpItnHandler, ReceiptBackfillDeps, ReceiptBackfiller};
     use crate::bindings::OffchainAssetReceiptVault;
-    use crate::poll_checkpoint;
+    use crate::poll_checkpoint::{
+        load_checkpoint_block, receipt_backfill_name,
+    };
     use crate::receipt_inventory::{
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
-        Shares, load_inventory,
+        ReceiptVaultKey, Shares, load_inventory,
     };
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
+    use crate::tokenized_asset::Network;
 
     async fn setup_test_pool() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()
@@ -779,15 +811,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
             store,
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -847,15 +881,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter1);
 
-        let backfiller1 = ReceiptBackfiller::new(
-            provider1,
+        let backfiller1 = ReceiptBackfiller::new(ReceiptBackfillDeps {
+            provider: provider1,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result1 =
             backfiller1.backfill_receipts(0, current_block).await.unwrap();
@@ -864,16 +900,16 @@ mod tests {
         // After the first run the aggregate has exactly one Discovered event
         // and the SQL checkpoint matches the chain head.
         let inventory_after_first =
-            load_inventory(&store, &vault).await.unwrap();
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         assert_eq!(
             inventory_after_first.receipts_with_balance().len(),
             1,
             "first run should produce exactly one receipt"
         );
         assert_eq!(
-            poll_checkpoint::load(
+            load_checkpoint_block(
                 &pool,
-                &poll_checkpoint::receipt_backfill_name(vault),
+                &receipt_backfill_name(Network::Base, vault),
             )
             .await
             .unwrap(),
@@ -891,15 +927,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter2);
 
-        let backfiller2 = ReceiptBackfiller::new(
-            provider2,
+        let backfiller2 = ReceiptBackfiller::new(ReceiptBackfillDeps {
+            provider: provider2,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result2 =
             backfiller2.backfill_receipts(0, current_block).await.unwrap();
@@ -909,16 +947,16 @@ mod tests {
         // (no duplicate Discovered event applied) and the checkpoint is
         // unchanged.
         let inventory_after_second =
-            load_inventory(&store, &vault).await.unwrap();
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         assert_eq!(
             inventory_after_second.receipts_with_balance().len(),
             1,
             "second run must not produce a duplicate receipt"
         );
         assert_eq!(
-            poll_checkpoint::load(
+            load_checkpoint_block(
                 &pool,
-                &poll_checkpoint::receipt_backfill_name(vault),
+                &receipt_backfill_name(Network::Base, vault),
             )
             .await
             .unwrap(),
@@ -964,15 +1002,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
             store,
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -1034,22 +1074,25 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
 
         assert_eq!(result.processed_count, 1);
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
 
         assert_eq!(receipts.len(), 1);
@@ -1108,15 +1151,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
             store,
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -1161,21 +1206,23 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
             store,
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         backfiller.backfill_receipts(0, current_block).await.unwrap();
 
-        let recorded = poll_checkpoint::load(
+        let recorded = load_checkpoint_block(
             &pool,
-            &poll_checkpoint::receipt_backfill_name(vault),
+            &receipt_backfill_name(Network::Base, vault),
         )
         .await
         .unwrap();
@@ -1406,15 +1453,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -1423,7 +1472,8 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify the receipt was actually discovered with correct ID and balance
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1, "Should discover exactly one receipt");
         assert_eq!(
@@ -1490,15 +1540,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -1510,7 +1562,8 @@ mod tests {
         assert_eq!(result.skipped_zero_balance, 0);
 
         // Verify: aggregate has no receipts at all
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         assert!(
             inventory.receipts_with_balance().is_empty(),
             "No receipts should be discovered from outbound/mint transfers"
@@ -1574,15 +1627,17 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
@@ -1590,7 +1645,8 @@ mod tests {
         // Should only process once despite appearing in both Deposit and Transfer
         assert_eq!(result.processed_count, 1);
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
         assert_eq!(
             receipts.len(),
@@ -1625,7 +1681,7 @@ mod tests {
         // Seed aggregate with a receipt at a stale lower balance
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(receipt_id_raw),
                     balance: Shares::from(stale_balance),
@@ -1674,22 +1730,25 @@ mod tests {
             .wallet(EthereumWallet::from(PrivateKeySigner::random()))
             .connect_mocked_client(asserter);
 
-        let backfiller = ReceiptBackfiller::new(
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
             provider,
             receipt_contract,
             bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
             vault,
-            store.clone(),
-            pool.clone(),
-            NoOpItnHandler,
-        );
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
 
         let result =
             backfiller.backfill_receipts(0, current_block).await.unwrap();
         assert_eq!(result.processed_count, 1);
 
         // Verify balance was reconciled upward from 500 to 750
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod burn_tracking;
 mod cmd;
 mod event;
 pub(crate) mod reconcile;
+mod vault_key;
 pub(crate) mod view;
 
 use alloy::primitives::{Address, B256, Bytes, TxHash, U256};
@@ -30,6 +31,7 @@ pub(crate) use burn_tracking::{
 pub(crate) use cmd::ReceiptInventoryCommand;
 pub(crate) use event::{ReceiptInventoryEvent, ReceiptSource};
 use reconcile::ReconcileError;
+pub(crate) use vault_key::ReceiptVaultKey;
 
 const RECEIPT_INVENTORY_MAX_ATTEMPTS: usize = 3;
 
@@ -224,6 +226,7 @@ impl ReceiptMetadata {
 
 /// Parameters for registering a newly minted receipt.
 pub(crate) struct MintedReceiptParams {
+    pub(crate) chain_id: u64,
     pub(crate) vault: Address,
     pub(crate) receipt_id: ReceiptId,
     pub(crate) shares: Shares,
@@ -260,6 +263,7 @@ pub(crate) trait ReceiptService: Send + Sync {
     /// replaces that reservation.
     async fn for_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: &IssuerRedemptionRequestId,
         shares_to_burn: Shares,
@@ -268,6 +272,7 @@ pub(crate) trait ReceiptService: Send + Sync {
 
     async fn reserve_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
         burns: Vec<BurnRecord>,
@@ -275,12 +280,14 @@ pub(crate) trait ReceiptService: Send + Sync {
 
     async fn release_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError>;
 
     async fn settle_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError>;
@@ -289,6 +296,7 @@ pub(crate) trait ReceiptService: Send + Sync {
     /// for startup reservation recovery.
     async fn reserved_redemptions(
         &self,
+        chain_id: u64,
         vault: Address,
     ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>;
 
@@ -298,6 +306,7 @@ pub(crate) trait ReceiptService: Send + Sync {
     /// Returns None if no receipt exists with this issuer_request_id.
     async fn find_by_issuer_request_id(
         &self,
+        chain_id: u64,
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
     ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError>;
@@ -330,9 +339,11 @@ impl CqrsReceiptService {
 /// so a future reader cannot silently diverge on the `None` case.
 pub(crate) async fn load_inventory(
     store: &Store<ReceiptInventory>,
+    chain_id: u64,
     vault: &Address,
 ) -> Result<ReceiptInventory, SendError<ReceiptInventory>> {
-    Ok(store.load(vault).await?.unwrap_or_default())
+    let key = ReceiptVaultKey::new(chain_id, *vault);
+    Ok(store.load(&key).await?.unwrap_or_default())
 }
 
 const fn receipt_inventory_operation(
@@ -387,12 +398,14 @@ where
 
 pub(crate) async fn send_receipt_inventory_command(
     store: &Store<ReceiptInventory>,
+    chain_id: u64,
     vault: &Address,
     command: ReceiptInventoryCommand,
 ) -> Result<(), SendError<ReceiptInventory>> {
+    let key = ReceiptVaultKey::new(chain_id, *vault);
     let operation = receipt_inventory_operation(&command);
     retry_receipt_inventory_conflicts(*vault, operation, || {
-        store.send(vault, command.clone())
+        store.send(&key, command.clone())
     })
     .await
 }
@@ -469,6 +482,7 @@ impl ReceiptService for CqrsReceiptService {
 
         send_receipt_inventory_command(
             &self.store,
+            params.chain_id,
             &params.vault,
             ReceiptInventoryCommand::DiscoverReceipt {
                 receipt_id: params.receipt_id,
@@ -487,12 +501,13 @@ impl ReceiptService for CqrsReceiptService {
 
     async fn for_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: &IssuerRedemptionRequestId,
         shares_to_burn: Shares,
         dust: Shares,
     ) -> Result<BurnPlan, BurnTrackingError> {
-        let inventory = load_inventory(&self.store, &vault).await?;
+        let inventory = load_inventory(&self.store, chain_id, &vault).await?;
 
         let receipts = inventory
             .receipts_with_balance_excluding(redemption_issuer_request_id);
@@ -501,12 +516,14 @@ impl ReceiptService for CqrsReceiptService {
 
     async fn reserve_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
         burns: Vec<BurnRecord>,
     ) -> Result<(), ReceiptRegistrationError> {
         send_receipt_inventory_command(
             &self.store,
+            chain_id,
             &vault,
             ReceiptInventoryCommand::ReserveBurn {
                 redemption_issuer_request_id,
@@ -520,11 +537,13 @@ impl ReceiptService for CqrsReceiptService {
 
     async fn release_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
         send_receipt_inventory_command(
             &self.store,
+            chain_id,
             &vault,
             ReceiptInventoryCommand::ReleaseBurn {
                 redemption_issuer_request_id,
@@ -537,11 +556,13 @@ impl ReceiptService for CqrsReceiptService {
 
     async fn settle_burn(
         &self,
+        chain_id: u64,
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
         send_receipt_inventory_command(
             &self.store,
+            chain_id,
             &vault,
             ReceiptInventoryCommand::SettleBurn {
                 redemption_issuer_request_id,
@@ -554,18 +575,21 @@ impl ReceiptService for CqrsReceiptService {
 
     async fn reserved_redemptions(
         &self,
+        chain_id: u64,
         vault: Address,
     ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError> {
-        let inventory = load_inventory(&self.store, &vault).await?;
+        let inventory = load_inventory(&self.store, chain_id, &vault).await?;
         Ok(inventory.reserved_redemptions())
     }
 
     async fn find_by_issuer_request_id(
         &self,
+        chain_id: u64,
         vault: &Address,
         issuer_request_id: &IssuerMintRequestId,
     ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
-        let receipt_inventory = load_inventory(&self.store, vault).await?;
+        let receipt_inventory =
+            load_inventory(&self.store, chain_id, vault).await?;
 
         let Some(receipt_id) =
             receipt_inventory.find_by_issuer_request_id(issuer_request_id)
@@ -1096,7 +1120,7 @@ impl ReceiptInventory {
 
 #[async_trait]
 impl EventSourced for ReceiptInventory {
-    type Id = Address;
+    type Id = ReceiptVaultKey;
     type Event = ReceiptInventoryEvent;
     type Command = ReceiptInventoryCommand;
     type Error = ReceiptInventoryError;
@@ -1208,7 +1232,7 @@ mod tests {
 
     use super::*;
     use crate::prepare_event_sourced_startup;
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
 
     const TEST_OA_SCHEMA: &str =
         "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
@@ -1383,7 +1407,7 @@ mod tests {
 
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: make_receipt_id(99),
                     balance: make_shares(500),
@@ -1397,7 +1421,8 @@ mod tests {
             .await
             .unwrap();
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
@@ -1421,7 +1446,7 @@ mod tests {
         // instead of degrading to an empty inventory).
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::ReserveBurn {
                     redemption_issuer_request_id: "red-00000000"
                         .parse()
@@ -1433,7 +1458,7 @@ mod tests {
             .unwrap();
 
         let inventory = store
-            .load(&vault)
+            .load(&ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault))
             .await
             .expect("load must not fail on a non-Discovered genesis event")
             .expect("a persisted stream must materialize an inventory");
@@ -1456,7 +1481,7 @@ mod tests {
 
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 discover_itn_receipt_cmd(
                     make_receipt_id(42),
                     make_shares(100),
@@ -1468,7 +1493,8 @@ mod tests {
             .await
             .unwrap();
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let found = inventory.find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, Some(make_receipt_id(42)));
     }
@@ -1489,7 +1515,7 @@ mod tests {
 
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(crate::test_utils::ANVIL_CHAIN_ID, vault),
                 discover_itn_receipt_cmd(
                     make_receipt_id(42),
                     make_shares(100),
@@ -1505,6 +1531,7 @@ mod tests {
 
         service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000001".parse().unwrap(),
                 vec![BurnRecord {
@@ -1516,7 +1543,11 @@ mod tests {
             .unwrap();
 
         let recovered = service
-            .find_by_issuer_request_id(&vault, &issuer_request_id)
+            .find_by_issuer_request_id(
+                ANVIL_CHAIN_ID,
+                &vault,
+                &issuer_request_id,
+            )
             .await
             .unwrap()
             .expect("ITN receipt must be found by issuer_request_id");
@@ -1534,7 +1565,8 @@ mod tests {
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let issuer_request_id = IssuerMintRequestId::random();
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let found = inventory.find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, None);
     }
@@ -1551,7 +1583,7 @@ mod tests {
         // Discover an external receipt (no issuer_request_id)
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 discover_receipt_cmd(
                     make_receipt_id(42),
                     make_shares(100),
@@ -1562,7 +1594,8 @@ mod tests {
             .await
             .unwrap();
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
 
         // External receipts should not be indexed by issuer_request_id
         let random_id = IssuerMintRequestId::random();
@@ -1672,7 +1705,7 @@ mod tests {
         for (i, (id, balance)) in receipts.into_iter().enumerate() {
             store
                 .send(
-                    &vault,
+                    &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                     discover_receipt_cmd(
                         make_receipt_id(id),
                         make_shares(balance),
@@ -1773,6 +1806,7 @@ mod tests {
                 first_barrier.wait().await;
                 send_receipt_inventory_command(
                     &first_store,
+                    ANVIL_CHAIN_ID,
                     &vault,
                     discover_receipt_cmd(
                         first_receipt_id,
@@ -1791,6 +1825,7 @@ mod tests {
                 second_barrier.wait().await;
                 send_receipt_inventory_command(
                     &second_store,
+                    ANVIL_CHAIN_ID,
                     &vault,
                     discover_receipt_cmd(
                         second_receipt_id,
@@ -1813,7 +1848,7 @@ mod tests {
                 .expect("second receipt should persist after retry");
         }
 
-        let inventory = load_inventory(&store, &vault)
+        let inventory = load_inventory(&store, ANVIL_CHAIN_ID, &vault)
             .await
             .expect("inventory should load");
         let expected_receipt_count = usize::try_from(pair_count * 2)
@@ -1914,6 +1949,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 &planning_redemption(),
                 make_shares(150),
@@ -1933,6 +1969,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 &planning_redemption(),
                 make_shares(100),
@@ -1953,6 +1990,7 @@ mod tests {
 
         let result = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 &planning_redemption(),
                 make_shares(100),
@@ -1973,6 +2011,7 @@ mod tests {
 
         let result = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 &planning_redemption(),
                 make_shares(100),
@@ -1993,6 +2032,7 @@ mod tests {
 
         let result = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
                 &planning_redemption(),
                 make_shares(50),
@@ -2013,6 +2053,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
                 &planning_redemption(),
                 make_shares(100),
@@ -2033,6 +2074,7 @@ mod tests {
 
         service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000001".parse().unwrap(),
                 vec![BurnRecord {
@@ -2045,6 +2087,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(50),
@@ -2066,6 +2109,7 @@ mod tests {
 
         service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000001".parse().unwrap(),
                 vec![BurnRecord {
@@ -2078,6 +2122,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(90),
@@ -2100,6 +2145,7 @@ mod tests {
 
         let err = service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000001".parse().unwrap(),
                 vec![
@@ -2137,6 +2183,7 @@ mod tests {
 
         service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 redemption_id.clone(),
                 vec![BurnRecord {
@@ -2149,6 +2196,7 @@ mod tests {
 
         let err = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(1),
@@ -2159,10 +2207,14 @@ mod tests {
 
         assert!(matches!(err, BurnTrackingError::InsufficientBalance { .. }));
 
-        service.release_burn(vault, redemption_id).await.unwrap();
+        service
+            .release_burn(ANVIL_CHAIN_ID, vault, redemption_id)
+            .await
+            .unwrap();
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(100),
@@ -2448,17 +2500,27 @@ mod tests {
             "red-00000001".parse().unwrap();
 
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 60)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 60)],
+            )
             .await
             .unwrap();
 
-        service.settle_burn(vault, redemption_id).await.unwrap();
+        service
+            .settle_burn(ANVIL_CHAIN_ID, vault, redemption_id)
+            .await
+            .unwrap();
 
         // The mirror balance itself must drop 100 -> 40 and the reservation
         // must be cleared. Checking internals distinguishes a real settlement
         // from merely leaving the reservation in place (which would leave the
         // same 40 available but a stale 100 mirror).
-        let inventory = load_inventory(&service.store, &vault).await.unwrap();
+        let inventory = load_inventory(&service.store, ANVIL_CHAIN_ID, &vault)
+            .await
+            .unwrap();
         let metadata = inventory
             .receipts
             .get(&make_receipt_id(1))
@@ -2471,6 +2533,7 @@ mod tests {
 
         let err = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(41),
@@ -2489,12 +2552,22 @@ mod tests {
             "red-00000001".parse().unwrap();
 
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 100)],
+            )
             .await
             .unwrap();
-        service.settle_burn(vault, redemption_id).await.unwrap();
+        service
+            .settle_burn(ANVIL_CHAIN_ID, vault, redemption_id)
+            .await
+            .unwrap();
 
-        let inventory = load_inventory(&service.store, &vault).await.unwrap();
+        let inventory = load_inventory(&service.store, ANVIL_CHAIN_ID, &vault)
+            .await
+            .unwrap();
         assert!(
             inventory.receipts_with_balance().is_empty(),
             "a fully settled receipt must be depleted and removed"
@@ -2575,15 +2648,27 @@ mod tests {
             "red-00000001".parse().unwrap();
 
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 100)],
+            )
             .await
             .unwrap();
-        service.release_burn(vault, redemption_id.clone()).await.unwrap();
+        service
+            .release_burn(ANVIL_CHAIN_ID, vault, redemption_id.clone())
+            .await
+            .unwrap();
         // Second release must NOT over-credit the balance.
-        service.release_burn(vault, redemption_id).await.unwrap();
+        service
+            .release_burn(ANVIL_CHAIN_ID, vault, redemption_id)
+            .await
+            .unwrap();
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(100),
@@ -2595,6 +2680,7 @@ mod tests {
 
         let err = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(101),
@@ -2611,12 +2697,17 @@ mod tests {
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
         service
-            .release_burn(vault, "red-00000001".parse().unwrap())
+            .release_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                "red-00000001".parse().unwrap(),
+            )
             .await
             .expect("releasing with no reservation must be a no-op");
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(100),
@@ -2634,6 +2725,7 @@ mod tests {
 
         service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000001".parse().unwrap(),
                 vec![burn(1, 60)],
@@ -2643,6 +2735,7 @@ mod tests {
 
         let err = service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 "red-00000002".parse().unwrap(),
                 vec![burn(1, 60)],
@@ -2665,17 +2758,28 @@ mod tests {
             "red-00000001".parse().unwrap();
 
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 60)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 60)],
+            )
             .await
             .unwrap();
         // Re-delivery of the same reservation must not double-count itself.
         service
-            .reserve_burn(vault, redemption_id, vec![burn(1, 60)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id,
+                vec![burn(1, 60)],
+            )
             .await
             .expect("re-reserving the same redemption must succeed");
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(40),
@@ -2699,17 +2803,32 @@ mod tests {
 
         // First attempt reserves receipt 1; the retry reserves receipt 2.
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 100)],
+            )
             .await
             .unwrap();
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(2, 100)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(2, 100)],
+            )
             .await
             .unwrap();
 
-        service.settle_burn(vault, redemption_id).await.unwrap();
+        service
+            .settle_burn(ANVIL_CHAIN_ID, vault, redemption_id)
+            .await
+            .unwrap();
 
-        let inventory = load_inventory(&service.store, &vault).await.unwrap();
+        let inventory = load_inventory(&service.store, ANVIL_CHAIN_ID, &vault)
+            .await
+            .unwrap();
 
         // Receipt 1's stale reservation was cleared by the retry, so settle
         // left it untouched; only receipt 2 was consumed (and depleted).
@@ -2735,13 +2854,19 @@ mod tests {
             "red-00000001".parse().unwrap();
 
         service
-            .reserve_burn(vault, redemption_id.clone(), vec![burn(1, 100)])
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                redemption_id.clone(),
+                vec![burn(1, 100)],
+            )
             .await
             .unwrap();
 
         // Another redemption sees receipt 1 fully reserved.
         let other = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &"red-00000002".parse().unwrap(),
                 make_shares(100),
@@ -2755,7 +2880,13 @@ mod tests {
 
         // The same redemption re-planning excludes its own reservation.
         let plan = service
-            .for_burn(vault, &redemption_id, make_shares(100), make_shares(0))
+            .for_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                &redemption_id,
+                make_shares(100),
+                make_shares(0),
+            )
             .await
             .unwrap();
         assert_eq!(plan.allocations[0].burn_amount, make_shares(100));
@@ -3106,6 +3237,7 @@ mod tests {
 
         service
             .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
                 vault,
                 receipt_id: make_receipt_id(1),
                 shares: make_shares(100),
@@ -3119,6 +3251,7 @@ mod tests {
 
         let plan = service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &planning_redemption(),
                 make_shares(50),
@@ -3145,6 +3278,7 @@ mod tests {
 
         service
             .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
                 vault,
                 receipt_id: make_receipt_id(42),
                 shares: make_shares(200),
@@ -3157,7 +3291,11 @@ mod tests {
             .expect("Registration should succeed");
 
         let found = service
-            .find_by_issuer_request_id(&vault, &issuer_request_id)
+            .find_by_issuer_request_id(
+                ANVIL_CHAIN_ID,
+                &vault,
+                &issuer_request_id,
+            )
             .await
             .expect("Lookup should succeed");
 
@@ -3185,6 +3323,7 @@ mod tests {
 
             service
                 .register_minted_receipt(MintedReceiptParams {
+                    chain_id: ANVIL_CHAIN_ID,
                     vault,
                     receipt_id: make_receipt_id(7),
                     shares: make_shares(500),
@@ -3197,7 +3336,8 @@ mod tests {
                 .expect("Registration should succeed (idempotent)");
         }
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
 
         assert_eq!(
@@ -3221,6 +3361,7 @@ mod tests {
 
         service
             .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
                 vault,
                 receipt_id: make_receipt_id(42),
                 shares: make_shares(100),
@@ -3232,7 +3373,8 @@ mod tests {
             .await
             .expect("Registration should succeed");
 
-        let inventory = load_inventory(&store, &vault).await.unwrap();
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
         let receipts = inventory.receipts_with_balance();
         assert_eq!(receipts.len(), 1);
         assert_eq!(
@@ -3344,5 +3486,199 @@ mod tests {
             stale_snapshot_count, 0,
             "Startup must clear incompatible ReceiptInventory snapshots"
         );
+    }
+
+    /// Executes the real migration file (via `include_str!`) so the test
+    /// cannot drift from what production runs. Running the sequence twice
+    /// proves both the rekey and its idempotency: legacy EIP-55 vault ids
+    /// gain the `8453:` prefix and lowercase casing exactly once, and
+    /// already-rekeyed ids are untouched.
+    #[tokio::test]
+    async fn rekey_migration_rekeys_legacy_receipt_ids_and_is_idempotent() {
+        const REKEY_MIGRATION: &str = include_str!(
+            "../../migrations/20260710155219_rekey_receipt_inventory_aggregate_id.sql"
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        let legacy_vault =
+            address!("0xabcdef1234567890abcdef1234567890abcdef12");
+        let legacy_id = legacy_vault.to_string();
+        // The fixture must be genuinely mixed-case EIP-55: with an
+        // all-same-character address, lowercase and EIP-55 coincide and the
+        // case normalization would go untested.
+        assert_ne!(legacy_id, format!("{legacy_vault:#x}"));
+
+        let rekeyed_vault =
+            address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let rekeyed_id = format!("8453:{rekeyed_vault:#x}");
+
+        for aggregate_id in [legacy_id.as_str(), rekeyed_id.as_str()] {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES (
+                    'ReceiptInventory',
+                    ?,
+                    1,
+                    'ReceiptInventoryEvent::Discovered',
+                    '1.0',
+                    '{}',
+                    '{}'
+                )
+                ",
+            )
+            .bind(aggregate_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'ReceiptInventory',
+                ?,
+                1,
+                0,
+                '{}',
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(legacy_id.as_str())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        for pass in 1..=2 {
+            sqlx::raw_sql(REKEY_MIGRATION).execute(&pool).await.unwrap();
+
+            let mut event_ids: Vec<String> = sqlx::query_scalar(
+                "
+                SELECT aggregate_id
+                FROM events
+                WHERE aggregate_type = 'ReceiptInventory'
+                ",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            event_ids.sort();
+
+            let mut expected =
+                vec![format!("8453:{legacy_vault:#x}"), rekeyed_id.clone()];
+            expected.sort();
+            assert_eq!(
+                event_ids, expected,
+                "pass {pass}: legacy id must be rekeyed to \
+                 8453:{{vault_lowercase}} and rekeyed ids left untouched"
+            );
+
+            let snapshot_ids: Vec<String> = sqlx::query_scalar(
+                "
+                SELECT aggregate_id
+                FROM snapshots
+                WHERE aggregate_type = 'ReceiptInventory'
+                ",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                snapshot_ids,
+                vec![format!("8453:{legacy_vault:#x}")],
+                "pass {pass}: snapshot id must follow the rekey"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn rekey_migration_aborts_on_unexpected_receipt_ids() {
+        const REKEY_MIGRATION: &str = include_str!(
+            "../../migrations/20260710155219_rekey_receipt_inventory_aggregate_id.sql"
+        );
+
+        for unexpected_id in
+            ["", "not-an-address", "0xabc:0xdef", ":0xabc", "8453:"]
+        {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect(":memory:")
+                .await
+                .unwrap();
+
+            sqlx::migrate!().run(&pool).await.unwrap();
+
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES (
+                    'ReceiptInventory',
+                    ?,
+                    1,
+                    'ReceiptInventoryEvent::Discovered',
+                    '1.0',
+                    '{}',
+                    '{}'
+                )
+                ",
+            )
+            .bind(unexpected_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+            let result = sqlx::raw_sql(REKEY_MIGRATION).execute(&pool).await;
+            assert!(
+                result.is_err(),
+                "migration must abort on unexpected id {unexpected_id:?}"
+            );
+
+            let untouched: String = sqlx::query_scalar(
+                "
+                SELECT aggregate_id
+                FROM events
+                WHERE aggregate_type = 'ReceiptInventory'
+                ",
+            )
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                untouched, unexpected_id,
+                "aborted migration must leave the row untouched"
+            );
+        }
     }
 }

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -38,6 +38,7 @@ pub(crate) struct ReceiptReconciler<Node> {
     provider: Node,
     receipt_contract: Address,
     bot_wallet: Address,
+    chain_id: u64,
     vault: Address,
     store: Arc<Store<ReceiptInventory>>,
 }
@@ -47,10 +48,11 @@ impl<Node> ReceiptReconciler<Node> {
         provider: Node,
         receipt_contract: Address,
         bot_wallet: Address,
+        chain_id: u64,
         vault: Address,
         store: Arc<Store<ReceiptInventory>>,
     ) -> Self {
-        Self { provider, receipt_contract, bot_wallet, vault, store }
+        Self { provider, receipt_contract, bot_wallet, chain_id, vault, store }
     }
 }
 
@@ -67,7 +69,8 @@ where
     pub(crate) async fn reconcile(
         &self,
     ) -> Result<ReconcileResult, ReconcileError> {
-        let inventory = load_inventory(&self.store, &self.vault).await?;
+        let inventory =
+            load_inventory(&self.store, self.chain_id, &self.vault).await?;
 
         let receipts: Vec<_> = inventory
             .receipts_with_balance()
@@ -164,6 +167,7 @@ where
 
         send_receipt_inventory_command(
             &self.store,
+            self.chain_id,
             &self.vault,
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id,
@@ -178,12 +182,12 @@ where
 
 pub(crate) async fn run_startup_reconciliation<P: Provider + Clone>(
     provider: P,
-    vault_receipt_contracts: &[(Address, Address)],
+    entries: &[(u64, Address, Address)],
     store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
 ) -> Result<(), ReconcileError> {
-    let results = stream::iter(vault_receipt_contracts.iter().copied())
-        .then(|(vault, receipt_contract)| {
+    let results = stream::iter(entries.iter().copied())
+        .then(|(chain_id, vault, receipt_contract)| {
             let provider = provider.clone();
             let store = store.clone();
             async move {
@@ -191,13 +195,14 @@ pub(crate) async fn run_startup_reconciliation<P: Provider + Clone>(
                     provider,
                     receipt_contract,
                     bot_wallet,
+                    chain_id,
                     vault,
                     store,
                 )
                 .reconcile()
                 .await;
 
-                (vault, receipt_contract, result)
+                (chain_id, vault, receipt_contract, result)
             }
         })
         .collect::<Vec<_>>()
@@ -209,7 +214,7 @@ pub(crate) async fn run_startup_reconciliation<P: Provider + Clone>(
     let mut failed_vaults = 0usize;
     let mut first_error = None;
 
-    for (vault, receipt_contract, result) in results {
+    for (_chain_id, vault, receipt_contract, result) in results {
         match result {
             Ok(result) => {
                 total_checked += result.checked;
@@ -259,9 +264,9 @@ mod tests {
     use super::*;
     use crate::receipt_inventory::{
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
-        Shares,
+        ReceiptVaultKey, Shares,
     };
-    use crate::test_utils::{LocalEvm, logs_contain_at};
+    use crate::test_utils::{ANVIL_CHAIN_ID, LocalEvm, logs_contain_at};
 
     async fn setup_store() -> Arc<Store<ReceiptInventory>> {
         let pool = SqlitePoolOptions::new()
@@ -284,7 +289,7 @@ mod tests {
     ) {
         store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(receipt_id),
                     balance: Shares::from(balance),
@@ -319,6 +324,7 @@ mod tests {
             provider,
             receipt_contract,
             evm.wallet_address,
+            ANVIL_CHAIN_ID,
             evm.vault_address,
             store,
         );
@@ -356,6 +362,7 @@ mod tests {
             provider,
             missing_receipt_contract,
             evm.wallet_address,
+            crate::test_utils::ANVIL_CHAIN_ID,
             evm.vault_address,
             store,
         );
@@ -415,8 +422,16 @@ mod tests {
         let result = run_startup_reconciliation(
             provider,
             &[
-                (evm.vault_address, receipt_contract),
-                (vault_without_contract, Address::random()),
+                (
+                    crate::test_utils::ANVIL_CHAIN_ID,
+                    evm.vault_address,
+                    receipt_contract,
+                ),
+                (
+                    crate::test_utils::ANVIL_CHAIN_ID,
+                    vault_without_contract,
+                    Address::random(),
+                ),
             ],
             &store,
             evm.wallet_address,
@@ -469,6 +484,7 @@ mod tests {
             provider,
             receipt_contract,
             evm.wallet_address,
+            ANVIL_CHAIN_ID,
             evm.vault_address,
             store.clone(),
         );
@@ -480,7 +496,9 @@ mod tests {
 
         // Verify the aggregate was updated — receipt should be depleted
         let inventory =
-            load_inventory(&store, &evm.vault_address).await.unwrap();
+            load_inventory(&store, ANVIL_CHAIN_ID, &evm.vault_address)
+                .await
+                .unwrap();
         let receipts = inventory.receipts_with_balance();
         assert!(
             receipts.is_empty(),
@@ -563,6 +581,7 @@ mod tests {
             bot_provider,
             receipt_contract,
             evm.wallet_address,
+            ANVIL_CHAIN_ID,
             evm.vault_address,
             store,
         );

--- a/src/receipt_inventory/vault_key.rs
+++ b/src/receipt_inventory/vault_key.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+use std::str::FromStr;
+
+use alloy::primitives::Address;
+
+/// Receipt inventory aggregate id: `{chain_id}:{vault}`.
+///
+/// Pre-multichain rows used bare EIP-55 `{vault}` addresses; the
+/// `rekey_receipt_inventory_aggregate_id` migration rewrites them to this
+/// chain-qualified lowercase form, so runtime lookups never consult a legacy
+/// key.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ReceiptVaultKey(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ReceiptVaultKeyError {
+    #[error("receipt vault key cannot be empty")]
+    Empty,
+}
+
+impl ReceiptVaultKey {
+    pub(crate) fn new(chain_id: u64, vault: Address) -> Self {
+        Self(format!("{chain_id}:{vault:#x}"))
+    }
+}
+
+impl fmt::Display for ReceiptVaultKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl FromStr for ReceiptVaultKey {
+    type Err = ReceiptVaultKeyError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.is_empty() {
+            return Err(ReceiptVaultKeyError::Empty);
+        }
+
+        Ok(Self(value.to_string()))
+    }
+}

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -110,6 +110,7 @@ pub(crate) struct BurnManager {
     receipt_service: Arc<dyn ReceiptService>,
     bot_wallet: Address,
     automatic_recovery_lock: Arc<Mutex<()>>,
+    receipt_chain_id: u64,
 }
 
 impl BurnManager {
@@ -123,12 +124,14 @@ impl BurnManager {
     ///   aggregate state during recovery
     /// * `receipt_service` - Service for finding receipts to burn
     /// * `bot_wallet` - Bot's wallet address that owns both shares and receipts
+    /// * `receipt_chain_id` - Chain id for receipt inventory aggregate keys
     pub(crate) fn new(
         vault_service: Arc<dyn VaultService>,
         view_pool: Pool<Sqlite>,
         store: Arc<Store<Redemption>>,
         receipt_service: Arc<dyn ReceiptService>,
         bot_wallet: Address,
+        receipt_chain_id: u64,
     ) -> Self {
         Self {
             vault_service,
@@ -137,6 +140,7 @@ impl BurnManager {
             receipt_service,
             bot_wallet,
             automatic_recovery_lock: Arc::new(Mutex::new(())),
+            receipt_chain_id,
         }
     }
 
@@ -362,7 +366,11 @@ impl BurnManager {
         let mut stuck: Vec<(Address, IssuerRedemptionRequestId)> = Vec::new();
 
         for vault in vaults {
-            match self.receipt_service.reserved_redemptions(*vault).await {
+            match self
+                .receipt_service
+                .reserved_redemptions(self.receipt_chain_id, *vault)
+                .await
+            {
                 Ok(redemptions) => {
                     stuck
                         .extend(redemptions.into_iter().map(|id| (*vault, id)));
@@ -1734,6 +1742,7 @@ impl BurnManager {
         let plan = self
             .receipt_service
             .for_burn(
+                self.receipt_chain_id,
                 vault,
                 issuer_request_id,
                 Shares::new(burn_shares),
@@ -1907,6 +1916,7 @@ impl BurnManager {
         let result = self
             .receipt_service
             .reserve_burn(
+                self.receipt_chain_id,
                 execution.vault,
                 issuer_request_id.clone(),
                 execution.planned_burns.clone(),
@@ -2216,7 +2226,11 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<(), BurnManagerError> {
         self.receipt_service
-            .release_burn(vault, issuer_request_id.clone())
+            .release_burn(
+                self.receipt_chain_id,
+                vault,
+                issuer_request_id.clone(),
+            )
             .await?;
         Ok(())
     }
@@ -2229,7 +2243,11 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<(), BurnManagerError> {
         self.receipt_service
-            .settle_burn(vault, issuer_request_id.clone())
+            .settle_burn(
+                self.receipt_chain_id,
+                vault,
+                issuer_request_id.clone(),
+            )
             .await?;
         Ok(())
     }
@@ -2438,7 +2456,8 @@ mod tests {
         BurnPlan, BurnTrackingError, CqrsReceiptService, MintedReceiptParams,
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
         ReceiptInventoryError, ReceiptLookupError, ReceiptRegistrationError,
-        ReceiptService, ReceiptSource, RecoveredReceipt, Shares,
+        ReceiptService, ReceiptSource, ReceiptVaultKey, RecoveredReceipt,
+        Shares,
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::view::{RedemptionViewReactor, find_burn_failed};
@@ -2446,7 +2465,7 @@ mod tests {
         BurnRecord, BurnRecoveryAction, IssuerRedemptionRequestId,
         RedemptionError,
     };
-    use crate::test_utils::{log_count_at, logs_contain_at};
+    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         AssetKey, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         UnderlyingSymbol,
@@ -2594,6 +2613,7 @@ mod tests {
 
         async fn for_burn(
             &self,
+            chain_id: u64,
             vault: Address,
             redemption_issuer_request_id: &IssuerRedemptionRequestId,
             shares_to_burn: Shares,
@@ -2601,6 +2621,7 @@ mod tests {
         ) -> Result<BurnPlan, BurnTrackingError> {
             self.inner
                 .for_burn(
+                    chain_id,
                     vault,
                     redemption_issuer_request_id,
                     shares_to_burn,
@@ -2611,17 +2632,24 @@ mod tests {
 
         async fn reserve_burn(
             &self,
+            chain_id: u64,
             vault: Address,
             redemption_issuer_request_id: IssuerRedemptionRequestId,
             burns: Vec<BurnRecord>,
         ) -> Result<(), ReceiptRegistrationError> {
             self.inner
-                .reserve_burn(vault, redemption_issuer_request_id, burns)
+                .reserve_burn(
+                    chain_id,
+                    vault,
+                    redemption_issuer_request_id,
+                    burns,
+                )
                 .await
         }
 
         async fn release_burn(
             &self,
+            _chain_id: u64,
             _vault: Address,
             _redemption_issuer_request_id: IssuerRedemptionRequestId,
         ) -> Result<(), ReceiptRegistrationError> {
@@ -2634,26 +2662,33 @@ mod tests {
 
         async fn settle_burn(
             &self,
+            chain_id: u64,
             vault: Address,
             redemption_issuer_request_id: IssuerRedemptionRequestId,
         ) -> Result<(), ReceiptRegistrationError> {
-            self.inner.settle_burn(vault, redemption_issuer_request_id).await
+            self.inner
+                .settle_burn(chain_id, vault, redemption_issuer_request_id)
+                .await
         }
 
         async fn reserved_redemptions(
             &self,
+            chain_id: u64,
             vault: Address,
         ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
         {
-            self.inner.reserved_redemptions(vault).await
+            self.inner.reserved_redemptions(chain_id, vault).await
         }
 
         async fn find_by_issuer_request_id(
             &self,
+            chain_id: u64,
             vault: &Address,
             issuer_request_id: &IssuerMintRequestId,
         ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
-            self.inner.find_by_issuer_request_id(vault, issuer_request_id).await
+            self.inner
+                .find_by_issuer_request_id(chain_id, vault, issuer_request_id)
+                .await
         }
     }
 
@@ -2825,7 +2860,7 @@ mod tests {
         ) {
             self.receipt_inventory_store
                 .send(
-                    &vault,
+                    &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                     ReceiptInventoryCommand::DiscoverReceipt {
                         receipt_id: ReceiptId::from(receipt_id),
                         balance: Shares::from(balance),
@@ -2980,6 +3015,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3015,7 +3051,7 @@ mod tests {
         // settle wiring were removed the reservation would linger here.
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -3074,6 +3110,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -3166,6 +3203,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3182,6 +3220,7 @@ mod tests {
             .await;
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -3192,7 +3231,10 @@ mod tests {
             .await
             .expect("seeding reservation should succeed");
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![issuer_request_id.clone()],
             "reservation should be held before force-complete"
         );
@@ -3233,7 +3275,7 @@ mod tests {
         // settle wiring were removed the reservation would linger here.
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -3289,6 +3331,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -3296,6 +3339,7 @@ mod tests {
         harness.discover_receipt(vault, uint!(42_U256), uint!(17_U256)).await;
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -3333,7 +3377,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id)
@@ -3389,6 +3433,7 @@ mod tests {
                 store.clone(),
                 receipt_service.clone(),
                 owner,
+                ANVIL_CHAIN_ID,
             );
             let issuer_request_id = IssuerRedemptionRequestId::random();
             create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -3398,6 +3443,7 @@ mod tests {
                 .await;
             receipt_service
                 .reserve_burn(
+                    ANVIL_CHAIN_ID,
                     vault,
                     issuer_request_id.clone(),
                     vec![BurnRecord {
@@ -3445,7 +3491,10 @@ mod tests {
                 "scenario {scenario} changed the redemption"
             );
             assert_eq!(
-                receipt_service.reserved_redemptions(vault).await.unwrap(),
+                receipt_service
+                    .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                    .await
+                    .unwrap(),
                 vec![issuer_request_id],
                 "scenario {scenario} released the reservation"
             );
@@ -3481,6 +3530,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3546,6 +3596,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3595,6 +3646,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -3635,6 +3687,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         // An unknown redemption is Uninitialized — force-complete must refuse
@@ -3678,6 +3731,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3786,6 +3840,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let receipt_info = ReceiptInformation::new(
@@ -3799,7 +3854,7 @@ mod tests {
 
         receipt_inventory_store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(99_U256)),
                     balance: Shares::from(
@@ -3871,6 +3926,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let receipt_info = ReceiptInformation::new(
@@ -3886,7 +3942,7 @@ mod tests {
 
         receipt_inventory_store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::DiscoverReceipt {
                     receipt_id: ReceiptId::from(uint!(99_U256)),
                     balance: Shares::from(
@@ -3949,6 +4005,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3994,7 +4051,7 @@ mod tests {
         // reuse shares that are about to be consumed.
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
@@ -4023,6 +4080,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4055,7 +4113,7 @@ mod tests {
 
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
@@ -4084,6 +4142,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4116,7 +4175,7 @@ mod tests {
 
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -4145,6 +4204,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4177,7 +4237,7 @@ mod tests {
 
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -4203,6 +4263,7 @@ mod tests {
             store.clone(),
             failing_receipt_service,
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         harness
@@ -4229,7 +4290,10 @@ mod tests {
             Redemption::BurnSubmitted { .. }
         ));
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![issuer_request_id.clone()]
         );
         let recovery_attempts: i64 = sqlx::query_scalar(
@@ -4269,6 +4333,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4310,6 +4375,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4371,6 +4437,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4420,6 +4487,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4515,6 +4583,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4562,6 +4631,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4617,6 +4687,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4658,6 +4729,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         manager.recover_burning_redemptions().await;
@@ -4681,6 +4753,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4730,6 +4803,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4770,6 +4844,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4832,6 +4907,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4909,6 +4985,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -4983,6 +5060,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -5052,6 +5130,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -5069,6 +5148,7 @@ mod tests {
 
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -5112,7 +5192,7 @@ mod tests {
 
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -5147,6 +5227,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -5165,6 +5246,7 @@ mod tests {
 
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -5204,7 +5286,7 @@ mod tests {
 
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -5248,6 +5330,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let tx_id = TxId::random();
 
@@ -5266,6 +5349,7 @@ mod tests {
 
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -5316,7 +5400,7 @@ mod tests {
         // still-pending tx may yet consume.
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
@@ -5389,7 +5473,7 @@ mod tests {
         );
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .expect("exhausted reservation query should succeed")
                 .contains(issuer_request_id),
@@ -5480,6 +5564,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let recovery_manager = manager.clone();
         let recovery_id = issuer_request_id.clone();
@@ -5578,6 +5663,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let recovery_manager = manager.clone();
         let recovery_id = issuer_request_id.clone();
@@ -5648,6 +5734,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let outcome = manager
@@ -5756,6 +5843,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
 
         let outcome = manager
@@ -5846,6 +5934,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
 
         let outcome = manager
@@ -5922,6 +6011,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         assert_eq!(
@@ -6003,6 +6093,7 @@ mod tests {
         // Seed a reservation so the test verifies it is settled on confirm.
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -6076,6 +6167,7 @@ mod tests {
             restarted_store.clone(),
             restarted_receipt_service.clone(),
             recovery_owner,
+            ANVIL_CHAIN_ID,
         );
         let result = manager.recover_single_burning(&issuer_request_id).await;
 
@@ -6104,7 +6196,7 @@ mod tests {
 
         assert!(
             restarted_receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
@@ -6129,7 +6221,7 @@ mod tests {
         ));
         assert!(
             restarted_receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .expect("restart reservation query should succeed")
                 .contains(&issuer_request_id),
@@ -6138,6 +6230,7 @@ mod tests {
         let contender = IssuerRedemptionRequestId::random();
         let availability = restarted_receipt_service
             .for_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 &contender,
                 Shares::new(uint!(1_U256)),
@@ -6183,6 +6276,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6302,6 +6396,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             recovery_owner,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6420,6 +6515,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
         assert!(matches!(
             manager.recover_single_burning(&issuer_request_id).await,
@@ -6568,6 +6664,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6575,6 +6672,7 @@ mod tests {
         harness.discover_receipt(vault, uint!(42_U256), uint!(17_U256)).await;
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -6628,7 +6726,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id)
@@ -6681,6 +6779,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             owner,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6744,6 +6843,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6757,6 +6857,7 @@ mod tests {
             .await;
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -6795,7 +6896,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id)
@@ -6842,6 +6943,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6911,6 +7013,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
@@ -6924,6 +7027,7 @@ mod tests {
             .await;
         receipt_service
             .reserve_burn(
+                ANVIL_CHAIN_ID,
                 vault,
                 issuer_request_id.clone(),
                 vec![BurnRecord {
@@ -6982,7 +7086,7 @@ mod tests {
         ));
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -7063,6 +7167,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
@@ -7097,7 +7202,10 @@ mod tests {
             "the exact persisted transaction must remain recoverable: {updated:?}"
         );
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![issuer_request_id],
             "ambiguous broadcast must retain the receipt reservation"
         );
@@ -7139,6 +7247,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
         harness
@@ -7172,7 +7281,10 @@ mod tests {
             "the submitted transaction must remain recoverable: {updated:?}"
         );
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![issuer_request_id],
             "ambiguous confirmation must retain the receipt reservation"
         );
@@ -7196,6 +7308,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -7232,7 +7345,7 @@ mod tests {
         // Reservation must be released since nothing landed on-chain.
         assert!(
             receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -7349,6 +7462,7 @@ mod tests {
             store.clone(),
             failing_receipt_service,
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
@@ -7373,7 +7487,10 @@ mod tests {
         );
         assert_eq!(vault_mock.get_multi_burn_call_count(), 0);
         assert_eq!(
-            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap(),
             vec![issuer_request_id.clone()],
             "failed release must leave the reservation visible for retry"
         );
@@ -7423,6 +7540,7 @@ mod tests {
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -7524,7 +7642,7 @@ mod tests {
         harness
             .receipt_inventory_store
             .send(
-                &vault,
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
                 ReceiptInventoryCommand::ReserveBurn {
                     redemption_issuer_request_id: redemption.clone(),
                     burns: vec![crate::redemption::BurnRecord {
@@ -7552,6 +7670,7 @@ mod tests {
             harness.store.clone(),
             harness.receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         // Receipt 1 funds the real burn; receipt 2 will hold the stuck
@@ -7593,7 +7712,7 @@ mod tests {
         assert!(
             harness
                 .receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id)
@@ -7604,7 +7723,7 @@ mod tests {
         assert!(
             harness
                 .receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .is_empty(),
@@ -7730,6 +7849,7 @@ mod tests {
             harness.store.clone(),
             harness.receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         harness
@@ -7769,7 +7889,7 @@ mod tests {
         assert!(
             harness
                 .receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
@@ -7792,6 +7912,7 @@ mod tests {
             harness.store.clone(),
             harness.receipt_service.clone(),
             TEST_WALLET,
+            ANVIL_CHAIN_ID,
         );
 
         harness
@@ -7820,7 +7941,7 @@ mod tests {
         assert!(
             harness
                 .receipt_service
-                .reserved_redemptions(vault)
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -192,7 +192,8 @@ where
         &self,
     ) -> Result<(), TransferPollError> {
         let Some(global) =
-            poll_checkpoint::load(&self.pool, TRANSFER_POLL).await?
+            poll_checkpoint::load_checkpoint_block(&self.pool, TRANSFER_POLL)
+                .await?
         else {
             return Ok(());
         };
@@ -213,11 +214,17 @@ where
             // checkpoint below the legacy global, and `advance`'s monotonic
             // forward-jump would silently skip every redemption between its
             // cursor and the global block.
-            if poll_checkpoint::load(&self.pool, &name).await?.is_some() {
+            if poll_checkpoint::load_checkpoint_block(&self.pool, &name)
+                .await?
+                .is_some()
+            {
                 continue;
             }
 
-            poll_checkpoint::advance(&self.pool, &name, global).await?;
+            poll_checkpoint::advance_checkpoint_block(
+                &self.pool, &name, global,
+            )
+            .await?;
         }
 
         Ok(())
@@ -302,8 +309,11 @@ where
         head: u64,
     ) -> Result<(), TransferPollError> {
         let checkpoint_name = poll_checkpoint::transfer_poll_name(vault);
-        let last_processed =
-            poll_checkpoint::load(&self.pool, &checkpoint_name).await?;
+        let last_processed = poll_checkpoint::load_checkpoint_block(
+            &self.pool,
+            &checkpoint_name,
+        )
+        .await?;
 
         let cursor = match last_processed {
             None => self.backfill_start_block,
@@ -360,8 +370,12 @@ where
                 }
             }
 
-            poll_checkpoint::advance(&self.pool, &checkpoint_name, chunk_to)
-                .await?;
+            poll_checkpoint::advance_checkpoint_block(
+                &self.pool,
+                &checkpoint_name,
+                chunk_to,
+            )
+            .await?;
 
             // The advance above moved the cursor past these transfers, making
             // the skip permanent: real user tokens in the redemption wallet
@@ -594,7 +608,7 @@ mod tests {
         create_transfer_log, setup_test_db_with_asset,
     };
     use crate::redemption::{IssuerRedemptionRequestId, Redemption};
-    use crate::test_utils::{log_count_at, logs_contain_at};
+    use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         UnderlyingSymbol,
@@ -667,6 +681,7 @@ mod tests {
                 store.clone(),
                 receipt_service,
                 bot_wallet,
+                ANVIL_CHAIN_ID,
             ));
 
         let provider = ProviderBuilder::new()
@@ -778,7 +793,7 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -824,7 +839,7 @@ mod tests {
 
         // Checkpoint still advances even with no detections
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -853,7 +868,7 @@ mod tests {
             setup_test_poller(vault, bot_wallet, None, &asserter, 50).await;
 
         // Pre-seed the vault's checkpoint at 200
-        poll_checkpoint::advance(
+        poll_checkpoint::advance_checkpoint_block(
             &setup.pool,
             &poll_checkpoint::transfer_poll_name(vault),
             200,
@@ -899,7 +914,7 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -984,7 +999,7 @@ mod tests {
         setup.poller.poll_once().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -1019,7 +1034,7 @@ mod tests {
 
         // No checkpoint saved since we skipped
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -1051,9 +1066,13 @@ mod tests {
         // A leftover global checkpoint from before the per-vault migration.
         // The vault has no per-vault checkpoint, so poll_once must ignore the
         // global value and scan from backfill_start_block (50).
-        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
-            .await
-            .unwrap();
+        poll_checkpoint::advance_checkpoint_block(
+            &setup.pool,
+            TRANSFER_POLL,
+            200,
+        )
+        .await
+        .unwrap();
 
         setup.poller.poll_once().await.unwrap();
 
@@ -1066,7 +1085,7 @@ mod tests {
              global checkpoint"
         );
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -1089,14 +1108,18 @@ mod tests {
         let setup =
             setup_test_poller(vault, bot_wallet, None, &asserter, 0).await;
 
-        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
-            .await
-            .unwrap();
+        poll_checkpoint::advance_checkpoint_block(
+            &setup.pool,
+            TRANSFER_POLL,
+            200,
+        )
+        .await
+        .unwrap();
 
         setup.poller.seed_per_vault_checkpoints().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -1123,7 +1146,7 @@ mod tests {
             setup_test_poller(vault, bot_wallet, None, &asserter, 0).await;
 
         // The vault scanned partway (block 100) before the restart...
-        poll_checkpoint::advance(
+        poll_checkpoint::advance_checkpoint_block(
             &setup.pool,
             &poll_checkpoint::transfer_poll_name(vault),
             100,
@@ -1131,14 +1154,18 @@ mod tests {
         .await
         .unwrap();
         // ...and a stale legacy global sits far ahead at block 5000.
-        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 5000)
-            .await
-            .unwrap();
+        poll_checkpoint::advance_checkpoint_block(
+            &setup.pool,
+            TRANSFER_POLL,
+            5000,
+        )
+        .await
+        .unwrap();
 
         setup.poller.seed_per_vault_checkpoints().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault),
             )
@@ -1183,7 +1210,7 @@ mod tests {
         ));
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault_b),
             )
@@ -1193,7 +1220,7 @@ mod tests {
             "the healthy vault must advance its checkpoint to head"
         );
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault_a),
             )
@@ -1284,14 +1311,18 @@ mod tests {
         let setup =
             setup_test_poller(vault_a, bot_wallet, None, &asserter, 0).await;
 
-        poll_checkpoint::advance(&setup.pool, TRANSFER_POLL, 200)
-            .await
-            .unwrap();
+        poll_checkpoint::advance_checkpoint_block(
+            &setup.pool,
+            TRANSFER_POLL,
+            200,
+        )
+        .await
+        .unwrap();
 
         setup.poller.seed_per_vault_checkpoints().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault_a),
             )
@@ -1301,7 +1332,9 @@ mod tests {
             "the legacy vault must inherit the global checkpoint"
         );
         assert_eq!(
-            poll_checkpoint::load(&setup.pool, TRANSFER_POLL).await.unwrap(),
+            poll_checkpoint::load_checkpoint_block(&setup.pool, TRANSFER_POLL)
+                .await
+                .unwrap(),
             None,
             "the migration must consume the legacy global row"
         );
@@ -1312,7 +1345,7 @@ mod tests {
         setup.poller.seed_per_vault_checkpoints().await.unwrap();
 
         assert_eq!(
-            poll_checkpoint::load(
+            poll_checkpoint::load_checkpoint_block(
                 &setup.pool,
                 &poll_checkpoint::transfer_poll_name(vault_b),
             )

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -51,8 +51,11 @@ pub fn test_alpaca_legacy_auth() -> (String, String, String) {
     (basic_auth, api_key, api_secret)
 }
 
-/// Anvil local chain ID
+/// Anvil local chain ID (Base test runtime).
 pub const ANVIL_CHAIN_ID: u64 = 31337;
+
+/// Chain ID for the Ethereum test runtime in multichain integration tests.
+pub const ETHEREUM_TEST_CHAIN_ID: u64 = 1;
 
 fn test_config() -> Result<Config, anyhow::Error> {
     Ok(Config {
@@ -69,6 +72,7 @@ fn test_config() -> Result<Config, anyhow::Error> {
         hyperdx: None,
         alpaca: AlpacaConfig::test_default(),
         subgraph_url: Url::parse("http://localhost:0/subgraph")?,
+        chains: Vec::new(),
     })
 }
 
@@ -109,13 +113,14 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
 
     // Create mock services for Mint aggregate
     let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
-    let mint_services = MintServices {
-        vault: Arc::new(MockVaultService::new_success()),
-        alpaca: Arc::new(MockAlpacaService::new_success()),
-        pool: pool.clone(),
+    let mint_services = MintServices::with_single_vault(
+        Network::Base,
+        Arc::new(MockVaultService::new_success()),
+        Arc::new(MockAlpacaService::new_success()),
+        Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
+        pool.clone(),
         bot,
-        receipts: Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
-    };
+    );
 
     // Setup Mint store (event-sorcery), mirroring the production wiring: the
     // reactor keeps receipt_inventory_view in sync with Mint events.
@@ -219,6 +224,7 @@ pub struct LocalEvm {
     pub wallet_address: Address,
     pub private_key: B256,
     pub endpoint: String,
+    pub chain_id: u64,
 }
 
 impl LocalEvm {
@@ -231,7 +237,17 @@ impl LocalEvm {
     /// - Provider connection fails
     /// - Any contract deployment step fails
     pub async fn new() -> Result<Self, LocalEvmError> {
-        let anvil = Anvil::new().spawn();
+        Self::with_chain_id(ANVIL_CHAIN_ID).await
+    }
+
+    /// Creates a new [`LocalEvm`] on an Anvil instance with the given chain ID.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if Anvil startup, provider connection, or contract
+    /// deployment fails.
+    pub async fn with_chain_id(chain_id: u64) -> Result<Self, LocalEvmError> {
+        let anvil = Anvil::new().chain_id(chain_id).spawn();
         let endpoint = anvil.ws_endpoint();
 
         let private_key = B256::from_slice(&anvil.keys()[0].to_bytes());
@@ -252,6 +268,7 @@ impl LocalEvm {
             wallet_address,
             private_key,
             endpoint,
+            chain_id,
         })
     }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -54,6 +54,12 @@ pub fn test_alpaca_legacy_auth() -> (String, String, String) {
 /// Anvil local chain ID (Base test runtime).
 pub const ANVIL_CHAIN_ID: u64 = 31337;
 
+/// ReceiptInventory aggregate id for integration tests (`{chain_id}:{vault:#x}`).
+#[must_use]
+pub fn receipt_inventory_aggregate_id(chain_id: u64, vault: Address) -> String {
+    format!("{chain_id}:{vault:#x}")
+}
+
 /// Chain ID for the Ethereum test runtime in multichain integration tests.
 pub const ETHEREUM_TEST_CHAIN_ID: u64 = 1;
 
@@ -115,6 +121,7 @@ pub async fn setup_test_rocket() -> anyhow::Result<rocket::Rocket<rocket::Build>
     let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
     let mint_services = MintServices::with_single_vault(
         Network::Base,
+        ANVIL_CHAIN_ID,
         Arc::new(MockVaultService::new_success()),
         Arc::new(MockAlpacaService::new_success()),
         Arc::new(CqrsReceiptService::new(receipt_inventory_store)),

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -10,13 +10,14 @@ use st0x_issuance_dto::{
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use tracing::error;
+use tracing::{error, warn};
 
 use super::{
     Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol, view::TokenizedAssetView,
 };
 use crate::auth::{InternalAuth, IssuerAuth};
+use crate::chain::ConfiguredNetworks;
 
 fn merge_token_listing(
     views: Vec<TokenizedAssetView>,
@@ -198,12 +199,13 @@ pub(crate) async fn list_tokenized_assets(
     responses(
         (status = 201, description = "Asset added (idempotent: also 201 if it already existed)",
             body = AddTokenizedAssetResponse),
-        (status = 422, description = "Empty underlying symbol"),
+        (status = 422, description = "Empty underlying symbol, or network \
+            without a chain configuration"),
         (status = 500, description = "Failed to add asset")
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, store), fields(
+#[tracing::instrument(skip(_auth, store, configured_networks), fields(
     underlying = %request.underlying,
     token = %request.token,
     network = %request.network,
@@ -213,8 +215,21 @@ pub(crate) async fn list_tokenized_assets(
 pub(crate) async fn add_tokenized_asset(
     _auth: InternalAuth,
     store: &rocket::State<Arc<Store<TokenizedAsset>>>,
+    configured_networks: &rocket::State<ConfiguredNetworks>,
     request: Json<AddTokenizedAssetRequest>,
 ) -> Result<(Status, Json<AddTokenizedAssetResponse>), Status> {
+    // An asset on a network with no chain config would make the next boot
+    // abort in `validate_configured_asset_networks`, bricking the service
+    // until the chain is configured or the asset removed. Reject upfront.
+    if !configured_networks.contains(request.network) {
+        warn!(
+            target: "asset",
+            network = %request.network,
+            "Rejected tokenized-asset registration for unconfigured network"
+        );
+        return Err(Status::UnprocessableEntity);
+    }
+
     let command = TokenizedAssetCommand::Add {
         underlying: request.underlying.clone(),
         token: request.token.clone(),
@@ -283,6 +298,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
+            chains: Vec::new(),
         }
     }
 
@@ -520,6 +536,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(store)
             .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
             .mount("/", routes![add_tokenized_asset]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -574,6 +591,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(store)
             .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
             .mount("/", routes![add_tokenized_asset]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -636,6 +654,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(store)
             .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
             .mount("/", routes![add_tokenized_asset]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -744,6 +763,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(store)
             .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
             .mount("/", routes![add_tokenized_asset]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -765,6 +785,55 @@ mod tests {
             .await;
 
         assert_eq!(response.status(), Status::Unauthorized);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_add_asset_on_unconfigured_network_returns_422() {
+        let pool = migrated_in_memory_pool().await;
+        let store = setup_tokenized_asset_store(&pool).await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(store.clone())
+            .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
+            .mount("/", routes![add_tokenized_asset]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "underlying": "AAPL",
+            "token": "tAAPL",
+            "network": "ethereum",
+            "vault": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+
+        let response = client
+            .post("/tokenized-assets")
+            .header(ContentType::JSON)
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["unconfigured network", "ethereum"]
+        ));
+
+        // The rejected registration must not have written the aggregate — a
+        // written-but-rejected asset would still brick the next boot.
+        let key =
+            AssetKey::new(UnderlyingSymbol::new("AAPL"), Network::Ethereum);
+        let asset = store.load(&key).await.expect("load must succeed");
+        assert!(asset.is_none(), "aggregate must not exist: {asset:?}");
     }
 
     async fn migrated_in_memory_pool() -> sqlx::Pool<sqlx::Sqlite> {

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -221,6 +221,8 @@ pub(crate) async fn add_tokenized_asset(
     // An asset on a network with no chain config would make the next boot
     // abort in `validate_configured_asset_networks`, bricking the service
     // until the chain is configured or the asset removed. Reject upfront.
+    // Non-Base networks are not fully wired for redemption/backfill until the
+    // multichain redemption PR lands — do not register them in staging early.
     if !configured_networks.contains(request.network) {
         warn!(
             target: "asset",
@@ -715,6 +717,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(store)
             .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([Network::Base]))
             .mount("/", routes![add_tokenized_asset]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -830,8 +833,10 @@ mod tests {
 
         // The rejected registration must not have written the aggregate — a
         // written-but-rejected asset would still brick the next boot.
-        let key =
-            AssetKey::new(UnderlyingSymbol::new("AAPL"), Network::Ethereum);
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("AAPL").unwrap(),
+            Network::Ethereum,
+        );
         let asset = store.load(&key).await.expect("load must succeed");
         assert!(asset.is_none(), "aggregate must not exist: {asset:?}");
     }

--- a/tests/dynamic_asset.rs
+++ b/tests/dynamic_asset.rs
@@ -9,8 +9,8 @@ use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
-use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{Network, initialize_rocket};
 
 /// Tests that adding a new tokenized asset at runtime is picked up by the
 /// receipt backfill loop and the transfer poller on their next polling pass,
@@ -92,11 +92,14 @@ async fn test_new_asset_triggers_backfills_and_monitors()
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &link_body.client_id.to_string(),
-        "alp-mint-msft",
-        "25.0",
-        "MSFT",
-        "tMSFT",
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-msft",
+            quantity: "25.0",
+            underlying: "MSFT",
+            token: "tMSFT",
+            network: Network::Base,
+        },
     )
     .await?;
 
@@ -213,11 +216,14 @@ async fn test_address_change_picked_up_on_next_pass()
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &link_body.client_id.to_string(),
-        "alp-mint-aapl-new",
-        "25.0",
-        "AAPL",
-        "tAAPL",
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-aapl-new",
+            quantity: "25.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
     )
     .await?;
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -32,8 +32,8 @@ use st0x_issuance::test_utils::{
     LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT, ROLE_WITHDRAW,
 };
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
-    LogLevel, SignerConfig,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
+    IpWhitelist, LogLevel, Network, SignerConfig,
 };
 
 pub type TestProviderBuilder = ProviderBuilder<
@@ -302,14 +302,31 @@ pub async fn preseed_tokenized_asset_into_pool(
     underlying: &str,
     token: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let aggregate_id = format!("{underlying}:base");
+    preseed_tokenized_asset_into_pool_with_network(
+        pool,
+        vault,
+        underlying,
+        token,
+        Network::Base,
+    )
+    .await
+}
+
+pub async fn preseed_tokenized_asset_into_pool_with_network(
+    pool: &sqlx::Pool<sqlx::Sqlite>,
+    vault: Address,
+    underlying: &str,
+    token: &str,
+    network: Network,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let aggregate_id = format!("{underlying}:{}", network.as_str());
     let now = Utc::now();
 
     let event_payload = json!({
         "Added": {
             "underlying": underlying,
             "token": token,
-            "network": "base",
+            "network": network.as_str(),
             "vault": vault,
             "added_at": now
         }
@@ -509,12 +526,13 @@ pub fn create_config_with_db(
     let mock_subgraph = setup_mock_subgraph(&vault_schemas);
     let subgraph_url =
         Url::parse(&mock_subgraph.base_url()).expect("valid mock subgraph URL");
+    let rpc_url = Url::parse(&evm.endpoint)?;
 
     Ok((
         Config {
             database_url: db_path.to_string(),
             database_max_connections: 5,
-            rpc_url: Url::parse(&evm.endpoint)?,
+            rpc_url: rpc_url.clone(),
             chain_id: ANVIL_CHAIN_ID,
             signer: SignerConfig::Local(evm.private_key),
             backfill_start_block: 0,
@@ -541,10 +559,56 @@ pub fn create_config_with_db(
                 connect_timeout_secs: 10,
                 request_timeout_secs: 30,
             },
-            subgraph_url,
+            subgraph_url: subgraph_url.clone(),
+            chains: vec![ChainConfig {
+                network: Network::Base,
+                chain_id: ANVIL_CHAIN_ID,
+                rpc_url,
+                subgraph_url,
+                backfill_start_block: 0,
+            }],
         },
         mock_subgraph,
     ))
+}
+
+/// Builds a [`Config`] wired to two Anvil chains: Base and Ethereum, both
+/// entries in `Config::chains`. Both chains share the mock subgraph.
+pub fn create_multichain_config_with_db(
+    db_path: &str,
+    mock_alpaca: &MockServer,
+    base_evm: &LocalEvm,
+    eth_evm: &LocalEvm,
+) -> Result<(Config, MockServer), Box<dyn std::error::Error>> {
+    let vault_schemas = HashMap::from([
+        (base_evm.vault_address, TEST_OA_SCHEMA_HASH),
+        (eth_evm.vault_address, TEST_OA_SCHEMA_HASH),
+    ]);
+    let mock_subgraph = setup_mock_subgraph(&vault_schemas);
+    let subgraph_url =
+        Url::parse(&mock_subgraph.base_url()).expect("valid mock subgraph URL");
+
+    let (mut base_config, _) =
+        create_config_with_db(db_path, mock_alpaca, base_evm)?;
+    base_config.subgraph_url = subgraph_url.clone();
+    base_config.chains = vec![
+        ChainConfig {
+            network: Network::Base,
+            chain_id: ANVIL_CHAIN_ID,
+            rpc_url: Url::parse(&base_evm.endpoint)?,
+            subgraph_url: subgraph_url.clone(),
+            backfill_start_block: 0,
+        },
+        ChainConfig {
+            network: Network::Ethereum,
+            chain_id: eth_evm.chain_id,
+            rpc_url: Url::parse(&eth_evm.endpoint)?,
+            subgraph_url,
+            backfill_start_block: 0,
+        },
+    ];
+
+    Ok((base_config, mock_subgraph))
 }
 
 pub async fn setup_roles(
@@ -580,6 +644,15 @@ pub async fn setup_roles_on_vault(
     Ok(())
 }
 
+pub struct MintFlowRequest<'a> {
+    pub client_id: &'a str,
+    pub tokenization_request_id: &'a str,
+    pub quantity: &'a str,
+    pub underlying: &'a str,
+    pub token: &'a str,
+    pub network: Network,
+}
+
 pub async fn perform_mint_and_confirm(
     client: &Client,
     wallet: Address,
@@ -590,11 +663,14 @@ pub async fn perform_mint_and_confirm(
     perform_mint_and_confirm_with(
         client,
         wallet,
-        client_id,
-        tokenization_request_id,
-        quantity,
-        "AAPL",
-        "tAAPL",
+        MintFlowRequest {
+            client_id,
+            tokenization_request_id,
+            quantity,
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
     )
     .await
 }
@@ -602,12 +678,16 @@ pub async fn perform_mint_and_confirm(
 pub async fn perform_mint_and_confirm_with(
     client: &Client,
     wallet: Address,
-    client_id: &str,
-    tokenization_request_id: &str,
-    quantity: &str,
-    underlying: &str,
-    token: &str,
+    request: MintFlowRequest<'_>,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    let MintFlowRequest {
+        client_id,
+        tokenization_request_id,
+        quantity,
+        underlying,
+        token,
+        network,
+    } = request;
     let mint_response = client
         .post("/inkind/issuance")
         .header(rocket::http::ContentType::JSON)
@@ -622,7 +702,7 @@ pub async fn perform_mint_and_confirm_with(
                 "qty": quantity,
                 "underlying_symbol": underlying,
                 "token_symbol": token,
-                "network": "base",
+                "network": network.as_str(),
                 "client_id": client_id,
                 "wallet_address": wallet
             })

--- a/tests/multi_vault_redemption.rs
+++ b/tests/multi_vault_redemption.rs
@@ -8,8 +8,8 @@ use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
-use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{Network, initialize_rocket};
 
 use crate::harness::create_provider;
 
@@ -86,11 +86,14 @@ async fn test_multi_vault_redemption_detects_on_all_vaults()
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &link_body.client_id.to_string(),
-        "alp-mint-aapl",
-        "50.0",
-        "AAPL",
-        "tAAPL",
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-aapl",
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
     )
     .await?;
 
@@ -98,11 +101,14 @@ async fn test_multi_vault_redemption_detects_on_all_vaults()
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &link_body.client_id.to_string(),
-        "alp-mint-tsla",
-        "30.0",
-        "TSLA",
-        "tTSLA",
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-tsla",
+            quantity: "30.0",
+            underlying: "TSLA",
+            token: "tTSLA",
+            network: Network::Base,
+        },
     )
     .await?;
 
@@ -251,11 +257,14 @@ async fn test_transfer_backfill_detects_transfers_while_down()
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &link_body.client_id.to_string(),
-        "alp-mint-tsla-backfill",
-        "30.0",
-        "TSLA",
-        "tTSLA",
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-tsla-backfill",
+            quantity: "30.0",
+            underlying: "TSLA",
+            token: "tTSLA",
+            network: Network::Base,
+        },
     )
     .await?;
 

--- a/tests/multichain_mint.rs
+++ b/tests/multichain_mint.rs
@@ -1,0 +1,146 @@
+#![allow(clippy::unwrap_used)]
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{U256, b256};
+use alloy::providers::ProviderBuilder;
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+use sqlx::sqlite::SqlitePoolOptions;
+
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{ETHEREUM_TEST_CHAIN_ID, Network, initialize_rocket};
+
+/// Verifies mint routing through `ChainRegistry`: Base mints land on the Base
+/// Anvil vault; Ethereum-network mints land on the second Anvil chain.
+#[tokio::test]
+async fn test_multichain_mint_routes_by_network()
+-> Result<(), Box<dyn std::error::Error>> {
+    let base_evm = LocalEvm::new().await?;
+    let eth_evm = LocalEvm::with_chain_id(ETHEREUM_TEST_CHAIN_ID).await?;
+
+    let mock_alpaca = MockServer::start();
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("multichain_mint.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
+    sqlx::migrate!("./migrations").run(&pool).await?;
+    harness::preseed_tokenized_asset_into_pool(
+        &pool,
+        base_evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+    harness::preseed_tokenized_asset_into_pool_with_network(
+        &pool,
+        eth_evm.vault_address,
+        "TSLA",
+        "tTSLA",
+        Network::Ethereum,
+    )
+    .await?;
+    pool.close().await;
+
+    let (config, _mock_subgraph) = harness::create_multichain_config_with_db(
+        &db_url,
+        &mock_alpaca,
+        &base_evm,
+        &eth_evm,
+    )?;
+
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+    let bot_wallet = base_evm.wallet_address;
+
+    harness::setup_roles(&base_evm, user_wallet, bot_wallet).await?;
+    harness::setup_roles(&eth_evm, user_wallet, bot_wallet).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    let user_wallet_instance = EthereumWallet::from(user_signer.clone());
+
+    let base_provider = ProviderBuilder::new()
+        .wallet(user_wallet_instance.clone())
+        .connect(&base_evm.endpoint)
+        .await?;
+    let base_vault = OffchainAssetReceiptVaultInstance::new(
+        base_evm.vault_address,
+        &base_provider,
+    );
+
+    let eth_provider = ProviderBuilder::new()
+        .wallet(user_wallet_instance)
+        .connect(&eth_evm.endpoint)
+        .await?;
+    let eth_vault = OffchainAssetReceiptVaultInstance::new(
+        eth_evm.vault_address,
+        &eth_provider,
+    );
+
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-base-aapl",
+            quantity: "25.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    // Baseline captured before the Ethereum mint runs, so the final assertion
+    // can detect an Ethereum mint erroneously landing on the Base vault.
+    let base_shares_after_base_mint =
+        harness::wait_for_shares(&base_vault, user_wallet).await?;
+    assert!(
+        base_shares_after_base_mint > U256::ZERO,
+        "Base mint should credit shares on the Base vault"
+    );
+
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        harness::MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-eth-tsla",
+            quantity: "10.0",
+            underlying: "TSLA",
+            token: "tTSLA",
+            network: Network::Ethereum,
+        },
+    )
+    .await?;
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+
+    let eth_shares = harness::wait_for_shares(&eth_vault, user_wallet).await?;
+    assert!(
+        eth_shares > U256::ZERO,
+        "Ethereum mint should credit shares on the Ethereum vault"
+    );
+
+    assert_eq!(
+        base_vault.balanceOf(user_wallet).call().await?,
+        base_shares_after_base_mint,
+        "Ethereum mint must not change the Base vault balance"
+    );
+
+    Ok(())
+}

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -19,6 +19,7 @@ use st0x_issuance::test_utils::{LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT};
 use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
     IpWhitelist, LogLevel, Network, SignerConfig, initialize_rocket,
+    receipt_inventory_aggregate_id,
 };
 
 use crate::harness::create_provider;
@@ -45,7 +46,7 @@ async fn wait_for_receipt_depleted(
               AND event_type = 'ReceiptInventoryEvent::Depleted'
             ",
         )
-        .bind(vault.to_string())
+        .bind(receipt_inventory_aggregate_id(ANVIL_CHAIN_ID, vault))
         .fetch_all(&pool)
         .await?;
 
@@ -342,7 +343,8 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
 
     // Query events table to verify the TSLA receipt was discovered by backfill.
     // Backfill stores ReceiptInventoryEvent::Discovered events in the events table.
-    let tsla_vault_str = tsla_vault.to_string();
+    let tsla_vault_aggregate_id =
+        receipt_inventory_aggregate_id(ANVIL_CHAIN_ID, tsla_vault);
     let receipt_count = sqlx::query_scalar!(
         r#"
         SELECT COUNT(*) as "count: i64"
@@ -351,7 +353,7 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
           AND aggregate_id = ?
           AND event_type = 'ReceiptInventoryEvent::Discovered'
         "#,
-        tsla_vault_str
+        tsla_vault_aggregate_id
     )
     .fetch_one(&pool)
     .await?;

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -17,8 +17,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::bindings::Receipt::ReceiptInstance;
 use st0x_issuance::test_utils::{LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT};
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
-    LogLevel, SignerConfig, initialize_rocket,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
+    IpWhitelist, LogLevel, Network, SignerConfig, initialize_rocket,
 };
 
 use crate::harness::create_provider;
@@ -284,10 +284,14 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
         HashMap::from([(evm.vault_address, harness::TEST_OA_SCHEMA_HASH)]);
     let mock_subgraph = harness::setup_mock_subgraph(&vault_schemas);
 
+    let rpc_url = Url::parse(&evm.endpoint)?;
+    let subgraph_url =
+        Url::parse(&mock_subgraph.base_url()).expect("valid mock subgraph URL");
+
     let config = Config {
         database_url,
         database_max_connections: 5,
-        rpc_url: Url::parse(&evm.endpoint)?,
+        rpc_url: rpc_url.clone(),
         chain_id: ANVIL_CHAIN_ID,
         signer: SignerConfig::Local(evm.private_key),
         backfill_start_block: 0,
@@ -314,8 +318,14 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
             connect_timeout_secs: 10,
             request_timeout_secs: 30,
         },
-        subgraph_url: Url::parse(&mock_subgraph.base_url())
-            .expect("valid mock subgraph URL"),
+        subgraph_url: subgraph_url.clone(),
+        chains: vec![ChainConfig {
+            network: Network::Base,
+            chain_id: ANVIL_CHAIN_ID,
+            rpc_url,
+            subgraph_url,
+            backfill_start_block: 0,
+        }],
     };
 
     // Start rocket - backfill should run and discover the TSLA receipt

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -9,8 +9,8 @@ use alloy::signers::local::PrivateKeySigner;
 use httpmock::prelude::*;
 
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
-use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{Network, initialize_rocket};
 
 use crate::harness::create_provider;
 
@@ -106,11 +106,14 @@ async fn test_three_round_trips() -> Result<(), Box<dyn std::error::Error>> {
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &client_id,
-        "smoke-r1-m1",
-        "1.0",
-        UNDERLYING,
-        TOKEN,
+        harness::MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: "smoke-r1-m1",
+            quantity: "1.0",
+            underlying: UNDERLYING,
+            token: TOKEN,
+            network: Network::Base,
+        },
     )
     .await?;
     let shares_r1 = harness::wait_for_shares(&vault, user_wallet).await?;
@@ -129,11 +132,14 @@ async fn test_three_round_trips() -> Result<(), Box<dyn std::error::Error>> {
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &client_id,
-        "smoke-r2-m1",
-        "1.5",
-        UNDERLYING,
-        TOKEN,
+        harness::MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: "smoke-r2-m1",
+            quantity: "1.5",
+            underlying: UNDERLYING,
+            token: TOKEN,
+            network: Network::Base,
+        },
     )
     .await?;
     let shares_after_first =
@@ -142,11 +148,14 @@ async fn test_three_round_trips() -> Result<(), Box<dyn std::error::Error>> {
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &client_id,
-        "smoke-r2-m2",
-        "0.5",
-        UNDERLYING,
-        TOKEN,
+        harness::MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: "smoke-r2-m2",
+            quantity: "0.5",
+            underlying: UNDERLYING,
+            token: TOKEN,
+            network: Network::Base,
+        },
     )
     .await?;
     let shares_r2 =
@@ -166,11 +175,14 @@ async fn test_three_round_trips() -> Result<(), Box<dyn std::error::Error>> {
     harness::perform_mint_and_confirm_with(
         &client,
         user_wallet,
-        &client_id,
-        "smoke-r3-m1",
-        "2.0",
-        UNDERLYING,
-        TOKEN,
+        harness::MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: "smoke-r3-m1",
+            quantity: "2.0",
+            underlying: UNDERLYING,
+            token: TOKEN,
+            network: Network::Base,
+        },
     )
     .await?;
     let shares_r3 = harness::wait_for_shares(&vault, user_wallet).await?;

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -13,8 +13,8 @@ use url::Url;
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::{
-    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, Config, Environment, IpWhitelist,
-    LogLevel, SignerConfig, initialize_rocket,
+    ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
+    IpWhitelist, LogLevel, Network, SignerConfig, initialize_rocket,
 };
 
 use crate::harness::create_provider;
@@ -41,10 +41,14 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
         HashMap::from([(evm.vault_address, harness::TEST_OA_SCHEMA_HASH)]);
     let mock_subgraph = harness::setup_mock_subgraph(&vault_schemas);
 
+    let rpc_url = Url::parse(&evm.endpoint)?;
+    let subgraph_url =
+        Url::parse(&mock_subgraph.base_url()).expect("valid mock subgraph URL");
+
     let config = Config {
         database_url: ":memory:".to_string(),
         database_max_connections: 5,
-        rpc_url: Url::parse(&evm.endpoint)?,
+        rpc_url: rpc_url.clone(),
         chain_id: ANVIL_CHAIN_ID,
         signer: SignerConfig::Local(evm.private_key),
         backfill_start_block: 0,
@@ -71,8 +75,14 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
             connect_timeout_secs: 10,
             request_timeout_secs: 30,
         },
-        subgraph_url: Url::parse(&mock_subgraph.base_url())
-            .expect("valid mock subgraph URL"),
+        subgraph_url: subgraph_url.clone(),
+        chains: vec![ChainConfig {
+            network: Network::Base,
+            chain_id: ANVIL_CHAIN_ID,
+            rpc_url,
+            subgraph_url,
+            backfill_start_block: 0,
+        }],
     };
 
     let rocket = initialize_rocket(config).await?;


### PR DESCRIPTION
## Motivation

Mint submit, confirm, and recovery paths used a single injected `VaultService`
from `registry.base()`. Multichain mint ITN requires resolving the signing
backend from `mint.network` via `ChainRegistry`.

Implements RAI-1206. Stacked on #210.

## Solution

- `MintServices` holds a per-network `VaultService` map seeded from
  `ChainRegistry::clone_vault_services()` at startup
- Submit, confirm, and recovery call `vault_for(network)` using the aggregate's
  persisted `network`
- `Network::Ethereum` variant (wire `"ethereum"`, Alpaca-compatible per RAI-1094)
- `POST /tokenized-assets` rejects registration for networks without a chain
  config (`ConfiguredNetworks` in Rocket state) — an asset on an unconfigured
  network would brick the next boot in `validate_configured_asset_networks`
- Integration tests configure extra chains via `Config.chains`
  (`create_multichain_config_with_db` harness); production env stays Base-only
- `tests/multichain_mint.rs`: dual Anvil (Base + Ethereum chain_id 1) e2e —
  Base AAPL mint unchanged, Ethereum TSLA mint lands on the second runtime
- Chain registry duplicate-`chain_id` unit test (Base + Ethereum)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

`nix develop -c cargo clippy --all-targets -- -D warnings` and
`nix develop -c cargo test --workspace` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Ethereum alongside Base across network handling and serialization.
  * Enabled multi-chain configuration and network-aware minting, redemption, and receipt processing.
  * Added end-to-end coverage for Base and Ethereum flows.

* **Bug Fixes**
  * Improved validation for network mismatches and unconfigured networks.
  * Updated receipt tracking to avoid cross-network collisions and support legacy fallback for Base.

* **Tests**
  * Expanded unit and integration tests for multi-network behavior, checkpoints, and contract/schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->