### PR TITLE
feat: AssetKey aggregate id and network-aware asset lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5804,8 +5804,10 @@ name = "st0x-issuance-dto"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "proptest",
  "serde",
  "serde_json",
+ "thiserror",
  "ts-rs",
  "utoipa",
 ]

--- a/SPEC.md
+++ b/SPEC.md
@@ -654,10 +654,11 @@ stateDiagram-v2
 ### TokenizedAsset Aggregate
 
 The `TokenizedAsset` aggregate manages which assets are supported for
-tokenization. The aggregate id is the `UnderlyingSymbol` today; the multichain
-cutover rekeys it to `{underlying}:{network}` (`AssetKey`) so the same
-underlying can be listed per network — see the [Multi-chain](#multi-chain)
-section for the target identity model and the migration/rollback story.
+tokenization. The aggregate id is the `AssetKey` — `{underlying}:{network}`
+(e.g. `AAPL:base`) — so the same underlying can be listed per network. See the
+[Multi-chain](#multi-chain) section for the identity model, and
+`docs/runbooks/tokenized-asset-aggregate-rekey.md` for migrating a
+pre-multichain store keyed by bare `UnderlyingSymbol`.
 
 **Aggregate State:**
 

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -19,7 +19,9 @@
 
 use reqwest::StatusCode;
 use reqwest::redirect::Policy;
-use st0x_issuance_dto::{TokenizedAssetStatusResponse, UnderlyingSymbol};
+use st0x_issuance_dto::{
+    Network, TokenizedAssetStatusResponse, UnderlyingSymbol,
+};
 use std::time::Duration;
 use url::Url;
 
@@ -87,6 +89,7 @@ impl IssuanceClient {
     pub async fn tokenized_asset_status(
         &self,
         underlying: &UnderlyingSymbol,
+        network: &Network,
     ) -> Result<Option<TokenizedAssetStatusResponse>, ClientError> {
         // Build the URL by appending percent-encoded path segments to the base
         // rather than `Url::join`ing a relative string: join drops a base path
@@ -107,6 +110,8 @@ impl IssuanceClient {
                 underlying_segment.as_str(),
                 "status",
             ]);
+
+        url.query_pairs_mut().append_pair("network", network.as_str());
 
         let response = self
             .http
@@ -150,6 +155,7 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(GET)
                 .path("/tokenized-assets/SGOV/status")
+                .query_param("network", "base")
                 .header(API_KEY_HEADER, "test-key");
             then.status(200).json_body(json!({
                 "underlying": "SGOV",
@@ -158,13 +164,16 @@ mod tests {
         });
 
         let status = client_for(&server)
-            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("SGOV").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect("request succeeds")
             .expect("asset exists");
 
         mock.assert();
-        assert_eq!(status.underlying, UnderlyingSymbol::new("SGOV"));
+        assert_eq!(status.underlying, UnderlyingSymbol::new("SGOV").unwrap());
         assert_eq!(status.status, TokenizedAssetStatus::Frozen);
     }
 
@@ -174,12 +183,16 @@ mod tests {
         let mock = server.mock(|when, then| {
             when.method(GET)
                 .path("/tokenized-assets/UNKNOWN/status")
+                .query_param("network", "base")
                 .header(API_KEY_HEADER, "test-key");
             then.status(404);
         });
 
         let status = client_for(&server)
-            .tokenized_asset_status(&UnderlyingSymbol::new("UNKNOWN"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("UNKNOWN").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect("request succeeds");
 
@@ -191,12 +204,17 @@ mod tests {
     async fn tokenized_asset_status_errors_on_unexpected_status() {
         let server = MockServer::start_async().await;
         let mock = server.mock(|when, then| {
-            when.method(GET).path("/tokenized-assets/SGOV/status");
+            when.method(GET)
+                .path("/tokenized-assets/SGOV/status")
+                .query_param("network", "base");
             then.status(500);
         });
 
         let err = client_for(&server)
-            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("SGOV").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect_err("a 500 must surface as an error, not None");
 
@@ -211,12 +229,17 @@ mod tests {
     async fn tokenized_asset_status_errors_on_malformed_body() {
         let server = MockServer::start_async().await;
         let mock = server.mock(|when, then| {
-            when.method(GET).path("/tokenized-assets/SGOV/status");
+            when.method(GET)
+                .path("/tokenized-assets/SGOV/status")
+                .query_param("network", "base");
             then.status(200).body("not json");
         });
 
         let err = client_for(&server)
-            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("SGOV").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect_err("a malformed 200 body must surface as a parse error");
 
@@ -231,7 +254,9 @@ mod tests {
     async fn tokenized_asset_status_preserves_base_path_prefix() {
         let server = MockServer::start_async().await;
         let mock = server.mock(|when, then| {
-            when.method(GET).path("/api/tokenized-assets/SGOV/status");
+            when.method(GET)
+                .path("/api/tokenized-assets/SGOV/status")
+                .query_param("network", "base");
             then.status(200).json_body(json!({
                 "underlying": "SGOV",
                 "status": "enabled"
@@ -246,7 +271,10 @@ mod tests {
             IssuanceClient::new(base, "test-key").expect("client builds");
 
         let status = client
-            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("SGOV").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect("request succeeds")
             .expect("asset exists");
@@ -266,7 +294,10 @@ mod tests {
         .expect("client builds");
 
         let err = client
-            .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("SGOV").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect_err("a cannot-be-a-base URL must error");
 
@@ -286,7 +317,9 @@ mod tests {
     async fn tokenized_asset_status_percent_encodes_path_unsafe_symbols() {
         let server = MockServer::start_async().await;
         let mock = server.mock(|when, then| {
-            when.method(GET).path("/tokenized-assets/FUND%2FA/status");
+            when.method(GET)
+                .path("/tokenized-assets/FUND%2FA/status")
+                .query_param("network", "base");
             then.status(200).json_body(json!({
                 "underlying": "FUND/A",
                 "status": "enabled"
@@ -294,7 +327,10 @@ mod tests {
         });
 
         let status = client_for(&server)
-            .tokenized_asset_status(&UnderlyingSymbol::new("FUND/A"))
+            .tokenized_asset_status(
+                &UnderlyingSymbol::new("FUND/A").unwrap(),
+                &Network::Base,
+            )
             .await
             .expect("request succeeds")
             .expect("asset exists");
@@ -313,12 +349,17 @@ mod tests {
         for code in [401u16, 403, 429] {
             let server = MockServer::start_async().await;
             let mock = server.mock(|when, then| {
-                when.method(GET).path("/tokenized-assets/SGOV/status");
+                when.method(GET)
+                    .path("/tokenized-assets/SGOV/status")
+                    .query_param("network", "base");
                 then.status(code);
             });
 
             let err = client_for(&server)
-                .tokenized_asset_status(&UnderlyingSymbol::new("SGOV"))
+                .tokenized_asset_status(
+                    &UnderlyingSymbol::new("SGOV").unwrap(),
+                    &Network::Base,
+                )
                 .await
                 .expect_err("a non-404 error status must surface as an error");
 

--- a/crates/dto/Cargo.toml
+++ b/crates/dto/Cargo.toml
@@ -6,10 +6,12 @@ edition = "2024"
 [dependencies]
 alloy-primitives = { workspace = true }
 serde = { workspace = true }
+thiserror.workspace = true
 ts-rs = { workspace = true }
 utoipa = { version = "5.5.0", optional = true }
 
 [dev-dependencies]
+proptest = "1.11.0"
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -13,14 +13,40 @@ use alloy_primitives::Address;
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
-/// Underlying equity symbol, e.g. `SGOV`. Also the `TokenizedAsset` aggregate id.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+/// Underlying equity symbol, e.g. `SGOV`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, TS)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
-pub struct UnderlyingSymbol(pub String);
+#[ts(type = "string")]
+pub struct UnderlyingSymbol(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum UnderlyingSymbolError {
+    #[error("underlying symbol must not be empty")]
+    Empty,
+}
 
 impl UnderlyingSymbol {
-    pub fn new(value: impl Into<String>) -> Self {
-        Self(value.into())
+    /// Constructs an underlying symbol from a non-empty wire value.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`UnderlyingSymbolError::Empty`] when `value` is empty or
+    /// whitespace-only after trimming. Surrounding whitespace is stripped from
+    /// the stored symbol.
+    pub fn new(
+        value: impl Into<String>,
+    ) -> Result<Self, UnderlyingSymbolError> {
+        let value = value.into();
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return Err(UnderlyingSymbolError::Empty);
+        }
+        Ok(Self(trimmed.to_string()))
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
@@ -31,15 +57,44 @@ impl std::fmt::Display for UnderlyingSymbol {
 }
 
 impl FromStr for UnderlyingSymbol {
-    type Err = std::convert::Infallible;
+    type Err = UnderlyingSymbolError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(Self::new(value))
+        Self::new(value)
+    }
+}
+
+impl TryFrom<String> for UnderlyingSymbol {
+    type Error = UnderlyingSymbolError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for UnderlyingSymbol {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
     }
 }
 
 /// Tokenized share symbol, e.g. `tSGOV`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, TS)]
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Serialize,
+    Deserialize,
+    TS,
+)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
 pub struct TokenSymbol(pub String);
 
@@ -84,6 +139,103 @@ impl Network {
 impl std::fmt::Display for Network {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum NetworkParseError {
+    #[error("unsupported network: {value}")]
+    Unsupported { value: String },
+}
+
+impl FromStr for Network {
+    type Err = NetworkParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "base" => Ok(Self::Base),
+            other => {
+                Err(NetworkParseError::Unsupported { value: other.to_string() })
+            }
+        }
+    }
+}
+
+/// Composite `TokenizedAsset` aggregate id and lookup key: `{underlying}:{network}`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, TS)]
+#[ts(type = "string")]
+pub struct AssetKey {
+    pub underlying: UnderlyingSymbol,
+    pub network: Network,
+}
+
+/// `AssetKey` serializes as the plain `{underlying}:{network}` string, so its
+/// OpenAPI schema must be a string as well -- the derived `ToSchema` would
+/// advertise an object with `underlying`/`network` properties that never
+/// appears on the wire.
+#[cfg(feature = "utoipa")]
+impl utoipa::PartialSchema for AssetKey {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        <String as utoipa::PartialSchema>::schema()
+    }
+}
+
+#[cfg(feature = "utoipa")]
+impl utoipa::ToSchema for AssetKey {}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AssetKeyParseError {
+    #[error("asset key must be {{underlying}}:{{network}}, got: {value}")]
+    InvalidFormat { value: String },
+    #[error(transparent)]
+    UnderlyingSymbol(#[from] UnderlyingSymbolError),
+    #[error(transparent)]
+    Network(#[from] NetworkParseError),
+}
+
+impl AssetKey {
+    #[must_use]
+    pub const fn new(underlying: UnderlyingSymbol, network: Network) -> Self {
+        Self { underlying, network }
+    }
+}
+
+impl std::fmt::Display for AssetKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.underlying, self.network)
+    }
+}
+
+impl FromStr for AssetKey {
+    type Err = AssetKeyParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let (underlying, network_str) =
+            value.rsplit_once(':').ok_or_else(|| {
+                AssetKeyParseError::InvalidFormat { value: value.to_string() }
+            })?;
+        let underlying = UnderlyingSymbol::new(underlying)?;
+        let network = network_str.parse()?;
+        Ok(Self::new(underlying, network))
+    }
+}
+
+impl Serialize for AssetKey {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(self)
+    }
+}
+
+impl<'de> Deserialize<'de> for AssetKey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        value.parse().map_err(serde::de::Error::custom)
     }
 }
 
@@ -176,6 +328,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     UnderlyingSymbol::export_all_to(out_dir)?;
     TokenSymbol::export_all_to(out_dir)?;
     Network::export_all_to(out_dir)?;
+    AssetKey::export_all_to(out_dir)?;
     TokenizedAssetDetailResponse::export_all_to(out_dir)?;
     TokenizedAssetStatus::export_all_to(out_dir)?;
     TokenizedAssetStatusResponse::export_all_to(out_dir)?;
@@ -188,6 +341,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
 
 #[cfg(test)]
 mod tests {
+    use proptest::prelude::*;
     use serde_json::json;
 
     use super::*;
@@ -197,9 +351,84 @@ mod tests {
     }
 
     #[test]
+    fn underlying_symbol_rejects_empty_and_whitespace() {
+        assert!(UnderlyingSymbol::new("").is_err());
+        assert!(UnderlyingSymbol::new("   ").is_err());
+        assert_eq!(UnderlyingSymbol::new("AAPL").unwrap().as_str(), "AAPL");
+        assert_eq!(UnderlyingSymbol::new(" AAPL ").unwrap().as_str(), "AAPL");
+        assert_eq!(
+            serde_json::from_value::<UnderlyingSymbol>(json!(" AAPL "))
+                .unwrap(),
+            UnderlyingSymbol::new("AAPL").unwrap()
+        );
+    }
+
+    prop_compose! {
+        fn arb_trimmed_symbol()(core in "[A-Z0-9][A-Z0-9._/-]{0,9}") -> String {
+            core
+        }
+    }
+
+    prop_compose! {
+        fn arb_whitespace()(ws in "[ \t]{0,8}") -> String {
+            ws
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn underlying_symbol_stores_trimmed_value(
+            core in arb_trimmed_symbol(),
+            prefix in arb_whitespace(),
+            suffix in arb_whitespace(),
+        ) {
+            let padded = format!("{prefix}{core}{suffix}");
+            let symbol = UnderlyingSymbol::new(&padded).unwrap();
+            prop_assert_eq!(symbol.as_str(), core);
+            prop_assert_eq!(symbol.as_str().trim(), symbol.as_str());
+        }
+
+        #[test]
+        fn underlying_symbol_rejects_whitespace_only(ws in "[ \t]+") {
+            prop_assert!(UnderlyingSymbol::new(ws).is_err());
+        }
+
+        #[test]
+        fn underlying_symbol_from_str_agrees_with_new(
+            core in arb_trimmed_symbol(),
+            prefix in arb_whitespace(),
+            suffix in arb_whitespace(),
+        ) {
+            let padded = format!("{prefix}{core}{suffix}");
+            prop_assert_eq!(
+                UnderlyingSymbol::from_str(&padded).unwrap(),
+                UnderlyingSymbol::new(&padded).unwrap(),
+            );
+        }
+
+        #[test]
+        fn underlying_symbol_serde_preserves_trimmed_value(
+            core in arb_trimmed_symbol(),
+            prefix in arb_whitespace(),
+            suffix in arb_whitespace(),
+        ) {
+            let symbol = UnderlyingSymbol::new(&core).unwrap();
+            let serialized = serde_json::to_value(&symbol).unwrap();
+            prop_assert_eq!(serialized, json!(core));
+
+            let from_padded = serde_json::from_value::<UnderlyingSymbol>(
+                json!(format!("{prefix}{core}{suffix}"))
+            )
+            .unwrap();
+            prop_assert_eq!(from_padded, symbol);
+        }
+    }
+
+    #[test]
     fn newtypes_serialize_as_bare_strings() {
         assert_eq!(
-            serde_json::to_value(UnderlyingSymbol::new("SGOV")).unwrap(),
+            serde_json::to_value(UnderlyingSymbol::new("SGOV").unwrap())
+                .unwrap(),
             json!("SGOV")
         );
         assert_eq!(
@@ -213,7 +442,7 @@ mod tests {
     fn newtypes_deserialize_from_bare_strings() {
         assert_eq!(
             serde_json::from_value::<UnderlyingSymbol>(json!("SGOV")).unwrap(),
-            UnderlyingSymbol::new("SGOV")
+            UnderlyingSymbol::new("SGOV").unwrap()
         );
         assert_eq!(
             serde_json::from_value::<TokenSymbol>(json!("tSGOV")).unwrap(),
@@ -238,19 +467,33 @@ mod tests {
                 "{invalid} must not deserialize as Network"
             );
         }
+        assert!(
+            serde_json::from_value::<UnderlyingSymbol>(json!("")).is_err(),
+            "empty underlying must not deserialize"
+        );
+        assert!(
+            serde_json::from_value::<UnderlyingSymbol>(json!("   ")).is_err(),
+            "whitespace-only underlying must not deserialize"
+        );
     }
 
     #[test]
     fn newtypes_display_their_inner_value() {
-        assert_eq!(UnderlyingSymbol::new("SGOV").to_string(), "SGOV");
+        assert_eq!(UnderlyingSymbol::new("SGOV").unwrap().to_string(), "SGOV");
         assert_eq!(TokenSymbol::new("tSGOV").to_string(), "tSGOV");
         assert_eq!(Network::Base.to_string(), "base");
     }
 
     #[test]
+    fn network_from_str_parses_wire_values() {
+        assert_eq!("base".parse::<Network>().unwrap(), Network::Base);
+        assert!("ethereum".parse::<Network>().is_err());
+    }
+
+    #[test]
     fn status_response_uses_snake_case_wire_format() {
         let response = TokenizedAssetStatusResponse {
-            underlying: UnderlyingSymbol::new("SGOV"),
+            underlying: UnderlyingSymbol::new("SGOV").unwrap(),
             status: TokenizedAssetStatus::Frozen,
         };
 
@@ -267,7 +510,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(response.underlying, UnderlyingSymbol::new("SGOV"));
+        assert_eq!(response.underlying, UnderlyingSymbol::new("SGOV").unwrap());
         assert_eq!(response.status, TokenizedAssetStatus::Enabled);
     }
 
@@ -308,7 +551,7 @@ mod tests {
     fn list_response_uses_snake_case_wire_format() {
         let response = TokenizedAssetsListResponse {
             tokens: vec![TokenizedAssetResponse {
-                underlying: UnderlyingSymbol::new("SGOV"),
+                underlying: UnderlyingSymbol::new("SGOV").unwrap(),
                 token: TokenSymbol::new("tSGOV"),
                 networks: vec![Network::Base],
             }],
@@ -329,7 +572,7 @@ mod tests {
     #[test]
     fn detail_response_serializes_vault_as_string_and_round_trips() {
         let response = TokenizedAssetDetailResponse {
-            underlying: UnderlyingSymbol::new("SGOV"),
+            underlying: UnderlyingSymbol::new("SGOV").unwrap(),
             token: TokenSymbol::new("tSGOV"),
             network: Network::Base,
             vault: vault(),
@@ -364,16 +607,47 @@ mod tests {
         }))
         .unwrap();
 
-        assert_eq!(request.underlying, UnderlyingSymbol::new("SGOV"));
+        assert_eq!(request.underlying, UnderlyingSymbol::new("SGOV").unwrap());
         assert_eq!(request.token, TokenSymbol::new("tSGOV"));
         assert_eq!(request.network, Network::Base);
         assert_eq!(request.vault, vault());
     }
 
     #[test]
+    fn asset_key_serializes_as_underlying_colon_network() {
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("SGOV").unwrap(),
+            Network::Base,
+        );
+        assert_eq!(key.to_string(), "SGOV:base");
+        assert_eq!(serde_json::to_value(&key).unwrap(), json!("SGOV:base"));
+        assert_eq!("SGOV:base".parse::<AssetKey>().unwrap(), key);
+    }
+
+    #[test]
+    fn asset_key_from_str_rejects_invalid_inputs() {
+        assert!(matches!(
+            "SGOV".parse::<AssetKey>().unwrap_err(),
+            AssetKeyParseError::InvalidFormat { .. }
+        ));
+        assert!(matches!(
+            ":base".parse::<AssetKey>().unwrap_err(),
+            AssetKeyParseError::UnderlyingSymbol(UnderlyingSymbolError::Empty)
+        ));
+        assert!(matches!(
+            "SGOV:".parse::<AssetKey>().unwrap_err(),
+            AssetKeyParseError::Network(NetworkParseError::Unsupported { .. })
+        ));
+        assert!(matches!(
+            "SGOV:ethereum".parse::<AssetKey>().unwrap_err(),
+            AssetKeyParseError::Network(NetworkParseError::Unsupported { .. })
+        ));
+    }
+
+    #[test]
     fn add_response_uses_snake_case_wire_format() {
         let response = AddTokenizedAssetResponse {
-            underlying: UnderlyingSymbol::new("SGOV"),
+            underlying: UnderlyingSymbol::new("SGOV").unwrap(),
         };
 
         assert_eq!(
@@ -424,6 +698,15 @@ mod tests {
         assert!(
             network_ts.contains("\"base\""),
             "Network must be a \"base\" string-literal union in TS:\n{network_ts}"
+        );
+
+        // `AssetKey` serializes as `"underlying:network"`; pin the TS alias so
+        // ts_rs can't regress to a struct shape the dashboard can't consume.
+        let asset_key_ts =
+            std::fs::read_to_string(out_dir.join("AssetKey.ts")).unwrap();
+        assert!(
+            asset_key_ts.contains("= string"),
+            "AssetKey must be a string alias in TS:\n{asset_key_ts}"
         );
 
         // The newtypes must resolve to a bare `string`, matching their

--- a/docs/runbooks/tokenized-asset-aggregate-rekey.md
+++ b/docs/runbooks/tokenized-asset-aggregate-rekey.md
@@ -1,0 +1,125 @@
+# TokenizedAsset aggregate rekey runbook (RAI-1205)
+
+Rekeys live `TokenizedAsset` aggregate ids from `{underlying}` to
+`{underlying}:{network}` (e.g. `AAPL` -> `AAPL:base`).
+
+## Preconditions
+
+- Issuance binary includes migration
+  `20260703235904_rekey_tokenized_asset_aggregate_id`.
+- Coordinate lockstep deploy with `st0x-issuance-client` and liquidity
+  (RAI-1212): internal detail/status callers must send `?network=`.
+- Maintenance window long enough for backup + single deploy + smoke check.
+
+## 1. Backup
+
+```bash
+cp /path/to/issuance.db /path/to/issuance.db.pre-asset-key-$(date -u +%Y%m%dT%H%M%SZ)
+```
+
+Verify the backup opens and row counts match production:
+
+```bash
+sqlite3 /path/to/issuance.db.pre-asset-key-<timestamp> \
+  "SELECT COUNT(*) FROM events WHERE aggregate_type = 'TokenizedAsset';"
+```
+
+## 2. Dry run on a copy
+
+```bash
+cp /path/to/issuance.db /tmp/issuance-dry-run.db
+```
+
+Before migrating, check for a partially migrated store. If a bare id and its
+rekeyed form both exist (e.g. `AAPL` **and** `AAPL:base`), appending `:base` to
+the bare rows would collide with the existing rows on the events primary key
+`(aggregate_type, aggregate_id, sequence)` and abort the migration
+mid-transaction. This query must return no rows; if it returns any, resolve the
+duplicate aggregate manually before proceeding:
+
+```sql
+SELECT bare.aggregate_id
+FROM events AS bare
+JOIN events AS rekeyed
+  ON rekeyed.aggregate_type = 'TokenizedAsset'
+ AND rekeyed.aggregate_id = bare.aggregate_id || ':base'
+WHERE bare.aggregate_type = 'TokenizedAsset'
+  AND bare.aggregate_id NOT GLOB '*:*'
+GROUP BY bare.aggregate_id;
+```
+
+(The migration itself also aborts, before touching any row, if it finds an empty
+`TokenizedAsset` aggregate id or a `:`-bearing id that is not a lowercase
+rekeyed `{underlying}:base` key. The guard uses case-sensitive `GLOB`, not
+`LIKE`, so mixed-case suffixes such as `AAPL:BASE` abort instead of being
+silently skipped.)
+
+Then apply the migration:
+
+```bash
+DATABASE_URL=sqlite:/tmp/issuance-dry-run.db sqlx migrate run
+```
+
+Validate rekey idempotency and view rebuild:
+
+```sql
+-- No underlying-only ids remain
+SELECT aggregate_id FROM events
+WHERE aggregate_type = 'TokenizedAsset' AND aggregate_id NOT GLOB '*:*';
+
+-- Expected shape
+SELECT aggregate_id FROM events
+WHERE aggregate_type = 'TokenizedAsset'
+LIMIT 5;
+```
+
+Start issuance against the copy
+(`DATABASE_URL=sqlite:/tmp/issuance-dry-run.db`). Confirm:
+
+- `GET /tokenized-assets` lists seeded assets.
+- `GET /tokenized-assets/AAPL/status?network=base` returns 200 (not 422).
+- `GET /tokenized-assets/AAPL/status` without `?network=` returns 422.
+
+Re-run `sqlx migrate run` on the same copy -- row counts and aggregate ids must
+be unchanged (migration is idempotent).
+
+## 3. Production cutover
+
+1. Stop issuance.
+2. Take a fresh backup (step 1).
+3. Run the duplicate-aggregate check from step 2 against the stopped production
+   database — it must return no rows before you deploy.
+4. Deploy the RAI-1205 binary; startup runs migrations automatically.
+5. Deploy matching `st0x-issuance-client` + liquidity freeze guard (RAI-1212).
+6. Smoke: token list, `?network=base` status for a known asset, one mint on
+   Base.
+
+## 4. Rollback
+
+1. Stop issuance.
+2. Restore the pre-cutover backup over the live database:
+
+   ```bash
+   cp /path/to/issuance.db.pre-asset-key-<timestamp> /path/to/issuance.db
+   ```
+
+   The database restore is mandatory, not optional: reverted code looks assets
+   up by the old `{underlying}` keys, so running it against a rekeyed store
+   silently finds no assets at all.
+
+3. Redeploy the previous issuance, `st0x-issuance-client`, and liquidity builds
+   together.
+
+Do not leave a mixed-version window: if liquidity still sends `?network=`
+against rolled-back issuance, freeze/status calls succeed harmlessly, but if
+liquidity is rolled back alone while issuance still requires `?network=`, the
+freeze guard receives 422 and rebalancing fail-closes until the versions match
+again.
+
+## 5. Idempotency notes
+
+- SQL migration only appends `:base` when `aggregate_id` has no `:` suffix.
+- `TokenizedAsset` schema version bump clears stale projections; catch-up
+  rebuilds `tokenized_asset_view` from rekeyed events.
+- Safe to re-run migration on a partially migrated copy during dry-run
+  validation.

--- a/migrations/20260703235904_rekey_tokenized_asset_aggregate_id.sql
+++ b/migrations/20260703235904_rekey_tokenized_asset_aggregate_id.sql
@@ -1,0 +1,49 @@
+-- Rekey TokenizedAsset aggregate ids from underlying-only to `{underlying}:base`.
+-- Assumption: legacy aggregate ids are bare equity tickers and never contain
+-- ':', so any ':' means the row is already in AssetKey form; the NOT GLOB
+-- guard is what makes re-runs idempotent. GLOB is case-sensitive (unlike LIKE),
+-- so mixed-case suffixes such as `AAPL:BASE` are not treated as already rekeyed.
+--
+-- Guard the assumption instead of trusting it: a ':'-bearing id that is not a
+-- rekeyed `{underlying}:base` key would be silently skipped by the updates
+-- below and left permanently unreadable. Inserting any such id into this
+-- CHECK-violating temp table aborts the migration transaction before any row
+-- is touched.
+CREATE TEMP TABLE rekey_precondition (
+    unexpected_aggregate_id TEXT CHECK (unexpected_aggregate_id IS NULL)
+);
+INSERT INTO rekey_precondition (unexpected_aggregate_id)
+SELECT aggregate_id
+FROM events
+WHERE aggregate_type = 'TokenizedAsset'
+  AND (
+    aggregate_id = ''
+    OR (
+      aggregate_id GLOB '*:*'
+      AND aggregate_id NOT GLOB '*:base'
+    )
+    -- GLOB '*' matches the empty string, so a blank-underlying id such as
+    -- ':base' would otherwise pass as "already rekeyed" despite being
+    -- unparseable as an AssetKey.
+    OR (
+      aggregate_id GLOB '*:base'
+      AND trim(substr(aggregate_id, 1, length(aggregate_id) - 5)) = ''
+    )
+  );
+DROP TABLE rekey_precondition;
+
+UPDATE events
+SET aggregate_id = aggregate_id || ':base'
+WHERE aggregate_type = 'TokenizedAsset'
+  AND aggregate_id != ''
+  AND aggregate_id NOT GLOB '*:*';
+
+UPDATE snapshots
+SET aggregate_id = aggregate_id || ':base'
+WHERE aggregate_type = 'TokenizedAsset'
+  AND aggregate_id != ''
+  AND aggregate_id NOT GLOB '*:*';
+
+-- View ids mirrored aggregate ids pre-migration; drop so projection catch-up
+-- rebuilds from the rekeyed event log (schema version bump also clears this).
+DELETE FROM tokenized_asset_view;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1894,7 +1894,7 @@ mod tests {
     };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
@@ -2158,7 +2158,7 @@ mod tests {
     fn test_metadata() -> RedemptionMetadata {
         RedemptionMetadata {
             issuer_request_id: IssuerRedemptionRequestId::random(),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             quantity: Quantity::new(Decimal::from(100)),
@@ -2722,7 +2722,7 @@ mod tests {
         if let TokenizationRequest::Redeem { ref mut underlying, .. } =
             mismatched
         {
-            *underlying = UnderlyingSymbol::new("WRONG");
+            *underlying = UnderlyingSymbol::new("WRONG").unwrap();
         }
 
         let alpaca: Arc<dyn AlpacaService> =
@@ -4124,10 +4124,11 @@ mod tests {
                 .build(())
                 .await
                 .expect("tokenized asset store should build");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let key = AssetKey::new(underlying.clone(), Network::Base);
         asset_store
             .send(
-                &underlying,
+                &key,
                 TokenizedAssetCommand::Add {
                     underlying: underlying.clone(),
                     token: TokenSymbol::new("tAAPL"),
@@ -5135,7 +5136,7 @@ mod tests {
 
         let issuer_request_id = crate::mint::IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-stuck-1");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -5281,7 +5282,7 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("alp-completed"),
                 quantity: crate::mint::Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -5322,7 +5323,7 @@ mod tests {
         use crate::redemption::{BurnExternalTxId, RedemptionEvent};
 
         let issuer = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));

--- a/src/alpaca/mock.rs
+++ b/src/alpaca/mock.rs
@@ -178,7 +178,7 @@ impl AlpacaService for MockAlpacaService {
                         "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
                     )),
                     status: RedeemRequestStatus::Completed,
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     quantity: Quantity::new(Decimal::from(100)),
                     wallet: address!(
@@ -202,21 +202,31 @@ impl AlpacaService for MockAlpacaService {
         }
 
         #[cfg(not(test))]
-        Ok(TokenizationRequest::Redeem {
-            id: tokenization_request_id.clone(),
-            issuer_request_id: IssuerRedemptionRequestId::new(b256!(
-                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
-            )),
-            status: RedeemRequestStatus::Completed,
-            underlying: UnderlyingSymbol::new("AAPL"),
-            token: TokenSymbol::new("tAAPL"),
-            quantity: Quantity::new(rust_decimal::Decimal::from(100)),
-            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
-            tx_hash: Some(b256!(
-                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
-            )),
-            updated_at: Some(Utc::now()),
-        })
+        {
+            let underlying = UnderlyingSymbol::new("AAPL").map_err(|_| {
+                AlpacaError::Api {
+                    status_code: 500,
+                    body: "mock misconfigured: AAPL is not a valid underlying"
+                        .to_string(),
+                }
+            })?;
+
+            return Ok(TokenizationRequest::Redeem {
+                id: tokenization_request_id.clone(),
+                issuer_request_id: IssuerRedemptionRequestId::new(b256!(
+                    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                )),
+                status: RedeemRequestStatus::Completed,
+                underlying,
+                token: TokenSymbol::new("tAAPL"),
+                quantity: Quantity::new(rust_decimal::Decimal::from(100)),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                tx_hash: Some(b256!(
+                    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                )),
+                updated_at: Some(Utc::now()),
+            });
+        }
     }
 }
 
@@ -314,7 +324,7 @@ mod tests {
         );
         RedeemRequest {
             issuer_request_id: IssuerRedemptionRequestId::new(tx_hash),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             client_id: ClientId::new(),
             quantity: Quantity::new(Decimal::from(100)),

--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -297,7 +297,7 @@ mod tests {
 
         let request = RedeemRequest {
             issuer_request_id: IssuerRedemptionRequestId::new(tx_hash),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             client_id,
             quantity: Quantity::new(Decimal::new(10050, 2)),

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -621,7 +621,7 @@ mod tests {
         );
         RedeemRequest {
             issuer_request_id: IssuerRedemptionRequestId::new(tx_hash),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             client_id,
             quantity: Quantity::new(rust_decimal::Decimal::from(100)),

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -251,7 +251,8 @@ mod tests {
     use super::*;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        TokenSymbol, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
+        AssetKey, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
 
@@ -346,10 +347,11 @@ mod tests {
                 .await
                 .expect("Failed to build tokenized asset store");
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let key = AssetKey::new(underlying.clone(), Network::Base);
         store
             .send(
-                &underlying,
+                &key,
                 TokenizedAssetCommand::Add {
                     underlying: underlying.clone(),
                     token: TokenSymbol::new("tAAPL"),
@@ -400,10 +402,11 @@ mod tests {
                 .await
                 .expect("Failed to build tokenized asset store");
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let key = AssetKey::new(underlying.clone(), Network::Base);
         store
             .send(
-                &underlying,
+                &key,
                 TokenizedAssetCommand::Add {
                     underlying: underlying.clone(),
                     token: TokenSymbol::new("tAAPL"),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,7 +946,7 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
                     &provider,
                     vault,
                     backfill_start_block,
-                    &underlying.0,
+                    underlying.as_str(),
                     receipt_inventory_store,
                     bot_wallet,
                 )

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -34,7 +34,7 @@ pub(crate) struct MintRequest {
 
 #[tracing::instrument(skip(_auth, mint_store, pool), fields(
     tokenization_request_id = %request.tokenization_request_id.0,
-    underlying = %request.underlying.0,
+    underlying = %request.underlying.as_str(),
     client_id = %request.client_id,
     quantity = %request.quantity
 ))]
@@ -119,7 +119,7 @@ mod tests {
         view::find_by_issuer_request_id,
     };
     use crate::test_utils::logs_contain_at;
-    use crate::tokenized_asset::TokenizedAssetCommand;
+    use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
 
     #[tokio::test]
     async fn test_initiate_mint_returns_issuer_request_id() {
@@ -160,7 +160,7 @@ mod tests {
             .await
             .expect("Failed to whitelist wallet");
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
@@ -172,7 +172,7 @@ mod tests {
             vault,
         };
         tokenized_asset_store
-            .send(&underlying, asset_cmd)
+            .send(&AssetKey::new(underlying.clone(), network), asset_cmd)
             .await
             .expect("Failed to add asset");
 
@@ -238,7 +238,10 @@ mod tests {
         } = harness;
 
         tokenized_asset_store
-            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .send(
+                &AssetKey::new(underlying.clone(), Network::Base),
+                TokenizedAssetCommand::Freeze,
+            )
             .await
             .expect("Failed to freeze asset");
 
@@ -258,7 +261,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-123",
             "qty": "100.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,
@@ -333,7 +336,10 @@ mod tests {
         let asset_store = tokenized_asset_store.clone();
 
         asset_store
-            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .send(
+                &AssetKey::new(underlying.clone(), Network::Base),
+                TokenizedAssetCommand::Freeze,
+            )
             .await
             .expect("Failed to freeze asset");
 
@@ -353,7 +359,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-123",
             "qty": "100.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,
@@ -385,7 +391,10 @@ mod tests {
         // Unfreezing must let new mints through again — the whole point of the
         // toggle is that issuance resumes after Unfreeze.
         asset_store
-            .send(&underlying, TokenizedAssetCommand::Unfreeze)
+            .send(
+                &AssetKey::new(underlying.clone(), Network::Base),
+                TokenizedAssetCommand::Unfreeze,
+            )
             .await
             .expect("Failed to unfreeze asset");
 
@@ -566,7 +575,7 @@ mod tests {
             ..
         } = TestHarness::new().await;
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
@@ -578,7 +587,7 @@ mod tests {
             vault,
         };
         tokenized_asset_store
-            .send(&underlying, asset_cmd)
+            .send(&AssetKey::new(underlying.clone(), network), asset_cmd)
             .await
             .expect("Failed to add asset");
 
@@ -662,7 +671,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-events-test",
             "qty": "50.0",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,
@@ -741,7 +750,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": tokenization_request_id,
             "qty": "75.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,
@@ -831,7 +840,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-123",
             "qty": "100.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,
@@ -882,7 +891,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-123",
             "qty": "100.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": "ethereum",
             "client_id": client_id,
@@ -1017,7 +1026,7 @@ mod tests {
         let request_body = serde_json::json!({
             "tokenization_request_id": "alp-123",
             "qty": "100.5",
-            "underlying_symbol": underlying.0,
+            "underlying_symbol": underlying.as_str(),
             "token_symbol": token.0,
             "network": network.as_str(),
             "client_id": client_id,

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -12,7 +12,7 @@ use super::{
     UnderlyingSymbol,
 };
 use crate::account::{AccountView, view::find_by_client_id};
-use crate::tokenized_asset::view::load_asset_by_underlying;
+use crate::tokenized_asset::view::load_asset_by_network;
 
 mod confirm;
 mod initiate;
@@ -195,7 +195,7 @@ pub(crate) async fn validate_asset_exists(
     token: &TokenSymbol,
     network: &Network,
 ) -> Result<(), MintApiError> {
-    let asset = load_asset_by_underlying(pool, underlying)
+    let asset = load_asset_by_network(pool, underlying, network)
         .await
         .map_err(|query_error| {
             error!(target: "mint", error = %query_error, "Failed to query asset");
@@ -215,7 +215,7 @@ pub(crate) async fn validate_asset_exists(
     if asset.status.is_frozen() {
         warn!(
             target: "mint",
-            underlying = %underlying.0,
+            underlying = %underlying.as_str(),
             token = %token.0,
             network = %network,
             "Rejecting mint for frozen asset"

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -16,7 +16,7 @@ use crate::auth::test_auth_config;
 use crate::config::{Config, Environment, LogLevel};
 use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
 use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
+use crate::tokenized_asset::{AssetKey, TokenizedAsset, TokenizedAssetCommand};
 use crate::vault::VaultService;
 use crate::vault::mock::MockVaultService;
 use crate::wallet::SignerConfig;
@@ -190,7 +190,7 @@ impl TestHarness {
             .await
             .expect("Failed to whitelist wallet");
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
@@ -203,7 +203,7 @@ impl TestHarness {
         };
 
         self.asset_store
-            .send(&underlying, asset_cmd)
+            .send(&AssetKey::new(underlying.clone(), network), asset_cmd)
             .await
             .expect("Failed to add asset");
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -19,7 +19,9 @@ use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptService, Shares,
 };
 use crate::redemption::has_unresolved_burn_intent;
-use crate::tokenized_asset::view::find_vault_by_underlying;
+use crate::tokenized_asset::view::{
+    TokenizedAssetViewError, TokenizedAssetViewFailure, find_vault,
+};
 use crate::vault::{
     PreparedMintTx, ReceiptInformation, TxId, VaultError, VaultService,
 };
@@ -301,6 +303,7 @@ struct MintSubmissionInput<'a> {
     tokenization_request_id: &'a TokenizationRequestId,
     quantity: &'a Quantity,
     underlying: &'a UnderlyingSymbol,
+    network: &'a Network,
     wallet: Address,
     journal_confirmed_at: DateTime<Utc>,
     receipt_note: Option<&'a str>,
@@ -553,6 +556,7 @@ impl Mint {
             tokenization_request_id,
             quantity,
             underlying,
+            network,
             wallet,
             journal_confirmed_at,
             ..
@@ -572,6 +576,7 @@ impl Mint {
                 tokenization_request_id,
                 quantity,
                 underlying,
+                network,
                 wallet: *wallet,
                 journal_confirmed_at: *journal_confirmed_at,
                 receipt_note: None,
@@ -594,31 +599,38 @@ impl Mint {
             tokenization_request_id,
             quantity,
             underlying,
+            network,
             wallet,
             journal_confirmed_at,
             receipt_note,
             external_tx_id,
         } = input;
-
         let unresolved_mint = has_unresolved_mint_intent(
             &services.pool,
             Some(&issuer_request_id),
         )
         .await
-        .map_err(|error| MintError::AssetView { message: error.to_string() })?;
-        let unresolved_burn =
-            has_unresolved_burn_intent(&services.pool, None).await.map_err(
-                |error| MintError::AssetView { message: error.to_string() },
-            )?;
+        .map_err(|error| {
+            MintError::AssetView(TokenizedAssetViewFailure::Database {
+                message: error.to_string(),
+            })
+        })?;
+        let unresolved_burn = has_unresolved_burn_intent(&services.pool, None)
+            .await
+            .map_err(|error| {
+                MintError::AssetView(TokenizedAssetViewFailure::Database {
+                    message: error.to_string(),
+                })
+            })?;
         if unresolved_mint || unresolved_burn {
             return Err(MintError::PendingWalletIntent);
         }
 
-        let vault = find_vault_by_underlying(&services.pool, underlying)
-            .await
-            .map_err(|e| MintError::AssetView { message: e.to_string() })?
+        let vault = find_vault(&services.pool, underlying, network)
+            .await?
             .ok_or_else(|| MintError::AssetNotFound {
                 underlying: underlying.clone(),
+                network: *network,
             })?;
 
         let assets = quantity.to_u256_with_18_decimals().map_err(|e| {
@@ -766,6 +778,7 @@ impl Mint {
             tokenization_request_id,
             quantity,
             underlying,
+            network,
             journal_confirmed_at,
             tx_id: stored_tx_id,
             ..
@@ -800,8 +813,7 @@ impl Mint {
 
                 // Best-effort receipt registration — vault lookup failure
                 // must not prevent TokensMinted from being emitted.
-                match find_vault_by_underlying(&services.pool, underlying).await
-                {
+                match find_vault(&services.pool, underlying, network).await {
                     Ok(Some(vault)) => {
                         let receipt_info = ReceiptInformation::new(
                             tokenization_request_id.clone(),
@@ -830,6 +842,8 @@ impl Mint {
                             warn!(
                                 target: "mint",
                                 issuer_request_id = %issuer_request_id,
+                                underlying = %underlying,
+                                network = %network,
                                 error = %err,
                                 "Failed to register minted receipt \
                                  (monitor/backfill will discover it)"
@@ -841,6 +855,7 @@ impl Mint {
                             target: "mint",
                             issuer_request_id = %issuer_request_id,
                             underlying = %underlying,
+                            network = %network,
                             "Vault not found for receipt registration \
                              (monitor/backfill will discover it)"
                         );
@@ -849,6 +864,8 @@ impl Mint {
                         warn!(
                             target: "mint",
                             issuer_request_id = %issuer_request_id,
+                            underlying = %underlying,
+                            network = %network,
                             error = %err,
                             "Vault lookup failed for receipt registration \
                              (monitor/backfill will discover it)"
@@ -943,16 +960,13 @@ impl Mint {
                 // Recover again, which hits the Minting arm to submit.
                 self.handle_deposit(issuer_request_id)
             }
-            Self::TxIntended { underlying, .. } => {
-                let vault =
-                    find_vault_by_underlying(&services.pool, underlying)
-                        .await
-                        .map_err(|error| MintError::AssetView {
-                            message: error.to_string(),
-                        })?
-                        .ok_or_else(|| MintError::AssetNotFound {
-                            underlying: underlying.clone(),
-                        })?;
+            Self::TxIntended { underlying, network, .. } => {
+                let vault = find_vault(&services.pool, underlying, network)
+                    .await?
+                    .ok_or_else(|| MintError::AssetNotFound {
+                        underlying: underlying.clone(),
+                        network: *network,
+                    })?;
 
                 if let Some(deposit_events) =
                     Self::recover_from_existing_receipt(
@@ -1047,16 +1061,13 @@ impl Mint {
         tx_hash: TxHash,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
-            Self::TxIntended { underlying, .. } => {
-                let vault =
-                    find_vault_by_underlying(&services.pool, underlying)
-                        .await
-                        .map_err(|error| MintError::AssetView {
-                            message: error.to_string(),
-                        })?
-                        .ok_or_else(|| MintError::AssetNotFound {
-                            underlying: underlying.clone(),
-                        })?;
+            Self::TxIntended { underlying, network, .. } => {
+                let vault = find_vault(&services.pool, underlying, network)
+                    .await?
+                    .ok_or_else(|| MintError::AssetNotFound {
+                        underlying: underlying.clone(),
+                        network: *network,
+                    })?;
                 let deposit_events = Self::recover_from_existing_receipt(
                     services,
                     &vault,
@@ -1107,6 +1118,7 @@ impl Mint {
             tokenization_request_id,
             quantity,
             underlying,
+            network,
             wallet,
             journal_confirmed_at,
             ..
@@ -1116,6 +1128,7 @@ impl Mint {
             tokenization_request_id,
             quantity,
             underlying,
+            network,
             wallet,
             journal_confirmed_at,
             ..
@@ -1128,11 +1141,11 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        let vault = find_vault_by_underlying(&services.pool, underlying)
-            .await
-            .map_err(|e| MintError::AssetView { message: e.to_string() })?
+        let vault = find_vault(&services.pool, underlying, network)
+            .await?
             .ok_or_else(|| MintError::AssetNotFound {
                 underlying: underlying.clone(),
+                network: *network,
             })?;
 
         if let Some(events) = Self::recover_from_existing_receipt(
@@ -1193,6 +1206,8 @@ impl Mint {
                         warn!(
                             target: "mint",
                             issuer_request_id = %issuer_request_id,
+                            underlying = %underlying,
+                            network = %network,
                             error = %err,
                             "Failed to register recovered receipt \
                              (monitor/backfill will discover it)"
@@ -1260,6 +1275,7 @@ impl Mint {
                             tokenization_request_id,
                             quantity,
                             underlying,
+                            network,
                             wallet: *wallet,
                             journal_confirmed_at: *journal_confirmed_at,
                             receipt_note: Some("Recovery mint"),
@@ -1283,6 +1299,7 @@ impl Mint {
                 tokenization_request_id,
                 quantity,
                 underlying,
+                network,
                 wallet: *wallet,
                 journal_confirmed_at: *journal_confirmed_at,
                 receipt_note: Some("Recovery mint"),
@@ -2283,12 +2300,14 @@ pub(crate) enum MintError {
         "Vault returned transaction metadata that differs from mint intent"
     )]
     SubmittedTransactionMismatch,
-    #[error("Asset not found for underlying: {underlying}")]
-    AssetNotFound { underlying: UnderlyingSymbol },
+    #[error(
+        "Asset not found for underlying: {underlying} on network: {network}"
+    )]
+    AssetNotFound { underlying: UnderlyingSymbol, network: Network },
     #[error("Quantity conversion: {message}")]
     QuantityConversion { message: String },
-    #[error("Asset view: {message}")]
-    AssetView { message: String },
+    #[error(transparent)]
+    AssetView(#[from] TokenizedAssetViewFailure),
     #[error("Alpaca: {message}")]
     Alpaca { message: String },
     #[error("Receipt lookup: {message}")]
@@ -2301,6 +2320,12 @@ pub(crate) enum MintError {
     PendingWalletIntent,
     #[error("Vault: {message}")]
     Vault { message: String },
+}
+
+impl From<TokenizedAssetViewError> for MintError {
+    fn from(error: TokenizedAssetViewError) -> Self {
+        Self::AssetView(error.into())
+    }
 }
 
 #[cfg(test)]
@@ -2333,7 +2358,9 @@ pub(crate) mod tests {
     use crate::prepare_event_sourced_startup;
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
     use crate::test_utils::{log_count_at, logs_contain_at};
-    use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
+    use crate::tokenized_asset::{
+        AssetKey, TokenizedAsset, TokenizedAssetCommand,
+    };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
@@ -2548,10 +2575,11 @@ pub(crate) mod tests {
                     .await
                     .unwrap();
 
-            let underlying = UnderlyingSymbol::new("AAPL");
+            let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+            let asset_key = AssetKey::new(underlying.clone(), Network::Base);
             asset_store
                 .send(
-                    &underlying,
+                    &asset_key,
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
                         token: TokenSymbol::new("tAAPL"),
@@ -2631,7 +2659,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -2716,7 +2744,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-123");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -2782,7 +2810,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-123");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -2827,7 +2855,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(50));
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -2879,7 +2907,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -2923,7 +2951,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -2971,7 +2999,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3018,7 +3046,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3057,7 +3085,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3119,7 +3147,7 @@ pub(crate) mod tests {
         let wrong_issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3160,7 +3188,7 @@ pub(crate) mod tests {
         let wrong_issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3200,7 +3228,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3262,7 +3290,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3332,7 +3360,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3394,7 +3422,7 @@ pub(crate) mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3467,7 +3495,7 @@ pub(crate) mod tests {
         let tokenization_request_id =
             TokenizationRequestId::new("alp-flow-456");
         let quantity = Quantity::new(Decimal::from(100));
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let client_id = ClientId::new();
@@ -3576,7 +3604,7 @@ pub(crate) mod tests {
                     "alp-integration-456",
                 ),
                 quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -3615,9 +3643,12 @@ pub(crate) mod tests {
 
         asset_store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: VAULT,
@@ -3949,9 +3980,12 @@ pub(crate) mod tests {
 
         asset_store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: VAULT,
@@ -4148,9 +4182,12 @@ pub(crate) mod tests {
 
         asset_store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: VAULT,
@@ -4377,7 +4414,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -4851,7 +4888,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -4927,7 +4964,7 @@ pub(crate) mod tests {
                         "tok-123",
                     ),
                     quantity: Quantity::new(Decimal::from(100)),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     client_id: ClientId::new(),
@@ -4970,7 +5007,7 @@ pub(crate) mod tests {
                         "tok-123",
                     ),
                     quantity: Quantity::new(Decimal::from(100)),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     client_id: ClientId::new(),
@@ -5014,7 +5051,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("tok-123"),
             quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             network: Network::Base,
             client_id: ClientId::new(),
@@ -5027,7 +5064,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("tok-123"),
             quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             network: Network::Base,
             client_id: ClientId::new(),

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1013,7 +1013,9 @@ mod tests {
         ReceiptInventoryCommand, ReceiptSource, Shares,
     };
     use crate::test_utils::{log_count_at, logs_contain_at};
-    use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
+    use crate::tokenized_asset::{
+        AssetKey, TokenizedAsset, TokenizedAssetCommand,
+    };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         PreparedMintTx, ReceiptInformation, TxId, VaultService,
@@ -1023,7 +1025,7 @@ mod tests {
     /// SQLite pool, wired with the same services the production recovery flow
     /// uses (vault, Alpaca, receipt inventory). The [`TokenizedAsset`]
     /// projection is populated with the AAPL -> [`VAULT`] mapping so the
-    /// recovery vault lookup (`find_vault_by_underlying`) resolves.
+    /// recovery vault lookup (`find_vault`) resolves.
     struct MintRecoveryFixture {
         mint_store: Arc<Store<Mint>>,
         receipt_store: Arc<Store<ReceiptInventory>>,
@@ -1065,9 +1067,12 @@ mod tests {
 
             asset_store
                 .send(
-                    &UnderlyingSymbol::new("AAPL"),
+                    &AssetKey::new(
+                        UnderlyingSymbol::new("AAPL").unwrap(),
+                        Network::Base,
+                    ),
                     TokenizedAssetCommand::Add {
-                        underlying: UnderlyingSymbol::new("AAPL"),
+                        underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                         token: TokenSymbol::new("tAAPL"),
                         network: Network::Base,
                         vault: VAULT,
@@ -1167,7 +1172,7 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 client_id: ClientId::new(),
@@ -1301,7 +1306,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
             issuer_request_id.clone(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(Decimal::from(100)),
             Utc::now(),
             None,

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -400,7 +400,7 @@ mod tests {
                         "alp-888",
                     ),
                     quantity: Quantity::new(Decimal::from(50)),
-                    underlying: UnderlyingSymbol::new("TSLA"),
+                    underlying: UnderlyingSymbol::new("TSLA").unwrap(),
                     token: TokenSymbol::new("tTSLA"),
                     network: Network::Base,
                     client_id: ClientId::new(),
@@ -437,7 +437,7 @@ mod tests {
             TokenizationRequestId::new("alp-888")
         );
         assert_eq!(found_quantity, Quantity::new(Decimal::from(50)));
-        assert_eq!(found_underlying, UnderlyingSymbol::new("TSLA"));
+        assert_eq!(found_underlying, UnderlyingSymbol::new("TSLA").unwrap());
         assert_eq!(found_token, TokenSymbol::new("tTSLA"));
         assert_eq!(found_network, Network::Base);
     }
@@ -460,7 +460,7 @@ mod tests {
             issuer_request_id: IssuerMintRequestId::random(),
             tokenization_request_id: TokenizationRequestId::new("alp-1"),
             quantity: Quantity::new(Decimal::from(100)),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             network: Network::Base,
             client_id: ClientId::new(),

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -516,7 +516,7 @@ mod tests {
         let events = vec![
             RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 wallet: address!("0x1111111111111111111111111111111111111111"),
                 quantity: Quantity::new(dec!(10)),

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -1375,7 +1375,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-roundtrip"),
             issuer_request_id.clone(),
-            UnderlyingSymbol::new("TSLA"),
+            UnderlyingSymbol::new("TSLA").unwrap(),
             Quantity(Decimal::new(5050, 2)),
             Utc::now(),
             Some("test notes".to_string()),
@@ -1623,7 +1623,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-cbor-test"),
             expected_id.clone(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity(Decimal::new(1005, 1)),
             Utc.timestamp_opt(1_704_067_200, 0).unwrap(),
             Some("cbor test".to_string()),
@@ -2778,7 +2778,7 @@ mod tests {
         ReceiptInformation::new(
             TokenizationRequestId::new("tok-test"),
             issuer_request_id.clone(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity(Decimal::new(100, 0)),
             Utc::now(),
             None,
@@ -2797,7 +2797,7 @@ mod tests {
             ReceiptInformation::new(
                 TokenizationRequestId::new(tok_id),
                 issuer_request_id,
-                UnderlyingSymbol::new(symbol),
+                UnderlyingSymbol::new(symbol).unwrap(),
                 Quantity(Decimal::new(qty, 2)),
                 Utc.timestamp_opt(timestamp_secs, 0).unwrap(),
                 notes,
@@ -2838,7 +2838,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-anvil-test"),
             original_issuer_request_id.clone(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity(Decimal::new(10050, 2)),
             chrono::Utc::now(),
             Some("Anvil integration test".to_string()),

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -375,7 +375,7 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let mint_id = IssuerMintRequestId::random();
 
@@ -415,7 +415,7 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let receipt_id = uint!(42_U256);
         let shares_minted = uint!(100_000000000000000000_U256);
@@ -484,7 +484,7 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let underlying = UnderlyingSymbol::new("NVDA");
+        let underlying = UnderlyingSymbol::new("NVDA").unwrap();
         let token = TokenSymbol::new("tNVDA");
         let mint_id = IssuerMintRequestId::random();
 
@@ -519,7 +519,7 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let underlying = UnderlyingSymbol::new("AMD");
+        let underlying = UnderlyingSymbol::new("AMD").unwrap();
         let token = TokenSymbol::new("tAMD");
         let receipt_id = uint!(7_U256);
         let shares_minted = uint!(250_500000000000000000_U256);
@@ -583,7 +583,7 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let underlying = UnderlyingSymbol::new("MSTR");
+        let underlying = UnderlyingSymbol::new("MSTR").unwrap();
         let token = TokenSymbol::new("tMSTR");
         let receipt_id = uint!(136_U256);
         let shares_minted = uint!(4_028802626000000000_U256);
@@ -651,8 +651,8 @@ mod tests {
         let harness =
             ReactorHarness::new(ReceiptInventoryViewReactor::new(pool.clone()));
 
-        let aapl_underlying = UnderlyingSymbol::new("AAPL");
-        let tsla_underlying = UnderlyingSymbol::new("TSLA");
+        let aapl_underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let tsla_underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let aapl_mint_id = IssuerMintRequestId::random();
         let tsla_mint_id = IssuerMintRequestId::random();
 
@@ -709,7 +709,7 @@ mod tests {
             .receive::<Mint>(
                 mint_id.clone(),
                 initiated_event(
-                    UnderlyingSymbol::new("AAPL"),
+                    UnderlyingSymbol::new("AAPL").unwrap(),
                     TokenSymbol::new("tAAPL"),
                     "alp-other",
                     address!("0x4444444444444444444444444444444444444444"),
@@ -804,7 +804,7 @@ mod tests {
         let pool = migrated_pool().await;
 
         let mint_id = IssuerMintRequestId::random();
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let receipt_id = uint!(42_U256);
         let shares_minted = uint!(100_000000000000000000_U256);
@@ -835,7 +835,7 @@ mod tests {
 
         // A stale pre-rebuild row must be replaced by the replay, not kept.
         let stale = ReceiptInventoryView::Pending {
-            underlying: UnderlyingSymbol::new("STALE"),
+            underlying: UnderlyingSymbol::new("STALE").unwrap(),
             token: TokenSymbol::new("tSTALE"),
         };
         seed_view_row(&pool, &aggregate_id, &stale).await;
@@ -867,7 +867,7 @@ mod tests {
         // Existing view content that must survive a failed rebuild.
         let survivor_id = IssuerMintRequestId::random();
         let survivor_view = ReceiptInventoryView::Pending {
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
         };
         seed_view_row(&pool, &survivor_id.to_string(), &survivor_view).await;
@@ -897,14 +897,14 @@ mod tests {
 
         let survivor_id = IssuerMintRequestId::random();
         let survivor_view = ReceiptInventoryView::Pending {
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
         };
         seed_view_row(&pool, &survivor_id.to_string(), &survivor_view).await;
 
         let replay_id = IssuerMintRequestId::random();
         let initiated = serde_json::to_string(&initiated_event(
-            UnderlyingSymbol::new("TSLA"),
+            UnderlyingSymbol::new("TSLA").unwrap(),
             TokenSymbol::new("tTSLA"),
             "alp-rebuild-write-failure",
             address!("0x1234567890abcdef1234567890abcdef12345678"),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -23,10 +23,8 @@ use crate::receipt_inventory::{
 use crate::redemption::{
     BurnRecord, RedemptionMetadata, has_unresolved_burn_intent,
 };
-use crate::tokenized_asset::UnderlyingSymbol;
-use crate::tokenized_asset::view::{
-    TokenizedAssetViewError, find_vault_by_underlying,
-};
+use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
+use crate::tokenized_asset::{Network, UnderlyingSymbol};
 use crate::vault::{
     BurnTxStatus, BurnVerification, MultiBurnEntry, SendableTxWithHash, TxId,
     VaultError, VaultService, VerifiedBurn, VerifiedShareTransfer,
@@ -278,7 +276,9 @@ impl BurnManager {
             }
         };
 
-        let vault = find_vault_by_underlying(&self.view_pool, &underlying)
+        // Burn routing is still Base-only in this PR; network-aware detect →
+        // Alpaca → burn lands in the upstack redemption PR (#215).
+        let vault = find_vault(&self.view_pool, &underlying, &Network::Base)
             .await?
             .ok_or(BurnManagerError::AssetNotFound { underlying })?;
 
@@ -490,7 +490,7 @@ impl BurnManager {
             return Ok(());
         }
 
-        let vault = find_vault_by_underlying(&self.view_pool, underlying)
+        let vault = find_vault(&self.view_pool, underlying, &Network::Base)
             .await?
             .ok_or_else(|| BurnManagerError::AssetNotFound {
                 underlying: underlying.clone(),
@@ -766,7 +766,7 @@ impl BurnManager {
         has_submitted: bool,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
         let vault =
-            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+            find_vault(&self.view_pool, &metadata.underlying, &Network::Base)
                 .await?
                 .ok_or_else(|| BurnManagerError::AssetNotFound {
                     underlying: metadata.underlying.clone(),
@@ -953,7 +953,7 @@ impl BurnManager {
         let action_already_reserved =
             pending_recovery == Some(PendingBurnRecovery::Reserved(action));
         let vault =
-            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+            find_vault(&self.view_pool, &metadata.underlying, &Network::Base)
                 .await?
                 .ok_or_else(|| BurnManagerError::AssetNotFound {
                     underlying: metadata.underlying.clone(),
@@ -1042,31 +1042,7 @@ impl BurnManager {
         command_result?;
 
         if status == BurnTxStatus::ProvablyDead {
-            let Some(Redemption::BurnIntended {
-                planned_burns,
-                sendable_tx,
-                external_tx_id,
-                ..
-            }) = self.store.load(issuer_request_id).await?
-            else {
-                return Err(BurnManagerError::InvalidAggregateState {
-                    current_state: "expected replacement BurnIntended"
-                        .to_string(),
-                });
-            };
-            let replacement_burns = recovery_burn_entries(&planned_burns);
-            self.store
-                .send(
-                    issuer_request_id,
-                    RedemptionCommand::BurnTokens {
-                        issuer_request_id: issuer_request_id.clone(),
-                        vault,
-                        burns: replacement_burns,
-                        dust_shares: sendable_tx.dust_shares,
-                        owner: self.bot_wallet,
-                        external_tx_id,
-                    },
-                )
+            self.submit_replacement_after_dead_burn(issuer_request_id, vault)
                 .await?;
         }
         drop(wallet_guard);
@@ -1080,6 +1056,39 @@ impl BurnManager {
         Ok(RecoveryOutcome::Executed)
     }
 
+    async fn submit_replacement_after_dead_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        vault: Address,
+    ) -> Result<(), BurnManagerError> {
+        let Some(Redemption::BurnIntended {
+            planned_burns,
+            sendable_tx,
+            external_tx_id,
+            ..
+        }) = self.store.load(issuer_request_id).await?
+        else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: "expected replacement BurnIntended".to_string(),
+            });
+        };
+        let replacement_burns = recovery_burn_entries(&planned_burns);
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::BurnTokens {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: replacement_burns,
+                    dust_shares: sendable_tx.dust_shares,
+                    owner: self.bot_wallet,
+                    external_tx_id,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
     async fn submit_prepared_replacement(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
@@ -1089,7 +1098,7 @@ impl BurnManager {
         external_tx_id: Option<BurnExternalTxId>,
     ) -> Result<(), BurnManagerError> {
         let vault =
-            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+            find_vault(&self.view_pool, &metadata.underlying, &Network::Base)
                 .await?
                 .ok_or_else(|| BurnManagerError::AssetNotFound {
                     underlying: metadata.underlying.clone(),
@@ -1204,9 +1213,10 @@ impl BurnManager {
                 external_tx_id,
                 ..
             } => {
-                let vault = find_vault_by_underlying(
+                let vault = find_vault(
                     &self.view_pool,
                     &metadata.underlying,
+                    &Network::Base,
                 )
                 .await?
                 .ok_or_else(|| {
@@ -1327,7 +1337,7 @@ impl BurnManager {
         };
 
         let Some(vault) =
-            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+            find_vault(&self.view_pool, &metadata.underlying, &Network::Base)
                 .await?
         else {
             let error_msg = format!(
@@ -2438,7 +2448,8 @@ mod tests {
     };
     use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
-        TokenSymbol, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
+        AssetKey, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
@@ -2791,10 +2802,13 @@ mod tests {
         ) {
             self.asset_store
                 .send(
-                    underlying,
+                    &AssetKey::new(underlying.clone(), Network::Base),
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
-                        token: TokenSymbol::new(format!("t{}", underlying.0)),
+                        token: TokenSymbol::new(format!(
+                            "t{}",
+                            underlying.as_str()
+                        )),
                         network: Network::Base,
                         vault,
                     },
@@ -2839,7 +2853,7 @@ mod tests {
     ) -> Redemption {
         let tokenization_request_id =
             TokenizationRequestId::new("alp-burn-456");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2955,7 +2969,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3016,7 +3030,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
         harness
             .discover_receipt(
@@ -3141,7 +3155,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3268,7 +3282,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -3366,7 +3380,9 @@ mod tests {
             let harness =
                 TestHarness::with_vault_mock(vault_mock.clone()).await;
             let TestHarness { store, receipt_service, pool, .. } = &harness;
-            harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+            harness
+                .add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault)
+                .await;
             let manager = BurnManager::new(
                 vault_mock.clone(),
                 pool.clone(),
@@ -3454,7 +3470,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3519,7 +3535,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3651,7 +3667,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3759,7 +3775,7 @@ mod tests {
         } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3775,7 +3791,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-mint-99"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(Decimal::new(10000, 2)),
             Utc::now(),
             None,
@@ -3844,7 +3860,7 @@ mod tests {
         } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3860,7 +3876,7 @@ mod tests {
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-bytes-test"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(Decimal::from(50)),
             Utc::now(),
             None,
@@ -3922,7 +3938,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -3997,7 +4013,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
@@ -4058,7 +4074,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
@@ -4119,7 +4135,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
@@ -4180,7 +4196,7 @@ mod tests {
                 inner: receipt_service.clone(),
             });
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock,
             pool.clone(),
@@ -4242,7 +4258,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
@@ -4297,7 +4313,7 @@ mod tests {
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let wallet = address!("0x9876543210fedcba9876543210fedcba98765432");
         let quantity = Quantity::new(Decimal::from(50));
@@ -4344,7 +4360,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -4393,7 +4409,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying_symbol = UnderlyingSymbol::new("AAPL");
+        let underlying_symbol = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying_symbol, vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
@@ -4418,7 +4434,7 @@ mod tests {
 
         let tokenization_request_id =
             TokenizationRequestId::new("alp-partial-burn");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(50));
@@ -4488,7 +4504,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
@@ -4535,7 +4551,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
@@ -4590,7 +4606,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
@@ -4654,7 +4670,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -4698,7 +4714,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         // Configure mock to return balance less than required (100 shares = 100e18)
@@ -4758,7 +4774,7 @@ mod tests {
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -4806,7 +4822,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
@@ -4877,7 +4893,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         // Configure mock to return balance less than required (100 shares = 100e18)
@@ -4952,7 +4968,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         // Configure mock to return 0 balance (burn already happened on-chain)
@@ -5027,7 +5043,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
         let manager = BurnManager::new(
@@ -5122,7 +5138,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
         let manager = BurnManager::new(
@@ -5223,7 +5239,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
         let manager = BurnManager::new(
@@ -5434,7 +5450,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5544,7 +5560,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5606,7 +5622,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5696,7 +5712,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5793,7 +5809,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5879,7 +5895,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -5969,7 +5985,7 @@ mod tests {
         let TestHarness { store, receipt_service, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
@@ -6279,7 +6295,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -6353,7 +6369,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
@@ -6545,7 +6561,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -6721,7 +6737,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -6888,7 +6904,7 @@ mod tests {
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -7039,7 +7055,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let manager = BurnManager::new(
             vault_mock,
@@ -7115,7 +7131,7 @@ mod tests {
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let manager = BurnManager::new(
             vault_mock,
@@ -7171,7 +7187,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
         let manager = BurnManager::new(
@@ -7325,7 +7341,7 @@ mod tests {
                 inner: receipt_service.clone(),
             });
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let manager = BurnManager::new(
             vault_mock.clone(),
@@ -7396,7 +7412,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         harness.add_asset(&underlying, vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
@@ -7526,7 +7542,7 @@ mod tests {
         let vault_mock = Arc::new(MockVaultService::new_success());
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
@@ -7704,7 +7720,7 @@ mod tests {
         let vault_mock = Arc::new(MockVaultService::new_failure());
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
@@ -7766,7 +7782,7 @@ mod tests {
     async fn test_recover_stuck_reservations_warns_and_leaves_unknown() {
         let harness = TestHarness::new().await;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
-        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
 
         let blockchain_service = Arc::new(MockVaultService::new_success())
             as Arc<dyn crate::vault::VaultService>;

--- a/src/redemption/journal_manager.rs
+++ b/src/redemption/journal_manager.rs
@@ -652,7 +652,7 @@ mod tests {
                 issuer_request_id,
                 RedemptionCommand::Detect {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -736,7 +736,7 @@ mod tests {
                 id: TokenizationRequestId::new("mock-tok"),
                 issuer_request_id: self.issuer_request_id.clone(),
                 status,
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 quantity: Quantity::new(Decimal::from(100)),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
@@ -1351,7 +1351,7 @@ mod tests {
                     id: TokenizationRequestId::new("mock-tok"),
                     issuer_request_id: self.issuer_request_id.clone(),
                     status: RedeemRequestStatus::Completed,
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     quantity: Quantity::new(Decimal::from(999)),
                     wallet: address!(
@@ -1770,7 +1770,7 @@ mod tests {
         let view = RedemptionView::AlpacaCalled {
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             quantity: quantity.clone(),

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -2169,7 +2169,7 @@ mod tests {
                 issuer_request_id: IssuerRedemptionRequestId::new(
                     detected_tx_hash,
                 ),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
                 quantity: Quantity::new(Decimal::from(1)),
@@ -2198,7 +2198,7 @@ mod tests {
     #[tokio::test]
     async fn test_detect_redemption_creates_event() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2250,7 +2250,7 @@ mod tests {
     #[tokio::test]
     async fn test_detect_redemption_when_already_detected_returns_error() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let wallet = address!("0x9876543210fedcba9876543210fedcba98765432");
         let quantity = Quantity::new(Decimal::from(50));
@@ -2296,7 +2296,7 @@ mod tests {
         assert!(replay::<Redemption>(vec![]).unwrap().is_none());
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("NVDA");
+        let underlying = UnderlyingSymbol::new("NVDA").unwrap();
         let token = TokenSymbol::new("tNVDA");
         let wallet = address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc");
         let quantity = Quantity::new(Decimal::from(25));
@@ -2345,7 +2345,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 wallet: address!(
                     "0x1234567890abcdef1234567890abcdef12345678"
@@ -2419,7 +2419,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("TSLA"),
+                underlying: UnderlyingSymbol::new("TSLA").unwrap(),
                 token: TokenSymbol::new("tTSLA"),
                 wallet: address!(
                     "0x9876543210fedcba9876543210fedcba98765432"
@@ -2489,7 +2489,7 @@ mod tests {
             .given(vec![
                 RedemptionEvent::Detected {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -2561,7 +2561,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-burning-456");
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let wallet = address!("0x9876543210fedcba9876543210fedcba98765432");
         let quantity = Quantity::new(Decimal::from(50));
@@ -2636,7 +2636,7 @@ mod tests {
             .given(vec![
                 RedemptionEvent::Detected {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -2691,7 +2691,7 @@ mod tests {
             .given(vec![
                 RedemptionEvent::Detected {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     wallet: address!(
                         "0x1234567890abcdef1234567890abcdef12345678"
@@ -2757,7 +2757,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("NVDA"),
+                underlying: UnderlyingSymbol::new("NVDA").unwrap(),
                 token: TokenSymbol::new("tNVDA"),
                 wallet: address!(
                     "0xfedcbafedcbafedcbafedcbafedcbafedcbafedc"
@@ -2804,7 +2804,7 @@ mod tests {
         vec![
             RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
                 quantity: Quantity::new(Decimal::from(100)),
@@ -3081,7 +3081,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-intended-456");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -3169,7 +3169,7 @@ mod tests {
             .given(vec![
                 RedemptionEvent::Detected {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("TSLA"),
+                    underlying: UnderlyingSymbol::new("TSLA").unwrap(),
                     token: TokenSymbol::new("tTSLA"),
                     wallet: user_wallet,
                     quantity: Quantity::new(Decimal::from(100)),
@@ -3239,7 +3239,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("NVDA"),
+                underlying: UnderlyingSymbol::new("NVDA").unwrap(),
                 token: TokenSymbol::new("tNVDA"),
                 wallet: address!(
                     "0xfedcbafedcbafedcbafedcbafedcbafedcbafedc"
@@ -3288,7 +3288,7 @@ mod tests {
             .given(vec![
                 RedemptionEvent::Detected {
                     issuer_request_id: issuer_request_id.clone(),
-                    underlying: UnderlyingSymbol::new("GOOG"),
+                    underlying: UnderlyingSymbol::new("GOOG").unwrap(),
                     token: TokenSymbol::new("tGOOG"),
                     wallet: address!(
                         "0xabababababababababababababababababababab"
@@ -3373,7 +3373,7 @@ mod tests {
         vec![
             RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("ARKK"),
+                underlying: UnderlyingSymbol::new("ARKK").unwrap(),
                 token: TokenSymbol::new("tARKK"),
                 wallet: address!("0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"),
                 quantity: Quantity::new(Decimal::from(17)),
@@ -3850,7 +3850,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
                 issuer_request_id: issuer_request_id.clone(),
-                underlying: UnderlyingSymbol::new("ARKK"),
+                underlying: UnderlyingSymbol::new("ARKK").unwrap(),
                 token: TokenSymbol::new("tARKK"),
                 wallet: address!(
                     "0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"
@@ -4154,7 +4154,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-complete-456");
-        let underlying = UnderlyingSymbol::new("AMZN");
+        let underlying = UnderlyingSymbol::new("AMZN").unwrap();
         let token = TokenSymbol::new("tAMZN");
         let wallet = address!("0xefefefefefefefefefefefefefefefefefefefef");
         let quantity = Quantity::new(Decimal::from(200));
@@ -4222,7 +4222,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-failed-456");
-        let underlying = UnderlyingSymbol::new("NFLX");
+        let underlying = UnderlyingSymbol::new("NFLX").unwrap();
         let token = TokenSymbol::new("tNFLX");
         let wallet = address!("0x1212121212121212121212121212121212121212");
         let quantity = Quantity::new(Decimal::from(150));
@@ -4283,7 +4283,7 @@ mod tests {
     #[tokio::test]
     async fn test_mark_failed_from_failed_state_succeeds() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -4477,7 +4477,7 @@ mod tests {
     fn test_metadata() -> RedemptionMetadata {
         RedemptionMetadata {
             issuer_request_id: IssuerRedemptionRequestId::random(),
-            underlying: UnderlyingSymbol::new("RKLB"),
+            underlying: UnderlyingSymbol::new("RKLB").unwrap(),
             token: TokenSymbol::new("tRKLB"),
             wallet: address!("0x9876543210fedcba9876543210fedcba98765432"),
             quantity: Quantity::new(Decimal::from(100)),
@@ -5002,7 +5002,7 @@ mod tests {
 
         history.push(RedemptionEvent::BurnResumed {
             issuer_request_id,
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             quantity: Quantity::new(Decimal::from(100)),

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -596,7 +596,7 @@ mod tests {
     use crate::redemption::{IssuerRedemptionRequestId, Redemption};
     use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
@@ -695,12 +695,13 @@ mod tests {
                 .build(())
                 .await
                 .unwrap();
-        let msft = UnderlyingSymbol::new("MSFT");
+        let msft = UnderlyingSymbol::new("MSFT").unwrap();
+        let key = AssetKey::new(msft.clone(), Network::Base);
         asset_store
             .send(
-                &msft,
+                &key,
                 TokenizedAssetCommand::Add {
-                    underlying: msft.clone(),
+                    underlying: msft,
                     token: TokenSymbol::new("tMSFT"),
                     network: Network::Base,
                     vault,

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -239,7 +239,7 @@ impl RedeemCallManager {
                     status = ?response.status,
                     created_at = %response.created_at,
                     issuer = %response.issuer,
-                    underlying = %response.underlying.0,
+                    underlying = %response.underlying.as_str(),
                     token = %response.token.0,
                     quantity = %response.quantity.0,
                     network = %response.network,
@@ -351,7 +351,7 @@ mod tests {
     };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     };
     use crate::vault::VaultService;
     use crate::vault::mock::MockVaultService;
@@ -446,10 +446,13 @@ mod tests {
         ) {
             self.asset_store
                 .send(
-                    underlying,
+                    &AssetKey::new(underlying.clone(), *network),
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
-                        token: TokenSymbol::new(format!("t{}", underlying.0)),
+                        token: TokenSymbol::new(format!(
+                            "t{}",
+                            underlying.as_str()
+                        )),
                         network: *network,
                         vault: address!(
                             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -472,7 +475,7 @@ mod tests {
                     RedemptionCommand::Detect {
                         issuer_request_id: issuer_request_id.clone(),
                         underlying: underlying.clone(),
-                        token: TokenSymbol::new(format!("t{}", underlying.0)),
+                        token: TokenSymbol::new(format!("t{}", underlying.as_str())),
                         wallet,
                         quantity: Quantity::new(Decimal::from(100)),
                         tx_hash: b256!(
@@ -525,7 +528,7 @@ mod tests {
         store: &Store<Redemption>,
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Redemption {
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -751,7 +754,7 @@ mod tests {
             as Arc<dyn crate::alpaca::AlpacaService>;
         let manager = harness.create_manager(alpaca_service);
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let network = Network::Base;
 
         harness.add_asset(&underlying, &network).await;
@@ -769,7 +772,7 @@ mod tests {
             as Arc<dyn crate::alpaca::AlpacaService>;
         let manager = RedeemCallManager::new(alpaca_service, store, pool);
 
-        let underlying = UnderlyingSymbol::new("UNKNOWN");
+        let underlying = UnderlyingSymbol::new("UNKNOWN").unwrap();
 
         let result = manager.lookup_network_for_asset(&underlying).await;
 
@@ -808,7 +811,7 @@ mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let client_id = ClientId::new();
         let alpaca_account = AlpacaAccountNumber("acc-recovery".to_string());
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let network = Network::Base;
 
         harness
@@ -868,7 +871,7 @@ mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let client_id = ClientId::new();
         let alpaca_account = AlpacaAccountNumber("acc-recovery".to_string());
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let network = Network::Base;
 
         harness
@@ -955,7 +958,7 @@ mod tests {
         let manager = harness.create_manager(alpaca_service);
 
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
         harness
@@ -998,7 +1001,7 @@ mod tests {
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let client_id = ClientId::new();
         let alpaca_account = AlpacaAccountNumber("acc-no-asset".to_string());
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
 
         harness
             .register_and_link_account(

--- a/src/redemption/test_utils.rs
+++ b/src/redemption/test_utils.rs
@@ -11,7 +11,7 @@ use crate::account::{
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::tokenized_asset::{
-    Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+    AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol,
 };
 
@@ -35,13 +35,13 @@ pub(crate) async fn setup_test_db_with_asset(
             .await
             .unwrap();
 
-    let underlying = UnderlyingSymbol::new("AAPL");
+    let underlying = UnderlyingSymbol::new("AAPL").unwrap();
     let token = TokenSymbol::new("tAAPL");
     let network = Network::Base;
 
     asset_store
         .send(
-            &underlying,
+            &AssetKey::new(underlying.clone(), network),
             TokenizedAssetCommand::Add {
                 underlying: underlying.clone(),
                 token,

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -347,7 +347,7 @@ mod tests {
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::view::list_enabled_assets;
     use crate::tokenized_asset::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
@@ -419,7 +419,13 @@ mod tests {
                 .await
                 .unwrap();
         asset_store
-            .send(&UnderlyingSymbol::new("AAPL"), TokenizedAssetCommand::Freeze)
+            .send(
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
+                TokenizedAssetCommand::Freeze,
+            )
             .await
             .expect("Failed to freeze asset");
 
@@ -612,12 +618,13 @@ mod tests {
                 .build(())
                 .await
                 .unwrap();
-        let tsla = UnderlyingSymbol::new("TSLA");
+        let tsla = UnderlyingSymbol::new("TSLA").unwrap();
+        let key = AssetKey::new(tsla.clone(), Network::Base);
         asset_store
             .send(
-                &tsla,
+                &key,
                 TokenizedAssetCommand::Add {
-                    underlying: tsla.clone(),
+                    underlying: tsla,
                     token: TokenSymbol::new("tTSLA"),
                     network: Network::Base,
                     vault,

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -849,7 +849,7 @@ mod tests {
                 id,
                 RedemptionEvent::Detected {
                     issuer_request_id: id.clone(),
-                    underlying: UnderlyingSymbol::new(underlying),
+                    underlying: UnderlyingSymbol::new(underlying).unwrap(),
                     token: TokenSymbol::new(format!("t{underlying}")),
                     wallet,
                     quantity: Quantity::new(Decimal::from(quantity)),
@@ -981,7 +981,7 @@ mod tests {
             ReactorHarness::new(RedemptionViewReactor::new(pool.clone()));
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
         let quantity = Quantity::new(Decimal::from(100));
@@ -1044,7 +1044,7 @@ mod tests {
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-tok-456");
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let wallet = address!("0x9876543210fedcba9876543210fedcba98765432");
         let quantity = Quantity::new(Decimal::from(50));
@@ -1127,7 +1127,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-burning-456");
-        let underlying = UnderlyingSymbol::new("NVDA");
+        let underlying = UnderlyingSymbol::new("NVDA").unwrap();
         let token = TokenSymbol::new("tNVDA");
         let wallet = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         let quantity = Quantity::new(Decimal::from(25));
@@ -1230,7 +1230,7 @@ mod tests {
             ReactorHarness::new(RedemptionViewReactor::new(pool.clone()));
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("META");
+        let underlying = UnderlyingSymbol::new("META").unwrap();
         let token = TokenSymbol::new("tMETA");
         let wallet = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
         let quantity = Quantity::new(Decimal::from(75));
@@ -1292,7 +1292,7 @@ mod tests {
             ReactorHarness::new(RedemptionViewReactor::new(pool.clone()));
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("GOOGL");
+        let underlying = UnderlyingSymbol::new("GOOGL").unwrap();
         let token = TokenSymbol::new("tGOOGL");
         let wallet = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let quantity = Quantity::new(Decimal::from(10));
@@ -1647,7 +1647,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("alp-burn-failed-456");
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let wallet = address!("0xdddddddddddddddddddddddddddddddddddddddd");
         let quantity = Quantity::new(Decimal::from(100));
@@ -1827,7 +1827,7 @@ mod tests {
 
         let detected_event = RedemptionEvent::Detected {
             issuer_request_id: issuer_request_id.clone(),
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
             quantity: quantity.clone(),
@@ -2053,7 +2053,7 @@ mod tests {
             ReactorHarness::new(RedemptionViewReactor::new(pool.clone()));
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let underlying = UnderlyingSymbol::new("RKLB");
+        let underlying = UnderlyingSymbol::new("RKLB").unwrap();
         let token = TokenSymbol::new("tRKLB");
         let wallet = address!("0x9876543210fedcba9876543210fedcba98765432");
         let quantity = Quantity::new(Decimal::from(100));
@@ -2150,7 +2150,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let tokenization_request_id =
             TokenizationRequestId::new("tok-resumed-789");
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let wallet = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let quantity = Quantity::new(Decimal::from(42));

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -31,7 +31,7 @@ use crate::receipt_inventory::{
     CqrsReceiptService, ReceiptInventory, view::ReceiptInventoryViewReactor,
 };
 use crate::tokenized_asset::{
-    Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+    AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     UnderlyingSymbol,
 };
 use crate::vault::mock::MockVaultService;
@@ -166,7 +166,7 @@ async fn seed_test_assets(
     ];
 
     for (underlying, token, vault) in assets {
-        let underlying = UnderlyingSymbol::new(underlying);
+        let underlying = UnderlyingSymbol::new(underlying)?;
         let command = TokenizedAssetCommand::Add {
             underlying: underlying.clone(),
             token: TokenSymbol::new(token),
@@ -174,7 +174,8 @@ async fn seed_test_assets(
             vault,
         };
 
-        match store.send(&underlying, command).await {
+        let key = AssetKey::new(underlying.clone(), Network::Base);
+        match store.send(&key, command).await {
             Ok(()) | Err(event_sorcery::AggregateError::AggregateConflict) => {}
             Err(err) => {
                 return Err(err.into());

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -4,18 +4,52 @@ use rocket::serde::json::Json;
 use rocket::{get, post};
 use sqlx::{Pool, Sqlite};
 use st0x_issuance_dto::{
-    AddTokenizedAssetRequest, AddTokenizedAssetResponse,
+    AddTokenizedAssetRequest, AddTokenizedAssetResponse, AssetKey,
     TokenizedAssetDetailResponse, TokenizedAssetResponse,
     TokenizedAssetStatusResponse, TokenizedAssetsListResponse,
 };
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use tracing::error;
 
 use super::{
-    TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
-    view::TokenizedAssetView,
+    Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+    UnderlyingSymbol, view::TokenizedAssetView,
 };
 use crate::auth::{InternalAuth, IssuerAuth};
+
+fn merge_token_listing(
+    views: Vec<TokenizedAssetView>,
+) -> Vec<TokenizedAssetResponse> {
+    let mut merged: BTreeMap<
+        (UnderlyingSymbol, TokenSymbol),
+        TokenizedAssetResponse,
+    > = BTreeMap::new();
+
+    for TokenizedAssetView { underlying, token, network, .. } in views {
+        let row_key = (underlying.clone(), token.clone());
+        merged
+            .entry(row_key)
+            .or_insert(TokenizedAssetResponse {
+                underlying,
+                token,
+                networks: Vec::new(),
+            })
+            .networks
+            .push(network);
+    }
+
+    let mut tokens: Vec<_> = merged.into_values().collect();
+    for row in &mut tokens {
+        row.networks.sort_by_key(Network::as_str);
+        row.networks.dedup();
+    }
+    tokens.sort_by(|left, right| {
+        (left.underlying.as_str(), left.token.0.as_str())
+            .cmp(&(right.underlying.as_str(), right.token.0.as_str()))
+    });
+    tokens
+}
 
 #[utoipa::path(
     get,
@@ -23,28 +57,39 @@ use crate::auth::{InternalAuth, IssuerAuth};
     tag = "tokenized-assets",
     params(
         ("underlying" = String, Path,
-            description = "Underlying equity symbol, e.g. SGOV")
+            description = "Underlying equity symbol, e.g. SGOV"),
+        ("network" = String, Query,
+            description = "Blockchain network wire value, e.g. base")
     ),
     responses(
         (status = 200, description = "Asset detail including freeze status",
             body = TokenizedAssetDetailResponse),
         (status = 404, description = "Unknown asset"),
+        (status = 422, description = "Missing or unsupported `network` query parameter"),
         (status = 500, description = "View load or deserialization failure")
     ),
     security(("internal_api_key" = []))
 )]
 #[tracing::instrument(skip(_auth, pool))]
-#[get("/tokenized-assets/<underlying>")]
+#[get("/tokenized-assets/<underlying>?<network>")]
 pub(crate) async fn get_tokenized_asset(
     underlying: &str,
+    network: Option<&str>,
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
 ) -> Result<Json<TokenizedAssetDetailResponse>, Status> {
-    let underlying_symbol = UnderlyingSymbol::new(underlying);
+    let Some(network) = network else {
+        return Err(Status::UnprocessableEntity);
+    };
+    let network =
+        network.parse::<Network>().map_err(|_| Status::UnprocessableEntity)?;
+    let underlying = UnderlyingSymbol::new(underlying)
+        .map_err(|_| Status::UnprocessableEntity)?;
 
-    let view = super::view::load_asset_by_underlying(
+    let view = super::view::load_asset_by_network(
         pool.inner(),
-        &underlying_symbol,
+        &underlying,
+        &network,
     )
     .await
     .map_err(|err| {
@@ -77,28 +122,38 @@ pub(crate) async fn get_tokenized_asset(
     tag = "tokenized-assets",
     params(
         ("underlying" = String, Path,
-            description = "Underlying equity symbol, e.g. SGOV")
+            description = "Underlying equity symbol, e.g. SGOV"),
+        ("network" = String, Query,
+            description = "Blockchain network wire value, e.g. base")
     ),
     responses(
         (status = 200, description = "Per-asset freeze status",
             body = TokenizedAssetStatusResponse),
         (status = 404, description = "Unknown asset"),
+        (status = 422, description = "Missing or unsupported `network` query parameter"),
         (status = 500,
             description = "Indeterminate (view load failure); retry, do not treat as enabled")
     ),
     security(("internal_api_key" = []))
 )]
 #[tracing::instrument(skip(_auth, pool))]
-#[get("/tokenized-assets/<underlying>/status")]
+#[get("/tokenized-assets/<underlying>/status?<network>")]
 pub(crate) async fn get_tokenized_asset_status(
     underlying: &str,
+    network: Option<&str>,
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
 ) -> Result<Json<TokenizedAssetStatusResponse>, Status> {
-    let underlying_symbol = UnderlyingSymbol::new(underlying);
+    let Some(network) = network else {
+        return Err(Status::UnprocessableEntity);
+    };
+    let network =
+        network.parse::<Network>().map_err(|_| Status::UnprocessableEntity)?;
+    let underlying = UnderlyingSymbol::new(underlying)
+        .map_err(|_| Status::UnprocessableEntity)?;
 
     let view =
-        super::view::load_asset_by_underlying(pool.inner(), &underlying_symbol)
+        super::view::load_asset_by_network(pool.inner(), &underlying, &network)
             .await
             .map_err(|err| {
                 error!(target: "asset", error = %err,
@@ -130,16 +185,7 @@ pub(crate) async fn list_tokenized_assets(
             rocket::http::Status::InternalServerError
         })?;
 
-    let tokens = views
-        .into_iter()
-        .map(|TokenizedAssetView { underlying, token, network, .. }| {
-            TokenizedAssetResponse {
-                underlying,
-                token,
-                networks: vec![network],
-            }
-        })
-        .collect();
+    let tokens = merge_token_listing(views);
 
     Ok(Json(TokenizedAssetsListResponse { tokens }))
 }
@@ -152,6 +198,7 @@ pub(crate) async fn list_tokenized_assets(
     responses(
         (status = 201, description = "Asset added (idempotent: also 201 if it already existed)",
             body = AddTokenizedAssetResponse),
+        (status = 422, description = "Empty underlying symbol"),
         (status = 500, description = "Failed to add asset")
     ),
     security(("internal_api_key" = []))
@@ -175,8 +222,10 @@ pub(crate) async fn add_tokenized_asset(
         vault: request.vault,
     };
 
+    let asset_key = AssetKey::new(request.underlying.clone(), request.network);
+
     store
-        .send(&request.underlying, command)
+        .send(&asset_key, command)
         .await
         .or_else(|err| match err {
             AggregateError::AggregateConflict => Ok(()),
@@ -198,6 +247,7 @@ pub(crate) async fn add_tokenized_asset(
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{B256, address};
+    use chrono::Utc;
     use event_sorcery::StoreBuilder;
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
@@ -212,7 +262,8 @@ mod tests {
     use crate::config::{Config, Environment, LogLevel};
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        AssetKey, AssetStatus, Network, TokenSymbol, TokenizedAsset,
+        TokenizedAssetCommand,
     };
     use crate::wallet::SignerConfig;
 
@@ -235,6 +286,62 @@ mod tests {
         }
     }
 
+    fn base_view(underlying: &str, token: &str) -> TokenizedAssetView {
+        TokenizedAssetView {
+            underlying: UnderlyingSymbol::new(underlying).unwrap(),
+            token: TokenSymbol::new(token),
+            network: Network::Base,
+            vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            status: AssetStatus::Enabled,
+            added_at: Utc::now(),
+        }
+    }
+
+    // Only one `Network` variant exists today, so the multi-chain collapse is
+    // exercised with two rows sharing the same (underlying, token) key: both
+    // must accumulate into a single response row whose `networks` is the
+    // deduplicated union. When a second network variant lands, the projection
+    // produces exactly this shape with distinct networks.
+    #[test]
+    fn merge_token_listing_merges_rows_sharing_underlying_and_token() {
+        let merged = merge_token_listing(vec![
+            base_view("AAPL", "tAAPL"),
+            base_view("AAPL", "tAAPL"),
+        ]);
+
+        assert_eq!(merged.len(), 1);
+        assert_eq!(
+            merged[0].underlying,
+            UnderlyingSymbol::new("AAPL").unwrap()
+        );
+        assert_eq!(merged[0].token, TokenSymbol::new("tAAPL"));
+        assert_eq!(
+            merged[0].networks,
+            vec![Network::Base],
+            "networks must be a deduplicated union, not repeated entries"
+        );
+    }
+
+    #[test]
+    fn merge_token_listing_sorts_rows_by_underlying() {
+        let merged = merge_token_listing(vec![
+            base_view("MSFT", "tMSFT"),
+            base_view("AAPL", "tAAPL"),
+        ]);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(
+            merged[0].underlying,
+            UnderlyingSymbol::new("AAPL").unwrap()
+        );
+        assert_eq!(merged[0].networks, vec![Network::Base]);
+        assert_eq!(
+            merged[1].underlying,
+            UnderlyingSymbol::new("MSFT").unwrap()
+        );
+        assert_eq!(merged[1].networks, vec![Network::Base]);
+    }
+
     #[tokio::test]
     async fn test_list_tokenized_assets_returns_added_assets() {
         let pool = SqlitePoolOptions::new()
@@ -250,11 +357,15 @@ mod tests {
 
         let store = setup_tokenized_asset_store(&pool).await;
 
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("AAPL").unwrap(),
+            Network::Base,
+        );
         store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &key,
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: address!(
@@ -566,6 +677,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_add_empty_underlying_returns_422() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("Failed to create in-memory database");
+
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        let store = setup_tokenized_asset_store(&pool).await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(store)
+            .manage(pool)
+            .mount("/", routes![add_tokenized_asset]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "underlying": "",
+            "token": "tAAPL",
+            "network": "base",
+            "vault": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+
+        let response = client
+            .post("/tokenized-assets")
+            .header(ContentType::JSON)
+            .header(Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    #[tokio::test]
     async fn test_add_asset_without_auth_returns_401() {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
@@ -633,11 +792,15 @@ mod tests {
         let pool = migrated_in_memory_pool().await;
         let store = setup_tokenized_asset_store(&pool).await;
 
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("AAPL").unwrap(),
+            Network::Base,
+        );
         store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &key,
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: address!(
@@ -659,7 +822,7 @@ mod tests {
             .expect("valid rocket instance");
 
         let before = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -678,7 +841,7 @@ mod tests {
         );
 
         store
-            .send(&UnderlyingSymbol::new("AAPL"), TokenizedAssetCommand::Freeze)
+            .send(&key, TokenizedAssetCommand::Freeze)
             .await
             .expect("Failed to freeze asset");
 
@@ -688,7 +851,7 @@ mod tests {
         ));
 
         let after = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -709,10 +872,7 @@ mod tests {
         // the guard's lifecycle, exercised through the same HTTP + projection
         // path.
         store
-            .send(
-                &UnderlyingSymbol::new("AAPL"),
-                TokenizedAssetCommand::Unfreeze,
-            )
+            .send(&key, TokenizedAssetCommand::Unfreeze)
             .await
             .expect("Failed to unfreeze asset");
 
@@ -722,7 +882,7 @@ mod tests {
         ));
 
         let unfrozen = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -744,11 +904,15 @@ mod tests {
         let pool = migrated_in_memory_pool().await;
         let store = setup_tokenized_asset_store(&pool).await;
 
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("AAPL").unwrap(),
+            Network::Base,
+        );
         store
             .send(
-                &UnderlyingSymbol::new("AAPL"),
+                &key,
                 TokenizedAssetCommand::Add {
-                    underlying: UnderlyingSymbol::new("AAPL"),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
                     network: Network::Base,
                     vault: address!(
@@ -770,7 +934,7 @@ mod tests {
             .expect("valid rocket instance");
 
         let enabled = client
-            .get("/tokenized-assets/AAPL")
+            .get("/tokenized-assets/AAPL?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -795,7 +959,7 @@ mod tests {
         );
 
         store
-            .send(&UnderlyingSymbol::new("AAPL"), TokenizedAssetCommand::Freeze)
+            .send(&key, TokenizedAssetCommand::Freeze)
             .await
             .expect("Failed to freeze asset");
 
@@ -805,7 +969,7 @@ mod tests {
         ));
 
         let frozen = client
-            .get("/tokenized-assets/AAPL")
+            .get("/tokenized-assets/AAPL?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -841,7 +1005,7 @@ mod tests {
         sqlx::query(
             r#"
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{"Live": {"bad_field": 1}}')
+            VALUES ('AAPL:base', 1, '{"Live": {"bad_field": 1}}')
             "#,
         )
         .execute(&pool)
@@ -859,7 +1023,7 @@ mod tests {
             .expect("valid rocket instance");
 
         let response = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -888,7 +1052,7 @@ mod tests {
             .expect("valid rocket instance");
 
         let response = client
-            .get("/tokenized-assets/UNKNOWN/status")
+            .get("/tokenized-assets/UNKNOWN/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -921,7 +1085,7 @@ mod tests {
         sqlx::query(
             r#"
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{"Live": null}')
+            VALUES ('AAPL:base', 1, '{"Live": null}')
             "#,
         )
         .execute(&pool)
@@ -939,7 +1103,7 @@ mod tests {
             .expect("valid rocket instance");
 
         let response = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(internal_api_key())
             .remote("127.0.0.1:8000".parse().unwrap())
             .dispatch()
@@ -964,12 +1128,94 @@ mod tests {
         sqlx::query(
             r#"
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{"Live": null}')
+            VALUES ('AAPL:base', 1, '{"Live": null}')
             "#,
         )
         .execute(&pool)
         .await
         .expect("Failed to insert non-live view row");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL?network=base")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::InternalServerError);
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Failed to load tokenized asset"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_status_missing_network_returns_422() {
+        let pool = migrated_in_memory_pool().await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL/status")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    // A present-but-unrecognised network wire value must map to 422 (the
+    // documented contract), not 404 -- it is a malformed query, not a missing
+    // asset.
+    #[tokio::test]
+    async fn test_get_status_unsupported_network_returns_422() {
+        let pool = migrated_in_memory_pool().await;
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let response = client
+            .get("/tokenized-assets/AAPL/status?network=solana")
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+    }
+
+    // The detail route binds `?<network>` independently of the status route, so
+    // its 422 contract for an absent network parameter needs its own guard.
+    #[tokio::test]
+    async fn test_get_detail_missing_network_returns_422() {
+        let pool = migrated_in_memory_pool().await;
 
         let rocket = rocket::build()
             .manage(test_config())
@@ -988,12 +1234,7 @@ mod tests {
             .dispatch()
             .await;
 
-        assert_eq!(response.status(), Status::InternalServerError);
-
-        assert!(logs_contain_at!(
-            tracing::Level::ERROR,
-            &["Failed to load tokenized asset"]
-        ));
+        assert_eq!(response.status(), Status::UnprocessableEntity);
     }
 
     #[tokio::test]
@@ -1035,7 +1276,7 @@ mod tests {
         // `InternalAuth` validates the key value, so knowing the header name is
         // not enough to reach the endpoint.
         let response = client
-            .get("/tokenized-assets/AAPL/status")
+            .get("/tokenized-assets/AAPL/status?network=base")
             .header(Header::new(
                 "X-API-KEY",
                 "wrong-key-00000000000000000000000000",

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -9,9 +9,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use super::view::{TokenizedAssetViewError, load_asset_by_underlying};
+use super::view::{TokenizedAssetViewError, load_asset_by_network};
 use super::{
-    AssetStatus, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
+    AssetKey, AssetStatus, Network, TokenizedAsset, TokenizedAssetCommand,
+    UnderlyingSymbol,
 };
 use crate::config::{
     DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, LogLevel,
@@ -54,9 +55,16 @@ enum IssuerCommand {
 
 #[derive(Args)]
 struct AssetArgs {
-    /// Underlying symbol, e.g. SGOV.
-    #[arg(value_parser = parse_underlying)]
+    /// Underlying symbol, e.g. SGOV. Upper-cased so `"sgov"` resolves to the
+    /// stored `SGOV` (assets are keyed by their upper-case symbol). Whitespace
+    /// trimming is handled by [`UnderlyingSymbol::new`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
     underlying: UnderlyingSymbol,
+    /// Blockchain network wire value, e.g. base. Required: assets are keyed
+    /// by `{underlying}:{network}`, so a silent default could freeze or
+    /// unfreeze the wrong chain's listing.
+    #[arg(long = "network", value_parser = |value: &str| value.parse::<Network>())]
+    network: Network,
     #[arg(
         long = "database-url",
         env = "DATABASE_URL",
@@ -108,7 +116,8 @@ async fn run_asset_command(
         AssetAdmin::connect(&args.database_url, args.database_max_connections)
             .await?;
 
-    execute(&admin, action, &args.underlying, prompt_confirm).await
+    execute(&admin, action, &args.underlying, &args.network, prompt_confirm)
+        .await
 }
 
 /// Orchestrates a single action against an already-connected admin. The
@@ -119,6 +128,7 @@ async fn execute(
     admin: &AssetAdmin,
     action: AssetAction,
     underlying: &UnderlyingSymbol,
+    network: &Network,
     confirm: impl Fn(&str) -> io::Result<bool>,
 ) -> anyhow::Result<()> {
     // Display the current status for the operator to confirm against, and reject
@@ -126,33 +136,40 @@ async fn execute(
     // not-found check — the freeze/unfreeze decision is NOT derived from it (see
     // `freeze`/`unfreeze`), so a concurrent write landing in the confirmation
     // window can never leave the asset in the wrong persisted state.
-    let report = admin.status(underlying).await?.ok_or_else(|| {
-        AssetAdminError::NotFound { underlying: underlying.clone() }
+    let report = admin.status(underlying, network).await?.ok_or_else(|| {
+        AssetAdminError::NotFound {
+            underlying: underlying.clone(),
+            network: *network,
+        }
     })?;
     println!("{report}");
 
     match action {
         AssetAction::Status => Ok(()),
         AssetAction::Freeze => {
-            if !confirm(&format!("Freeze {underlying}?"))? {
+            if !confirm(&format!("Freeze {underlying} on {network}?"))? {
                 anyhow::bail!("aborted by operator");
             }
-            match admin.freeze(underlying).await? {
-                FreezeOutcome::Froze => println!("Froze {underlying}."),
+            match admin.freeze(underlying, network).await? {
+                FreezeOutcome::Froze => {
+                    println!("Froze {underlying} on {network}.");
+                }
                 FreezeOutcome::AlreadyFrozen => {
-                    println!("{underlying} was already frozen.");
+                    println!("{underlying} on {network} was already frozen.");
                 }
             }
             Ok(())
         }
         AssetAction::Unfreeze => {
-            if !confirm(&format!("Unfreeze {underlying}?"))? {
+            if !confirm(&format!("Unfreeze {underlying} on {network}?"))? {
                 anyhow::bail!("aborted by operator");
             }
-            match admin.unfreeze(underlying).await? {
-                UnfreezeOutcome::Unfroze => println!("Unfroze {underlying}."),
+            match admin.unfreeze(underlying, network).await? {
+                UnfreezeOutcome::Unfroze => {
+                    println!("Unfroze {underlying} on {network}.");
+                }
                 UnfreezeOutcome::AlreadyEnabled => {
-                    println!("{underlying} was already enabled.");
+                    println!("{underlying} on {network} was already enabled.");
                 }
             }
             Ok(())
@@ -192,6 +209,7 @@ pub(crate) enum UnfreezeOutcome {
 #[derive(Debug)]
 pub(crate) struct AssetStatusReport {
     pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) network: Network,
     pub(crate) status: AssetStatus,
 }
 
@@ -201,7 +219,7 @@ impl std::fmt::Display for AssetStatusReport {
             AssetStatus::Frozen => "frozen",
             AssetStatus::Enabled => "enabled",
         };
-        write!(f, "{} is {state}", self.underlying)
+        write!(f, "{} on {} is {state}", self.underlying, self.network)
     }
 }
 
@@ -217,8 +235,8 @@ pub(crate) enum AssetAdminError {
     Reconcile(#[from] ReconcileError),
     #[error("aggregate error: {0}")]
     Aggregate(Box<AggregateError<LifecycleError<TokenizedAsset>>>),
-    #[error("{underlying} is not a supported tokenized asset")]
-    NotFound { underlying: UnderlyingSymbol },
+    #[error("{underlying} is not a supported tokenized asset on {network}")]
+    NotFound { underlying: UnderlyingSymbol, network: Network },
 }
 
 // `Store::send` yields an un-boxed `AggregateError`; box it on conversion so the
@@ -261,10 +279,12 @@ impl AssetAdmin {
     pub(crate) async fn status(
         &self,
         underlying: &UnderlyingSymbol,
+        network: &Network,
     ) -> Result<Option<AssetStatusReport>, AssetAdminError> {
-        Ok(load_asset_by_underlying(&self.pool, underlying).await?.map(
+        Ok(load_asset_by_network(&self.pool, underlying, network).await?.map(
             |view| AssetStatusReport {
                 underlying: underlying.clone(),
+                network: *network,
                 status: view.status,
             },
         ))
@@ -283,13 +303,15 @@ impl AssetAdmin {
     pub(crate) async fn freeze(
         &self,
         underlying: &UnderlyingSymbol,
+        network: &Network,
     ) -> Result<FreezeOutcome, AssetAdminError> {
         let already_frozen = matches!(
-            self.status(underlying).await?.map(|report| report.status),
+            self.status(underlying, network).await?.map(|report| report.status),
             Some(AssetStatus::Frozen)
         );
 
-        self.dispatch(underlying, TokenizedAssetCommand::Freeze).await?;
+        self.dispatch(underlying, network, TokenizedAssetCommand::Freeze)
+            .await?;
 
         Ok(if already_frozen {
             FreezeOutcome::AlreadyFrozen
@@ -307,13 +329,15 @@ impl AssetAdmin {
     pub(crate) async fn unfreeze(
         &self,
         underlying: &UnderlyingSymbol,
+        network: &Network,
     ) -> Result<UnfreezeOutcome, AssetAdminError> {
         let already_enabled = matches!(
-            self.status(underlying).await?.map(|report| report.status),
+            self.status(underlying, network).await?.map(|report| report.status),
             Some(AssetStatus::Enabled)
         );
 
-        self.dispatch(underlying, TokenizedAssetCommand::Unfreeze).await?;
+        self.dispatch(underlying, network, TokenizedAssetCommand::Unfreeze)
+            .await?;
 
         Ok(if already_enabled {
             UnfreezeOutcome::AlreadyEnabled
@@ -325,25 +349,13 @@ impl AssetAdmin {
     async fn dispatch(
         &self,
         underlying: &UnderlyingSymbol,
+        network: &Network,
         command: TokenizedAssetCommand,
     ) -> Result<(), AssetAdminError> {
-        self.store.send(underlying, command).await?;
+        let key = AssetKey::new(underlying.clone(), *network);
+        self.store.send(&key, command).await?;
         Ok(())
     }
-}
-
-/// Rejects an empty or whitespace-only underlying at the CLI boundary so a typo
-/// fails fast with a clear parse error instead of a later "not a supported
-/// asset" lookup failure. Trims surrounding whitespace and upper-cases the
-/// symbol so `" sgov "` resolves to the stored `SGOV` (assets are keyed by their
-/// upper-case symbol) instead of silently missing the lookup.
-fn parse_underlying(value: &str) -> Result<UnderlyingSymbol, String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        return Err("underlying symbol must not be empty".to_string());
-    }
-
-    Ok(UnderlyingSymbol::new(trimmed.to_ascii_uppercase()))
 }
 
 /// Validates the database URL uses the `sqlite:` scheme so a wrong env value
@@ -403,10 +415,11 @@ mod tests {
                 .await
                 .expect("Failed to build tokenized asset store");
 
-        let underlying = UnderlyingSymbol::new(underlying);
+        let underlying = UnderlyingSymbol::new(underlying).unwrap();
+        let key = AssetKey::new(underlying.clone(), Network::Base);
         store
             .send(
-                &underlying,
+                &key,
                 TokenizedAssetCommand::Add {
                     underlying: underlying.clone(),
                     token: TokenSymbol::new(format!("t{underlying}")),
@@ -426,31 +439,43 @@ mod tests {
     #[tokio::test]
     async fn freeze_then_unfreeze_round_trip() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
 
-        let report =
-            admin.status(&underlying).await.unwrap().expect("asset exists");
+        let report = admin
+            .status(&underlying, &Network::Base)
+            .await
+            .unwrap()
+            .expect("asset exists");
         assert_eq!(report.status, AssetStatus::Enabled);
-        assert_eq!(format!("{report}"), "SGOV is enabled");
+        assert_eq!(format!("{report}"), "SGOV on base is enabled");
 
         assert_eq!(
-            admin.freeze(&underlying).await.unwrap(),
+            admin.freeze(&underlying, &Network::Base).await.unwrap(),
             FreezeOutcome::Froze
         );
-        let frozen = admin.status(&underlying).await.unwrap().expect("exists");
+        let frozen = admin
+            .status(&underlying, &Network::Base)
+            .await
+            .unwrap()
+            .expect("exists");
         assert_eq!(frozen.status, AssetStatus::Frozen);
-        assert_eq!(format!("{frozen}"), "SGOV is frozen");
+        assert_eq!(format!("{frozen}"), "SGOV on base is frozen");
         assert!(logs_contain_at!(
             tracing::Level::INFO,
             &["Freezing tokenized asset", "SGOV"]
         ));
 
         assert_eq!(
-            admin.unfreeze(&underlying).await.unwrap(),
+            admin.unfreeze(&underlying, &Network::Base).await.unwrap(),
             UnfreezeOutcome::Unfroze
         );
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Enabled
         );
         assert!(logs_contain_at!(
@@ -462,26 +487,26 @@ mod tests {
     #[tokio::test]
     async fn freeze_and_unfreeze_report_idempotent_no_ops() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
 
         // A second freeze of an already-frozen asset (and a second unfreeze of an
         // already-enabled one) is a zero-event no-op the aggregate dedups, and is
         // reported as the AlreadyFrozen / AlreadyEnabled label.
         assert_eq!(
-            admin.freeze(&underlying).await.unwrap(),
+            admin.freeze(&underlying, &Network::Base).await.unwrap(),
             FreezeOutcome::Froze
         );
         assert_eq!(
-            admin.freeze(&underlying).await.unwrap(),
+            admin.freeze(&underlying, &Network::Base).await.unwrap(),
             FreezeOutcome::AlreadyFrozen
         );
 
         assert_eq!(
-            admin.unfreeze(&underlying).await.unwrap(),
+            admin.unfreeze(&underlying, &Network::Base).await.unwrap(),
             UnfreezeOutcome::Unfroze
         );
         assert_eq!(
-            admin.unfreeze(&underlying).await.unwrap(),
+            admin.unfreeze(&underlying, &Network::Base).await.unwrap(),
             UnfreezeOutcome::AlreadyEnabled
         );
     }
@@ -491,7 +516,10 @@ mod tests {
         let admin = admin_with_asset("SGOV").await;
         assert!(
             admin
-                .status(&UnderlyingSymbol::new("UNKNOWN"))
+                .status(
+                    &UnderlyingSymbol::new("UNKNOWN").unwrap(),
+                    &Network::Base
+                )
                 .await
                 .unwrap()
                 .is_none()
@@ -501,13 +529,19 @@ mod tests {
     #[tokio::test]
     async fn execute_rejects_unknown_asset() {
         let admin = admin_with_asset("SGOV").await;
-        let unknown = UnderlyingSymbol::new("UNKNOWN");
+        let unknown = UnderlyingSymbol::new("UNKNOWN").unwrap();
 
         // The not-found rejection is `execute`'s entry-point behavior for all
         // three subcommands; assert the operator-facing message.
-        let err = execute(&admin, AssetAction::Freeze, &unknown, |_| Ok(true))
-            .await
-            .expect_err("an unknown asset must be rejected");
+        let err = execute(
+            &admin,
+            AssetAction::Freeze,
+            &unknown,
+            &Network::Base,
+            |_| Ok(true),
+        )
+        .await
+        .expect_err("an unknown asset must be rejected");
         assert!(
             err.to_string().contains("is not a supported tokenized asset"),
             "unexpected error: {err}"
@@ -517,15 +551,25 @@ mod tests {
     #[tokio::test]
     async fn execute_freeze_aborts_without_dispatching_when_declined() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
 
-        let result =
-            execute(&admin, AssetAction::Freeze, &underlying, |_| Ok(false))
-                .await;
+        let result = execute(
+            &admin,
+            AssetAction::Freeze,
+            &underlying,
+            &Network::Base,
+            |_| Ok(false),
+        )
+        .await;
 
         assert!(result.is_err(), "declined freeze must return an error");
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Enabled,
             "a declined freeze must not change state"
         );
@@ -534,14 +578,25 @@ mod tests {
     #[tokio::test]
     async fn execute_freeze_dispatches_when_confirmed() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
 
-        execute(&admin, AssetAction::Freeze, &underlying, |_| Ok(true))
-            .await
-            .expect("confirmed freeze succeeds");
+        execute(
+            &admin,
+            AssetAction::Freeze,
+            &underlying,
+            &Network::Base,
+            |_| Ok(true),
+        )
+        .await
+        .expect("confirmed freeze succeeds");
 
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Frozen,
             "a confirmed freeze must change state"
         );
@@ -550,16 +605,29 @@ mod tests {
     #[tokio::test]
     async fn execute_unfreeze_aborts_without_dispatching_when_declined() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
-        admin.freeze(&underlying).await.expect("freeze succeeds");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
+        admin
+            .freeze(&underlying, &Network::Base)
+            .await
+            .expect("freeze succeeds");
 
-        let result =
-            execute(&admin, AssetAction::Unfreeze, &underlying, |_| Ok(false))
-                .await;
+        let result = execute(
+            &admin,
+            AssetAction::Unfreeze,
+            &underlying,
+            &Network::Base,
+            |_| Ok(false),
+        )
+        .await;
 
         assert!(result.is_err(), "declined unfreeze must return an error");
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Frozen,
             "a declined unfreeze must not change state"
         );
@@ -568,15 +636,29 @@ mod tests {
     #[tokio::test]
     async fn execute_unfreeze_dispatches_when_confirmed() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
-        admin.freeze(&underlying).await.expect("freeze succeeds");
-
-        execute(&admin, AssetAction::Unfreeze, &underlying, |_| Ok(true))
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
+        admin
+            .freeze(&underlying, &Network::Base)
             .await
-            .expect("confirmed unfreeze succeeds");
+            .expect("freeze succeeds");
+
+        execute(
+            &admin,
+            AssetAction::Unfreeze,
+            &underlying,
+            &Network::Base,
+            |_| Ok(true),
+        )
+        .await
+        .expect("confirmed unfreeze succeeds");
 
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Enabled,
             "a confirmed unfreeze must change state"
         );
@@ -585,16 +667,25 @@ mod tests {
     #[tokio::test]
     async fn execute_status_never_prompts_or_mutates() {
         let admin = admin_with_asset("SGOV").await;
-        let underlying = UnderlyingSymbol::new("SGOV");
+        let underlying = UnderlyingSymbol::new("SGOV").unwrap();
 
-        execute(&admin, AssetAction::Status, &underlying, |_| {
-            panic!("status must not prompt for confirmation")
-        })
+        execute(
+            &admin,
+            AssetAction::Status,
+            &underlying,
+            &Network::Base,
+            |_| panic!("status must not prompt for confirmation"),
+        )
         .await
         .expect("status succeeds");
 
         assert_eq!(
-            admin.status(&underlying).await.unwrap().expect("exists").status,
+            admin
+                .status(&underlying, &Network::Base)
+                .await
+                .unwrap()
+                .expect("exists")
+                .status,
             AssetStatus::Enabled
         );
     }
@@ -614,21 +705,38 @@ mod tests {
     }
 
     #[test]
-    fn parse_underlying_trims_uppercases_and_rejects_blank() {
+    fn issuer_cli_uppercases_underlying_and_rejects_blank() {
+        let IssuerCli { command: IssuerCommand::Freeze(args) } =
+            IssuerCli::try_parse_from([
+                "issuer",
+                "freeze",
+                " sgov ",
+                "--network",
+                "base",
+            ])
+            .unwrap()
+        else {
+            panic!("expected freeze command");
+        };
         assert_eq!(
-            parse_underlying(" sgov ").unwrap(),
-            UnderlyingSymbol::new("SGOV"),
+            args.underlying,
+            UnderlyingSymbol::new("SGOV").unwrap(),
             "input is trimmed and upper-cased to the stored symbol"
         );
-        assert_eq!(
-            parse_underlying("SGOV").unwrap(),
-            UnderlyingSymbol::new("SGOV")
-        );
-        assert!(parse_underlying("").is_err(), "empty must be rejected");
-        assert!(
-            parse_underlying("   ").is_err(),
-            "whitespace-only must be rejected"
-        );
+
+        for blank in ["", "   "] {
+            assert!(
+                IssuerCli::try_parse_from([
+                    "issuer",
+                    "freeze",
+                    blank,
+                    "--network",
+                    "base",
+                ])
+                .is_err(),
+                "{blank:?} must be rejected at parse time"
+            );
+        }
     }
 
     #[test]

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use view::TokenizedAssetView;
 // The asset wire newtypes are defined once in the shared `st0x-issuance-dto`
 // crate so the API DTOs, Rust clients, and the TypeScript dashboard all share a
 // single definition.
+pub(crate) use st0x_issuance_dto::AssetKey;
 pub(crate) use st0x_issuance_dto::{Network, TokenSymbol};
 pub use st0x_issuance_dto::{TokenizedAssetStatus, UnderlyingSymbol};
 
@@ -67,7 +68,7 @@ pub(crate) struct TokenizedAsset {
 
 #[async_trait]
 impl EventSourced for TokenizedAsset {
-    type Id = UnderlyingSymbol;
+    type Id = AssetKey;
     type Event = TokenizedAssetEvent;
     type Command = TokenizedAssetCommand;
     type Error = Never;
@@ -76,7 +77,7 @@ impl EventSourced for TokenizedAsset {
 
     const AGGREGATE_TYPE: &'static str = "TokenizedAsset";
     const PROJECTION: Table = Table("tokenized_asset_view");
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -274,7 +275,7 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_add_asset_creates_new_asset() {
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let token = TokenSymbol::new("tAAPL");
         let network = Network::Base;
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
@@ -322,14 +323,14 @@ mod tests {
 
         TestHarness::<TokenizedAsset>::with(())
             .given(vec![TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault,
                 added_at: chrono::Utc::now(),
             }])
             .when(TokenizedAssetCommand::Add {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault,
@@ -351,14 +352,14 @@ mod tests {
 
         let events = TestHarness::<TokenizedAsset>::with(())
             .given(vec![TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             }])
             .when(TokenizedAssetCommand::Add {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault: vault_b,
@@ -390,7 +391,7 @@ mod tests {
 
     fn added_event(vault: Address) -> TokenizedAssetEvent {
         TokenizedAssetEvent::Added {
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             network: Network::Base,
             vault,
@@ -547,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_apply_asset_added_updates_state() {
-        let underlying = UnderlyingSymbol::new("TSLA");
+        let underlying = UnderlyingSymbol::new("TSLA").unwrap();
         let token = TokenSymbol::new("tTSLA");
         let network = Network::Base;
         let vault = address!("0xfedcbafedcbafedcbafedcbafedcbafedcbafedc");
@@ -588,7 +589,7 @@ mod tests {
 
         let asset = replay::<TokenizedAsset>(vec![
             TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault: vault_a,
@@ -618,14 +619,14 @@ mod tests {
 
         let asset = replay::<TokenizedAsset>(vec![
             TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault: vault_a,
                 added_at: chrono::Utc::now(),
             },
             TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL2"),
                 network: Network::Base,
                 vault: vault_b,
@@ -650,7 +651,7 @@ mod tests {
 
         let asset = replay::<TokenizedAsset>(vec![
             TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault: vault_a,
@@ -658,7 +659,7 @@ mod tests {
             },
             TokenizedAssetEvent::Frozen { frozen_at: chrono::Utc::now() },
             TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL2"),
                 network: Network::Base,
                 vault: vault_b,
@@ -674,7 +675,7 @@ mod tests {
 
     #[test]
     fn test_underlying_symbol_display() {
-        let symbol = UnderlyingSymbol::new("AAPL");
+        let symbol = UnderlyingSymbol::new("AAPL").unwrap();
         assert_eq!(format!("{symbol}"), "AAPL");
     }
 
@@ -690,6 +691,202 @@ mod tests {
         assert_eq!(format!("{network}"), "base");
     }
 
+    /// Executes the real migration file (via `include_str!`) so the test
+    /// cannot drift from what production runs. Running the sequence twice
+    /// proves both the rekey and its idempotency: legacy bare-ticker ids gain
+    /// `:base` exactly once, already-rekeyed ids are untouched, and the view
+    /// is cleared for projection catch-up.
+    #[tokio::test]
+    async fn rekey_migration_rekeys_legacy_ids_and_is_idempotent() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+
+        sqlx::migrate!().run(&pool).await.unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'TokenizedAsset',
+                'AAPL',
+                1,
+                'TokenizedAssetEvent::Added',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                payload,
+                timestamp
+            )
+            VALUES ('TokenizedAsset', 'AAPL', 1, '{}', 1)
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "
+            INSERT INTO tokenized_asset_view (view_id, version, payload)
+            VALUES ('AAPL', 1, '{}')
+            ",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        const REKEY_MIGRATION: &str = include_str!(
+            "../../migrations/20260703235904_rekey_tokenized_asset_aggregate_id.sql"
+        );
+
+        for pass in 1..=2 {
+            sqlx::raw_sql(REKEY_MIGRATION).execute(&pool).await.unwrap();
+
+            let event_ids: Vec<(String,)> = sqlx::query_as(
+                "
+                SELECT aggregate_id
+                FROM events
+                WHERE aggregate_type = 'TokenizedAsset'
+                ",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                event_ids,
+                vec![("AAPL:base".to_string(),)],
+                "event aggregate_id wrong after pass {pass}"
+            );
+
+            let snapshot_ids: Vec<(String,)> = sqlx::query_as(
+                "
+                SELECT aggregate_id
+                FROM snapshots
+                WHERE aggregate_type = 'TokenizedAsset'
+                ",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap();
+            assert_eq!(
+                snapshot_ids,
+                vec![("AAPL:base".to_string(),)],
+                "snapshot aggregate_id wrong after pass {pass}"
+            );
+
+            let view_rows: Vec<(String,)> =
+                sqlx::query_as("SELECT view_id FROM tokenized_asset_view")
+                    .fetch_all(&pool)
+                    .await
+                    .unwrap();
+            assert!(
+                view_rows.is_empty(),
+                "view must be cleared after pass {pass}"
+            );
+        }
+    }
+
+    /// Precondition guard: unexpected aggregate ids must abort before any row
+    /// is rekeyed. Each case seeds one violating id plus a legacy `AAPL` row;
+    /// the migration must fail and leave both ids untouched.
+    #[tokio::test]
+    async fn rekey_migration_aborts_on_unexpected_aggregate_ids() {
+        const REKEY_MIGRATION: &str = include_str!(
+            "../../migrations/20260703235904_rekey_tokenized_asset_aggregate_id.sql"
+        );
+
+        for unexpected_id in ["", "AAPL:BASE", "NVDA:ethereum", ":base"] {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect(":memory:")
+                .await
+                .unwrap();
+
+            sqlx::migrate!().run(&pool).await.unwrap();
+
+            for aggregate_id in ["AAPL", unexpected_id] {
+                sqlx::query(
+                    "
+                    INSERT INTO events (
+                        aggregate_type,
+                        aggregate_id,
+                        sequence,
+                        event_type,
+                        event_version,
+                        payload,
+                        metadata
+                    )
+                    VALUES (
+                        'TokenizedAsset',
+                        ?,
+                        1,
+                        'TokenizedAssetEvent::Added',
+                        '1.0',
+                        '{}',
+                        '{}'
+                    )
+                    ",
+                )
+                .bind(aggregate_id)
+                .execute(&pool)
+                .await
+                .unwrap();
+            }
+
+            let migration_result =
+                sqlx::raw_sql(REKEY_MIGRATION).execute(&pool).await;
+            assert!(
+                migration_result.is_err(),
+                "migration must abort when unexpected id {unexpected_id:?} is present"
+            );
+
+            let mut event_ids: Vec<String> = sqlx::query_as::<_, (String,)>(
+                "
+                SELECT aggregate_id
+                FROM events
+                WHERE aggregate_type = 'TokenizedAsset'
+                ",
+            )
+            .fetch_all(&pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(aggregate_id,)| aggregate_id)
+            .collect();
+            event_ids.sort();
+            let mut expected_ids =
+                vec!["AAPL".to_string(), unexpected_id.to_string()];
+            expected_ids.sort();
+            assert_eq!(
+                event_ids, expected_ids,
+                "ids must be unchanged after aborted migration for {unexpected_id:?}"
+            );
+        }
+    }
+
     /// Regression: pre-event-sorcery snapshot and `tokenized_asset_view` payloads
     /// must be cleared before `StoreBuilder::build` projection catch-up.
     #[tokio::test]
@@ -703,6 +900,7 @@ mod tests {
         sqlx::migrate!().run(&pool).await.unwrap();
 
         let underlying = "AAPL";
+        let aggregate_id = "AAPL:base";
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
         let now = Utc::now();
 
@@ -760,7 +958,7 @@ mod tests {
             )
             ",
         )
-        .bind(underlying)
+        .bind(aggregate_id)
         .bind(
             serde_json::json!({
                 "Added": {
@@ -806,7 +1004,7 @@ mod tests {
             )
             ",
         )
-        .bind(underlying)
+        .bind(aggregate_id)
         .bind(stale.to_string())
         .execute(&pool)
         .await
@@ -818,7 +1016,7 @@ mod tests {
             VALUES (?, 1, ?)
             ",
         )
-        .bind(underlying)
+        .bind(aggregate_id)
         .bind(stale.to_string())
         .execute(&pool)
         .await
@@ -838,7 +1036,7 @@ mod tests {
               AND aggregate_id = ?
             ",
         )
-        .bind(underlying)
+        .bind(aggregate_id)
         .fetch_one(&pool)
         .await
         .unwrap();
@@ -851,7 +1049,7 @@ mod tests {
         let view_payload: String = sqlx::query_scalar(
             "SELECT payload FROM tokenized_asset_view WHERE view_id = ?",
         )
-        .bind(underlying)
+        .bind(aggregate_id)
         .fetch_one(&pool)
         .await
         .unwrap();

--- a/src/tokenized_asset/view.rs
+++ b/src/tokenized_asset/view.rs
@@ -3,7 +3,37 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 
-use super::{AssetStatus, Network, TokenSymbol, UnderlyingSymbol};
+use super::{AssetKey, AssetStatus, Network, TokenSymbol, UnderlyingSymbol};
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error,
+)]
+pub(crate) enum TokenizedAssetViewFailure {
+    #[error("Database error: {message}")]
+    Database { message: String },
+    #[error("Deserialization error: {message}")]
+    Deserialization { message: String },
+    #[error(
+        "tokenized asset {key} has a non-live (null `$.Live`) projection row"
+    )]
+    NonLiveRow { key: AssetKey },
+}
+
+impl From<TokenizedAssetViewError> for TokenizedAssetViewFailure {
+    fn from(error: TokenizedAssetViewError) -> Self {
+        match error {
+            TokenizedAssetViewError::Database(error) => {
+                Self::Database { message: error.to_string() }
+            }
+            TokenizedAssetViewError::Deserialization(error) => {
+                Self::Deserialization { message: error.to_string() }
+            }
+            TokenizedAssetViewError::NonLiveRow { key } => {
+                Self::NonLiveRow { key }
+            }
+        }
+    }
+}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum TokenizedAssetViewError {
@@ -12,9 +42,9 @@ pub(crate) enum TokenizedAssetViewError {
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
     #[error(
-        "tokenized asset {underlying} has a non-live (null `$.Live`) projection row"
+        "tokenized asset {key} has a non-live (null `$.Live`) projection row"
     )]
-    NonLiveRow { underlying: UnderlyingSymbol },
+    NonLiveRow { key: AssetKey },
 }
 
 /// Read model for a tokenized asset, projected from the
@@ -62,16 +92,16 @@ pub(crate) async fn list_enabled_assets(
         .collect()
 }
 
-/// Loads the full tokenized asset view for a given underlying symbol.
+/// Loads the full tokenized asset view for a composite asset key.
 ///
 /// Returns `Ok(Some(view))` for a live asset, `Ok(None)` if no row exists
 /// (unknown asset), or an error — including
 /// [`TokenizedAssetViewError::NonLiveRow`] when a row exists but its `$.Live`
 /// is null (a non-live or corrupt projection: known but indeterminate, not
 /// "unknown").
-pub(crate) async fn load_asset_by_underlying(
+pub(crate) async fn load_asset(
     pool: &Pool<Sqlite>,
-    underlying: &UnderlyingSymbol,
+    key: &AssetKey,
 ) -> Result<Option<TokenizedAssetView>, TokenizedAssetViewError> {
     let row = sqlx::query!(
         r#"
@@ -79,7 +109,7 @@ pub(crate) async fn load_asset_by_underlying(
         FROM tokenized_asset_view
         WHERE view_id = ?
         "#,
-        underlying.0
+        key.to_string()
     )
     .fetch_optional(pool)
     .await?;
@@ -88,15 +118,8 @@ pub(crate) async fn load_asset_by_underlying(
         return Ok(None);
     };
 
-    // A row whose `$.Live` is NULL is a non-live lifecycle state (e.g. a
-    // `Failed` lifecycle) or a corrupt projection: the asset is *known* but its
-    // state is indeterminate, which is distinct from an unknown asset. Surface
-    // it as an error so the status endpoint returns 500 ("indeterminate,
-    // retry") rather than 404 ("unknown"). See SPEC.md's status-code semantics.
     let Some(live) = row.live else {
-        return Err(TokenizedAssetViewError::NonLiveRow {
-            underlying: underlying.clone(),
-        });
+        return Err(TokenizedAssetViewError::NonLiveRow { key: key.clone() });
     };
 
     let view: TokenizedAssetView = serde_json::from_str(&live)?;
@@ -104,22 +127,29 @@ pub(crate) async fn load_asset_by_underlying(
     Ok(Some(view))
 }
 
-/// Finds the vault address for a given underlying symbol.
-///
-/// Delegates to [`load_asset_by_underlying`] and so inherits its contract:
-/// `Ok(Some(vault))` if a supported asset with that underlying exists
-/// (including a frozen one — in-flight redemptions and mints of a frozen asset
-/// must still resolve their vault), `Ok(None)` only when no row exists (unknown
-/// asset), or an error on database/deserialization failure — including
-/// [`TokenizedAssetViewError::NonLiveRow`] when a row exists but its `$.Live`
-/// is null (known but indeterminate, not "not found"). Callers in the mint and
-/// redemption flows therefore see a propagated error, not `Ok(None)`, for a
-/// non-live row.
-pub(crate) async fn find_vault_by_underlying(
+/// Loads an asset by underlying symbol and network.
+pub(crate) async fn load_asset_by_network(
     pool: &Pool<Sqlite>,
     underlying: &UnderlyingSymbol,
+    network: &Network,
+) -> Result<Option<TokenizedAssetView>, TokenizedAssetViewError> {
+    load_asset(pool, &AssetKey::new(underlying.clone(), *network)).await
+}
+
+/// Finds the vault address for a given underlying symbol on a specific network.
+///
+/// Delegates to [`load_asset_by_network`] and so inherits its contract:
+/// `Ok(Some(vault))` if a supported asset with that key exists (including a
+/// frozen one), `Ok(None)` only when no row exists (unknown asset), or an error
+/// on database/deserialization failure -- including
+/// [`TokenizedAssetViewError::NonLiveRow`] when a row exists but its `$.Live`
+/// is null.
+pub(crate) async fn find_vault(
+    pool: &Pool<Sqlite>,
+    underlying: &UnderlyingSymbol,
+    network: &Network,
 ) -> Result<Option<Address>, TokenizedAssetViewError> {
-    Ok(load_asset_by_underlying(pool, underlying)
+    Ok(load_asset_by_network(pool, underlying, network)
         .await?
         .map(|asset| asset.vault))
 }
@@ -135,7 +165,8 @@ mod tests {
     use super::*;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
-        AssetStatus, TokenizedAsset, TokenizedAssetCommand, TokenizedAssetEvent,
+        AssetKey, AssetStatus, TokenizedAsset, TokenizedAssetCommand,
+        TokenizedAssetEvent,
     };
 
     struct TestHarness {
@@ -166,13 +197,17 @@ mod tests {
         }
 
         async fn add_asset(&self, underlying: &str, vault: Address) {
-            let underlying = UnderlyingSymbol::new(underlying);
+            let underlying = UnderlyingSymbol::new(underlying).unwrap();
+            let key = AssetKey::new(underlying.clone(), Network::Base);
             self.store
                 .send(
-                    &underlying,
+                    &key,
                     TokenizedAssetCommand::Add {
                         underlying: underlying.clone(),
-                        token: TokenSymbol::new(format!("t{}", underlying.0)),
+                        token: TokenSymbol::new(format!(
+                            "t{}",
+                            underlying.as_str()
+                        )),
                         network: Network::Base,
                         vault,
                     },
@@ -206,7 +241,7 @@ mod tests {
         assert_eq!(result.len(), 2);
 
         let underlyings: Vec<_> =
-            result.iter().map(|asset| asset.underlying.0.as_str()).collect();
+            result.iter().map(|asset| asset.underlying.as_str()).collect();
 
         assert!(underlyings.contains(&"AAPL"));
         assert!(underlyings.contains(&"TSLA"));
@@ -232,10 +267,13 @@ mod tests {
             address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         harness.add_asset("AAPL", expected_vault).await;
 
-        let result =
-            find_vault_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await
-                .expect("Query should succeed");
+        let result = find_vault(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await
+        .expect("Query should succeed");
 
         assert_eq!(result, Some(expected_vault));
     }
@@ -245,10 +283,13 @@ mod tests {
         let harness = TestHarness::new().await;
         let TestHarness { pool, .. } = &harness;
 
-        let result =
-            find_vault_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await
-                .expect("Query should succeed");
+        let result = find_vault(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await
+        .expect("Query should succeed");
 
         assert_eq!(result, None);
     }
@@ -277,7 +318,7 @@ mod tests {
         // Seed only the events table — no view row.
         let event_payload =
             serde_json::to_string(&TokenizedAssetEvent::Added {
-                underlying: UnderlyingSymbol::new("AAPL"),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
                 network: Network::Base,
                 vault,
@@ -296,7 +337,7 @@ mod tests {
                 payload,
                 metadata
             )
-            VALUES ('TokenizedAsset', 'AAPL', 1, 'TokenizedAssetEvent::Added', '1.0', ?, '{}')
+            VALUES ('TokenizedAsset', 'AAPL:base', 1, 'TokenizedAssetEvent::Added', '1.0', ?, '{}')
             ",
         )
         .bind(&event_payload)
@@ -318,7 +359,7 @@ mod tests {
         let after = list_enabled_assets(&pool).await.unwrap();
         assert_eq!(after.len(), 1);
 
-        assert_eq!(after[0].underlying.0, "AAPL");
+        assert_eq!(after[0].underlying.as_str(), "AAPL");
         assert_eq!(after[0].vault, vault);
 
         // The catch-up log is emitted by event-sorcery under target "cqrs"
@@ -362,7 +403,7 @@ mod tests {
         // large gap reproduces the sparse, shared-counter sequencing that aborted
         // catch-up in production.
         let added = serde_json::to_string(&TokenizedAssetEvent::Added {
-            underlying: UnderlyingSymbol::new("AAPL"),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
             network: Network::Base,
             vault,
@@ -389,7 +430,7 @@ mod tests {
                     payload,
                     metadata
                 )
-                VALUES ('TokenizedAsset', 'AAPL', ?, ?, '1.0', ?, '{}')
+                VALUES ('TokenizedAsset', 'AAPL:base', ?, ?, '1.0', ?, '{}')
                 ",
             )
             .bind(sequence)
@@ -409,17 +450,20 @@ mod tests {
 
         // `Frozen` applied on top of `Added` proves in-order replay across the
         // gap -- an out-of-order or dropped event could not yield `Frozen`.
-        let asset =
-            load_asset_by_underlying(&pool, &UnderlyingSymbol::new("AAPL"))
-                .await
-                .unwrap()
-                .expect("asset rebuilt despite the sequence gap");
+        let asset = load_asset_by_network(
+            &pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await
+        .unwrap()
+        .expect("asset rebuilt despite the sequence gap");
         assert_eq!(asset.status, AssetStatus::Frozen);
         assert_eq!(asset.vault, vault);
 
         // The view advances to the max event sequence, not the event count.
         let (version,): (i64,) = sqlx::query_as(
-            "SELECT version FROM tokenized_asset_view WHERE view_id = 'AAPL'",
+            "SELECT version FROM tokenized_asset_view WHERE view_id = 'AAPL:base'",
         )
         .fetch_one(&pool)
         .await
@@ -440,16 +484,19 @@ mod tests {
         sqlx::query(
             "
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{\"Live\": {\"bad_field\": 1}}')
+            VALUES ('AAPL:base', 1, '{\"Live\": {\"bad_field\": 1}}')
             ",
         )
         .execute(pool)
         .await
         .unwrap();
 
-        let result =
-            load_asset_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await;
+        let result = load_asset_by_network(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await;
 
         assert!(matches!(
             result.unwrap_err(),
@@ -471,21 +518,24 @@ mod tests {
         sqlx::query(
             "
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{\"Live\": null}')
+            VALUES ('AAPL:base', 1, '{\"Live\": null}')
             ",
         )
         .execute(pool)
         .await
         .unwrap();
 
-        let result =
-            load_asset_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await;
+        let result = load_asset_by_network(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await;
 
         assert!(matches!(
             result.unwrap_err(),
-            TokenizedAssetViewError::NonLiveRow { underlying }
-                if underlying.0 == "AAPL"
+            TokenizedAssetViewError::NonLiveRow { key }
+                if key.to_string() == "AAPL:base"
         ));
     }
 
@@ -501,21 +551,24 @@ mod tests {
         sqlx::query(
             "
             INSERT INTO tokenized_asset_view (view_id, version, payload)
-            VALUES ('AAPL', 1, '{\"Live\": null}')
+            VALUES ('AAPL:base', 1, '{\"Live\": null}')
             ",
         )
         .execute(pool)
         .await
         .unwrap();
 
-        let result =
-            find_vault_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await;
+        let result = find_vault(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await;
 
         assert!(matches!(
             result.unwrap_err(),
-            TokenizedAssetViewError::NonLiveRow { underlying }
-                if underlying.0 == "AAPL"
+            TokenizedAssetViewError::NonLiveRow { key }
+                if key.to_string() == "AAPL:base"
         ));
     }
 
@@ -532,10 +585,13 @@ mod tests {
         // projection must apply to the view row.
         harness.add_asset("AAPL", vault_b).await;
 
-        let result =
-            find_vault_by_underlying(pool, &UnderlyingSymbol::new("AAPL"))
-                .await
-                .expect("Query should succeed");
+        let result = find_vault(
+            pool,
+            &UnderlyingSymbol::new("AAPL").unwrap(),
+            &Network::Base,
+        )
+        .await
+        .expect("Query should succeed");
 
         assert_eq!(
             result,
@@ -552,22 +608,23 @@ mod tests {
         let harness = TestHarness::new().await;
         let TestHarness { pool, store } = &harness;
 
-        let underlying = UnderlyingSymbol::new("AAPL");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
         harness.add_asset("AAPL", vault).await;
 
-        let before = load_asset_by_underlying(pool, &underlying)
+        let key = AssetKey::new(underlying.clone(), Network::Base);
+        let before = load_asset(pool, &key)
             .await
             .unwrap()
             .expect("asset exists before freeze");
         assert_eq!(before.status, AssetStatus::Enabled);
 
         store
-            .send(&underlying, TokenizedAssetCommand::Freeze)
+            .send(&key, TokenizedAssetCommand::Freeze)
             .await
             .expect("Failed to freeze asset");
 
-        let after = load_asset_by_underlying(pool, &underlying)
+        let after = load_asset(pool, &key)
             .await
             .unwrap()
             .expect("asset exists after freeze");
@@ -580,7 +637,7 @@ mod tests {
 
         // A frozen asset must still resolve its vault so in-flight redemptions
         // and mints can complete.
-        let resolved = find_vault_by_underlying(pool, &underlying)
+        let resolved = find_vault(pool, &underlying, &Network::Base)
             .await
             .expect("Query should succeed");
         assert_eq!(resolved, Some(vault));

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -1167,7 +1167,7 @@ mod tests {
         ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(Decimal::from(100)),
             Utc::now(),
             None,

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -935,7 +935,7 @@ mod tests {
         ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(dec!(100.5)),
             Utc::now(),
             Some("test mint".to_string()),
@@ -983,7 +983,7 @@ mod tests {
         let info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(dec!(100.5)),
             Utc::now(),
             None,

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -650,7 +650,7 @@ mod tests {
         ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
             IssuerMintRequestId::random(),
-            UnderlyingSymbol::new("AAPL"),
+            UnderlyingSymbol::new("AAPL").unwrap(),
             Quantity::new(Decimal::from(100)),
             Utc::now(),
             None,

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -302,7 +302,7 @@ pub async fn preseed_tokenized_asset_into_pool(
     underlying: &str,
     token: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let aggregate_id = underlying;
+    let aggregate_id = format!("{underlying}:base");
     let now = Utc::now();
 
     let event_payload = json!({
@@ -385,7 +385,7 @@ pub async fn preseed_frozen_tokenized_asset(
         )
         ",
     )
-    .bind(underlying)
+    .bind(format!("{underlying}:base"))
     .bind(&frozen_payload)
     .execute(&pool)
     .await?;

--- a/tests/tokenized_asset_status.rs
+++ b/tests/tokenized_asset_status.rs
@@ -7,6 +7,7 @@ use httpmock::MockServer;
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::tokenized_asset::{TokenizedAssetStatus, UnderlyingSymbol};
 use st0x_issuance_client::IssuanceClient;
+use st0x_issuance_dto::Network;
 
 const UNDERLYING: &str = "TSLA";
 const TOKEN: &str = "tTSLA";
@@ -51,10 +52,13 @@ async fn tokenized_asset_status_via_client()
     let client = IssuanceClient::new(base_url, INTERNAL_API_KEY)?;
 
     let status = client
-        .tokenized_asset_status(&UnderlyingSymbol::new(UNDERLYING))
+        .tokenized_asset_status(
+            &UnderlyingSymbol::new(UNDERLYING).unwrap(),
+            &Network::Base,
+        )
         .await?
         .expect("seeded asset has a status");
-    assert_eq!(status.underlying, UnderlyingSymbol::new(UNDERLYING));
+    assert_eq!(status.underlying, UnderlyingSymbol::new(UNDERLYING).unwrap());
     assert_eq!(
         status.status,
         TokenizedAssetStatus::Enabled,
@@ -62,18 +66,28 @@ async fn tokenized_asset_status_via_client()
     );
 
     let frozen = client
-        .tokenized_asset_status(&UnderlyingSymbol::new(FROZEN_UNDERLYING))
+        .tokenized_asset_status(
+            &UnderlyingSymbol::new(FROZEN_UNDERLYING).unwrap(),
+            &Network::Base,
+        )
         .await?
         .expect("seeded frozen asset has a status");
-    assert_eq!(frozen.underlying, UnderlyingSymbol::new(FROZEN_UNDERLYING));
+    assert_eq!(
+        frozen.underlying,
+        UnderlyingSymbol::new(FROZEN_UNDERLYING).unwrap()
+    );
     assert_eq!(
         frozen.status,
         TokenizedAssetStatus::Frozen,
         "asset with a Frozen event should report frozen through the client"
     );
 
-    let unknown =
-        client.tokenized_asset_status(&UnderlyingSymbol::new("NOPE")).await?;
+    let unknown = client
+        .tokenized_asset_status(
+            &UnderlyingSymbol::new("NOPE").unwrap(),
+            &Network::Base,
+        )
+        .await?;
     assert!(unknown.is_none(), "unknown asset should have no status");
 
     Ok(())

--- a/tests/vault_upgrade.rs
+++ b/tests/vault_upgrade.rs
@@ -31,7 +31,7 @@ async fn test_vault_upgrade_via_add_endpoint()
 
     // Query the internal detail endpoint to verify the vault was updated
     let response = client
-        .get("/tokenized-assets/AAPL")
+        .get("/tokenized-assets/AAPL?network=base")
         .header(rocket::http::Header::new(
             "X-API-KEY",
             "test-key-12345678901234567890123456",


### PR DESCRIPTION
## Motivation

`TokenizedAsset` aggregates were keyed by underlying symbol alone, so an asset
could exist on only one chain. Multichain token listing and network-aware
mint/redemption routing need assets tracked per `(underlying, network)`, and
the existing aggregate store has to be rekeyed in place — live deployments
already hold events under the old ids.

Implements RAI-1205. Stacked on #210.

## Solution

- `AssetKey` (`{underlying}:{network}`) as the `TokenizedAsset` aggregate id;
  utoipa `schema(as = String)` keeps the OpenAPI shape
- In-place aggregate-store rekey migration (`events.aggregate_id`,
  `snapshots`) plus view rebuild, with runbook
  `docs/runbooks/tokenized-asset-aggregate-rekey.md` (backup/restore,
  prod-copy dry run, idempotent steps); the migration aborts if any
  pre-existing `:`-bearing aggregate id would collide with the new format,
  and its test executes the real migration SQL file
- All live `store.send` call sites rekeyed: add-asset, mint
  initiate/confirm/recovery, redemption burn + redeem-call managers
- `GET /tokenized-assets` merges rows for the same `(underlying, token)`
  across chains — union of `networks[]`, deduped and sorted; JSON shape
  unchanged, row count drops to one per asset
- `POST /tokenized-assets` rejects an empty underlying (422) — it would write
  an aggregate under the id `:{network}`, which `AssetKey::from_str` can
  never read back
- Admin/CLI freeze, unfreeze, and status take a required `--network` (no
  silent Base default)
- Required `?network=` on internal detail/status endpoints — dto + client
  break; liquidity re-pin coordinated in the same deploy window (RAI-1212)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tokenized assets are now fully network-aware (status, detail, listing, freeze/unfreeze) using a composite `"{underlying}:{network}"` asset identifier.
  * API endpoints accept an optional `network` query (e.g. `?network=base`) and merge listing rows by underlying/token across networks.
  * Added a runbook for the tokenized-asset aggregate rekey process.

* **Bug Fixes**
  * Asset resolution in mint, redemption, and CLI flows now targets the selected network.
  * Invalid or missing `network` now yields `422` where applicable; underlying validation is enforced.

* **Chores / Tests**
  * Updated chain config duplicate detection and refreshed tests/mocks to use network-scoped identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->