### PR TITLE
ci: grant pull-requests write so externally-merged label applies

### DIFF
--- a/.github/workflows/externally-merged.yaml
+++ b/.github/workflows/externally-merged.yaml
@@ -24,7 +24,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   label:


### PR DESCRIPTION
## Motivation

- The `externally-merged` workflow's `push-backstop` job failed on every merge-queue push to `main`: the label-apply step returned `HTTP 403 Resource not accessible by integration` ([failed run](https://github.com/ST0x-Technology/st0x.issuance/actions/runs/28191554555)).
- Root cause: the job labels a PR via the `issues/{n}/labels` REST endpoint, which GitHub gates behind `pull-requests: write`. The workflow only granted `pull-requests: read`, so the write was rejected and the job exited 1.
- When the label never lands, Linear does not treat the Graphite-closed PR as merged and the linked issue stays open — which is the exact problem this workflow exists to solve.

## Solution

- Bump the workflow-level `pull-requests` permission from `read` to `write`.
- Mirrors the equivalent, working workflow in the [liquidity repo](https://github.com/ST0x-Technology/st0x.liquidity/blob/master/.github/workflows/externally-merged.yaml), which already uses `pull-requests: write`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic — N/A, CI-permissions-only change (one line in a workflow file); verified against the failing run and the working liquidity workflow
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

RAI-1231