### PR TITLE
feat: partition receipt backfill and reconcile by chain

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -896,8 +896,12 @@ left for on-chain settlement or manual intervention.
 The per-vault receipt backfill cursor (previously `BackfillCheckpoint` events on
 this aggregate) is not domain state — it is a single mutable counter with no
 audit value, so it is persisted in the `poll_checkpoints` SQL table under the
-key `receipt_backfill:<vault_address_lowercase>`. See the polling checkpoints
-persistence section below.
+key `receipt_backfill:<network>:<vault_address_lowercase>`. Each
+`(network,
+vault)` pair keeps an independent cursor because block numbers are
+chain-specific. For Base only, `load_receipt_backfill` falls back to the legacy
+vault-only key `receipt_backfill:<vault_address_lowercase>` seeded from
+pre-multichain `BackfillCheckpoint` events.
 
 ## Core Functionality
 
@@ -1656,19 +1660,23 @@ any redemption transfers that occurred while the service was down. This ensures
 no redemptions are silently missed due to downtime.
 
 The configured `backfill_start_block` is only the first-run seed; after a
-successful range, the service persists a single `transfer_poll` row in the
+successful range, the service persists a per-(network, vault)
+`transfer_poll:{network}:{vault_address_lowercase}` row in the
 `poll_checkpoints` SQL table and the next startup resumes at
-`last_processed_block + 1`. The checkpoint advances only after the requested
-range succeeds, and writes are monotonic so a shorter later range cannot move
-progress backward. Idempotency is still guaranteed by the
-`IssuerRedemptionRequestId` derived from each transaction hash — the Redemption
-aggregate rejects duplicate detections.
+`last_processed_block + 1`. For Base only, `load_transfer_poll` falls back to
+the legacy global key `transfer_poll` when the per-vault row does not exist yet.
+The checkpoint advances only after the requested range succeeds, and writes are
+monotonic so a shorter later range cannot move progress backward. Idempotency is
+still guaranteed by the `IssuerRedemptionRequestId` derived from each
+transaction hash — the Redemption aggregate rejects duplicate detections.
 
-This mirrors the receipt backfill pattern, where per-vault checkpoints are
-tracked under the keys `receipt_backfill:<vault_lowercase>` in the same
-`poll_checkpoints` table. Both checkpoints are intentionally not event-sourced:
-they are single mutable values whose history has no audit worth keeping, and
-modeling them as aggregates was the root cause of the 2026-05-19 OOM (RAI-617).
+This mirrors the receipt backfill pattern, where per-(network, vault)
+checkpoints are tracked under `receipt_backfill:<network>:<vault_lowercase>` in
+the same `poll_checkpoints` table, with the legacy
+`receipt_backfill:<vault_lowercase>` fallback for Base. Both checkpoints are
+intentionally not event-sourced: they are single mutable values whose history
+has no audit worth keeping, and modeling them as aggregates was the root cause
+of the 2026-05-19 OOM (RAI-617).
 
 **Note:** The bot's wallet serves as the redemption destination. When users send
 shares to this wallet, they're initiating a redemption. Since the bot already
@@ -2567,11 +2575,12 @@ supported long-term configuration: the target shape is one
 per configured network, with `.env.example` as the authoritative record of that
 shape. Parsing those variables into `Config::chains` is its own change; until it
 lands, the flat legacy vars remain the only live config path. Checkpoints are
