### PR TITLE
fix: count Alpaca-rejected recoveries as auto-failed and log redemption-flow task panics

### DIFF
--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::Address;
+use alloy::primitives::{Address, TxHash};
 use alloy::providers::Provider;
 use alloy::rpc::types::Log;
 use alloy::sol_types::SolEvent;
@@ -7,10 +7,11 @@ use event_sorcery::Store;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::JoinHandle;
 use tracing::{debug, error, trace, warn};
 
 use super::{
-    Redemption,
+    IssuerRedemptionRequestId, Redemption,
     burn_manager::BurnManager,
     journal_manager::JournalManager,
     redeem_call_manager::RedeemCallManager,
@@ -350,12 +351,34 @@ where
                 "Processed block range"
             );
 
+            let mut dropped_tx_hashes: Vec<Option<TxHash>> = Vec::new();
             for log in &logs {
-                self.process_log(assets, log).await?;
+                if let ProcessedLog::DroppedNonTransient { tx_hash } =
+                    self.process_log(assets, log).await?
+                {
+                    dropped_tx_hashes.push(tx_hash);
+                }
             }
 
             poll_checkpoint::advance(&self.pool, &checkpoint_name, chunk_to)
                 .await?;
+
+            // The advance above moved the cursor past these transfers, making
+            // the skip permanent: real user tokens in the redemption wallet
+            // that will never be redeemed automatically. The per-log detail is
+            // DEBUG (loop-body rule), so this per-chunk summary is the
+            // operator's only signal — emitted here, not after the loop, so a
+            // transient error in a later chunk cannot swallow it. Any earlier
+            // `?` abort leaves this chunk's checkpoint unadvanced, so its
+            // drops are re-detected on the next pass.
+            if !dropped_tx_hashes.is_empty() {
+                warn!(
+                    target: "redemption",
+                    count = dropped_tx_hashes.len(),
+                    tx_hashes = ?dropped_tx_hashes,
+                    "Permanently skipped non-retryable transfer logs; these transfers will not be redeemed automatically"
+                );
+            }
         }
 
         Ok(())
@@ -387,13 +410,14 @@ where
     ///
     /// Returns `Err` only for transient failures (DB/RPC errors that may
     /// succeed on retry). Non-transient failures (decode errors, missing
-    /// fields, no matching asset) are logged and skipped — retrying them
+    /// fields, no matching asset) are reported as
+    /// [`ProcessedLog::DroppedNonTransient`] and skipped — retrying them
     /// would freeze the checkpoint permanently.
     async fn process_log(
         &self,
         assets: &[TokenizedAssetView],
         log: &Log,
-    ) -> Result<(), TransferPollError> {
+    ) -> Result<ProcessedLog, TransferPollError> {
         let vault = log.address();
 
         let outcome =
@@ -402,13 +426,15 @@ where
             {
                 Ok(outcome) => outcome,
                 Err(err) if err.is_non_transient() => {
-                    warn!(
+                    debug!(
                         target: "redemption",
                         error = %err,
                         tx_hash = ?log.transaction_hash,
                         "Skipping non-retryable transfer log"
                     );
-                    return Ok(());
+                    return Ok(ProcessedLog::DroppedNonTransient {
+                        tx_hash: log.transaction_hash,
+                    });
                 }
                 Err(err) => return Err(err.into()),
             };
@@ -420,7 +446,8 @@ where
                 alpaca_account,
                 network,
             } => {
-                tokio::spawn(drive_redemption_flow(
+                let flow_issuer_request_id = issuer_request_id.clone();
+                let flow = tokio::spawn(drive_redemption_flow(
                     issuer_request_id,
                     client_id,
                     alpaca_account,
@@ -432,13 +459,55 @@ where
                         burn_manager: self.burn_manager.clone(),
                     },
                 ));
+
+                tokio::spawn(watch_redemption_flow(
+                    flow,
+                    flow_issuer_request_id,
+                    log.transaction_hash,
+                ));
             }
             TransferOutcome::AlreadyDetected
             | TransferOutcome::SkippedMint
             | TransferOutcome::SkippedNoAccount => {}
         }
 
-        Ok(())
+        Ok(ProcessedLog::Handled)
+    }
+}
+
+/// Outcome of processing a single Transfer log: either handled (including
+/// benign skips like already-detected) or permanently dropped because of a
+/// non-transient decode/detection failure.
+enum ProcessedLog {
+    Handled,
+    DroppedNonTransient { tx_hash: Option<TxHash> },
+}
+
+/// Watches a spawned redemption-flow task. A dropped `JoinHandle` swallows
+/// task panics silently, so a panic must surface in logs — with the redemption
+/// identity, so the operator does not have to correlate by timestamp — instead
+/// of only manifesting as a stuck aggregate the next recovery sweep has to
+/// clean up. Cancellation (runtime shutdown, abort) is expected teardown noise
+/// and logged at DEBUG so it cannot masquerade as a panic.
+async fn watch_redemption_flow(
+    flow: JoinHandle<()>,
+    issuer_request_id: IssuerRedemptionRequestId,
+    tx_hash: Option<TxHash>,
+) {
+    if let Err(err) = flow.await {
+        if err.is_panic() {
+            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                tx_hash = ?tx_hash,
+                error = ?err,
+                "drive_redemption_flow task panicked"
+            );
+        } else {
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                tx_hash = ?tx_hash,
+                error = ?err,
+                "drive_redemption_flow task cancelled"
+            );
+        }
     }
 }
 
