### PR TITLE
fix: retry Alpaca redeem calls and tolerate absent tx_hash in poll responses

### DIFF
--- a/src/alpaca/mod.rs
+++ b/src/alpaca/mod.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, TxHash};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use rust_decimal::Decimal;
@@ -157,31 +157,39 @@ pub(crate) enum TokenizationRequest {
         wallet: Address,
         #[serde(
             rename = "tx_hash",
+            default,
             deserialize_with = "deserialize_optional_b256"
         )]
-        tx_hash: Option<B256>,
+        tx_hash: Option<TxHash>,
         updated_at: Option<DateTime<Utc>>,
     },
 }
 
 fn deserialize_optional_b256<'de, D>(
     deserializer: D,
-) -> Result<Option<B256>, D::Error>
+) -> Result<Option<TxHash>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
-    let s: String = serde::Deserialize::deserialize(deserializer)?;
-    if s.is_empty() {
-        Ok(None)
-    } else {
-        s.parse().map(Some).map_err(serde::de::Error::custom)
+    // Alpaca returns an empty string for a still-Pending redeem's tx_hash
+    // (observed in production polling); JSON `null` and an omitted field
+    // (handled by `#[serde(default)]` on the field) are tolerated defensively,
+    // not observed behavior. Treat all three as `None`; only a non-empty
+    // string is parsed as a hash. A type error here would surface as a
+    // non-retryable `Parse` error and stall an otherwise-healthy redemption.
+    let opt: Option<String> = serde::Deserialize::deserialize(deserializer)?;
+    match opt.as_deref() {
+        None | Some("") => Ok(None),
+        Some(value) => {
+            value.parse().map(Some).map_err(serde::de::Error::custom)
+        }
     }
 }
 
 /// Errors that can occur during Alpaca API operations.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum AlpacaError {
-    #[error("Reqwest error")]
+    #[error("Reqwest error: {0}")]
     Reqwest(#[from] reqwest::Error),
     /// Failed to parse response after 200 OK - NOT retryable
     #[error("Failed to parse response: {source}")]
@@ -420,5 +428,34 @@ mod tests {
         assert_eq!(requests.len(), 2);
         assert!(matches!(requests[0], TokenizationRequest::Mint { .. }));
         assert!(matches!(requests[1], TokenizationRequest::Redeem { .. }));
+    }
+
+    #[test]
+    fn test_redeem_deserializes_absent_null_and_empty_tx_hash_as_none() {
+        // A still-Pending redeem's tx_hash arrives as an empty string
+        // (observed); JSON null and an omitted field are tolerated
+        // defensively. All three must deserialize to None rather than a
+        // non-retryable Parse error that would stall the redemption.
+        let base = r#"{"tokenization_request_id":"00000000-0000-0000-0000-000000000001","issuer_request_id":"0x1111111111111111111111111111111111111111111111111111111111111111","type":"redeem","status":"pending","underlying_symbol":"SPYM","token_symbol":"tSPYM","qty":"0.1","wallet_address":"0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","updated_at":"2026-06-11T04:02:33.530523Z""#;
+
+        for tx_hash_field in ["", r#","tx_hash":null"#, r#","tx_hash":"""#] {
+            let json = format!("{base}{tx_hash_field}}}");
+            let parsed: TokenizationRequest = serde_json::from_str(&json)
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "failed to parse with tx_hash `{tx_hash_field}`: {err}"
+                    )
+                });
+
+            match parsed {
+                TokenizationRequest::Redeem { tx_hash, .. } => assert_eq!(
+                    tx_hash, None,
+                    "tx_hash `{tx_hash_field}` should deserialize to None"
+                ),
+                other @ TokenizationRequest::Mint { .. } => {
+                    panic!("expected Redeem, got {other:?}")
+                }
+            }
+        }
     }
 }