-keyed per network: transfer polling under `transfer_poll:{network}` and receipt
-backfill under `receipt_backfill:<network>:<vault_address_lowercase>`, with the
-pre-multichain rows (`transfer_poll`, `receipt_backfill:<vault_lowercase>`)
-readable as Base-only fallbacks. Once staging and production migrate, the
-flat-var mapping and those legacy checkpoint fallbacks are deleted.
+keyed per `(network, vault)`: transfer polling under
+`transfer_poll:{network}:{vault_address_lowercase}` and receipt backfill under
+`receipt_backfill:<network>:<vault_address_lowercase>`, with the pre-multichain
+rows (`transfer_poll`, `receipt_backfill:<vault_lowercase>`) readable as
+Base-only fallbacks. Once staging and production migrate, the flat-var mapping
+and those legacy checkpoint fallbacks are deleted.
 
 **Asset identity (breaking):** `TokenizedAsset` aggregate id becomes the
 `AssetKey` — `{underlying}:{network}` (e.g. `AAPL:base`). The internal asset

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -129,6 +129,11 @@ pub enum ChainRegistryError {
 }
 
 impl<P> ChainRegistry<P> {
+    #[cfg(test)]
+    pub(crate) fn empty_for_tests(_provider: &P) -> Self {
+        Self { runtimes: HashMap::new() }
+    }
+
     pub(crate) fn get(&self, network: Network) -> Option<&ChainRuntime<P>> {
         self.runtimes.get(&network)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,7 +54,7 @@ use crate::redemption::{
 };
 use crate::tokenized_asset::{
     TokenizedAsset, TokenizedAssetView, UnderlyingSymbol,
-    view::list_enabled_assets,
+    validate_no_cross_network_vault_collisions, view::list_enabled_assets,
 };
 use poll_checkpoint::load_receipt_backfill;
 
@@ -338,12 +338,7 @@ pub async fn initialize_rocket(
     )
     .await
     {
-        error!(
-            target: "receipt",
-            error = %error,
-            "Startup reconciliation failed — receipt balances may be stale \
-             until the next withdraw event triggers reconciliation"
-        );
+        error.log();
     }
 
     // The synchronous recovery pass runs with a timeout before the HTTP server
@@ -984,6 +979,8 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
         return Ok(vec![]);
     }
 
+    validate_no_cross_network_vault_collisions(&assets)?;
+
     info!(
         target: "receipt",
         asset_count = assets.len(),
@@ -993,7 +990,17 @@ async fn run_all_receipt_backfills<P: Provider + Clone>(
     stream::iter(assets)
         .then(
             |TokenizedAssetView { vault, underlying, network, .. }| async move {
-                let runtime = chain_registry.get_required(network)?;
+                let runtime = chain_registry.get_required(network).inspect_err(
+                    |error| {
+                        warn!(
+                            target: "receipt",
+                            %network,
+                            %vault,
+                            error = %error,
+                            "Chain registry miss while preparing receipt backfill"
+                        );
+                    },
+                )?;
                 run_single_vault_backfill(
                     &VaultBackfillCtx {
                         pool,
@@ -1077,6 +1084,90 @@ async fn run_single_vault_backfill<P: Provider + Clone>(
     Ok(VaultBackfillConfig { chain_id, network, vault, receipt_contract })
 }
 
+struct ReconciliationFailures {
+    first: Option<ReconciliationFailure>,
+    count: usize,
+}
+
+struct ReconciliationFailure {
+    network: Network,
+    vault: Address,
+    source: anyhow::Error,
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "startup reconciliation failed for {failed_vaults} of {total_vaults} vaults"
+)]
+struct StartupReconciliationError {
+    failed_vaults: usize,
+    total_vaults: usize,
+    first_network: Network,
+    first_vault: Address,
+    #[source]
+    source: anyhow::Error,
+}
+
+impl StartupReconciliationError {
+    fn log(&self) {
+        warn!(
+            target: "receipt",
+            failed_vaults = self.failed_vaults,
+            total_vaults = self.total_vaults,
+            first_network = %self.first_network,
+            first_vault = %self.first_vault,
+            error = %self.source,
+            "Startup reconciliation failed — receipt balances may be stale \
+             until the next withdraw event triggers reconciliation"
+        );
+    }
+}
+
+impl ReconciliationFailures {
+    const fn new() -> Self {
+        Self { first: None, count: 0 }
+    }
+
+    fn record(
+        &mut self,
+        network: Network,
+        vault: Address,
+        source: anyhow::Error,
+    ) {
+        debug!(
+            target: "receipt",
+            %network,
+            %vault,
+            error = %source,
+            "Startup reconciliation failed for vault; continuing with the \
+             remaining vaults"
+        );
+
+        self.count += 1;
+        if self.first.is_none() {
+            self.first = Some(ReconciliationFailure { network, vault, source });
+        }
+    }
+
+    fn finish(
+        self,
+        total_vaults: usize,
+    ) -> Result<(), StartupReconciliationError> {
+        let Some(ReconciliationFailure { network, vault, source }) = self.first
+        else {
+            return Ok(());
+        };
+
+        Err(StartupReconciliationError {
+            failed_vaults: self.count,
+            total_vaults,
+            first_network: network,
+            first_vault: vault,
+            source,
+        })
+    }
+}
+
 /// Attempts reconciliation for every vault even when earlier vaults fail —
 /// a transient RPC failure on one network must not leave the remaining
 /// networks' receipt inventories unreconciled at boot.
@@ -1085,8 +1176,8 @@ async fn run_startup_reconciliation_for_vaults<P: Provider + Clone>(
     vault_configs: &[VaultBackfillConfig],
     store: &Arc<Store<ReceiptInventory>>,
     bot_wallet: Address,
-) -> Result<(), anyhow::Error> {
-    let mut failed_vaults = 0_usize;
+) -> Result<(), StartupReconciliationError> {
+    let mut failures = ReconciliationFailures::new();
 
     for &VaultBackfillConfig { chain_id, network, vault, receipt_contract } in
         vault_configs
@@ -1105,26 +1196,11 @@ async fn run_startup_reconciliation_for_vaults<P: Provider + Clone>(
         .await;
 
         if let Err(error) = outcome {
-            failed_vaults += 1;
-            warn!(
-                target: "receipt",
-                %network,
-                %vault,
-                error = %error,
-                "Startup reconciliation failed for vault; continuing with \
-                 the remaining vaults"
-            );
+            failures.record(network, vault, error);
         }
     }
 
-    if failed_vaults > 0 {
-        return Err(anyhow::anyhow!(
-            "startup reconciliation failed for {failed_vaults} of {} vaults",
-            vault_configs.len()
-        ));
-    }
-
-    Ok(())
+    failures.finish(vault_configs.len())
 }
 
 fn next_receipt_backfill_block(
@@ -1512,23 +1588,31 @@ fn spawn_mint_recovery_worker(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{U256, address, uint};
+    use alloy::primitives::{Address, U256, address, uint};
     use alloy::providers::ProviderBuilder;
     use alloy::providers::mock::Asserter;
+    use event_sorcery::test_store;
     use rust_decimal::Decimal;
+    use sqlx::sqlite::SqlitePoolOptions;
     use std::collections::HashMap;
     use std::str::FromStr;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
     use tokio::sync::Notify;
+    use tracing::Level;
+    use tracing_test::traced_test;
 
     use super::{
         BURN_RECOVERY_RECONCILE_INTERVAL, Environment, Quantity,
-        QuantityConversionError, ReceiptContractAddress, VaultAddress,
+        QuantityConversionError, ReceiptContractAddress,
+        ReconciliationFailures, VaultAddress, VaultBackfillConfig,
         cached_receipt_contract, mount_api_docs, next_receipt_backfill_block,
-        run_burn_recovery_reconciler,
+        run_burn_recovery_reconciler, run_startup_reconciliation_for_vaults,
     };
+    use crate::chain::{ChainRegistry, ChainRegistryError};
+    use crate::receipt_inventory::ReceiptInventory;
+    use crate::test_utils::{log_count_at, logs_contain_at};
 
     #[tokio::test]
     async fn burn_recovery_reconciler_repeats_after_each_interval() {
@@ -1853,5 +1937,104 @@ mod tests {
         let start_block = next_receipt_backfill_block(Some(20), 50).unwrap();
 
         assert_eq!(start_block, 50);
+    }
+
+    mod receipt_inventory_reconciliation {
+        use super::*;
+
+        #[traced_test]
+        #[test]
+        fn reconciliation_failures_log_details_once_per_level() {
+            let base_vault =
+                address!("0x1111111111111111111111111111111111111111");
+            let ethereum_vault =
+                address!("0x2222222222222222222222222222222222222222");
+            let mut failures = ReconciliationFailures::new();
+
+            failures.record(
+                crate::Network::Base,
+                base_vault,
+                anyhow::anyhow!("Base RPC unavailable"),
+            );
+            failures.record(
+                crate::Network::Ethereum,
+                ethereum_vault,
+                anyhow::anyhow!("Ethereum RPC unavailable"),
+            );
+
+            let error = failures.finish(2).unwrap_err();
+            error.log();
+
+            assert_eq!(error.failed_vaults, 2);
+            assert_eq!(error.total_vaults, 2);
+            assert_eq!(error.first_network, crate::Network::Base);
+            assert_eq!(error.first_vault, base_vault);
+            assert_eq!(error.source.to_string(), "Base RPC unavailable");
+            assert_eq!(
+                log_count_at!(
+                    Level::DEBUG,
+                    &["Startup reconciliation failed for vault"]
+                ),
+                2
+            );
+            assert!(logs_contain_at!(
+                Level::WARN,
+                &["Startup reconciliation failed", "Base RPC unavailable", "2"]
+            ));
+        }
+
+        #[traced_test]
+        #[tokio::test]
+        async fn unconfigured_network_failure_keeps_context_and_logs() {
+            let provider =
+                ProviderBuilder::new().connect_mocked_client(Asserter::new());
+            let registry = ChainRegistry::empty_for_tests(&provider);
+            let pool = SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_lazy(":memory:")
+                .unwrap();
+            let store = Arc::new(test_store::<ReceiptInventory>(pool, ()));
+            let vault = address!("0x3333333333333333333333333333333333333333");
+            let receipt_contract =
+                address!("0x4444444444444444444444444444444444444444");
+            let configs = [VaultBackfillConfig {
+                chain_id: 1,
+                network: crate::Network::Ethereum,
+                vault,
+                receipt_contract,
+            }];
+
+            let error = run_startup_reconciliation_for_vaults(
+                &registry,
+                &configs,
+                &store,
+                Address::ZERO,
+            )
+            .await
+            .unwrap_err();
+            error.log();
+
+            assert!(matches!(
+                error.source.downcast_ref::<ChainRegistryError>(),
+                Some(ChainRegistryError::NetworkNotConfigured {
+                    network: crate::Network::Ethereum
+                })
+            ));
+            assert!(logs_contain_at!(
+                Level::DEBUG,
+                &[
+                    "Startup reconciliation failed for vault",
+                    "ethereum",
+                    "network ethereum is not configured"
+                ]
+            ));
+            assert!(logs_contain_at!(
+                Level::WARN,
+                &[
+                    "Startup reconciliation failed",
+                    "network ethereum is not configured"
+                ]
+            ));
+        }
     }
 }

--- a/src/poll_checkpoint.rs
+++ b/src/poll_checkpoint.rs
@@ -63,7 +63,11 @@ pub(crate) async fn advance_transfer_poll(
     .await
 }
 
-/// Per-network receipt backfill checkpoint name.
+/// Per-network checkpoint name for the receipt backfiller for a given vault.
+///
+/// Block numbers are chain-specific, so the same vault address on two
+/// networks must track independent checkpoints -- a shared key would let one
+/// chain's head block skip the other chain's backfill entirely.
 pub(crate) fn receipt_backfill_name(
     network: Network,
     vault: Address,
@@ -156,7 +160,6 @@ pub(crate) async fn advance_checkpoint_block(
 
     Ok(())
 }
-
 /// Deletes the checkpoint row for `name`.
 ///
 /// Used by one-time migrations that must not leave their source checkpoint
@@ -300,6 +303,37 @@ mod tests {
         );
     }
 
+    /// Block numbers are chain-specific, so the same vault address deployed
+    /// on two networks must keep independent backfill checkpoints -- a shared
+    /// key would let the chain with the higher head block permanently skip
+    /// the other chain's backfill.
+    #[tokio::test]
+    async fn receipt_backfill_checkpoints_are_independent_per_network() {
+        let pool = setup_pool().await;
+        let vault = address!("00000000000000000000000000000000000000aa");
+
+        advance_receipt_backfill(&pool, Network::Base, vault, 100)
+            .await
+            .unwrap();
+        advance_receipt_backfill(&pool, Network::Ethereum, vault, 50)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            load_receipt_backfill(&pool, Network::Base, vault).await.unwrap(),
+            Some(100),
+            "Base must keep its own checkpoint for the shared vault address"
+        );
+        assert_eq!(
+            load_receipt_backfill(&pool, Network::Ethereum, vault)
+                .await
+                .unwrap(),
+            Some(50),
+            "Ethereum must keep its own checkpoint for the shared vault \
+             address"
+        );
+    }
+
     /// The Base poller must fall back to the legacy single-chain
     /// `transfer_poll` key when no per-network checkpoint exists yet --
     /// otherwise an upgraded deployment restarts from `backfill_start_block`
@@ -339,6 +373,14 @@ mod tests {
             receipt_backfill_name(Network::Base, vault),
             "receipt_backfill:base:0xaabbccddeeff00112233445566778899aabbccdd"
         );
+        assert_eq!(
+            receipt_backfill_name(Network::Ethereum, vault),
+            "receipt_backfill:ethereum:0xaabbccddeeff00112233445566778899aabbccdd"
+        );
+        assert_eq!(
+            legacy_receipt_backfill_name(vault),
+            "receipt_backfill:0xaabbccddeeff00112233445566778899aabbccdd"
+        );
     }
 
     #[tokio::test]
@@ -362,8 +404,8 @@ mod tests {
     /// Production aggregate IDs were written via `Address::to_string()`, which
     /// produces EIP-55 mixed-case hex. The migration that seeds
     /// `poll_checkpoints` from existing `BackfillCheckpoint` events must
-    /// normalize that to lowercase so the seeded row matches the runtime key
-    /// built by `receipt_backfill_name`.
+    /// normalize that to lowercase so the seeded row matches the legacy key
+    /// that `load_receipt_backfill` falls back to for Base.
     #[tokio::test]
     async fn migration_seeds_receipt_backfill_with_lowercase_key() {
         let pool = setup_pool().await;
@@ -411,7 +453,7 @@ mod tests {
 
         // Re-run the receipt_backfill seeding step verbatim from the
         // migration. If the SQL is ever changed and no longer matches the
-        // runtime key format, this assertion fails.
+        // legacy key format the Base fallback reads, this assertion fails.
         sqlx::query(
             "
             INSERT INTO poll_checkpoints (name, block_number)
@@ -434,7 +476,14 @@ mod tests {
         assert_eq!(
             load_receipt_backfill(&pool, Network::Base, vault).await.unwrap(),
             Some(12345),
-            "seeded checkpoint must be readable via the runtime key"
+            "seeded legacy checkpoint must be readable via the Base fallback"
+        );
+        assert_eq!(
+            load_receipt_backfill(&pool, Network::Ethereum, vault)
+                .await
+                .unwrap(),
+            None,
+            "non-Base networks must not inherit the legacy Base checkpoint"
         );
     }
 }

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -199,13 +199,14 @@ pub(crate) async fn list_tokenized_assets(
     responses(
         (status = 201, description = "Asset added (idempotent: also 201 if it already existed)",
             body = AddTokenizedAssetResponse),
-        (status = 422, description = "Empty underlying symbol, or network \
-            without a chain configuration"),
+        (status = 422, description = "Empty underlying symbol, network \
+            without a chain configuration, or vault address already used on \
+            another network"),
         (status = 500, description = "Failed to add asset")
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, store, configured_networks), fields(
+#[tracing::instrument(skip(_auth, store, pool, configured_networks), fields(
     underlying = %request.underlying,
     token = %request.token,
     network = %request.network,
@@ -215,6 +216,7 @@ pub(crate) async fn list_tokenized_assets(
 pub(crate) async fn add_tokenized_asset(
     _auth: InternalAuth,
     store: &rocket::State<Arc<Store<TokenizedAsset>>>,
+    pool: &rocket::State<Pool<Sqlite>>,
     configured_networks: &rocket::State<ConfiguredNetworks>,
     request: Json<AddTokenizedAssetRequest>,
 ) -> Result<(Status, Json<AddTokenizedAssetResponse>), Status> {
@@ -228,6 +230,40 @@ pub(crate) async fn add_tokenized_asset(
             target: "asset",
             network = %request.network,
             "Rejected tokenized-asset registration for unconfigured network"
+        );
+        return Err(Status::UnprocessableEntity);
+    }
+
+    // Same guard as boot-time backfill: reject before the Add lands so a
+    // shared vault across networks never waits until the next restart to fail.
+    let mut assets = super::view::list_enabled_assets(pool.inner())
+        .await
+        .map_err(|error| {
+            error!(
+                target: "asset",
+                error = %error,
+                "Failed to list enabled assets before add"
+            );
+            Status::InternalServerError
+        })?;
+    assets.push(TokenizedAssetView {
+        underlying: request.underlying.clone(),
+        token: request.token.clone(),
+        network: request.network,
+        vault: request.vault,
+        status: super::AssetStatus::Enabled,
+        added_at: chrono::Utc::now(),
+    });
+    if let Err(collision) =
+        super::validate_no_cross_network_vault_collisions(&assets)
+    {
+        warn!(
+            target: "asset",
+            vault = %collision.vault,
+            first = %collision.first,
+            second = %collision.second,
+            "Rejected tokenized-asset registration: vault address already \
+             used on another network"
         );
         return Err(Status::UnprocessableEntity);
     }
@@ -835,6 +871,75 @@ mod tests {
         // written-but-rejected asset would still brick the next boot.
         let key = AssetKey::new(
             UnderlyingSymbol::new("AAPL").unwrap(),
+            Network::Ethereum,
+        );
+        let asset = store.load(&key).await.expect("load must succeed");
+        assert!(asset.is_none(), "aggregate must not exist: {asset:?}");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_add_asset_rejects_vault_shared_across_networks() {
+        let pool = migrated_in_memory_pool().await;
+        let store = setup_tokenized_asset_store(&pool).await;
+        let shared_vault =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+        store
+            .send(
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::Base,
+                    vault: shared_vault,
+                },
+            )
+            .await
+            .expect("base asset should add");
+
+        let rocket = rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(store.clone())
+            .manage(pool)
+            .manage(ConfiguredNetworks::from_iter([
+                Network::Base,
+                Network::Ethereum,
+            ]))
+            .mount("/", routes![add_tokenized_asset]);
+
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let request_body = serde_json::json!({
+            "underlying": "MSFT",
+            "token": "tMSFT",
+            "network": "ethereum",
+            "vault": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        });
+
+        let response = client
+            .post("/tokenized-assets")
+            .header(ContentType::JSON)
+            .header(internal_api_key())
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(request_body.to_string())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["vault address already", "another network"]
+        ));
+
+        let key = AssetKey::new(
+            UnderlyingSymbol::new("MSFT").unwrap(),
             Network::Ethereum,
         );
         let asset = store.load(&key).await.expect("load must succeed");

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use event_sorcery::{EventSourced, Never, Table};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 pub(crate) use api::{
     add_tokenized_asset, get_tokenized_asset, get_tokenized_asset_status,
@@ -54,6 +55,44 @@ impl From<AssetStatus> for TokenizedAssetStatus {
             AssetStatus::Frozen => Self::Frozen,
         }
     }
+}
+
+/// Two enabled assets on different networks share one vault address.
+///
+/// Receipt inventory is keyed by `(chain_id, vault)`, so the streams no longer
+/// merge, but a shared address across networks is still a misconfiguration:
+/// transfer matching, admin tooling, and operator mental models assume a vault
+/// address identifies one deployment. Reject at boot and at add time.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[error(
+    "vault address {vault} is configured on both {first} and {second}; \
+     one address cannot serve two networks"
+)]
+pub(crate) struct CrossNetworkVaultCollision {
+    pub(crate) vault: Address,
+    pub(crate) first: Network,
+    pub(crate) second: Network,
+}
+
+/// Rejects enabled-asset sets where the same vault address appears on more
+/// than one network.
+pub(crate) fn validate_no_cross_network_vault_collisions(
+    assets: &[TokenizedAssetView],
+) -> Result<(), CrossNetworkVaultCollision> {
+    let mut vault_networks: HashMap<Address, Network> = HashMap::new();
+
+    assets.iter().try_for_each(|asset| {
+        match vault_networks.insert(asset.vault, asset.network) {
+            Some(first) if first != asset.network => {
+                Err(CrossNetworkVaultCollision {
+                    vault: asset.vault,
+                    first,
+                    second: asset.network,
+                })
+            }
+            _ => Ok(()),
+        }
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -267,10 +306,62 @@ mod tests {
 
     use super::{
         AssetStatus, Network, TokenSymbol, TokenizedAsset,
-        TokenizedAssetCommand, TokenizedAssetEvent, UnderlyingSymbol,
+        TokenizedAssetCommand, TokenizedAssetEvent, TokenizedAssetView,
+        UnderlyingSymbol, validate_no_cross_network_vault_collisions,
     };
     use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
+
+    fn enabled_asset(
+        underlying: &str,
+        network: Network,
+        vault: Address,
+    ) -> TokenizedAssetView {
+        TokenizedAssetView {
+            underlying: UnderlyingSymbol::new(underlying).unwrap(),
+            token: TokenSymbol::new(format!("t{underlying}")),
+            network,
+            vault,
+            status: AssetStatus::Enabled,
+            added_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn cross_network_vault_address_collision_is_rejected() {
+        let shared = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let assets = vec![
+            enabled_asset("AAPL", Network::Base, shared),
+            enabled_asset("MSFT", Network::Ethereum, shared),
+        ];
+
+        let error =
+            validate_no_cross_network_vault_collisions(&assets).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("base"), "missing first network: {message}");
+        assert!(
+            message.contains("ethereum"),
+            "missing second network: {message}"
+        );
+    }
+
+    #[test]
+    fn distinct_vault_addresses_across_networks_pass_validation() {
+        let assets = vec![
+            enabled_asset(
+                "AAPL",
+                Network::Base,
+                address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            ),
+            enabled_asset(
+                "AAPL",
+                Network::Ethereum,
+                address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+            ),
+        ];
+
+        assert!(validate_no_cross_network_vault_collisions(&assets).is_ok());
+    }
 
     #[traced_test]
     #[tokio::test]

--- a/tests/harness/alpaca_mocks.rs
+++ b/tests/harness/alpaca_mocks.rs
@@ -58,27 +58,41 @@ pub fn setup_redemption_mocks_with_states(
         then.status(200).respond_with(
             move |req: &httpmock::HttpMockRequest| {
                 let body: serde_json::Value =
-                    serde_json::from_slice(req.body().as_ref()).unwrap();
-                let issuer_request_id =
-                    body["issuer_request_id"].as_str().unwrap().to_string();
-                let tx_hash =
-                    body["tx_hash"].as_str().unwrap().to_string();
-                let qty = body["qty"].as_str().unwrap().to_string();
+                    serde_json::from_slice(req.body().as_ref())
+                        .expect("redeem request body must be valid JSON");
+                let issuer_request_id = body["issuer_request_id"]
+                    .as_str()
+                    .expect("redeem request must include issuer_request_id")
+                    .to_string();
+                let tx_hash = body["tx_hash"]
+                    .as_str()
+                    .expect("redeem request must include tx_hash")
+                    .to_string();
+                let qty = body["qty"]
+                    .as_str()
+                    .expect("redeem request must include qty")
+                    .to_string();
                 let underlying_symbol = body["underlying_symbol"]
                     .as_str()
-                    .unwrap()
+                    .expect("redeem request must include underlying_symbol")
                     .to_string();
-                let token_symbol =
-                    body["token_symbol"].as_str().unwrap().to_string();
+                let token_symbol = body["token_symbol"]
+                    .as_str()
+                    .expect("redeem request must include token_symbol")
+                    .to_string();
                 let wallet_address = body["wallet_address"]
                     .as_str()
-                    .unwrap()
+                    .expect("redeem request must include wallet_address")
                     .to_string();
-                let network =
-                    body["network"].as_str().unwrap().to_string();
+                let network = body["network"]
+                    .as_str()
+                    .expect("redeem request must include network")
+                    .to_string();
 
-                shared_state_redeem.lock().unwrap().push(
-                    RedemptionState {
+                shared_state_redeem
+                    .lock()
+                    .expect("redemption mock state mutex must not be poisoned")
+                    .push(RedemptionState {
                         issuer_request_id: issuer_request_id.clone(),
                         tx_hash: tx_hash.clone(),
                         qty: qty.clone(),
@@ -86,8 +100,7 @@ pub fn setup_redemption_mocks_with_states(
                         token_symbol: token_symbol.clone(),
                         wallet_address: wallet_address.clone(),
                         network: network.clone(),
-                    },
-                );
+                    });
 
                 let response_body = serde_json::to_string(&json!({
                     "tokenization_request_id": format!("tok-redeem-{}", issuer_request_id),
@@ -105,7 +118,7 @@ pub fn setup_redemption_mocks_with_states(
                     "tx_hash": tx_hash,
                     "fees": "0.5"
                 }))
-                .unwrap();
+                .expect("redeem mock response must serialize");
 
                 httpmock::HttpMockResponse {
                     status: Some(200),
@@ -143,7 +156,7 @@ pub fn setup_redemption_mocks_with_states(
 
                 let matched = shared_state
                     .lock()
-                    .unwrap()
+                    .expect("redemption mock state mutex must not be poisoned")
                     .iter()
                     .find(|s| {
                         format!("tok-redeem-{}", s.issuer_request_id) == tok_id
@@ -177,7 +190,7 @@ pub fn setup_redemption_mocks_with_states(
                     "tx_hash": state.tx_hash,
                     "fees": "0.5"
                 }))
-                .unwrap();
+                .expect("poll mock response must serialize");
 
                 httpmock::HttpMockResponse {
                     status: Some(200),

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -115,7 +115,10 @@ pub async fn wait_for_mock_hits(
     expected: usize,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let start = tokio::time::Instant::now();
-    let timeout = tokio::time::Duration::from_secs(5);
+    // Must comfortably exceed the transfer poller's 5s POLL_INTERVAL: a
+    // transfer landing just after a poll pass is only detected on the next
+    // tick, so a 5s wait races the poller by construction.
+    let timeout = tokio::time::Duration::from_secs(15);
     let poll_interval = tokio::time::Duration::from_millis(50);
 
     loop {
@@ -241,7 +244,9 @@ pub async fn seed_tokenized_asset_with(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(
             json!({
                 "underlying": underlying,
@@ -423,14 +428,18 @@ pub async fn setup_account(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(json!({"email": "user@example.com"}).to_string())
         .dispatch()
         .await;
 
     assert_eq!(register_response.status(), rocket::http::Status::Ok);
-    let _: RegisterAccountResponse =
-        register_response.into_json().await.unwrap();
+    let _: RegisterAccountResponse = register_response
+        .into_json()
+        .await
+        .expect("register response must contain valid JSON");
 
     let link_response = client
         .post("/accounts/connect")
@@ -439,7 +448,9 @@ pub async fn setup_account(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(
             json!({"email": "user@example.com", "account": "USER123"})
                 .to_string(),
@@ -448,8 +459,10 @@ pub async fn setup_account(
         .await;
 
     assert_eq!(link_response.status(), rocket::http::Status::Ok);
-    let link_body: AccountLinkResponse =
-        link_response.into_json().await.unwrap();
+    let link_body: AccountLinkResponse = link_response
+        .into_json()
+        .await
+        .expect("link response must contain valid JSON");
 
     let whitelist_response = client
         .post(format!("/accounts/{}/wallets", link_body.client_id))
@@ -458,7 +471,9 @@ pub async fn setup_account(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(json!({"wallet": user_wallet}).to_string())
         .dispatch()
         .await;
@@ -574,15 +589,21 @@ pub fn create_config_with_db(
 
 /// Builds a [`Config`] wired to two Anvil chains: Base and Ethereum, both
 /// entries in `Config::chains`. Both chains share the mock subgraph.
+/// `eth_vault_address` is passed explicitly rather than read from `eth_evm`:
+/// both Anvil chains deploy from the same key and nonce, so
+/// `eth_evm.vault_address` equals `base_evm.vault_address`, and twin
+/// addresses would make cross-chain routing assertions vacuous. Multichain
+/// tests deploy an additional vault on the Ethereum chain and use its address.
 pub fn create_multichain_config_with_db(
     db_path: &str,
     mock_alpaca: &MockServer,
     base_evm: &LocalEvm,
     eth_evm: &LocalEvm,
+    eth_vault_address: Address,
 ) -> Result<(Config, MockServer), Box<dyn std::error::Error>> {
     let vault_schemas = HashMap::from([
         (base_evm.vault_address, TEST_OA_SCHEMA_HASH),
-        (eth_evm.vault_address, TEST_OA_SCHEMA_HASH),
+        (eth_vault_address, TEST_OA_SCHEMA_HASH),
     ]);
     let mock_subgraph = setup_mock_subgraph(&vault_schemas);
     let subgraph_url =
@@ -695,7 +716,9 @@ pub async fn perform_mint_and_confirm_with(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(
             json!({
                 "tokenization_request_id": tokenization_request_id,
@@ -712,7 +735,10 @@ pub async fn perform_mint_and_confirm_with(
         .await;
 
     assert_eq!(mint_response.status(), rocket::http::Status::Ok);
-    let mint_body: MintResponse = mint_response.into_json().await.unwrap();
+    let mint_body: MintResponse = mint_response
+        .into_json()
+        .await
+        .expect("mint response must contain valid JSON");
     let issuer_request_id = mint_body.issuer_request_id.to_string();
 
     let confirm_response = client
@@ -722,7 +748,9 @@ pub async fn perform_mint_and_confirm_with(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
         ))
-        .remote("127.0.0.1:8000".parse().unwrap())
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
         .body(
             json!({
                 "tokenization_request_id": tokenization_request_id,

--- a/tests/multichain_mint.rs
+++ b/tests/multichain_mint.rs
@@ -21,6 +21,16 @@ async fn test_multichain_mint_routes_by_network()
     let base_evm = LocalEvm::new().await?;
     let eth_evm = LocalEvm::with_chain_id(ETHEREUM_TEST_CHAIN_ID).await?;
 
+    // Both Anvils deploy from the same key and nonce, so the default vault
+    // addresses collide across chains. Receipt inventory is keyed by
+    // `{chain_id}:{vault}`, so colliding addresses would not merge streams —
+    // but twin addresses would make the routing assertions vacuous. Deploy a
+    // distinct vault on the Ethereum chain so a wrong-chain call cannot
+    // masquerade as the right one.
+    let (eth_vault_address, eth_authorizer_address) =
+        eth_evm.deploy_additional_vault().await?;
+    assert_ne!(eth_vault_address, base_evm.vault_address);
+
     let mock_alpaca = MockServer::start();
     let mint_callback_mock =
         harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
@@ -41,7 +51,7 @@ async fn test_multichain_mint_routes_by_network()
     .await?;
     harness::preseed_tokenized_asset_into_pool_with_network(
         &pool,
-        eth_evm.vault_address,
+        eth_vault_address,
         "TSLA",
         "tTSLA",
         Network::Ethereum,
@@ -54,6 +64,7 @@ async fn test_multichain_mint_routes_by_network()
         &mock_alpaca,
         &base_evm,
         &eth_evm,
+        eth_vault_address,
     )?;
 
     let rocket = initialize_rocket(config).await?;
@@ -67,7 +78,14 @@ async fn test_multichain_mint_routes_by_network()
     let bot_wallet = base_evm.wallet_address;
 
     harness::setup_roles(&base_evm, user_wallet, bot_wallet).await?;
-    harness::setup_roles(&eth_evm, user_wallet, bot_wallet).await?;
+    harness::setup_roles_on_vault(
+        &eth_evm,
+        eth_authorizer_address,
+        eth_vault_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
 
     let link_body = harness::setup_account(&client, user_wallet).await;
 
@@ -87,7 +105,7 @@ async fn test_multichain_mint_routes_by_network()
         .connect(&eth_evm.endpoint)
         .await?;
     let eth_vault = OffchainAssetReceiptVaultInstance::new(
-        eth_evm.vault_address,
+        eth_vault_address,
         &eth_provider,
     );
 

--- a/tests/multichain_receipt_backfill.rs
+++ b/tests/multichain_receipt_backfill.rs
@@ -1,0 +1,171 @@
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{U256, b256};
+use alloy::providers::ProviderBuilder;
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::time::Duration;
+
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{ETHEREUM_TEST_CHAIN_ID, Network, initialize_rocket};
+
+/// Verifies receipt startup backfill discovers receipts through each asset's
+/// own chain provider.
+///
+/// The receipt is minted BEFORE the service starts, on a vault deployed as an
+/// additional instance on the Ethereum chain -- its address differs from
+/// `base_evm.vault_address` and the contract exists ONLY on the Ethereum
+/// chain, so a lookup through the wrong (Base) provider could never find it.
+/// Because the mint pre-dates the service, live receipt monitoring never sees
+/// the deposit; only the startup backfill, querying the Ethereum RPC, can put
+/// the receipt into inventory. Burn planning draws exclusively on inventoried
+/// receipts, so the redemption burn completing proves the backfill discovered
+/// the receipt via the Ethereum provider.
+#[tokio::test]
+async fn test_multichain_receipt_backfill_uses_chain_provider()
+-> Result<(), Box<dyn std::error::Error>> {
+    let base_evm = LocalEvm::new().await?;
+    let eth_evm = LocalEvm::with_chain_id(ETHEREUM_TEST_CHAIN_ID).await?;
+    let (eth_vault_address, eth_authorizer_address) =
+        eth_evm.deploy_additional_vault().await?;
+    assert_ne!(
+        eth_vault_address, base_evm.vault_address,
+        "test precondition: the Ethereum vault address must not collide with \
+         the Base vault"
+    );
+
+    let mock_alpaca = MockServer::start();
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+    let bot_wallet = base_evm.wallet_address;
+
+    harness::setup_roles_on_vault(
+        &eth_evm,
+        eth_authorizer_address,
+        eth_vault_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
+
+    // Pre-start mint: receipt + shares land on the bot wallet. The shares
+    // then move to the user so the post-start transfer back to the bot can
+    // trigger a redemption, while the ERC-1155 receipt stays with the bot
+    // for the burn.
+    let mint_amount = U256::from(50) * U256::from(10).pow(U256::from(18));
+    let (_receipt_id, shares) = eth_evm
+        .mint_directly_on_vault(eth_vault_address, mint_amount, bot_wallet)
+        .await?;
+
+    let bot_signer = PrivateKeySigner::from_bytes(&eth_evm.private_key)?;
+    let bot_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(bot_signer))
+        .connect(&eth_evm.endpoint)
+        .await?;
+    let bot_vault_instance = OffchainAssetReceiptVaultInstance::new(
+        eth_vault_address,
+        &bot_provider,
+    );
+    bot_vault_instance
+        .transfer(user_wallet, shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("multichain_receipt_backfill.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
+    sqlx::migrate!("./migrations").run(&pool).await?;
+    harness::preseed_tokenized_asset_into_pool(
+        &pool,
+        base_evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+    harness::preseed_tokenized_asset_into_pool_with_network(
+        &pool,
+        eth_vault_address,
+        "TSLA",
+        "tTSLA",
+        Network::Ethereum,
+    )
+    .await?;
+    pool.close().await;
+
+    let (mut config, _mock_subgraph) =
+        harness::create_multichain_config_with_db(
+            &db_url,
+            &mock_alpaca,
+            &base_evm,
+            &eth_evm,
+            eth_vault_address,
+        )?;
+    // The periodic receipt backfill must never fire within this test's
+    // lifetime: it could discover the pre-start receipt and rescue a broken
+    // STARTUP backfill, which is the path this test exists to prove.
+    config.receipt_poll_interval = Duration::from_secs(3600);
+
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    harness::setup_account(&client, user_wallet).await;
+
+    // Transferring the shares back to the bot triggers redemption detection;
+    // the subsequent burn can only draw on the receipt that startup backfill
+    // discovered through the Ethereum provider.
+    let user_provider = ProviderBuilder::new()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&eth_evm.endpoint)
+        .await?;
+    let user_vault_instance = OffchainAssetReceiptVaultInstance::new(
+        eth_vault_address,
+        &user_provider,
+    );
+
+    // Baseline captured before the redemption trigger: any wrong-chain mint
+    // or burn during the redemption would move the Base vault's total supply.
+    // (The bot wallet never holds Base-vault shares in this test, so a
+    // balance check there would be trivially zero.)
+    let base_provider =
+        ProviderBuilder::new().connect(&base_evm.endpoint).await?;
+    let base_vault_instance = OffchainAssetReceiptVaultInstance::new(
+        base_evm.vault_address,
+        &base_provider,
+    );
+    let base_supply_before = base_vault_instance.totalSupply().call().await?;
+
+    user_vault_instance
+        .transfer(bot_wallet, shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    harness::wait_for_mock_hit(&redeem_mock).await?;
+    harness::wait_for_burn(&user_vault_instance, bot_wallet).await?;
+
+    assert_eq!(
+        base_vault_instance.totalSupply().call().await?,
+        base_supply_before,
+        "Base vault total supply must be unchanged by the Ethereum-vault \
+         redemption"
+    );
+
+    Ok(())
+}

--- a/tests/multichain_redemption.rs
+++ b/tests/multichain_redemption.rs
@@ -23,6 +23,16 @@ async fn test_multichain_redemption_routes_by_network()
     let base_evm = LocalEvm::new().await?;
     let eth_evm = LocalEvm::with_chain_id(ETHEREUM_TEST_CHAIN_ID).await?;
 
+    // Both Anvils deploy from the same key and nonce, so the default vault
+    // addresses collide across chains. Receipt inventory is keyed by
+    // `{chain_id}:{vault}`, so colliding addresses would not merge streams —
+    // but twin addresses would make the routing assertions vacuous. Deploy a
+    // distinct vault on the Ethereum chain so a wrong-chain call cannot
+    // masquerade as the right one.
+    let (eth_vault_address, eth_authorizer_address) =
+        eth_evm.deploy_additional_vault().await?;
+    assert_ne!(eth_vault_address, base_evm.vault_address);
+
     let mock_alpaca = MockServer::start();
     let mint_callback_mock =
         harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
@@ -51,7 +61,7 @@ async fn test_multichain_redemption_routes_by_network()
     .await?;
     harness::preseed_tokenized_asset_into_pool_with_network(
         &pool,
-        eth_evm.vault_address,
+        eth_vault_address,
         "TSLA",
         "tTSLA",
         Network::Ethereum,
@@ -64,6 +74,7 @@ async fn test_multichain_redemption_routes_by_network()
         &mock_alpaca,
         &base_evm,
         &eth_evm,
+        eth_vault_address,
     )?;
 
     let rocket = initialize_rocket(config).await?;
@@ -77,7 +88,14 @@ async fn test_multichain_redemption_routes_by_network()
     let bot_wallet = base_evm.wallet_address;
 
     harness::setup_roles(&base_evm, user_wallet, bot_wallet).await?;
-    harness::setup_roles(&eth_evm, user_wallet, bot_wallet).await?;
+    harness::setup_roles_on_vault(
+        &eth_evm,
+        eth_authorizer_address,
+        eth_vault_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
 
     let link_body = harness::setup_account(&client, user_wallet).await;
 
@@ -103,7 +121,7 @@ async fn test_multichain_redemption_routes_by_network()
         .connect(&eth_evm.endpoint)
         .await?;
     let eth_vault = OffchainAssetReceiptVaultInstance::new(
-        eth_evm.vault_address,
+        eth_vault_address,
         &eth_provider,
     );
 


### PR DESCRIPTION
## Motivation

Startup receipt backfill, periodic backfill, and startup reconciliation all
used the Base chain RPC for every vault, so multichain assets on other
networks never backfilled or reconciled correctly.

Implements RAI-1208. Stacked on #215.

## Solution

- `run_all_receipt_backfills` resolves each asset's provider and
  `backfill_start_block` from `ChainRegistry`
- Receipt backfill checkpoints are keyed per `(network, vault)` — block
  numbers are chain-specific — with legacy vault-only fallback for Base
- Startup reconciliation runs per vault on that vault's chain RPC
- Reconciliation failures retain the originating chain error, emit one DEBUG
  event per failed vault, and emit one WARN summary after all vaults are tried
- Periodic receipt backfill spawns one task per configured network (each fetches
  its own chain head)
- `tests/multichain_receipt_backfill.rs` launches Rocket, configures the account
  through the public API, triggers an Ethereum redemption, and verifies the
  Ethereum burn completes without changing Base supply

## Operational questions

- Which network and vault failed reconciliation, and why? Inspect the per-vault
  DEBUG event on the `receipt` target.
- How widespread was startup reconciliation failure? Inspect the WARN summary's
  `failed_vaults`, `total_vaults`, and first-failure fields.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Green locally:

- `nix develop -c cargo test --workspace`
- `nix develop -c cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `nix develop -c cargo fmt --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved multichain receipt backfill and redemption routing so each network uses the correct vault and chain provider.
  - Prevented checkpoint data from one network from affecting another.
  - Added safe legacy checkpoint fallback for Base network data.
  - Ensured polling resumes correctly and does not move backward.

- **Tests**
  - Added coverage for independent multichain checkpoints, minting, redemptions, and receipt backfills.
  - Increased mock-operation wait time to improve test reliability.

- **Documentation**
  - Updated multichain checkpointing behavior and network-specific storage details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