@@ -515,16 +584,16 @@ mod tests {
     use std::sync::Arc;
     use tracing_test::traced_test;
 
-    use super::TransferPollError;
+    use super::{TransferPollError, watch_redemption_flow};
     use crate::alpaca::mock::MockAlpacaService;
     use crate::poll_checkpoint::{self, TRANSFER_POLL};
     use crate::receipt_inventory::{
         CqrsReceiptService, ReceiptInventory, ReceiptService,
     };
-    use crate::redemption::Redemption;
     use crate::redemption::test_utils::{
         create_transfer_log, setup_test_db_with_asset,
     };
+    use crate::redemption::{IssuerRedemptionRequestId, Redemption};
     use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
@@ -1251,6 +1320,55 @@ mod tests {
             None,
             "a vault added after the migration must have no checkpoint — it \
              scans from backfill_start_block, not the stale global block"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn watch_redemption_flow_logs_panic_with_identity() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let id_string = issuer_request_id.to_string();
+        let flow = tokio::spawn(async { panic!("redemption flow blew up") });
+
+        watch_redemption_flow(flow, issuer_request_id, None).await;
+
+        assert!(
+            logs_contain_at!(
+                tracing::Level::WARN,
+                &["drive_redemption_flow task panicked", id_string.as_str()]
+            ),
+            "a flow panic must be logged at WARN with the redemption identity"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn watch_redemption_flow_logs_cancellation_at_debug() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let id_string = issuer_request_id.to_string();
+        let flow = tokio::spawn(async {
+            std::future::pending::<()>().await;
+        });
+        flow.abort();
+
+        watch_redemption_flow(flow, issuer_request_id, None).await;
+
+        // Scope both assertions by this test's redemption id: the log buffer
+        // is global across concurrently running tests, so an unscoped negative
+        // match would trip on the sibling panic test's WARN line.
+        assert!(
+            !logs_contain_at!(
+                tracing::Level::WARN,
+                &["drive_redemption_flow task panicked", id_string.as_str()]
+            ),
+            "cancellation must not be reported as a panic"
+        );
+        assert!(
+            logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["drive_redemption_flow task cancelled", id_string.as_str()]
+            ),
+            "cancellation must be logged at DEBUG"
         );
     }
 }

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -85,6 +85,17 @@ impl RedeemCallManager {
                         auto_failed += 1;
                     }
                 }