--- a/src/alpaca/service.rs
+++ b/src/alpaca/service.rs
@@ -205,41 +205,56 @@ impl AlpacaService for RealAlpacaService {
 
         debug!(target: "alpaca", %url, method = "POST", "Calling Alpaca redeem endpoint");
 
-        let response = self
-            .client
-            .post(&url)
-            .basic_auth(&self.api_key, Some(&self.api_secret))
-            .header("APCA-API-KEY-ID", &self.api_key)
-            .header("APCA-API-SECRET-KEY", &self.api_secret)
-            .json(&request)
-            .send()
-            .await?;
+        (|| async {
+            let response = self
+                .client
+                .post(&url)
+                .basic_auth(&self.api_key, Some(&self.api_secret))
+                .header("APCA-API-KEY-ID", &self.api_key)
+                .header("APCA-API-SECRET-KEY", &self.api_secret)
+                .json(&request)
+                .send()
+                .await?;
 
-        let status = response.status();
+            let status = response.status();
 
-        match status {
-            reqwest::StatusCode::OK => {
-                let body = response.text().await?;
-                serde_json::from_str(&body).map_err(|e| {
-                    tracing::error!(
-                        target: "alpaca",
-                        %body,
-                        error = %e,
-                        "Failed to parse Alpaca redeem response"
-                    );
-                    AlpacaError::Parse { body, source: e }
-                })
+            match status {
+                reqwest::StatusCode::OK => {
+                    let body = response.text().await?;
+                    serde_json::from_str(&body).map_err(|e| {
+                        tracing::error!(
+                            target: "alpaca",
+                            %body,
+                            error = %e,
+                            "Failed to parse Alpaca redeem response"
+                        );
+                        AlpacaError::Parse { body, source: e }
+                    })
+                }
+                reqwest::StatusCode::UNAUTHORIZED
+                | reqwest::StatusCode::FORBIDDEN => {
+                    let body = response.text().await?;
+                    Err(AlpacaError::Auth(body))
+                }
+                status => {
+                    let body = response.text().await?;
+                    Err(AlpacaError::Api { status_code: status.as_u16(), body })
+                }
             }
-            reqwest::StatusCode::UNAUTHORIZED
-            | reqwest::StatusCode::FORBIDDEN => {
-                let body = response.text().await?;
-                Err(AlpacaError::Auth(body))
-            }
-            status => {
-                let body = response.text().await?;
-                Err(AlpacaError::Api { status_code: status.as_u16(), body })
-            }
-        }
+        })
+        .retry(
+            ExponentialBuilder::default()
+                .with_max_times(self.max_retries)
+                .with_jitter(),
+        )
+        .when(|e: &AlpacaError| e.is_retryable())
+        .notify(|err: &AlpacaError, dur: std::time::Duration| {
+            tracing::debug!(
+                target: "alpaca",
+                "Alpaca redeem call failed with {err}, retrying after {dur:?}"
+            );
+        })
+        .await
     }
 
     async fn poll_request_status(
@@ -378,6 +393,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_send_mint_callback_success() {
         let server = MockServer::start();
@@ -406,6 +422,13 @@ mod tests {
 
         assert!(result.is_ok());
         mock.assert();
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Sending mint callback to Alpaca", "test-account"]
+            ),
+            "expected DEBUG log with the account-scoped callback URL"
+        );
     }
 
     #[tokio::test]
@@ -610,6 +633,7 @@ mod tests {
         }
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_call_redeem_endpoint_success() {
         let server = MockServer::start();
@@ -662,6 +686,13 @@ mod tests {
         assert!(matches!(response.r#type, TokenizationRequestType::Redeem));
         assert!(matches!(response.status, RedeemRequestStatus::Pending));
         mock.assert();
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Calling Alpaca redeem endpoint", "test-account"]
+            ),
+            "expected DEBUG log with the account-scoped redeem URL"
+        );
     }
 
     #[tokio::test]
@@ -1038,6 +1069,13 @@ mod tests {
         );
         assert!(!err.is_retryable(), "RequestNotFound must not be retryable");
         mock.assert_calls(1);
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Polling Alpaca request status", "tok-NOT-FOUND"]
+            ),
+            "expected DEBUG poll log naming the tokenization request id"
+        );
     }
 
     #[tokio::test]
@@ -1484,5 +1522,48 @@ mod tests {
         assert!(matches!(err, AlpacaError::Parse { .. }));
         assert!(!err.is_retryable(), "Parse errors must NOT be retryable");
         mock.assert_calls(1);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_call_redeem_endpoint_retries_retryable_errors() {
+        // Regression: call_redeem_endpoint previously made a single HTTP call
+        // with no retry, so one transient 5xx from Alpaca permanently failed
+        // the redemption. It must retry retryable errors like the other
+        // endpoints do — here one retry means two calls total.
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1/accounts/test-account/tokenization/callback/redeem");
+            then.status(500).body("Internal Server Error");
+        });
+
+        let service = RealAlpacaService::new(
+            server.base_url(),
+            "test-account".to_string(),
+            "test-key".to_string(),
+            "test-secret".to_string(),
+            10,
+            30,
+        )
+        .unwrap()
+        .with_max_retries(1);
+
+        let request = create_redeem_request();
+        let result = service.call_redeem_endpoint(request).await;
+
+        assert!(matches!(
+            result,
+            Err(AlpacaError::Api { status_code: 500, .. })
+        ));
+        mock.assert_calls(2);
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Alpaca redeem call failed with", "retrying after"]
+            ),
+            "expected DEBUG retry log from the notify callback"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Two pre-existing Alpaca-path bugs, both found by the whole-repo audit, that can
terminalize an otherwise-healthy redemption on a single transient response:

- `call_redeem_endpoint` was the only Alpaca call with no retry wrapper (unlike
  `send_mint_callback` and `poll_request_status`). One transient 5xx or network
  blip recorded `AlpacaCallFailed` and stranded the redemption.
- `deserialize_optional_b256` deserialized `tx_hash` unconditionally as a
  `String`, so a JSON `null` or an omitted field produced a non-retryable
  `Parse` error rather than `None` — stalling polling of a still-Pending redeem
  until it timed out and was marked failed.

## Solution

- Wrap `call_redeem_endpoint` in the same `backon` exponential retry gated by
  `is_retryable()` that the sibling endpoints use.
- Deserialize `tx_hash` via `Option<String>` and add `#[serde(default)]`, so an
  empty string, `null`, or an absent field all map to `None`.
- Include the underlying reqwest error in `AlpacaError::Reqwest`'s Display so
  network failures are diagnosable from logs.
- Add regression tests (retry-on-5xx count; null/empty/absent tx_hash → None)
  and the missing `#[traced_test]` log assertions on the callback / redeem /
  not-found tests.

Deferred (blocked by in-flight PRs): giving `RedeemRequestStatus` /
`TokenizationRequestType` a `#[serde(other)]` catch-all requires editing
`admin.rs`, which #211/#221 rewrite.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs