### PR TITLE
ops: add multichain staging validation runbook and smoke script

### DIFF
--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -124,6 +124,12 @@ impl std::fmt::Display for TokenSymbol {
 pub enum Network {
     Base,
     /// Ethereum L1.
+    ///
+    /// The wire value `"ethereum"` follows the Alpaca ITN issuer guide's
+    /// `network` enum
+    /// (<https://docs.alpaca.markets/docs/tokenization-guide-for-issuer>);
+    /// the staging sandbox mint/redeem validation confirms it against live
+    /// Alpaca before any production cutover.
     Ethereum,
 }
 
@@ -500,6 +506,7 @@ mod tests {
     fn network_from_str_parses_wire_values() {
         assert_eq!("base".parse::<Network>().unwrap(), Network::Base);
         assert_eq!("ethereum".parse::<Network>().unwrap(), Network::Ethereum);
+        assert!("arbitrum".parse::<Network>().is_err());
     }
 
     #[test]

--- a/docs/runbooks/multichain-staging-validation.md
+++ b/docs/runbooks/multichain-staging-validation.md
@@ -1,0 +1,208 @@
+# Multichain staging validation runbook (RAI-1210)
+
+Manual Alpaca **sandbox** end-to-end on a second ITN `network` wire (default:
+`ethereum`). CI Anvil tests cover routing logic; this runbook proves the
+deployed stack against real Alpaca + chain B infrastructure.
+
+## External gates (must be green before starting)
+
+| Issue                                                                                                               | What                                                              |
+| ------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
+| [RAI-1099](https://linear.app/makeitrain/issue/RAI-1099)                                                            | Alpaca sandbox issuer enabled on target `network`                 |
+| [RAI-1095](https://linear.app/makeitrain/issue/RAI-1095) / [RAI-1096](https://linear.app/makeitrain/issue/RAI-1096) | Chain B vault deployed and permissioned                           |
+| [RAI-1100](https://linear.app/makeitrain/issue/RAI-1100)-[RAI-1104](https://linear.app/makeitrain/issue/RAI-1104)   | RPC, Turnkey/local signing, gas, subgraph URL for chain B         |
+| [RAI-1212](https://linear.app/makeitrain/issue/RAI-1212)                                                            | Liquidity freeze guard sends `?network=` (lockstep with RAI-1205) |
+
+Issuance multichain code (RAI-1204-1208) must be on the staging host. If
+upgrading an existing single-chain DB, run
+[`tokenized-asset-aggregate-rekey.md`](tokenized-asset-aggregate-rekey.md)
+first.
+
+**Additionally:** production/staging parsing of multichain chain config
+(`CHAIN_ETHEREUM_*` / `[[chains]]` -> a second `ChainRegistry` entry) is **not
+yet implemented** -- `Config::chains` only ever holds the single Base entry
+mapped from the legacy env vars; extra entries are appended by the test harness
+alone. This runbook is not executable until that config path lands; treat it as
+a blocking gate alongside the table above.
+
+## 1. Staging config checklist
+
+On the staging host, confirm:
+
+- **Base (legacy block):** `RPC_URL`, `CHAIN_ID=8453`, `SUBGRAPH_URL`,
+  `BACKFILL_START_BLOCK` -- unchanged from pre-multichain.
+- **Ethereum registry entry:** second chain wired (via deploy secrets / planned
+  `CHAIN_ETHEREUM_*` env -- the shape is documented in `.env.secrets.example`
+  and the SPEC.md Multi-chain section). A live asset whose network has no
+  registry entry **aborts startup** (the process exits with a
+  `network ethereum is not configured` error in the failure chain) -- there is
+  no running-but-degraded state to grep for; if the service is up, this check
+  passed.
+- **Signing backend:** exactly one of Turnkey (`TURNKEY_ORG_ID`,
+  `TURNKEY_API_PRIVATE_KEY`, `TURNKEY_ADDRESS`) or local dev (`EVM_PRIVATE_KEY`)
+  — see `src/wallet/mod.rs` and `.env.secrets.example`. The bot address must be
+  permissioned to sign burns on **both** chains.
+- **Bot wallet** funded with native gas on **both** chains.
+
+Record the chain B vault address from
+[RAI-1095](https://linear.app/makeitrain/issue/RAI-1095) deploy output -- needed
+for asset registration below.
+
+## 2. Preflight (issuance HTTP)
+
+From a host that can reach staging with the internal API key. The preflight,
+register, and verify commands all hit `InternalAuth` endpoints, which require
+**both** a valid `X-API-KEY` **and** a client IP inside `INTERNAL_IP_RANGES`
+(default: localhost + Docker ranges only) -- a whitelisted key from a
+non-whitelisted host gets **403**, which the script reports as an unexpected
+status. Run from the staging host itself or a bastion whose IP is in
+`INTERNAL_IP_RANGES`:
+
+```bash
+export ISSUER_BASE_URL=https://staging-issuance.example   # adjust
+export ISSUER_API_KEY=...                                   # internal key
+./scripts/multichain-staging-smoke.nu preflight
+# If the execute bit is missing on the checkout, invoke through nu instead:
+# nu ./scripts/multichain-staging-smoke.nu preflight
+```
+
+Expect:
+
+- `GET .../status?network=base` -> **200** for a known Base asset (**404** if
+  staging has no Base asset registered -- the script accepts either).
+- `GET .../status` without `?network=` -> **422**.
+- `GET .../status?network=ethereum` -> **200** or **404** (404 before
+  registration).
+
+## 3. Base parity smoke
+
+Before exercising chain B, confirm Base-only behaviour is unchanged:
+
+1. Alpaca sandbox **mint on `base`** for an existing asset (e.g. smoke symbol
+   used in staging today).
+2. Confirm journal -> on-chain mint -> callback completes (existing monitoring).
+3. Optional: sandbox **redeem on `base`** and verify burn on Base.
+
+If Base regresses, stop -- do not proceed to chain B.
+
+## 4. Register chain B asset
+
+**Do not register before the Ethereum chain config is live** (section 1
+checklist complete). `POST /tokenized-assets` rejects an unconfigured `network`
+with **422** before any event is written (`ConfiguredNetworks` guard in
+`src/tokenized_asset/api.rs`), so a failed registration attempt leaves nothing
+to remediate. Once config is present and registration succeeds, the
+`TokenizedAsset` is persisted immediately; on the next process start, startup
+validation requires every live asset's network to have a registry entry.
+
+**Back up the staging database first.** A successful registration is the first
+irreversible step of this runbook (see "If validation fails" below): copy the
+SQLite file (e.g. `cp issuance.db issuance.db.pre-chain-b`) while the service is
+stopped or idle, so a full back-out stays possible.
+
+Register the RAI-1095 vault on `ethereum` (replace symbols / vault):
+
+```bash
+export STAGING_UNDERLYING=TSLA
+export STAGING_TOKEN=tTSLA
+export STAGING_ETHEREUM_VAULT=0x...   # chain B vault from RAI-1095
+
+./scripts/multichain-staging-smoke.nu register-ethereum-asset
+./scripts/multichain-staging-smoke.nu verify-ethereum-asset
+```
+
+Optionally, from an Alpaca-whitelisted IP, run
+`./scripts/multichain-staging-smoke.nu verify-token-list` to confirm ITN list
+merge (`networks[]` includes `ethereum` for the test row).
+
+**Then restart the issuance service before proceeding.** Transfer pollers are
+spawned once at startup, per network that has at least one **live** asset on
+that network at boot (`list_enabled_assets`: `Enabled` or `Frozen` — same set
+startup validation walks). The ethereum asset did not exist when the service
+came up, so no ethereum poller is running and the redeem in section 6 would
+never be detected. After the restart, confirm the startup log shows
+`Spawning transfer poller for network` with `network=ethereum`. Note the
+checkpoint behaviour: a first-ever ethereum poll has no `transfer_poll:ethereum`
+checkpoint and starts scanning from that chain's `backfill_start_block`, so set
+it near the current head block to avoid a long historic scan.
+
+## 5. Alpaca sandbox mint on `ethereum`
+
+This step is **Alpaca-driven** -- issuance receives ITN callbacks; you do not
+POST mint initiate yourself.
+
+1. In Alpaca sandbox, start a tokenization **mint** with `"network": "ethereum"`
+   for the registered `(underlying, token)`.
+2. Watch issuance logs for the mint progressing through submit, confirm, and
+   callback (entries carry the `issuer_request_id`). The mint path does not log
+   a `network` field, so the routing proof is the on-chain check below.
+3. Verify on-chain: share balance increased on the **Ethereum** vault
+   (Etherscan), not Base. This is the authoritative wrong-chain check.
+4. Confirm Alpaca received a successful mint callback.
+
+Failure modes:
+
+| Symptom                       | Likely cause                                                 |
+| ----------------------------- | ------------------------------------------------------------ |
+| Mint stuck in `MintingFailed` | Wrong-chain RPC, signer misconfiguration, or gas on Ethereum |
+| Callback never sent           | Alpaca API error -- check issuance `alpaca` logs             |
+| Shares on wrong chain         | Registry misconfiguration -- see RAI-1206                    |
+
+Use `GET /admin/stuck` (see [`ops-recovery-guide.md`](../ops-recovery-guide.md))
+if a mint does not reach a terminal state.
+
+## 6. Alpaca sandbox redeem on `ethereum`
+
+1. Ensure the test wallet holds chain B shares from step 5.
+2. In Alpaca sandbox, initiate **redeem** with `"network": "ethereum"`.
+3. User sends shares to the bot wallet on the **Ethereum** vault (Alpaca flow).
+4. Watch issuance logs:
+   - The post-registration restart (section 4) logged
+     `Spawning transfer poller for network` with `network=ethereum` at startup.
+   - Successful detection logs `Redemption transfer detected` with
+     `issuer_request_id` (the value is the tx hash; the field name is not
+     `tx_hash`) and `from`.
+   - `Alpaca redeem API call succeeded` carries `network=ethereum`.
+   - Burn submits on Ethereum RPC via the Turnkey/local signer, not Base —
+     confirmed by the on-chain balance check below.
+5. Confirm Alpaca redeem completes and on-chain balance decreased on Ethereum.
+
+## If validation fails
+
+- **Stuck mint or redemption:** use `GET /admin/stuck` and the recovery
+  endpoints per [`ops-recovery-guide.md`](../ops-recovery-guide.md). Recovery
+  routes by the aggregate's persisted `network`, so recovering a chain B
+  aggregate acts on chain B — it cannot touch Base state.
+- **Retrying:** no de-registration is needed. `register-ethereum-asset` GETs the
+  asset first and skips POST when token/vault/network already match; it aborts
+  on mismatch (a different vault emits `VaultAddressUpdated` on re-POST, and
+  token typos are not compared server-side). A failed mint/redeem can be
+  re-driven after recovery without touching the asset.
+- **Do not remove the `CHAIN_ETHEREUM_*` config while the ethereum asset
+  exists.** There is no de-listing command, and freezing does not help: startup
+  validation checks every live asset — frozen included — against the registry,
+  so pulling the chain config after registration leaves the host unable to boot
+  (the premature-registration warning in section 4 applies in reverse).
+- **Full back-out:** stop the service, restore the database from the
+  pre-registration backup taken in section 4, and only then remove the chain B
+  config. This is the only supported way to unwind the registration itself.
+
+## 7. Close-out checklist (RAI-1210 done)
+
+- [ ] Preflight script green on staging.
+- [ ] Base parity mint (and optionally redeem) unchanged.
+- [ ] Chain B asset registered; ITN list shows expected `networks[]`.
+- [ ] Alpaca sandbox mint on `ethereum` completed end-to-end.
+- [ ] Alpaca sandbox redeem on `ethereum` completed end-to-end.
+- [ ] No stuck mints/redemptions (`/admin/stuck` empty or explained).
+- [ ] Linear [RAI-1210](https://linear.app/makeitrain/issue/RAI-1210) updated
+      with date, staging host, and test asset symbols.
+- [ ] Umbrella [RAI-1098](https://linear.app/makeitrain/issue/RAI-1098) and gate
+      [RAI-1200](https://linear.app/makeitrain/issue/RAI-1200) closed with PR
+      links once all MVP success criteria on RAI-1098 are met.
+
+## References
+
+- [`docs/ops-recovery-guide.md`](../ops-recovery-guide.md) -- stuck tx recovery
+- [`tokenized-asset-aggregate-rekey.md`](tokenized-asset-aggregate-rekey.md) --
+  DB cutover before multichain deploy

--- a/docs/runbooks/multichain-staging-validation.md
+++ b/docs/runbooks/multichain-staging-validation.md
@@ -116,15 +116,17 @@ Optionally, from an Alpaca-whitelisted IP, run
 merge (`networks[]` includes `ethereum` for the test row).
 
 **Then restart the issuance service before proceeding.** Transfer pollers are
-spawned once at startup, per network that has at least one **live** asset on
-that network at boot (`list_enabled_assets`: `Enabled` or `Frozen` — same set
-startup validation walks). The ethereum asset did not exist when the service
-came up, so no ethereum poller is running and the redeem in section 6 would
-never be detected. After the restart, confirm the startup log shows
-`Spawning transfer poller for network` with `network=ethereum`. Note the
-checkpoint behaviour: a first-ever ethereum poll has no `transfer_poll:ethereum`
-checkpoint and starts scanning from that chain's `backfill_start_block`, so set
-it near the current head block to avoid a long historic scan.
+spawned once at startup, per network that has at least one live listing on that
+network at boot (`list_enabled_assets` — same set startup validation walks;
+underlying freeze does not remove a listing from this set, so a frozen-only
+network still gets a poller and still blocks boot if unconfigured). The ethereum
+asset did not exist when the service came up, so no ethereum poller is running
+and the redeem in section 6 would never be detected. After the restart, confirm
+the startup log shows `Spawning transfer poller for network` with
+`network=ethereum`. Note the checkpoint behaviour: a first-ever ethereum poll
+has no `transfer_poll:ethereum` checkpoint and starts scanning from that chain's
+`backfill_start_block`, so set it near the current head block to avoid a long
+historic scan.
 
 ## 5. Alpaca sandbox mint on `ethereum`
 

--- a/scripts/multichain-staging-smoke.nu
+++ b/scripts/multichain-staging-smoke.nu
@@ -1,0 +1,249 @@
+#!/usr/bin/env nu
+# Preflight and registration helpers for multichain staging validation (RAI-1210).
+# See docs/runbooks/multichain-staging-validation.md.
+
+def base-url []: nothing -> string {
+    $env.ISSUER_BASE_URL? | default "http://localhost:8000"
+}
+
+def api-key []: nothing -> string {
+    let key = $env.ISSUER_API_KEY?
+    if $key == null {
+        error make {msg: "set ISSUER_API_KEY"}
+    }
+    $key
+}
+
+def staging-underlying []: nothing -> string {
+    $env.STAGING_UNDERLYING? | default "TSLA"
+}
+
+def staging-token []: nothing -> string {
+    $env.STAGING_TOKEN? | default "tTSLA"
+}
+
+def auth-headers []: nothing -> list<string> {
+    [X-API-KEY (api-key)]
+}
+
+def fetch-status [url: string]: nothing -> int {
+    (
+        http get --headers (auth-headers) --full --allow-errors
+            --max-time 10sec $url
+    ).status
+}
+
+# HTTP checks for the ?network= contract.
+def "main preflight" [] {
+    let base = (base-url)
+    let underlying = (staging-underlying)
+    print $"== Preflight: ($base) =="
+
+    let status_base = (
+        fetch-status $"($base)/tokenized-assets/($underlying)/status?network=base"
+    )
+    print $"GET .../status?network=base -> ($status_base) \(expect 200 or 404\)"
+    if $status_base not-in [200 404] {
+        error make {msg: "unexpected status for base network query"}
+    }
+
+    let status_missing = (
+        fetch-status $"($base)/tokenized-assets/($underlying)/status"
+    )
+    print $"GET .../status \(no ?network=\) -> ($status_missing) \(expect 422\)"
+    if $status_missing != 422 {
+        error make {msg: "missing ?network= must return 422"}
+    }
+
+    let status_eth = (
+        fetch-status $"($base)/tokenized-assets/($underlying)/status?network=ethereum"
+    )
+    print $"GET .../status?network=ethereum -> ($status_eth) \(expect 200 or 404\)"
+    if $status_eth not-in [200 404] {
+        error make {msg: "unexpected status for ethereum network query"}
+    }
+
+    print "Preflight OK"
+}
+
+# POST the chain B vault (needs STAGING_ETHEREUM_VAULT). GETs first and skips
+# POST when token/vault/network already match; aborts on mismatch.
+def "main register-ethereum-asset" [] {
+    let vault = $env.STAGING_ETHEREUM_VAULT?
+    if $vault == null {
+        error make {msg: "set STAGING_ETHEREUM_VAULT to the chain B vault address"}
+    }
+
+    let base = (base-url)
+    let underlying = (staging-underlying)
+    let token = (staging-token)
+    print $"== Register ($underlying) on ethereum =="
+
+    let detail_url = $"($base)/tokenized-assets/($underlying)?network=ethereum"
+    let existing = (
+        http get --headers (auth-headers) --full --allow-errors
+            --max-time 10sec $detail_url
+    )
+
+    if $existing.status == 200 {
+        let body = $existing.body
+        let registered_vault = ($body.vault? | default "" | str downcase)
+        let registered_token = ($body.token? | default "")
+        let registered_network = ($body.network? | default "")
+
+        if $registered_vault != ($vault | str downcase) {
+            error make {
+                msg: $"ethereum asset already registered with vault ($registered_vault), refusing ($vault)"
+            }
+        }
+        if $registered_token != $token {
+            error make {
+                msg: $"ethereum asset already registered with token ($registered_token), refusing ($token)"
+            }
+        }
+        if $registered_network != "ethereum" {
+            error make {
+                msg: $"ethereum asset has unexpected network ($registered_network)"
+            }
+        }
+
+        print "Asset already registered with matching token/vault/network; skipping POST"
+        return
+    }
+
+    if $existing.status != 404 {
+        error make {
+            msg: $"unexpected GET before register: ($existing.status) ($existing.body)"
+        }
+    }
+
+    let response = (
+        http post
+            --content-type application/json
+            --headers (auth-headers)
+            --full --allow-errors
+            --max-time 10sec
+            $"($base)/tokenized-assets"
+            {
+                underlying: $underlying,
+                token: $token,
+                network: "ethereum",
+                vault: $vault,
+            }
+    )
+    print $"POST /tokenized-assets -> ($response.status) \(expect 201\)"
+    if $response.status != 201 {
+        error make {
+            msg: $"asset registration failed: ($response.status) ($response.body)"
+        }
+    }
+}
+
+# GET the internal asset detail with ?network=ethereum (expect 200) and
+# confirm the registered vault matches STAGING_ETHEREUM_VAULT.
+def "main verify-ethereum-asset" [] {
+    let vault = $env.STAGING_ETHEREUM_VAULT?
+    if $vault == null {
+        error make {msg: "set STAGING_ETHEREUM_VAULT to the chain B vault address"}
+    }
+
+    let base = (base-url)
+    let underlying = (staging-underlying)
+    print "== Verify chain B asset registered =="
+
+    let response = (
+        http get --headers (auth-headers) --full --allow-errors
+            --max-time 10sec
+            $"($base)/tokenized-assets/($underlying)?network=ethereum"
+    )
+    print $"GET .../($underlying)?network=ethereum -> ($response.status) \(expect 200\)"
+    if $response.status != 200 {
+        error make {
+            msg: $"ethereum asset detail not found: ($response.status) ($response.body)"
+        }
+    }
+
+    let registered_vault = ($response.body.vault? | default "" | str downcase)
+    if $registered_vault != ($vault | str downcase) {
+        error make {
+            msg: $"registered vault ($registered_vault) does not match STAGING_ETHEREUM_VAULT ($vault)"
+        }
+    }
+
+    let registered_token = ($response.body.token? | default "")
+    if $registered_token != (staging-token) {
+        error make {
+            msg: $"registered token ($registered_token) does not match STAGING_TOKEN ((staging-token))"
+        }
+    }
+
+    print ($response.body | to json)
+}
+
+# GET the ITN token list -- Alpaca auth, run from an Alpaca-whitelisted IP.
+def "main verify-token-list" [] {
+    let base = (base-url)
+    let underlying = (staging-underlying)
+    let token = (staging-token)
+    print "== Verify ITN token list (Alpaca auth -- run from Alpaca IP range) =="
+
+    let response = (
+        http get --headers (auth-headers) --full --allow-errors
+            --max-time 10sec
+            $"($base)/tokenized-assets"
+    )
+    print $"GET /tokenized-assets -> ($response.status) \(expect 200\)"
+    if $response.status != 200 {
+        error make {
+            msg: $"token list request failed: ($response.status) ($response.body)"
+        }
+    }
+
+    let body = $response.body
+    print ($body | to json)
+
+    let matching_rows = (
+        $body.tokens?
+        | default []
+        | where underlying == $underlying and token == $token
+    )
+    if ($matching_rows | length) != 1 {
+        error make {
+            msg: $"expected exactly 1 token-list row for ($underlying)/($token), found ($matching_rows | length)"
+        }
+    }
+
+    let networks = (
+        $matching_rows
+        | first
+        | get networks?
+        | default []
+    )
+    if "ethereum" not-in $networks {
+        error make {
+            msg: $"token list row for ($underlying)/($token) missing network ethereum"
+        }
+    }
+
+    print $"Token list includes ethereum for ($underlying)/($token)"
+}
+
+def main [] {
+    print -e "Usage: multichain-staging-smoke.nu <command>
+
+Commands:
+  preflight                 HTTP checks for the ?network= contract
+  register-ethereum-asset   POST chain B vault after GET pre-check (needs
+                            STAGING_ETHEREUM_VAULT)
+  verify-ethereum-asset     GET internal detail ?network=ethereum and check
+                            token and vault (needs STAGING_ETHEREUM_VAULT)
+  verify-token-list         GET ITN list -- Alpaca IP whitelist only
+
+Environment:
+  ISSUER_BASE_URL           default http://localhost:8000
+  ISSUER_API_KEY            required
+  STAGING_UNDERLYING        default TSLA
+  STAGING_TOKEN             default tTSLA
+  STAGING_ETHEREUM_VAULT    required for register/verify-ethereum-asset"
+    exit 1
+}


### PR DESCRIPTION
## Motivation

RAI-1210 closes the multichain MVP with manual Alpaca sandbox validation on a
second ITN `network` wire. Operators need a repeatable runbook and HTTP helpers
before triggering Alpaca sandbox mint/redeem flows on staging.

Implements RAI-1210. Stacks on the config-templates branch (#218).

## Solution

- Add `docs/runbooks/multichain-staging-validation.md` — external gates, Base
  parity, chain B registration (including the restart-after-registration step
  and the premature-registration boot-abort warning), Alpaca sandbox
  mint/redeem steps, close-out checklist
- Add `scripts/multichain-staging-smoke.nu` — preflight `?network=` checks,
  register/verify ethereum asset via internal auth
- Document the `"ethereum"` wire value's Alpaca ITN issuer-guide provenance on
  `Network::Ethereum` and pin an unsupported-network parse rejection in tests

## Test plan

- [x] `cargo test -p st0x-issuance-dto network_from_str`
- [ ] Execute runbook on staging once RAI-1099 + chain B infra gates are green

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Multichain staging validation” runbook for end-to-end Ethereum-backed sandbox checks.
  * Introduced an authenticated multichain staging smoke script to preflight, register, and verify Ethereum assets.
* **Bug Fixes**
  * Improved validation for supported network wire values, ensuring unsupported values fail parsing.
* **Documentation**
  * Expanded guidance on the Ethereum wire value’s staging validation behavior and operational failure/recovery steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->