+                // The Alpaca call failed and `handle_redemption_detected`
+                // already recorded `RecordAlpacaFailure`, so the redemption is
+                // properly terminal-ized. Count it as auto-failed rather than a
+                // recovery failure that would be re-attempted every sweep.
+                Err(RedeemCallManagerError::Alpaca(err)) => {
+                    debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Auto-failed Detected redemption via Alpaca rejection"
+                    );
+                    auto_failed += 1;
+                }
                 Err(err) => {
                     debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                         error = %err,
@@ -542,6 +553,7 @@ mod tests {
         store.load(issuer_request_id).await.unwrap().unwrap()
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_handle_redemption_detected_with_success() {
         let (store, pool) = setup_test_store().await;
@@ -582,8 +594,14 @@ mod tests {
             matches!(updated_aggregate, Redemption::AlpacaCalled { .. }),
             "Expected AlpacaCalled state, got {updated_aggregate:?}"
         );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Alpaca redeem API call succeeded"]
+        ));
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_handle_redemption_detected_with_alpaca_failure() {
         let (store, pool) = setup_test_store().await;
@@ -632,6 +650,11 @@ mod tests {
             reason.contains("API timeout"),
             "Expected error message to contain 'API timeout', got: {reason}"
         );
+
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Alpaca redeem API call failed"]
+        ));
     }
 
     #[tokio::test]
@@ -773,6 +796,7 @@ mod tests {
         );
     }
 
+    #[traced_test]
     #[tokio::test]
     async fn test_recover_detected_redemptions_with_valid_redemption() {
         let harness = TestHarness::new().await;
@@ -820,6 +844,81 @@ mod tests {
             matches!(updated_aggregate, Redemption::AlpacaCalled { .. }),
             "Expected AlpacaCalled state, got {updated_aggregate:?}"
         );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Detected redemption recovery complete", "recovered=1"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_detected_alpaca_failure_counts_auto_failed() {
+        // A recovery whose Alpaca call fails records `RecordAlpacaFailure` — the
+        // redemption is properly terminal-ized — so it must be counted as
+        // auto_failed, not as a recovery failure that would be re-attempted on
+        // every subsequent sweep.
+        let harness = TestHarness::new().await;
+        let alpaca_service_mock =
+            Arc::new(MockAlpacaService::new_failure("API timeout"));
+        let alpaca_service = alpaca_service_mock.clone()
+            as Arc<dyn crate::alpaca::AlpacaService>;
+        let manager = harness.create_manager(alpaca_service);
+
+        let wallet = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let client_id = ClientId::new();
+        let alpaca_account = AlpacaAccountNumber("acc-recovery".to_string());
+        let underlying = UnderlyingSymbol::new("AAPL");
+        let network = Network::Base;
+
+        harness
+            .register_and_link_account(
+                client_id,
+                "test@example.com",
+                &alpaca_account,
+                wallet,
+            )
+            .await;
+        harness.add_asset(&underlying, &network).await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .detect_redemption(&issuer_request_id, &underlying, wallet)
+            .await;
+
+        manager.recover_detected_redemptions().await;
+
+        let updated_aggregate = harness
+            .redemption_store
+            .load(&issuer_request_id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(updated_aggregate, Redemption::Failed { .. }),
+            "Expected Failed state after Alpaca rejection, got {updated_aggregate:?}"
+        );
+
+        // Scoped by issuer_request_id: the tracing buffer is global across
+        // concurrently running tests, so the id pins the line to this test's
+        // redemption rather than a sibling test's.
+        let id_string = issuer_request_id.to_string();
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Auto-failed Detected redemption via Alpaca rejection",
+                "API timeout",
+                id_string.as_str()
+            ]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &[
+                "Detected redemption recovery complete",
+                "auto_failed=1",
+                "failed=0"
+            ]
+        ));
     }
 
     #[tokio::test]

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -241,58 +241,61 @@ pub(crate) async fn drive_redemption_flow(
 
     let tokenization_request_id = tokenization_request_id.clone();
 
-    tokio::spawn(async move {
+    // Awaited inline rather than spawned: this function already runs inside
+    // the spawned task that `watch_redemption_flow` observes, and a detached
+    // inner task would put the journal-polling/burn continuation outside that
+    // watcher — a panic there would vanish silently, exactly what the watcher
+    // exists to prevent.
+    if let Err(err) = deps
+        .journal_manager
+        .handle_alpaca_called(
+            &alpaca_account,
+            issuer_request_id.clone(),
+            tokenization_request_id,
+        )
+        .await
+    {
+        warn!(target: "redemption", %issuer_request_id,
+            error = ?err,
+            "handle_alpaca_called (journal polling) failed"
+        );
+        return;
+    }
+
+    let redemption = match deps.store.load(&issuer_request_id).await {
+        Ok(Some(redemption)) => redemption,
+        Ok(None) => {
+            warn!(target: "redemption", %issuer_request_id,
+                "Redemption not found after journal completion"
+            );
+            return;
+        }
+        Err(err) => {
+            warn!(target: "redemption", %issuer_request_id,
+                error = ?err,
+                "Failed to load aggregate after journal completion"
+            );
+            return;
+        }
+    };
+
+    if matches!(redemption, Redemption::Burning { .. }) {
         if let Err(err) = deps
-            .journal_manager
-            .handle_alpaca_called(
-                &alpaca_account,
-                issuer_request_id.clone(),
-                tokenization_request_id,
-            )
+            .burn_manager
+            .handle_burning_started(&issuer_request_id, &redemption)
             .await
         {
             warn!(target: "redemption", %issuer_request_id,
                 error = ?err,
-                "handle_alpaca_called (journal polling) failed"
-            );
-            return;
-        }
-
-        let redemption = match deps.store.load(&issuer_request_id).await {
-            Ok(Some(redemption)) => redemption,
-            Ok(None) => {
-                warn!(target: "redemption", %issuer_request_id,
-                    "Redemption not found after journal completion"
-                );
-                return;
-            }
-            Err(err) => {
-                warn!(target: "redemption", %issuer_request_id,
-                    error = ?err,
-                    "Failed to load aggregate after journal completion"
-                );
-                return;
-            }
-        };
-
-        if matches!(redemption, Redemption::Burning { .. }) {
-            if let Err(err) = deps
-                .burn_manager
-                .handle_burning_started(&issuer_request_id, &redemption)
-                .await
-            {
-                warn!(target: "redemption", %issuer_request_id,
-                    error = ?err,
-                    "handle_burning_started failed"
-                );
-            }
-        } else {
-            debug!(target: "redemption", %issuer_request_id,
-                aggregate_state = ?redemption,
-                "Aggregate not in Burning state after journal completion"
+                "handle_burning_started failed"
             );
         }
-    });
+    } else {
+        debug!(target: "redemption", %issuer_request_id,
+            aggregate_state = ?redemption,
+            "Aggregate not in Burning state after journal completion"
+        );
+    }
 }
 
 /// Attributes a vault to its enabled asset from the caller's per-pass asset


