### PR TITLE
fix: record mirror balance (not available) when recovering an ITN mint receipt

### DIFF
--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Bytes, TxHash, U256};
+use alloy::primitives::{Bytes, U256};
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::AggregateError;
@@ -209,8 +209,6 @@ pub(crate) enum BurnTrackingError {
 pub(crate) struct ReceiptWithBalance {
     pub(crate) receipt_id: ReceiptId,
     pub(crate) available_balance: Shares,
-    pub(crate) tx_hash: TxHash,
-    pub(crate) block_number: u64,
     pub(crate) receipt_info: Option<ReceiptInformation>,
     /// Original on-chain encoded bytes. Used to pass exact deposit bytes back
     /// to redeem(), avoiding re-encoding legacy JSON receipts as CBOR.
@@ -759,8 +757,6 @@ mod tests {
         let receipts = vec![ReceiptWithBalance {
             receipt_id: ReceiptId::from(uint!(1_U256)),
             available_balance: Shares::new(uint!(100_000000000000000000_U256)),
-            tx_hash: TxHash::ZERO,
-            block_number: 0,
             receipt_info: None,
             receipt_info_bytes: None,
         }];
@@ -794,8 +790,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     30_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -804,8 +798,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     40_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -814,8 +806,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     50_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -855,8 +845,6 @@ mod tests {
         let receipts = vec![ReceiptWithBalance {
             receipt_id: ReceiptId::from(uint!(1_U256)),
             available_balance: Shares::new(uint!(50_000000000000000000_U256)),
-            tx_hash: TxHash::ZERO,
-            block_number: 0,
             receipt_info: None,
             receipt_info_bytes: None,
         }];
@@ -883,16 +871,12 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     10079999999000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
             ReceiptWithBalance {
                 receipt_id: ReceiptId::from(uint!(124_U256)),
                 available_balance: Shares::new(uint!(1000000000_U256)),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -928,8 +912,6 @@ mod tests {
         let receipts = vec![ReceiptWithBalance {
             receipt_id: ReceiptId::from(uint!(131_U256)),
             available_balance: Shares::new(uint!(10079999999000000000_U256)),
-            tx_hash: TxHash::ZERO,
-            block_number: 0,
             receipt_info: None,
             receipt_info_bytes: None,
         }];
@@ -958,8 +940,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     10_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -968,8 +948,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     30_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -978,8 +956,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     60_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1027,8 +1003,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     100_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1037,8 +1011,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     50_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1091,8 +1063,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     40_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1101,8 +1071,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     50_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1163,8 +1131,6 @@ mod tests {
         let receipts = vec![ReceiptWithBalance {
             receipt_id: ReceiptId::from(uint!(1_U256)),
             available_balance: Shares::new(uint!(100_000000000000000000_U256)),
-            tx_hash: TxHash::ZERO,
-            block_number: 0,
             receipt_info: None,
             receipt_info_bytes: None,
         }];
@@ -1186,8 +1152,6 @@ mod tests {
             ReceiptWithBalance {
                 receipt_id: ReceiptId::from(uint!(1_U256)),
                 available_balance: Shares::new(U256::ZERO),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1196,8 +1160,6 @@ mod tests {
                 available_balance: Shares::new(uint!(
                     100_000000000000000000_U256
                 )),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             },
@@ -1228,8 +1190,6 @@ mod tests {
             ReceiptWithBalance {
                 receipt_id: ReceiptId::from(U256::from(id)),
                 available_balance: Shares::new(U256::from(balance)),
-                tx_hash: TxHash::ZERO,
-                block_number: 0,
                 receipt_info: None,
                 receipt_info_bytes: None,
             }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -508,20 +508,24 @@ impl ReceiptService for CqrsReceiptService {
             return Ok(None);
         };
 
-        let receipt = receipt_inventory
-            .receipts_with_balance()
-            .into_iter()
-            .find(|r| r.receipt_id == receipt_id)
-            .ok_or(ReceiptLookupError::Inconsistent {
+        // Recovery records how many shares the deposit actually created, which
+        // is the receipt's mirror balance. `available_balance` (mirror minus
+        // outstanding reservations) is the wrong source here: it is zero for a
+        // fully-reserved receipt, so recovering a mint whose receipt is reserved
+        // by a pending redemption would record `shares_minted = 0` for a real
+        // on-chain deposit.
+        let metadata = receipt_inventory.receipts.get(&receipt_id).ok_or(
+            ReceiptLookupError::Inconsistent {
                 issuer_request_id: issuer_request_id.clone(),
                 receipt_id,
-            })?;
+            },
+        )?;
 
         Ok(Some(RecoveredReceipt {
             receipt_id: receipt_id.inner(),
-            tx_hash: receipt.tx_hash,
-            shares: receipt.available_balance.inner(),
-            block_number: receipt.block_number,
+            tx_hash: metadata.tx_hash,
+            shares: metadata.balance.inner(),
+            block_number: metadata.block_number,
         }))
     }
 }
@@ -576,8 +580,6 @@ impl ReceiptInventory {
         ReceiptWithBalance {
             receipt_id,
             available_balance,
-            tx_hash: metadata.tx_hash,
-            block_number: metadata.block_number,
             receipt_info: metadata.receipt_info.clone(),
             receipt_info_bytes: metadata.receipt_info_bytes.clone(),
         }
@@ -1402,6 +1404,61 @@ mod tests {
         let inventory = load_inventory(&store, &vault).await.unwrap();
         let found = inventory.find_by_issuer_request_id(&issuer_request_id);
         assert_eq!(found, Some(make_receipt_id(42)));
+    }
+
+    #[tokio::test]
+    async fn test_recovery_reports_mirror_balance_for_fully_reserved_receipt() {
+        // Regression: a fully-reserved receipt has available_balance == 0, but
+        // its mirror balance (the real on-chain amount the deposit created) is
+        // intact. Recovery must report the mirror balance as `shares`, not the
+        // reserved-away available balance, or `ExistingMintRecovered` records
+        // `shares_minted == 0` for a real on-chain deposit.
+        let store = setup_store().await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let tx_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        store
+            .send(
+                &vault,
+                discover_itn_receipt_cmd(
+                    make_receipt_id(42),
+                    make_shares(100),
+                    1000,
+                    tx_hash,
+                    issuer_request_id.clone(),
+                ),
+            )
+            .await
+            .unwrap();
+
+        let service = CqrsReceiptService::new(store.clone());
+
+        service
+            .reserve_burn(
+                vault,
+                "red-00000001".parse().unwrap(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(42),
+                    shares_burned: U256::from(100),
+                }],
+            )
+            .await
+            .unwrap();
+
+        let recovered = service
+            .find_by_issuer_request_id(&vault, &issuer_request_id)
+            .await
+            .unwrap()
+            .expect("ITN receipt must be found by issuer_request_id");
+
+        assert_eq!(
+            recovered.shares,
+            U256::from(100),
+            "recovery must report the mirror balance, not the zero available balance of a fully-reserved receipt"
+        );
     }
 
     #[tokio::test]

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use event_sorcery::{EntityList, Never, Reactor, deps};
 use serde::{Deserialize, Serialize};
-use sqlx::{Pool, Sqlite, SqlitePool};
+use sqlx::{Pool, Sqlite, SqliteConnection, SqlitePool};
 use tracing::{debug, warn};
 
 use crate::mint::{IssuerMintRequestId, Mint, MintEvent};
@@ -32,10 +32,6 @@ pub(crate) async fn rebuild_receipt_inventory_view(
 ) -> Result<(), ReceiptInventoryViewError> {
     debug!(target: "receipt", "Rebuilding receipt inventory view from events");
 
-    sqlx::query!("DELETE FROM receipt_inventory_view").execute(pool).await?;
-
-    let reactor = ReceiptInventoryViewReactor::new(pool.clone());
-
     let rows = sqlx::query!(
         r#"
         SELECT
@@ -49,11 +45,32 @@ pub(crate) async fn rebuild_receipt_inventory_view(
     .fetch_all(pool)
     .await?;
 
-    for row in rows {
-        let mint_id: IssuerMintRequestId = row.aggregate_id.parse()?;
-        let event: MintEvent = serde_json::from_str(&row.payload)?;
-        reactor.project(&mint_id, &event).await;
+    // Parse every event before deleting anything, so a malformed row aborts the
+    // rebuild while the existing (possibly stale) rows are still intact rather
+    // than leaving the view table empty after the DELETE.
+    let events = rows
+        .into_iter()
+        .map(|row| -> Result<_, ReceiptInventoryViewError> {
+            let mint_id: IssuerMintRequestId = row.aggregate_id.parse()?;
+            let event: MintEvent = serde_json::from_str(&row.payload)?;
+            Ok((mint_id, event))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let mut transaction = pool.begin().await?;
+    sqlx::query!("DELETE FROM receipt_inventory_view")
+        .execute(&mut *transaction)
+        .await?;
+
+    for (mint_id, event) in events {
+        ReceiptInventoryViewReactor::project_on(
+            &mut transaction,
+            &mint_id,
+            &event,
+        )
+        .await?;
     }
+    transaction.commit().await?;
 
     debug!(target: "receipt", "Receipt inventory view rebuild complete");
 
@@ -149,6 +166,30 @@ impl ReceiptInventoryViewReactor {
     }
 
     async fn project(&self, mint_id: &IssuerMintRequestId, event: &MintEvent) {
+        let mut connection = match self.pool.acquire().await {
+            Ok(connection) => connection,
+            Err(error) => {
+                warn!(target: "receipt", view_id = %mint_id, error = %error,
+                    "Failed to acquire connection for receipt inventory view"
+                );
+                return;
+            }
+        };
+
+        if let Err(error) =
+            Self::project_on(&mut connection, mint_id, event).await
+        {
+            warn!(target: "receipt", view_id = %mint_id, error = %error,
+                "Failed to project receipt inventory view"
+            );
+        }
+    }
+
+    async fn project_on(
+        connection: &mut SqliteConnection,
+        mint_id: &IssuerMintRequestId,
+        event: &MintEvent,
+    ) -> Result<(), ReceiptInventoryViewError> {
         // Only these events transition the view; skip the rest to avoid a
         // pointless read-write cycle.
         if !matches!(
@@ -157,20 +198,11 @@ impl ReceiptInventoryViewReactor {
                 | MintEvent::TokensMinted { .. }
                 | MintEvent::ExistingMintRecovered { .. }
         ) {
-            return;
+            return Ok(());
         }
 
         let view_id = mint_id.to_string();
-
-        let current = match self.load(&view_id).await {
-            Ok(view) => view,
-            Err(error) => {
-                warn!(target: "receipt", view_id, error = %error,
-                    "Failed to load receipt inventory view; skipping update"
-                );
-                return;
-            }
-        };
+        let current = Self::load(connection, &view_id).await?;
 
         let updated = match event {
             MintEvent::Initiated { underlying, token, .. } => {
@@ -199,18 +231,14 @@ impl ReceiptInventoryViewReactor {
                 *shares_minted,
                 *recovered_at,
             ),
-            _ => return,
+            _ => return Ok(()),
         };
 
-        if let Err(error) = self.upsert(&view_id, &updated).await {
-            warn!(target: "receipt", view_id, error = %error,
-                "Failed to write receipt inventory view"
-            );
-        }
+        Self::upsert(connection, &view_id, &updated).await
     }
 
     async fn load(
-        &self,
+        connection: &mut SqliteConnection,
         view_id: &str,
     ) -> Result<ReceiptInventoryView, ReceiptInventoryViewError> {
         let row = sqlx::query!(
@@ -221,7 +249,7 @@ impl ReceiptInventoryViewReactor {
             "#,
             view_id
         )
-        .fetch_optional(&self.pool)
+        .fetch_optional(connection)
         .await?;
 
         match row {
@@ -231,7 +259,7 @@ impl ReceiptInventoryViewReactor {
     }
 
     async fn upsert(
-        &self,
+        connection: &mut SqliteConnection,
         view_id: &str,
         view: &ReceiptInventoryView,
     ) -> Result<(), ReceiptInventoryViewError> {
@@ -249,7 +277,7 @@ impl ReceiptInventoryViewReactor {
             payload,
             payload
         )
-        .execute(&self.pool)
+        .execute(connection)
         .await?;
 
         Ok(())
@@ -719,5 +747,194 @@ mod tests {
 
             assert_eq!(load_view(&pool, &mint_id).await, original_view);
         }
+    }
+
+    /// Inserts a raw `Mint` event row the way `rebuild_receipt_inventory_view`
+    /// reads it back (only `aggregate_id` and `payload` matter to the rebuild
+    /// query).
+    async fn insert_mint_event_row(
+        pool: &SqlitePool,
+        aggregate_id: &str,
+        sequence: i64,
+        payload: &str,
+    ) {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, ?, 'MintEvent', '1.0', ?, '{}')
+            ",
+        )
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(payload)
+        .execute(pool)
+        .await
+        .expect("Failed to insert event row");
+    }
+
+    async fn seed_view_row(
+        pool: &SqlitePool,
+        view_id: &str,
+        view: &ReceiptInventoryView,
+    ) {
+        let payload = serde_json::to_string(view).unwrap();
+        sqlx::query(
+            "
+            INSERT INTO receipt_inventory_view (view_id, version, payload)
+            VALUES (?, 1, ?)
+            ",
+        )
+        .bind(view_id)
+        .bind(&payload)
+        .execute(pool)
+        .await
+        .expect("Failed to seed view row");
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_replays_mint_events_and_replaces_stale_rows() {
+        let pool = migrated_pool().await;
+
+        let mint_id = IssuerMintRequestId::random();
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let token = TokenSymbol::new("tAAPL");
+        let receipt_id = uint!(42_U256);
+        let shares_minted = uint!(100_000000000000000000_U256);
+
+        let initiated = serde_json::to_string(&initiated_event(
+            underlying.clone(),
+            token.clone(),
+            "alp-rebuild",
+            address!("0x1234567890abcdef1234567890abcdef12345678"),
+        ))
+        .unwrap();
+        let minted = serde_json::to_string(&MintEvent::TokensMinted {
+            issuer_request_id: IssuerMintRequestId::random(),
+            tx_hash: b256!(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            ),
+            receipt_id,
+            shares_minted,
+            gas_used: 50000,
+            block_number: 1000,
+            minted_at: Utc::now(),
+        })
+        .unwrap();
+
+        let aggregate_id = mint_id.to_string();
+        insert_mint_event_row(&pool, &aggregate_id, 1, &initiated).await;
+        insert_mint_event_row(&pool, &aggregate_id, 2, &minted).await;
+
+        // A stale pre-rebuild row must be replaced by the replay, not kept.
+        let stale = ReceiptInventoryView::Pending {
+            underlying: UnderlyingSymbol::new("STALE"),
+            token: TokenSymbol::new("tSTALE"),
+        };
+        seed_view_row(&pool, &aggregate_id, &stale).await;
+
+        rebuild_receipt_inventory_view(&pool)
+            .await
+            .expect("rebuild must succeed on well-formed events");
+
+        let ReceiptInventoryView::Active {
+            receipt_id: view_receipt_id,
+            underlying: view_underlying,
+            initial_amount,
+            current_balance,
+            ..
+        } = load_view(&pool, &mint_id).await
+        else {
+            panic!("Expected Active variant after rebuild");
+        };
+        assert_eq!(view_receipt_id, receipt_id);
+        assert_eq!(view_underlying, underlying);
+        assert_eq!(initial_amount, shares_minted);
+        assert_eq!(current_balance, shares_minted);
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_aborts_without_clearing_view_on_malformed_event() {
+        let pool = migrated_pool().await;
+
+        // Existing view content that must survive a failed rebuild.
+        let survivor_id = IssuerMintRequestId::random();
+        let survivor_view = ReceiptInventoryView::Pending {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+        };
+        seed_view_row(&pool, &survivor_id.to_string(), &survivor_view).await;
+
+        let aggregate_id = IssuerMintRequestId::random().to_string();
+        insert_mint_event_row(&pool, &aggregate_id, 1, "not valid json").await;
+
+        let result = rebuild_receipt_inventory_view(&pool).await;
+        assert!(
+            matches!(
+                result,
+                Err(ReceiptInventoryViewError::Deserialization(_))
+            ),
+            "a malformed event payload must abort the rebuild, got {result:?}"
+        );
+
+        assert_eq!(
+            load_view(&pool, &survivor_id).await,
+            survivor_view,
+            "a failed rebuild must leave existing view rows intact"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rebuild_rolls_back_when_projection_write_fails() {
+        let pool = migrated_pool().await;
+
+        let survivor_id = IssuerMintRequestId::random();
+        let survivor_view = ReceiptInventoryView::Pending {
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+        };
+        seed_view_row(&pool, &survivor_id.to_string(), &survivor_view).await;
+
+        let replay_id = IssuerMintRequestId::random();
+        let initiated = serde_json::to_string(&initiated_event(
+            UnderlyingSymbol::new("TSLA"),
+            TokenSymbol::new("tTSLA"),
+            "alp-rebuild-write-failure",
+            address!("0x1234567890abcdef1234567890abcdef12345678"),
+        ))
+        .unwrap();
+        insert_mint_event_row(&pool, &replay_id.to_string(), 1, &initiated)
+            .await;
+
+        sqlx::query(
+            "
+            CREATE TRIGGER fail_receipt_inventory_rebuild
+            BEFORE INSERT ON receipt_inventory_view
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated projection write failure');
+            END
+            ",
+        )
+        .execute(&pool)
+        .await
+        .expect("Failed to create projection failure trigger");
+
+        let result = rebuild_receipt_inventory_view(&pool).await;
+        assert!(
+            matches!(result, Err(ReceiptInventoryViewError::Database(_))),
+            "a projection write failure must fail the rebuild, got {result:?}"
+        );
+        assert_eq!(
+            load_view(&pool, &survivor_id).await,
+            survivor_view,
+            "a projection write failure must roll back the cleared view"
+        );
     }
 }


### PR DESCRIPTION
## Motivation

Two pre-existing receipt-inventory correctness bugs found by the whole-repo
audit:

- `CqrsReceiptService::find_by_issuer_request_id` sourced the recovered
  `shares` from `available_balance` (mirror balance minus outstanding
  reservations). For a receipt fully reserved by a pending redemption that value
  is zero, so recovering that mint would record `shares_minted = 0` in
  `ExistingMintRecovered` — and thus in `Mint::Completed` and the mint view —
  even though the real on-chain deposit created the full amount.
- `rebuild_receipt_inventory_view` deleted all rows and then replayed events; a
  deserialization error mid-replay left the view table empty (only events up to
  the failing one were reprojected), silently dropping historical mints.

## Solution

- Recover `shares` from the receipt's mirror balance (`metadata.balance`), while
  still sourcing `tx_hash`/`block_number` from the receipt row. Add a regression
  test that fully reserves a receipt and asserts recovery reports the mirror
  balance, not the zeroed available balance.
- Parse every event before the `DELETE` in the rebuild, so a malformed row
  aborts while the existing rows are still intact rather than emptying the view.

Deferred (blocked / out of scope): the reconciler's analogous
available-vs-mirror comparison and the `ReceiptWithBalance` `mirror_balance`
field both live in `burn_tracking.rs`, which #221 rewrites; the
`ReceiptInventoryView::Depleted`/`current_balance` staleness needs the burn
read-path design. Tracked for the deferred list.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt recovery so fully reserved receipts now report the correct share amount instead of zero.
  * Made receipt inventory view rebuilds safer: malformed event data now stops the rebuild without clearing existing view records, reducing the risk of empty or stale results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->