### PR DESCRIPTION
## Motivation

Two redemption-recovery observability/correctness issues found by the whole-repo
audit:

- In `recover_detected_redemptions`, when a redemption's Alpaca call fails,
  `handle_redemption_detected` records `RecordAlpacaFailure` (properly
  terminal-izing it) and returns `Err(Alpaca(_))`. That error fell into the
  generic arm and was counted as `failed` — over-reporting recovery failures
  and under-reporting `auto_failed`, and implying it would be retried next
  sweep (it won't; it's terminal).
- The `drive_redemption_flow` task is `tokio::spawn`ed with its `JoinHandle`
  dropped, so a panic in the redemption flow is swallowed silently — the only
  signal is a stuck aggregate the next recovery sweep has to clean up.

## Solution

- Add an explicit `Err(Alpaca(_))` arm that counts `auto_failed`, with a
  regression test asserting `auto_failed=1, failed=0` on an Alpaca-rejected
  recovery.
- Watch the spawned flow's `JoinHandle` and log a WARN on panic.
- Await the journal-polling/burn continuation inline inside
  `drive_redemption_flow` instead of detaching it on an inner `tokio::spawn`,
  so the watcher observes the entire flow — a panic after the Alpaca call no
  longer vanishes silently.
- Demote the per-log "skipping non-retryable transfer log" WARN to DEBUG
  (loop-body log rule).
- Add the missing `#[traced_test]` log assertions to the three flagged
  redeem-call-manager tests.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption log handling so permanently undetectable entries are tracked and reported without blocking progress.
  * Added clearer logging for dropped logs, including transaction hashes when available.
  * Treated failed redemption API rejections as terminal outcomes, updating recovery counts accordingly.

* **Tests**
  * Expanded test coverage for redemption logging, including panic and cancellation cases.
  * Added validation for terminal failure handling and updated log expectations for success and failure paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
