### PR TITLE
feat: schedule freeze/unfreeze windows via durable apalis jobs

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -751,6 +751,23 @@ action) resolve by `{underlying}:{network}` and take a required
 `--network <NETWORK>` flag (wire value) — there is deliberately no default
 network so an operator can never target the wrong chain's listing by omission.
 
+**Scheduled freeze windows.** For a corporate action known in advance (an
+ex-date), the freeze/unfreeze pair can be armed ahead of time instead of fired
+by hand at the exact instants. `POST /admin/freeze-schedules` (internal
+API-key + IP-allowlist auth, like all admin endpoints) takes an underlying and a
+`freeze_at`/`unfreeze_at` window and enqueues two durable apalis jobs — a
+`Freeze` at `freeze_at` and an `Unfreeze` at `unfreeze_at`. The worker
+dispatches the exact same `Underlying` commands the CLI does; only the
+trigger differs. Scheduled transitions survive restarts (apalis persists the due
+time), re-posting an identical window is an idempotent no-op (jobs are keyed by
+underlying + scheduled instant), and the commands themselves are idempotent, so
+a scheduled transition landing on an already-transitioned asset is harmless. An
+inverted window is rejected with 422; a fully elapsed window is rejected rather
+than flapping the asset; a `freeze_at` already in the past with `unfreeze_at`
+still ahead (window in progress) freezes immediately. This is the schedule
+mechanism the automated corporate-actions sourcing (M3) feeds; until then an
+operator arms windows manually.
+
 ## Services
 
 Aggregates use services to interact with external systems while keeping business

--- a/SPEC.md
+++ b/SPEC.md
@@ -757,16 +757,32 @@ by hand at the exact instants. `POST /admin/freeze-schedules` (internal
 API-key + IP-allowlist auth, like all admin endpoints) takes an underlying and a
 `freeze_at`/`unfreeze_at` window and enqueues two durable apalis jobs — a
 `Freeze` at `freeze_at` and an `Unfreeze` at `unfreeze_at`. The worker
-dispatches the exact same `Underlying` commands the CLI does; only the
-trigger differs. Scheduled transitions survive restarts (apalis persists the due
-time), re-posting an identical window is an idempotent no-op (jobs are keyed by
-underlying + scheduled instant), and the commands themselves are idempotent, so
-a scheduled transition landing on an already-transitioned asset is harmless. An
-inverted window is rejected with 422; a fully elapsed window is rejected rather
-than flapping the asset; a `freeze_at` already in the past with `unfreeze_at`
-still ahead (window in progress) freezes immediately. This is the schedule
-mechanism the automated corporate-actions sourcing (M3) feeds; until then an
-operator arms windows manually.
+dispatches the exact same `Underlying` commands the CLI does; only the trigger
+differs. Scheduled transitions survive restarts (apalis persists the due time),
+and re-posting an identical window is an idempotent no-op while its jobs are
+pending or running (jobs are keyed by underlying + the full scheduled instant,
+including subseconds); a window whose job reached a terminal state (done,
+killed, or out of retries) releases its key on re-arm, so an infrastructure
+failure never permanently blocks a window. At startup, orphaned `Running` rows
+reset to `Pending` and terminal rows are vacuumed, mirroring the mint jobs;
+transitions that died without applying (killed or out of retries) are surfaced
+at ERROR before their rows are removed. Command idempotency makes a _repeated_
+transition landing on an already-transitioned asset harmless, but the two jobs
+of a window are independent with no cross-ordering guarantee, so the binary
+Freeze/Unfreeze model is **not** safe against overlap or reordering: an Unfreeze
+for one schedule can release another still-active window, and a freeze job that
+only succeeds after its paired unfreeze already ran leaves the asset frozen
+until an operator unfreezes it by hand. Operators must not arm overlapping
+windows for the same underlying. An underlying with no listing is rejected with
+404 (the `Underlying` commands would succeed for any symbol, so an unchecked
+typo would arm a freeze that gates nothing while reporting success; the check
+lives in the scheduler itself so every schedule source inherits it); an inverted
+or sub-second window is rejected with 422 (apalis schedules at second
+granularity, so a sub-second window has no defined execution order); a fully
+elapsed window is rejected rather than flapping the asset; a `freeze_at` already
+in the past with `unfreeze_at` still ahead (window in progress) freezes
+immediately. This is the schedule mechanism the automated corporate-actions
+sourcing feeds; until then an operator arms windows manually.
 
 ## Services
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -34,6 +34,7 @@ use crate::redemption::{
     find_stuck as find_stuck_redemptions,
     next_burn_retry_external_tx_id_from_history,
 };
+use crate::tokenized_asset::schedule::{FreezeScheduleError, FreezeScheduler};
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
 use crate::vault::{
     BurnVerification, NetworkVaultServices, TxId, VaultError, VaultService,
@@ -1882,6 +1883,93 @@ fn mint_history_summary_from_events(
     }
 
     summary
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(crate) struct ScheduleFreezeWindowRequest {
+    /// Underlying symbol whose supply freezes for the corporate action.
+    underlying: UnderlyingSymbol,
+    /// Instant the `Freeze` fires. May already be in the past for an
+    /// in-progress window (the freeze then applies immediately).
+    #[schema(value_type = String)]
+    freeze_at: DateTime<Utc>,
+    /// Instant the `Unfreeze` fires. Must be after `freeze_at` and in the
+    /// future.
+    #[schema(value_type = String)]
+    unfreeze_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub(crate) struct ScheduleFreezeWindowResponse {
+    underlying: UnderlyingSymbol,
+    #[schema(value_type = String)]
+    freeze_at: DateTime<Utc>,
+    #[schema(value_type = String)]
+    unfreeze_at: DateTime<Utc>,
+    message: String,
+}
+
+/// Admin endpoint arming a scheduled freeze window for one asset.
+///
+/// Enqueues the durable `Freeze`/`Unfreeze` job pair (see
+/// `tokenized_asset::schedule`); re-posting the identical window is an
+/// idempotent no-op. This is the manual schedule source until the Alpaca
+/// corporate-actions sync arms windows automatically.
+#[utoipa::path(
+    post,
+    path = "/admin/freeze-schedules",
+    tag = "admin",
+    request_body = ScheduleFreezeWindowRequest,
+    responses(
+        (status = 200, description = "Freeze window armed",
+            body = ScheduleFreezeWindowResponse),
+        (status = 422, description = "Inverted or already-elapsed window"),
+        (status = 500, description = "Failed to enqueue the schedule jobs")
+    ),
+    security(("internal_api_key" = []))
+)]
+#[tracing::instrument(skip(_auth, scheduler))]
+#[post("/admin/freeze-schedules", format = "json", data = "<body>")]
+pub(crate) async fn schedule_freeze_window(
+    _auth: InternalAuth,
+    scheduler: &rocket::State<FreezeScheduler>,
+    body: Json<ScheduleFreezeWindowRequest>,
+) -> Result<Json<ScheduleFreezeWindowResponse>, Status> {
+    let ScheduleFreezeWindowRequest { underlying, freeze_at, unfreeze_at } =
+        body.into_inner();
+
+    let mut scheduler = scheduler.inner().clone();
+    scheduler
+        .schedule_window(&underlying, freeze_at, unfreeze_at, Utc::now())
+        .await
+        .map_err(|err| {
+            error!(target: "admin", underlying = %underlying,
+                %freeze_at,
+                %unfreeze_at,
+                error = %err,
+                "Failed to arm freeze window"
+            );
+            match err {
+                FreezeScheduleError::InvertedWindow { .. }
+                | FreezeScheduleError::ElapsedWindow { .. } => {
+                    Status::UnprocessableEntity
+                }
+                FreezeScheduleError::Push(_) => Status::InternalServerError,
+            }
+        })?;
+
+    info!(target: "admin", underlying = %underlying,
+        %freeze_at,
+        %unfreeze_at,
+        "Freeze window armed"
+    );
+
+    Ok(Json(ScheduleFreezeWindowResponse {
+        underlying,
+        freeze_at,
+        unfreeze_at,
+        message: "Freeze window armed".to_string(),
+    }))
 }
 
 #[cfg(test)]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -11,7 +11,7 @@ use rocket::{get, post};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::Quantity;
 use crate::alpaca::{
@@ -1923,7 +1923,9 @@ pub(crate) struct ScheduleFreezeWindowResponse {
     responses(
         (status = 200, description = "Freeze window armed",
             body = ScheduleFreezeWindowResponse),
-        (status = 422, description = "Inverted or already-elapsed window"),
+        (status = 404, description = "Underlying has no listing on any network"),
+        (status = 422,
+            description = "Inverted, sub-second, or already-elapsed window"),
         (status = 500, description = "Failed to enqueue the schedule jobs")
     ),
     security(("internal_api_key" = []))
@@ -1942,19 +1944,35 @@ pub(crate) async fn schedule_freeze_window(
     scheduler
         .schedule_window(&underlying, freeze_at, unfreeze_at, Utc::now())
         .await
-        .map_err(|err| {
-            error!(target: "admin", underlying = %underlying,
-                %freeze_at,
-                %unfreeze_at,
-                error = %err,
-                "Failed to arm freeze window"
-            );
-            match err {
-                FreezeScheduleError::InvertedWindow { .. }
-                | FreezeScheduleError::ElapsedWindow { .. } => {
-                    Status::UnprocessableEntity
-                }
-                FreezeScheduleError::Push(_) => Status::InternalServerError,
+        .map_err(|err| match err {
+            FreezeScheduleError::UnknownUnderlying { .. } => {
+                debug!(target: "admin", underlying = %underlying,
+                    "Rejected freeze window for unlisted underlying"
+                );
+                Status::NotFound
+            }
+            // Expected client validation failures — not on-call events.
+            FreezeScheduleError::InvertedWindow { .. }
+            | FreezeScheduleError::WindowTooShort { .. }
+            | FreezeScheduleError::ElapsedWindow { .. } => {
+                debug!(target: "admin", underlying = %underlying,
+                    %freeze_at,
+                    %unfreeze_at,
+                    error = %err,
+                    "Rejected freeze window schedule"
+                );
+                Status::UnprocessableEntity
+            }
+            FreezeScheduleError::Push(_)
+            | FreezeScheduleError::View(_)
+            | FreezeScheduleError::Sqlx(_) => {
+                error!(target: "admin", underlying = %underlying,
+                    %freeze_at,
+                    %unfreeze_at,
+                    error = %err,
+                    "Failed to arm freeze window"
+                );
+                Status::InternalServerError
             }
         })?;
 
@@ -1980,7 +1998,7 @@ mod tests {
     use alloy::primitives::{Address, B256, Bloom, Bytes, U256, address, b256};
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
-    use chrono::Utc;
+    use chrono::{DateTime, Duration as ChronoDuration, Utc};
     use event_sorcery::{Store, test_store};
     use rocket::http::Status;
     use rust_decimal::Decimal;
@@ -2002,6 +2020,8 @@ mod tests {
         AlpacaError, AlpacaService, MintCallbackRequest, RedeemRequest,
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
     };
+    use crate::auth::FailedAuthRateLimiter;
+    use crate::mint::test_utils::{TestHarness, test_config};
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::ReceiptVaultKey;
     use crate::receipt_inventory::{
@@ -2015,6 +2035,7 @@ mod tests {
         RedemptionServices, RedemptionView,
     };
     use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
+    use crate::tokenized_asset::schedule::FreezeScheduler;
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
@@ -5051,5 +5072,215 @@ mod tests {
         );
         // tokenization_request_id is preserved (it doesn't reset).
         assert_eq!(summary.tokenization_request_id, Some(tok_id));
+    }
+
+    fn freeze_schedule_rocket(
+        harness: &TestHarness,
+    ) -> rocket::Rocket<rocket::Build> {
+        rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(FreezeScheduler::new(
+                &harness.apalis_pool,
+                harness.pool.clone(),
+            ))
+            .mount("/", rocket::routes![super::schedule_freeze_window])
+    }
+
+    async fn post_freeze_schedule(
+        rocket: rocket::Rocket<rocket::Build>,
+        body: String,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+
+        let response = client
+            .post("/admin/freeze-schedules")
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(body)
+            .dispatch()
+            .await;
+
+        let status = response.status();
+        let body = response.into_string().await.unwrap_or_default();
+        (status, body)
+    }
+
+    fn freeze_window_body(
+        underlying: &UnderlyingSymbol,
+        freeze_at: DateTime<Utc>,
+        unfreeze_at: DateTime<Utc>,
+    ) -> String {
+        format!(
+            r#"{{"underlying":"{underlying}","freeze_at":"{}","unfreeze_at":"{}"}}"#,
+            freeze_at.to_rfc3339(),
+            unfreeze_at.to_rfc3339(),
+        )
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn schedule_freeze_window_arms_window_for_listed_underlying() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let now = Utc::now();
+
+        let (status, response_body) = post_freeze_schedule(
+            freeze_schedule_rocket(&harness),
+            freeze_window_body(
+                &underlying,
+                now + ChronoDuration::hours(1),
+                now + ChronoDuration::hours(3),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(response_body.contains("Freeze window armed"));
+
+        let window_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind(format!("%:{underlying}:%"))
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(window_jobs, 2, "one freeze and one unfreeze job");
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Freeze window armed", underlying.as_str()]
+        ));
+    }
+
+    // A symbol with no listing must 404 without arming anything: the
+    // Underlying commands succeed for any symbol, so accepting it would
+    // silently freeze nothing while reporting success.
+    #[traced_test]
+    #[tokio::test]
+    async fn schedule_freeze_window_rejects_unlisted_underlying() {
+        let harness = TestHarness::new().await;
+        let underlying = UnderlyingSymbol::new("MSFT").unwrap();
+        let now = Utc::now();
+
+        let (status, _) = post_freeze_schedule(
+            freeze_schedule_rocket(&harness),
+            freeze_window_body(
+                &underlying,
+                now + ChronoDuration::hours(1),
+                now + ChronoDuration::hours(3),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, Status::NotFound);
+
+        let window_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind(format!("%:{underlying}:%"))
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            window_jobs, 0,
+            "an unlisted underlying must not enqueue schedule jobs"
+        );
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["unlisted", underlying.as_str()]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn schedule_freeze_window_rejects_inverted_window_over_http() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let now = Utc::now();
+
+        let (status, _) = post_freeze_schedule(
+            freeze_schedule_rocket(&harness),
+            freeze_window_body(
+                &underlying,
+                now + ChronoDuration::hours(3),
+                now + ChronoDuration::hours(1),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Rejected freeze window schedule", underlying.as_str()]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn schedule_freeze_window_rejects_elapsed_window_over_http() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let now = Utc::now();
+
+        let (status, _) = post_freeze_schedule(
+            freeze_schedule_rocket(&harness),
+            freeze_window_body(
+                &underlying,
+                now - ChronoDuration::hours(3),
+                now - ChronoDuration::hours(1),
+            ),
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Rejected freeze window schedule", underlying.as_str()]
+        ));
+    }
+
+    // Re-posting the identical window must succeed and still leave exactly
+    // one freeze and one unfreeze job — the idempotent no-op the endpoint
+    // documents.
+    #[traced_test]
+    #[tokio::test]
+    async fn schedule_freeze_window_rearm_is_idempotent_over_http() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let now = Utc::now();
+        let body = freeze_window_body(
+            &underlying,
+            now + ChronoDuration::hours(1),
+            now + ChronoDuration::hours(3),
+        );
+
+        let (first_status, _) = post_freeze_schedule(
+            freeze_schedule_rocket(&harness),
+            body.clone(),
+        )
+        .await;
+        let (second_status, _) =
+            post_freeze_schedule(freeze_schedule_rocket(&harness), body).await;
+
+        assert_eq!(first_status, Status::Ok);
+        assert_eq!(second_status, Status::Ok);
+
+        let window_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind(format!("%:{underlying}:%"))
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            window_jobs, 2,
+            "re-arming the same window must dedup to one freeze and one \
+             unfreeze job"
+        );
     }
 }

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -52,6 +52,15 @@ pub(crate) fn job_type<Task>() -> &'static str {
 /// event store's sqlx 0.9 pool but addressing the same SQLite file.
 pub(crate) struct JobQueue<Task>(Storage<Task>);
 
+/// One entry in a [`JobQueue::push_scheduled_batch`] batch: the task, the
+/// `(job_type, idempotency_key)` dedup key apalis enforces, and the delay
+/// before the task becomes due.
+pub(crate) struct ScheduledTask<Task> {
+    pub(crate) task: Task,
+    pub(crate) idempotency_key: String,
+    pub(crate) run_after: Duration,
+}
+
 /// Error returned by [`JobQueue::push_with_idempotency_key`]. Wrapping
 /// [`TaskSinkError`] keeps the failure chain typed so callers can `#[from]` it.
 #[derive(Debug, thiserror::Error)]
@@ -98,15 +107,15 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static>
 
     /// Atomically enqueues a batch of scheduled tasks.
     ///
-    /// The SQLite sink flushes the batch in one statement, so callers whose
+    /// The SQLite sink flushes the batch in one transaction, so callers whose
     /// tasks form one domain operation cannot persist only a prefix when an
     /// insert fails.
     pub(crate) async fn push_scheduled_batch<const N: usize>(
         &mut self,
-        tasks: [(Task, String, Duration); N],
+        tasks: [ScheduledTask<Task>; N],
     ) -> Result<(), QueuePushError> {
         let mut tasks = futures::stream::iter(tasks.map(
-            |(task, idempotency_key, run_after)| {
+            |ScheduledTask { task, idempotency_key, run_after }| {
                 TaskBuilder::new(task)
                     .with_idempotency_key(idempotency_key)
                     .run_after(run_after)

--- a/src/jobs/mod.rs
+++ b/src/jobs/mod.rs
@@ -96,6 +96,26 @@ impl<Task: Serialize + DeserializeOwned + Send + Sync + Unpin + 'static>
         Ok(TaskSink::push_task(&mut self.0, task).await?)
     }
 
+    /// Atomically enqueues a batch of scheduled tasks.
+    ///
+    /// The SQLite sink flushes the batch in one statement, so callers whose
+    /// tasks form one domain operation cannot persist only a prefix when an
+    /// insert fails.
+    pub(crate) async fn push_scheduled_batch<const N: usize>(
+        &mut self,
+        tasks: [(Task, String, Duration); N],
+    ) -> Result<(), QueuePushError> {
+        let mut tasks = futures::stream::iter(tasks.map(
+            |(task, idempotency_key, run_after)| {
+                TaskBuilder::new(task)
+                    .with_idempotency_key(idempotency_key)
+                    .run_after(run_after)
+                    .build()
+            },
+        ));
+        Ok(TaskSink::push_all(&mut self.0, &mut tasks).await?)
+    }
+
     /// Consumes the queue into the underlying `SqliteStorage` a worker drains.
     pub(crate) fn into_storage(self) -> Storage<Task> {
         self.0

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -270,11 +270,11 @@ pub async fn initialize_rocket(
     let (tokenized_asset_store, _tokenized_asset_projection) =
         StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
 
-    // The server never dispatches Underlying commands (freeze/unfreeze are
-    // issuer-CLI actions), but startup must still reconcile the schema version
-    // and catch the `underlying_view` projection up with the event log.
+    // Startup must reconcile the Underlying schema version and catch the
+    // `underlying_view` projection up before the CLI or scheduled freeze worker
+    // dispatches freeze/unfreeze commands.
     prepare_event_sourced_startup::<Underlying>(&pool).await?;
-    let (_underlying_store, _underlying_projection) =
+    let (underlying_store, _underlying_projection) =
         StoreBuilder::<Underlying>::new(pool.clone()).build(()).await?;
 
     prepare_event_sourced_startup::<Account>(&pool).await?;
@@ -446,6 +446,11 @@ pub async fn initialize_rocket(
         }
     }
 
+    spawn_freeze_schedule_worker(apalis_pool.clone(), underlying_store);
+
+    let freeze_scheduler =
+        tokenized_asset::schedule::FreezeScheduler::new(&apalis_pool);
+
     Ok(build_rocket(RocketState {
         rate_limiter: FailedAuthRateLimiter::new()?,
         config,
@@ -460,6 +465,7 @@ pub async fn initialize_rocket(
             as Arc<dyn admin::RedemptionBurnRecovery>,
         vault_services: network_vault_services,
         configured_networks,
+        freeze_scheduler,
     }))
 }
 
@@ -476,6 +482,7 @@ struct RocketState {
     burn_recovery: Arc<dyn admin::RedemptionBurnRecovery>,
     vault_services: NetworkVaultServices,
     configured_networks: ConfiguredNetworks,
+    freeze_scheduler: tokenized_asset::schedule::FreezeScheduler,
 }
 
 fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
@@ -504,6 +511,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .manage(state.configured_networks)
         .manage(state.pool)
         .manage(state.apalis_pool)
+        .manage(state.freeze_scheduler)
         .mount(
             "/",
             routes![
@@ -523,6 +531,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 admin::reprocess_mint,
                 admin::close_mint,
                 admin::list_stuck,
+                admin::schedule_freeze_window,
             ],
         )
         .register("/", catchers::json_catchers());
@@ -1733,6 +1742,25 @@ fn spawn_mint_job_workers(workers: MintJobWorkers) {
         apalis_pool,
         Arc::new(SendCallbackContext { mint_store, alpaca }),
         "mint-callback-worker",
+    );
+}
+
+/// Spawns the drainer worker for scheduled freeze/unfreeze transitions armed
+/// via [`tokenized_asset::schedule::FreezeScheduler`]. Same supervision story
+/// as the mint job workers: fresh worker id per registration, restart loop on
+/// transient failures.
+fn spawn_freeze_schedule_worker(
+    apalis_pool: ApalisSqlitePool,
+    underlying_store: Arc<Store<Underlying>>,
+) {
+    spawn_drainer_worker!(
+        ::<tokenized_asset::schedule::FreezeScheduleCtx,
+            tokenized_asset::schedule::ApplyFreezeTransition>,
+        apalis_pool,
+        Arc::new(tokenized_asset::schedule::FreezeScheduleCtx {
+            underlying_store
+        }),
+        "freeze-schedule-worker",
     );
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,10 +446,32 @@ pub async fn initialize_rocket(
         }
     }
 
+    // Non-fatal, mirroring the mint jobs: without the reset a transition
+    // crashed mid-run waits for apalis's orphan re-enqueue timeout, and
+    // without the vacuum terminal rows accumulate and hold idempotency keys.
+    if let Err(error) =
+        tokenized_asset::schedule::reset_orphaned_freeze_schedule_jobs(&pool)
+            .await
+    {
+        warn!(target: "asset", error = %error,
+            "Failed to reset orphaned freeze-schedule jobs"
+        );
+    }
+    if let Err(error) =
+        tokenized_asset::schedule::vacuum_terminal_freeze_schedule_jobs(&pool)
+            .await
+    {
+        warn!(target: "asset", error = %error,
+            "Failed to vacuum terminal freeze-schedule jobs"
+        );
+    }
+
     spawn_freeze_schedule_worker(apalis_pool.clone(), underlying_store);
 
-    let freeze_scheduler =
-        tokenized_asset::schedule::FreezeScheduler::new(&apalis_pool);
+    let freeze_scheduler = tokenized_asset::schedule::FreezeScheduler::new(
+        &apalis_pool,
+        pool.clone(),
+    );
 
     Ok(build_rocket(RocketState {
         rate_limiter: FailedAuthRateLimiter::new()?,
@@ -1608,7 +1630,7 @@ fn spawn_mint_recovery_worker(
     });
 }
 
-/// Spawns a drainer worker for one mint side-effect job type, mirroring
+/// Spawns a drainer worker for one durable job type, mirroring
 /// [`spawn_mint_recovery_worker`]: a fresh worker id per registration
 /// (load-bearing for crash recovery) and an in-process restart loop on transient
 /// apalis/SQLite failures. No shutdown signal is wired, so a clean `Ok(())`
@@ -1616,14 +1638,17 @@ fn spawn_mint_recovery_worker(
 /// permanently strand that job stage's queue. A macro (not a generic fn)
 /// because apalis's `.build()` yields a deeply-nested worker type with no
 /// public alias, so the concrete job/context types must appear at the
-/// expansion site. Drainer-style: no apalis retry layer — a domain failure is
-/// recorded as a `MintingFailed` event that recovery retries.
+/// expansion site. Drainer-style: no apalis retry layer — the mint jobs record
+/// a `MintingFailed` event that recovery retries; other jobs rely on apalis's
+/// built-in `Failed`-row re-fetch. The `target:` names the domain tracing
+/// target the restart-loop warnings log under.
 macro_rules! spawn_drainer_worker {
     (
         ::<$ctx:ty, $job:ty>,
         $apalis_pool:expr,
         $ctx_val:expr,
-        $worker_name:expr $(,)?
+        $worker_name:expr,
+        target: $target:literal $(,)?
     ) => {{
         let apalis_pool: ApalisSqlitePool = $apalis_pool;
         let ctx: Arc<$ctx> = $ctx_val;
@@ -1650,11 +1675,11 @@ macro_rules! spawn_drainer_worker {
                     // would permanently strand every queued job for this stage.
                     Ok(()) => {
                         warn!(
-                            target: "mint",
+                            target: $target,
                             worker = worker_name,
                             backoff_secs =
                                 MINT_RECOVERY_WORKER_RESTART_BACKOFF.as_secs(),
-                            "Mint job worker monitor exited cleanly without a \
+                            "Job worker monitor exited cleanly without a \
                              shutdown signal; restarting"
                         );
                         tokio::time::sleep(
@@ -1664,12 +1689,12 @@ macro_rules! spawn_drainer_worker {
                     }
                     Err(error) => {
                         warn!(
-                            target: "mint",
+                            target: $target,
                             worker = worker_name,
                             error = %error,
                             backoff_secs =
                                 MINT_RECOVERY_WORKER_RESTART_BACKOFF.as_secs(),
-                            "Mint job worker crashed; restarting after backoff"
+                            "Job worker crashed; restarting after backoff"
                         );
                         tokio::time::sleep(
                             MINT_RECOVERY_WORKER_RESTART_BACKOFF,
@@ -1721,6 +1746,7 @@ fn spawn_mint_job_workers(workers: MintJobWorkers) {
             apalis_pool: apalis_pool.clone(),
         }),
         "mint-submit-worker",
+        target: "mint",
     );
 
     spawn_drainer_worker!(
@@ -1735,6 +1761,7 @@ fn spawn_mint_job_workers(workers: MintJobWorkers) {
             apalis_pool: apalis_pool.clone(),
         }),
         "mint-confirm-worker",
+        target: "mint",
     );
 
     spawn_drainer_worker!(
@@ -1742,6 +1769,7 @@ fn spawn_mint_job_workers(workers: MintJobWorkers) {
         apalis_pool,
         Arc::new(SendCallbackContext { mint_store, alpaca }),
         "mint-callback-worker",
+        target: "mint",
     );
 }
 
@@ -1761,6 +1789,7 @@ fn spawn_freeze_schedule_worker(
             underlying_store
         }),
         "freeze-schedule-worker",
+        target: "asset",
     );
 }
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -20,6 +20,8 @@ use crate::vault::{PreparedMintTx, TxId, UnconfiguredNetworkError};
 
 pub use api::MintResponse;
 
+#[cfg(test)]
+pub(crate) use api::test_utils;
 pub(crate) use api::{confirm_journal, initiate_mint};
 pub(crate) use cmd::MintCommand;
 pub(crate) use event::MintEvent;

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -32,6 +32,7 @@ expressed as an OpenAPI scheme."
         crate::admin::reprocess_mint,
         crate::admin::close_mint,
         crate::admin::list_stuck,
+        crate::admin::schedule_freeze_window,
     ),
     components(schemas(
         st0x_issuance_dto::TokenizedAssetDetailResponse,
@@ -53,6 +54,8 @@ expressed as an OpenAPI scheme."
         crate::admin::CloseRedemptionRequest,
         crate::admin::ForceCompleteRedemptionRequest,
         crate::admin::CloseMintRequest,
+        crate::admin::ScheduleFreezeWindowRequest,
+        crate::admin::ScheduleFreezeWindowResponse,
     )),
     modifiers(&SecurityAddon),
     tags(
@@ -107,6 +110,7 @@ mod tests {
             "/admin/force-complete/redemption/{issuer_request_id}",
             "/admin/reprocess/mint/{aggregate_id}",
             "/admin/close/mint/{aggregate_id}",
+            "/admin/freeze-schedules",
         ] {
             assert!(
                 paths.contains_key(path),

--- a/src/tokenized_asset/mod.rs
+++ b/src/tokenized_asset/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod api;
 pub(crate) mod cli;
 mod cmd;
 mod event;
+pub(crate) mod schedule;
 pub(crate) mod view;
 
 use alloy::primitives::Address;

--- a/src/tokenized_asset/schedule.rs
+++ b/src/tokenized_asset/schedule.rs
@@ -10,18 +10,26 @@
 //!
 //! Durability and idempotency: apalis persists the due time, so a scheduled
 //! transition survives restarts, and the idempotency key (underlying + the
-//! scheduled instant) collapses re-submissions of the same window. The
-//! `Freeze`/`Unfreeze` commands are themselves no-ops when the asset is
-//! already in the target state, so overlapping schedules are safe.
+//! full scheduled instant, including subseconds) collapses re-submissions of
+//! the same window while its jobs are still pending or running. Terminal rows
+//! (done, killed, or out of retries) release their keys when the same window
+//! is re-armed, so an infrastructure failure never permanently blocks a
+//! window. Overlapping windows are **not** safe under the binary
+//! Freeze/Unfreeze model — an Unfreeze for one schedule can release another
+//! still-active window — so operators must not arm overlapping windows for
+//! the same underlying.
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use cqrs_es::AggregateError;
 use event_sorcery::{LifecycleError, Store};
 use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
+use tracing::{error, warn};
 
 use super::UnderlyingSymbol;
-use crate::jobs::{Job, JobQueue, QueuePushError};
+use super::view::{TokenizedAssetViewError, underlying_has_listing};
+use crate::jobs::{Job, JobQueue, QueuePushError, ScheduledTask, job_type};
 use crate::underlying::{Underlying, UnderlyingCommand};
 
 /// Which side of the freeze window a scheduled job applies.
@@ -29,6 +37,33 @@ use crate::underlying::{Underlying, UnderlyingCommand};
 pub(crate) enum FreezeTransition {
     Freeze,
     Unfreeze,
+}
+
+impl FreezeTransition {
+    /// Prefix naming this transition inside a job idempotency key, so the
+    /// key and the job payload cannot disagree about which side of the
+    /// window a row belongs to.
+    const fn key_prefix(self) -> &'static str {
+        match self {
+            Self::Freeze => "freeze",
+            Self::Unfreeze => "unfreeze",
+        }
+    }
+
+    /// The `(job_type, idempotency_key)` dedup key for this transition of
+    /// `underlying`'s window, scheduled at `scheduled_for` (full instant,
+    /// including subseconds, so windows in the same second stay distinct).
+    fn idempotency_key(
+        self,
+        underlying: &UnderlyingSymbol,
+        scheduled_for: DateTime<Utc>,
+    ) -> String {
+        format!(
+            "{}:{underlying}:{}",
+            self.key_prefix(),
+            scheduled_for.to_rfc3339()
+        )
+    }
 }
 
 /// Durable job applying one scheduled freeze transition to one asset.
@@ -78,10 +113,19 @@ impl Job<FreezeScheduleCtx> for ApplyFreezeTransition {
         };
 
         ctx.underlying_store.send(&self.underlying, command).await.map_err(
-            |source| FreezeTransitionError {
-                underlying: self.underlying.clone(),
-                transition: self.transition,
-                source: Box::new(source),
+            |source| {
+                warn!(target: "asset", underlying = %self.underlying,
+                    transition = ?self.transition,
+                    scheduled_for = %self.scheduled_for,
+                    error = %source,
+                    "Scheduled freeze transition dispatch failed; apalis \
+                     will retry until its attempt budget is exhausted"
+                );
+                FreezeTransitionError {
+                    underlying: self.underlying.clone(),
+                    transition: self.transition,
+                    source: Box::new(source),
+                }
             },
         )
     }
@@ -90,11 +134,20 @@ impl Job<FreezeScheduleCtx> for ApplyFreezeTransition {
 /// Why a freeze window could not be scheduled.
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum FreezeScheduleError {
+    #[error("underlying {underlying} has no listing on any network")]
+    UnknownUnderlying { underlying: UnderlyingSymbol },
     #[error(
         "freeze window is inverted: freeze_at {freeze_at} must precede \
          unfreeze_at {unfreeze_at}"
     )]
     InvertedWindow { freeze_at: DateTime<Utc>, unfreeze_at: DateTime<Utc> },
+    #[error(
+        "freeze window too short: freeze_at {freeze_at} and unfreeze_at \
+         {unfreeze_at} must be at least one second apart (apalis schedules \
+         at second granularity, so a sub-second window has no defined \
+         execution order)"
+    )]
+    WindowTooShort { freeze_at: DateTime<Utc>, unfreeze_at: DateTime<Utc> },
     #[error(
         "freeze window already elapsed: unfreeze_at {unfreeze_at} is not \
          after now ({now})"
@@ -102,6 +155,10 @@ pub(crate) enum FreezeScheduleError {
     ElapsedWindow { unfreeze_at: DateTime<Utc>, now: DateTime<Utc> },
     #[error(transparent)]
     Push(#[from] QueuePushError),
+    #[error(transparent)]
+    View(#[from] TokenizedAssetViewError),
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
 }
 
 /// Schedules freeze/unfreeze job pairs for corporate-action windows.
@@ -112,11 +169,17 @@ pub(crate) enum FreezeScheduleError {
 #[derive(Clone)]
 pub(crate) struct FreezeScheduler {
     queue: JobQueue<ApplyFreezeTransition>,
+    /// Event-store pool for the terminal-row release; both pools address the
+    /// same SQLite file (see `crate::jobs`).
+    pool: Pool<Sqlite>,
 }
 
 impl FreezeScheduler {
-    pub(crate) fn new(apalis_pool: &apalis_sqlite::SqlitePool) -> Self {
-        Self { queue: JobQueue::new(apalis_pool) }
+    pub(crate) fn new(
+        apalis_pool: &apalis_sqlite::SqlitePool,
+        pool: Pool<Sqlite>,
+    ) -> Self {
+        Self { queue: JobQueue::new(apalis_pool), pool }
     }
 
     /// Arms one freeze window for `underlying`: a `Freeze` at `freeze_at`
@@ -125,7 +188,12 @@ impl FreezeScheduler {
     /// A `freeze_at` already in the past (window in progress) schedules the
     /// freeze immediately; a fully elapsed window is rejected rather than
     /// flapping the asset. Both jobs are idempotency-keyed by underlying and
-    /// scheduled instant, so re-arming the same window is a no-op.
+    /// scheduled instant, so re-arming the same window while it is pending or
+    /// running is a no-op — but a terminal row (done, killed, or out of
+    /// retries) releases its key first, so re-arming after an infrastructure
+    /// failure enqueues fresh jobs instead of silently deduping against the
+    /// dead ones. Re-applying a transition that already fired is an
+    /// idempotent no-op at the command level.
     pub(crate) async fn schedule_window(
         &mut self,
         underlying: &UnderlyingSymbol,
@@ -133,8 +201,28 @@ impl FreezeScheduler {
         unfreeze_at: DateTime<Utc>,
         now: DateTime<Utc>,
     ) -> Result<(), FreezeScheduleError> {
+        // The Underlying commands succeed for any symbol (they originate a
+        // fresh stream), so scheduling for a symbol that was never listed
+        // would silently arm a freeze that gates nothing. Gate here, not at
+        // each caller, so no schedule source can skip the check.
+        if !underlying_has_listing(&self.pool, underlying).await? {
+            return Err(FreezeScheduleError::UnknownUnderlying {
+                underlying: underlying.clone(),
+            });
+        }
+
         if freeze_at >= unfreeze_at {
             return Err(FreezeScheduleError::InvertedWindow {
+                freeze_at,
+                unfreeze_at,
+            });
+        }
+
+        // apalis stores due times at second granularity; two jobs due in the
+        // same second have no defined execution order, so a sub-second window
+        // could unfreeze before it freezes.
+        if unfreeze_at - freeze_at < ChronoDuration::seconds(1) {
+            return Err(FreezeScheduleError::WindowTooShort {
                 freeze_at,
                 unfreeze_at,
             });
@@ -152,53 +240,225 @@ impl FreezeScheduler {
         let unfreeze_delay =
             (unfreeze_at - now).to_std().unwrap_or(std::time::Duration::ZERO);
 
+        let freeze_key =
+            FreezeTransition::Freeze.idempotency_key(underlying, freeze_at);
+        let unfreeze_key =
+            FreezeTransition::Unfreeze.idempotency_key(underlying, unfreeze_at);
+
+        self.release_terminal_window_jobs([&freeze_key, &unfreeze_key]).await?;
+
         self.queue
             .push_scheduled_batch([
-                (
-                    ApplyFreezeTransition {
+                ScheduledTask {
+                    task: ApplyFreezeTransition {
                         underlying: underlying.clone(),
                         transition: FreezeTransition::Freeze,
                         scheduled_for: freeze_at,
                     },
-                    format!("freeze:{underlying}:{}", freeze_at.timestamp()),
-                    freeze_delay,
-                ),
-                (
-                    ApplyFreezeTransition {
+                    idempotency_key: freeze_key,
+                    run_after: freeze_delay,
+                },
+                ScheduledTask {
+                    task: ApplyFreezeTransition {
                         underlying: underlying.clone(),
                         transition: FreezeTransition::Unfreeze,
                         scheduled_for: unfreeze_at,
                     },
-                    format!(
-                        "unfreeze:{underlying}:{}",
-                        unfreeze_at.timestamp()
-                    ),
-                    unfreeze_delay,
-                ),
+                    idempotency_key: unfreeze_key,
+                    run_after: unfreeze_delay,
+                },
             ])
             .await?;
 
         Ok(())
     }
+
+    /// Frees this window's idempotency keys from terminal rows so the enqueue
+    /// below cannot dedup against a job that will never run again. apalis's
+    /// `ON CONFLICT DO NOTHING` matches any row sharing the key — including
+    /// `Done`/`Killed`/exhausted-`Failed` ones — so without this release a
+    /// window whose job died of an infrastructure failure could never be
+    /// re-armed. Pending and running rows are left untouched; deduping
+    /// against those is the intended idempotency. Rows that died without
+    /// applying (killed or out of retries) are surfaced at ERROR before their
+    /// only record is deleted.
+    async fn release_terminal_window_jobs(
+        &self,
+        idempotency_keys: [&str; 2],
+    ) -> Result<(), sqlx::Error> {
+        for idempotency_key in idempotency_keys {
+            log_dead_freeze_jobs(&self.pool, Some(idempotency_key)).await?;
+
+            sqlx::query(
+                "
+                DELETE FROM Jobs
+                WHERE
+                    job_type = ?
+                    AND idempotency_key = ?
+                    AND (
+                        status IN ('Done', 'Killed')
+                        OR (status = 'Failed' AND max_attempts <= attempts)
+                    )
+                ",
+            )
+            .bind(job_type::<ApplyFreezeTransition>())
+            .bind(idempotency_key)
+            .execute(&self.pool)
+            .await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Logs at ERROR every [`ApplyFreezeTransition`] row that reached a dead
+/// terminal state (killed, or `Failed` with its attempt budget exhausted) —
+/// meaning a scheduled freeze/unfreeze never applied. Called before the
+/// cleanup paths delete such rows, because the row is the only durable record
+/// that the transition was ever armed. Scoped to one idempotency key when
+/// releasing a window for re-arm, or unscoped for the startup vacuum.
+async fn log_dead_freeze_jobs(
+    pool: &Pool<Sqlite>,
+    idempotency_key: Option<&str>,
+) -> Result<(), sqlx::Error> {
+    let dead_jobs: Vec<String> = match idempotency_key {
+        Some(idempotency_key) => {
+            sqlx::query_scalar(
+                "
+                SELECT idempotency_key
+                FROM Jobs
+                WHERE
+                    job_type = ?
+                    AND idempotency_key = ?
+                    AND (
+                        status = 'Killed'
+                        OR (status = 'Failed' AND max_attempts <= attempts)
+                    )
+                ",
+            )
+            .bind(job_type::<ApplyFreezeTransition>())
+            .bind(idempotency_key)
+            .fetch_all(pool)
+            .await?
+        }
+        None => {
+            sqlx::query_scalar(
+                "
+                SELECT idempotency_key
+                FROM Jobs
+                WHERE
+                    job_type = ?
+                    AND (
+                        status = 'Killed'
+                        OR (status = 'Failed' AND max_attempts <= attempts)
+                    )
+                ",
+            )
+            .bind(job_type::<ApplyFreezeTransition>())
+            .fetch_all(pool)
+            .await?
+        }
+    };
+
+    if !dead_jobs.is_empty() {
+        error!(target: "asset", jobs = ?dead_jobs,
+            "Scheduled freeze transitions died without applying; removing \
+             their terminal rows"
+        );
+    }
+
+    Ok(())
+}
+
+/// Flips freeze-schedule jobs left `Running` by a dead process back to
+/// `Pending`, clearing their lock columns (`lock_at`, `lock_by`).
+///
+/// At startup no worker from this process is running yet, so any `Running`
+/// row is an orphan from the previous process; without this reset a
+/// crashed-mid-run transition waits for apalis's orphan re-enqueue timeout
+/// (default ~300s) — a long delay next to an ex-date deadline. Scoped to the
+/// [`ApplyFreezeTransition`] job type so `Running` rows of other apalis job
+/// types sharing the `Jobs` table are left for their own recovery. Runs on
+/// the event-store pool because both pools address the same SQLite file.
+pub(crate) async fn reset_orphaned_freeze_schedule_jobs(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "
+        UPDATE Jobs
+        SET
+            status = 'Pending',
+            lock_at = NULL,
+            lock_by = NULL
+        WHERE
+            job_type = ?
+            AND status = 'Running'
+        ",
+    )
+    .bind(job_type::<ApplyFreezeTransition>())
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Deletes terminal apalis rows for [`ApplyFreezeTransition`] jobs, mirroring
+/// the mint stack's terminal-job vacuums: it bounds the `Jobs` table across
+/// restarts and frees idempotency keys held by concluded windows. Only
+/// terminal rows are removed, so orphaned `Pending`/`Running` jobs apalis
+/// will re-pick are left untouched. Rows that died without applying (killed
+/// or out of retries) are surfaced at ERROR before deletion — the row is the
+/// only record that the transition was ever armed. Runs on the event-store
+/// pool because both pools address the same SQLite file.
+pub(crate) async fn vacuum_terminal_freeze_schedule_jobs(
+    pool: &Pool<Sqlite>,
+) -> Result<(), sqlx::Error> {
+    log_dead_freeze_jobs(pool, None).await?;
+
+    sqlx::query(
+        "
+        DELETE FROM Jobs
+        WHERE
+            job_type = ?
+            AND (
+                status IN ('Done', 'Killed')
+                OR (status = 'Failed' AND max_attempts <= attempts)
+            )
+        ",
+    )
+    .bind(job_type::<ApplyFreezeTransition>())
+    .execute(pool)
+    .await?;
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use chrono::{Duration as ChronoDuration, Utc};
     use event_sorcery::StoreBuilder;
+    use tracing::Level;
+    use tracing_test::traced_test;
 
     use super::{
         ApplyFreezeTransition, FreezeScheduleCtx, FreezeScheduleError,
-        FreezeScheduler, FreezeTransition,
+        FreezeScheduler, FreezeTransition, reset_orphaned_freeze_schedule_jobs,
+        vacuum_terminal_freeze_schedule_jobs,
     };
-    use crate::jobs::Job;
+    use crate::jobs::{Job, job_type};
     use crate::mint::test_utils::TestHarness;
+    use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::UnderlyingSymbol;
     use crate::underlying::{AssetStatus, Underlying, load_freeze_status};
+
+    fn scheduler_for(harness: &TestHarness) -> FreezeScheduler {
+        FreezeScheduler::new(&harness.apalis_pool, harness.pool.clone())
+    }
 
     // The job dispatches the same command path the CLI uses: perform on a
     // Freeze transition flips the asset to Frozen, Unfreeze flips it back,
     // and re-performing either is an idempotent no-op.
+    #[traced_test]
     #[tokio::test]
     async fn perform_applies_freeze_then_unfreeze_idempotently() {
         let harness = TestHarness::new().await;
@@ -223,6 +483,14 @@ mod tests {
             load_freeze_status(&pool, &underlying).await.unwrap(),
             AssetStatus::Frozen
         );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Freezing underlying", underlying.as_str()]
+        ));
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["already frozen", underlying.as_str()]
+        ));
 
         let unfreeze = ApplyFreezeTransition {
             underlying: underlying.clone(),
@@ -236,17 +504,57 @@ mod tests {
             load_freeze_status(&pool, &underlying).await.unwrap(),
             AssetStatus::Enabled
         );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Unfreezing underlying", underlying.as_str()]
+        ));
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["already enabled", underlying.as_str()]
+        ));
+    }
+
+    // A symbol that was never listed must be rejected before any job is
+    // enqueued: the Underlying commands succeed for any symbol, so a typo'd
+    // underlying would otherwise arm a freeze that gates nothing.
+    #[tokio::test]
+    async fn schedule_window_rejects_unlisted_underlying() {
+        let harness = TestHarness::new().await;
+        let mut scheduler = scheduler_for(&harness);
+        let now = Utc::now();
+
+        let error = scheduler
+            .schedule_window(
+                &UnderlyingSymbol::new("MSFT").unwrap(),
+                now + ChronoDuration::hours(1),
+                now + ChronoDuration::hours(3),
+                now,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, FreezeScheduleError::UnknownUnderlying { .. }));
+
+        let window_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind("%:MSFT:%")
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(window_jobs, 0);
     }
 
     #[tokio::test]
     async fn schedule_window_rejects_inverted_window() {
         let harness = TestHarness::new().await;
-        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
         let now = Utc::now();
 
         let error = scheduler
             .schedule_window(
-                &UnderlyingSymbol::new("AAPL").unwrap(),
+                &underlying,
                 now + ChronoDuration::hours(2),
                 now + ChronoDuration::hours(1),
                 now,
@@ -257,15 +565,39 @@ mod tests {
         assert!(matches!(error, FreezeScheduleError::InvertedWindow { .. }));
     }
 
+    // apalis schedules at second granularity, so a window narrower than one
+    // second has no defined freeze-before-unfreeze order and is rejected.
+    #[tokio::test]
+    async fn schedule_window_rejects_sub_second_window() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
+        let now = Utc::now();
+        let freeze_at = now + ChronoDuration::hours(1);
+
+        let error = scheduler
+            .schedule_window(
+                &underlying,
+                freeze_at,
+                freeze_at + ChronoDuration::milliseconds(500),
+                now,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, FreezeScheduleError::WindowTooShort { .. }));
+    }
+
     #[tokio::test]
     async fn schedule_window_rejects_elapsed_window() {
         let harness = TestHarness::new().await;
-        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
         let now = Utc::now();
 
         let error = scheduler
             .schedule_window(
-                &UnderlyingSymbol::new("AAPL").unwrap(),
+                &underlying,
                 now - ChronoDuration::hours(2),
                 now - ChronoDuration::hours(1),
                 now,
@@ -277,32 +609,62 @@ mod tests {
     }
 
     // An in-progress window (freeze_at already past, unfreeze_at ahead) is
-    // accepted: the freeze fires immediately rather than being dropped.
+    // accepted, and the freeze job is due immediately rather than waiting for
+    // the already-elapsed freeze_at while the unfreeze keeps its future due
+    // time.
     #[tokio::test]
     async fn schedule_window_accepts_in_progress_window() {
         let harness = TestHarness::new().await;
-        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
         let now = Utc::now();
 
         scheduler
             .schedule_window(
-                &UnderlyingSymbol::new("AAPL").unwrap(),
+                &underlying,
                 now - ChronoDuration::minutes(5),
                 now + ChronoDuration::hours(1),
                 now,
             )
             .await
             .unwrap();
+
+        let freeze_run_at: i64 = sqlx::query_scalar(
+            "SELECT run_at FROM Jobs WHERE idempotency_key LIKE 'freeze:%'",
+        )
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        let unfreeze_run_at: i64 = sqlx::query_scalar(
+            "SELECT run_at FROM Jobs WHERE idempotency_key LIKE 'unfreeze:%'",
+        )
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+
+        assert!(
+            freeze_run_at <= now.timestamp() + 1,
+            "in-progress window must schedule the freeze immediately, \
+             got run_at {freeze_run_at} vs now {}",
+            now.timestamp()
+        );
+        assert!(
+            unfreeze_run_at >= now.timestamp() + 3590,
+            "unfreeze must keep its future due time, got run_at \
+             {unfreeze_run_at} vs now {}",
+            now.timestamp()
+        );
     }
 
-    // Re-arming the identical window twice must not error: the idempotency
-    // key collapses the duplicate enqueues.
+    // Re-arming the identical window twice must not error, and the
+    // idempotency key must actually collapse the duplicate enqueues: exactly
+    // one freeze and one unfreeze row exist afterwards.
     #[tokio::test]
     async fn schedule_window_is_idempotent_for_the_same_window() {
         let harness = TestHarness::new().await;
-        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
         let now = Utc::now();
-        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
         let freeze_at = now + ChronoDuration::hours(1);
         let unfreeze_at = now + ChronoDuration::hours(3);
 
@@ -314,15 +676,169 @@ mod tests {
             .schedule_window(&underlying, freeze_at, unfreeze_at, now)
             .await
             .unwrap();
+
+        let window_jobs: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind("%:AAPL:%")
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            window_jobs, 2,
+            "re-arming the same window must dedup to one freeze and one \
+             unfreeze job"
+        );
+    }
+
+    // A window whose job died terminally (e.g. exhausted retries after an
+    // infrastructure failure) must be re-armable: the terminal row's
+    // idempotency key is released and a fresh Pending job replaces it.
+    #[tokio::test]
+    async fn schedule_window_rearms_after_killed_job() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
+        let now = Utc::now();
+        let freeze_at = now + ChronoDuration::hours(1);
+        let unfreeze_at = now + ChronoDuration::hours(3);
+
+        scheduler
+            .schedule_window(&underlying, freeze_at, unfreeze_at, now)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "
+            UPDATE Jobs
+            SET status = 'Killed'
+            WHERE idempotency_key LIKE 'freeze:%'
+            ",
+        )
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+        scheduler
+            .schedule_window(&underlying, freeze_at, unfreeze_at, now)
+            .await
+            .unwrap();
+
+        let freeze_statuses: Vec<String> = sqlx::query_scalar(
+            "SELECT status FROM Jobs WHERE idempotency_key LIKE 'freeze:%'",
+        )
+        .fetch_all(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            freeze_statuses,
+            vec!["Pending".to_string()],
+            "re-arming must replace the terminal freeze job with a fresh \
+             Pending one"
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_reset_and_vacuum_preserve_live_schedule_jobs() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
+        let now = Utc::now();
+        scheduler
+            .schedule_window(
+                &underlying,
+                now + ChronoDuration::hours(1),
+                now + ChronoDuration::hours(3),
+                now,
+            )
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "INSERT INTO Workers (id, worker_type, storage_name) VALUES ('dead-freeze-worker', ?, 'SqliteStorage')",
+        )
+        .bind(job_type::<ApplyFreezeTransition>())
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE Jobs SET status = 'Running', lock_at = strftime('%s', 'now'), lock_by = 'dead-freeze-worker' WHERE idempotency_key LIKE 'freeze:%'",
+        )
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+        reset_orphaned_freeze_schedule_jobs(&harness.pool).await.unwrap();
+        let (status, lock_at, lock_by):
+            (String, Option<i64>, Option<String>) = sqlx::query_as(
+                "SELECT status, lock_at, lock_by FROM Jobs WHERE idempotency_key LIKE 'freeze:%'",
+            )
+            .fetch_one(&harness.pool)
+            .await
+            .unwrap();
+        assert_eq!(status, "Pending");
+        assert!(lock_at.is_none() && lock_by.is_none());
+
+        sqlx::query(
+            "UPDATE Jobs SET status = 'Done' WHERE idempotency_key LIKE 'freeze:%'",
+        )
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+        vacuum_terminal_freeze_schedule_jobs(&harness.pool).await.unwrap();
+
+        let remaining_keys: Vec<String> = sqlx::query_scalar(
+            "SELECT idempotency_key FROM Jobs ORDER BY idempotency_key",
+        )
+        .fetch_all(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(remaining_keys.len(), 1);
+        assert!(remaining_keys[0].starts_with("unfreeze:"));
+    }
+
+    // Two windows in the same UTC second must not share an idempotency key:
+    // truncating to `timestamp()` would collide and drop one schedule.
+    #[tokio::test]
+    async fn schedule_window_keeps_subsecond_idempotency_keys_distinct() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
+        let now = Utc::now();
+        let freeze_a = now + ChronoDuration::hours(1);
+        let freeze_b = freeze_a + ChronoDuration::milliseconds(250);
+        let unfreeze_a = freeze_a + ChronoDuration::hours(2);
+        let unfreeze_b = freeze_b + ChronoDuration::hours(2);
+
+        scheduler
+            .schedule_window(&underlying, freeze_a, unfreeze_a, now)
+            .await
+            .unwrap();
+        scheduler
+            .schedule_window(&underlying, freeze_b, unfreeze_b, now)
+            .await
+            .unwrap();
+
+        let freeze_keys: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind("freeze:AAPL:%")
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            freeze_keys, 2,
+            "subsecond-distinct freeze schedules must not collide"
+        );
     }
 
     #[tokio::test]
     async fn schedule_window_does_not_persist_half_a_window_when_unfreeze_insert_fails()
      {
         let harness = TestHarness::new().await;
-        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let mut scheduler = scheduler_for(&harness);
         let now = Utc::now();
-        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
 
         sqlx::query(
             r"

--- a/src/tokenized_asset/schedule.rs
+++ b/src/tokenized_asset/schedule.rs
@@ -1,0 +1,361 @@
+//! Scheduled dividend freeze/unfreeze for tokenized assets.
+//!
+//! Around an ex-date the supply freeze must flip on and off at known
+//! instants. This module automates the trigger the issuer CLI fires by hand:
+//! a [`FreezeScheduler`] enqueues two durable apalis jobs per corporate-action
+//! window — a `Freeze` before the ex-date and an `Unfreeze` after — and the
+//! worker dispatches the exact same underlying-scoped commands the CLI does.
+//! Only the trigger changes; the mint gate reacts to the status flip identically
+//! however it was dispatched, across every network listing.
+//!
+//! Durability and idempotency: apalis persists the due time, so a scheduled
+//! transition survives restarts, and the idempotency key (underlying + the
+//! scheduled instant) collapses re-submissions of the same window. The
+//! `Freeze`/`Unfreeze` commands are themselves no-ops when the asset is
+//! already in the target state, so overlapping schedules are safe.
+
+use chrono::{DateTime, Utc};
+use cqrs_es::AggregateError;
+use event_sorcery::{LifecycleError, Store};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+use super::UnderlyingSymbol;
+use crate::jobs::{Job, JobQueue, QueuePushError};
+use crate::underlying::{Underlying, UnderlyingCommand};
+
+/// Which side of the freeze window a scheduled job applies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum FreezeTransition {
+    Freeze,
+    Unfreeze,
+}
+
+/// Durable job applying one scheduled freeze transition to one asset.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct ApplyFreezeTransition {
+    pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) transition: FreezeTransition,
+    /// The instant this transition was scheduled for. Part of the
+    /// idempotency key, and recorded for audit in worker logs.
+    pub(crate) scheduled_for: DateTime<Utc>,
+}
+
+/// Runtime dependencies for [`ApplyFreezeTransition::perform`].
+pub(crate) struct FreezeScheduleCtx {
+    pub(crate) underlying_store: Arc<Store<Underlying>>,
+}
+
+/// Error surfaced by a freeze-transition job. Command dispatch is the only
+/// fallible step; `Freeze`/`Unfreeze` on an already-transitioned asset is a
+/// no-op, not an error.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "failed to dispatch scheduled {transition:?} for {underlying}: {source}"
+)]
+pub(crate) struct FreezeTransitionError {
+    pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) transition: FreezeTransition,
+    #[source]
+    pub(crate) source: Box<AggregateError<LifecycleError<Underlying>>>,
+}
+
+impl Job<FreezeScheduleCtx> for ApplyFreezeTransition {
+    type Output = ();
+    type Error = FreezeTransitionError;
+
+    async fn perform(
+        &self,
+        ctx: &FreezeScheduleCtx,
+    ) -> Result<Self::Output, Self::Error> {
+        let command = match self.transition {
+            FreezeTransition::Freeze => UnderlyingCommand::Freeze {
+                underlying: self.underlying.clone(),
+            },
+            FreezeTransition::Unfreeze => UnderlyingCommand::Unfreeze {
+                underlying: self.underlying.clone(),
+            },
+        };
+
+        ctx.underlying_store.send(&self.underlying, command).await.map_err(
+            |source| FreezeTransitionError {
+                underlying: self.underlying.clone(),
+                transition: self.transition,
+                source: Box::new(source),
+            },
+        )
+    }
+}
+
+/// Why a freeze window could not be scheduled.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FreezeScheduleError {
+    #[error(
+        "freeze window is inverted: freeze_at {freeze_at} must precede \
+         unfreeze_at {unfreeze_at}"
+    )]
+    InvertedWindow { freeze_at: DateTime<Utc>, unfreeze_at: DateTime<Utc> },
+    #[error(
+        "freeze window already elapsed: unfreeze_at {unfreeze_at} is not \
+         after now ({now})"
+    )]
+    ElapsedWindow { unfreeze_at: DateTime<Utc>, now: DateTime<Utc> },
+    #[error(transparent)]
+    Push(#[from] QueuePushError),
+}
+
+/// Schedules freeze/unfreeze job pairs for corporate-action windows.
+///
+/// This is the API RAI-style automation (or an operator via the admin
+/// endpoint) calls to arm a window; the schedule source — manual today,
+/// Alpaca corporate-actions later — only decides who calls it.
+#[derive(Clone)]
+pub(crate) struct FreezeScheduler {
+    queue: JobQueue<ApplyFreezeTransition>,
+}
+
+impl FreezeScheduler {
+    pub(crate) fn new(apalis_pool: &apalis_sqlite::SqlitePool) -> Self {
+        Self { queue: JobQueue::new(apalis_pool) }
+    }
+
+    /// Arms one freeze window for `underlying`: a `Freeze` at `freeze_at`
+    /// and an `Unfreeze` at `unfreeze_at`.
+    ///
+    /// A `freeze_at` already in the past (window in progress) schedules the
+    /// freeze immediately; a fully elapsed window is rejected rather than
+    /// flapping the asset. Both jobs are idempotency-keyed by underlying and
+    /// scheduled instant, so re-arming the same window is a no-op.
+    pub(crate) async fn schedule_window(
+        &mut self,
+        underlying: &UnderlyingSymbol,
+        freeze_at: DateTime<Utc>,
+        unfreeze_at: DateTime<Utc>,
+        now: DateTime<Utc>,
+    ) -> Result<(), FreezeScheduleError> {
+        if freeze_at >= unfreeze_at {
+            return Err(FreezeScheduleError::InvertedWindow {
+                freeze_at,
+                unfreeze_at,
+            });
+        }
+
+        if unfreeze_at <= now {
+            return Err(FreezeScheduleError::ElapsedWindow {
+                unfreeze_at,
+                now,
+            });
+        }
+
+        let freeze_delay =
+            (freeze_at - now).to_std().unwrap_or(std::time::Duration::ZERO);
+        let unfreeze_delay =
+            (unfreeze_at - now).to_std().unwrap_or(std::time::Duration::ZERO);
+
+        self.queue
+            .push_scheduled_batch([
+                (
+                    ApplyFreezeTransition {
+                        underlying: underlying.clone(),
+                        transition: FreezeTransition::Freeze,
+                        scheduled_for: freeze_at,
+                    },
+                    format!("freeze:{underlying}:{}", freeze_at.timestamp()),
+                    freeze_delay,
+                ),
+                (
+                    ApplyFreezeTransition {
+                        underlying: underlying.clone(),
+                        transition: FreezeTransition::Unfreeze,
+                        scheduled_for: unfreeze_at,
+                    },
+                    format!(
+                        "unfreeze:{underlying}:{}",
+                        unfreeze_at.timestamp()
+                    ),
+                    unfreeze_delay,
+                ),
+            ])
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use chrono::{Duration as ChronoDuration, Utc};
+    use event_sorcery::StoreBuilder;
+
+    use super::{
+        ApplyFreezeTransition, FreezeScheduleCtx, FreezeScheduleError,
+        FreezeScheduler, FreezeTransition,
+    };
+    use crate::jobs::Job;
+    use crate::mint::test_utils::TestHarness;
+    use crate::tokenized_asset::UnderlyingSymbol;
+    use crate::underlying::{AssetStatus, Underlying, load_freeze_status};
+
+    // The job dispatches the same command path the CLI uses: perform on a
+    // Freeze transition flips the asset to Frozen, Unfreeze flips it back,
+    // and re-performing either is an idempotent no-op.
+    #[tokio::test]
+    async fn perform_applies_freeze_then_unfreeze_idempotently() {
+        let harness = TestHarness::new().await;
+        let underlying = harness.setup_account_and_asset().await.underlying;
+        let pool = harness.pool.clone();
+        let (underlying_store, _projection) =
+            StoreBuilder::<Underlying>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        let ctx = FreezeScheduleCtx { underlying_store };
+
+        let freeze = ApplyFreezeTransition {
+            underlying: underlying.clone(),
+            transition: FreezeTransition::Freeze,
+            scheduled_for: Utc::now(),
+        };
+        freeze.perform(&ctx).await.unwrap();
+        freeze.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            load_freeze_status(&pool, &underlying).await.unwrap(),
+            AssetStatus::Frozen
+        );
+
+        let unfreeze = ApplyFreezeTransition {
+            underlying: underlying.clone(),
+            transition: FreezeTransition::Unfreeze,
+            scheduled_for: Utc::now(),
+        };
+        unfreeze.perform(&ctx).await.unwrap();
+        unfreeze.perform(&ctx).await.unwrap();
+
+        assert_eq!(
+            load_freeze_status(&pool, &underlying).await.unwrap(),
+            AssetStatus::Enabled
+        );
+    }
+
+    #[tokio::test]
+    async fn schedule_window_rejects_inverted_window() {
+        let harness = TestHarness::new().await;
+        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let now = Utc::now();
+
+        let error = scheduler
+            .schedule_window(
+                &UnderlyingSymbol::new("AAPL").unwrap(),
+                now + ChronoDuration::hours(2),
+                now + ChronoDuration::hours(1),
+                now,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, FreezeScheduleError::InvertedWindow { .. }));
+    }
+
+    #[tokio::test]
+    async fn schedule_window_rejects_elapsed_window() {
+        let harness = TestHarness::new().await;
+        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let now = Utc::now();
+
+        let error = scheduler
+            .schedule_window(
+                &UnderlyingSymbol::new("AAPL").unwrap(),
+                now - ChronoDuration::hours(2),
+                now - ChronoDuration::hours(1),
+                now,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, FreezeScheduleError::ElapsedWindow { .. }));
+    }
+
+    // An in-progress window (freeze_at already past, unfreeze_at ahead) is
+    // accepted: the freeze fires immediately rather than being dropped.
+    #[tokio::test]
+    async fn schedule_window_accepts_in_progress_window() {
+        let harness = TestHarness::new().await;
+        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let now = Utc::now();
+
+        scheduler
+            .schedule_window(
+                &UnderlyingSymbol::new("AAPL").unwrap(),
+                now - ChronoDuration::minutes(5),
+                now + ChronoDuration::hours(1),
+                now,
+            )
+            .await
+            .unwrap();
+    }
+
+    // Re-arming the identical window twice must not error: the idempotency
+    // key collapses the duplicate enqueues.
+    #[tokio::test]
+    async fn schedule_window_is_idempotent_for_the_same_window() {
+        let harness = TestHarness::new().await;
+        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let now = Utc::now();
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let freeze_at = now + ChronoDuration::hours(1);
+        let unfreeze_at = now + ChronoDuration::hours(3);
+
+        scheduler
+            .schedule_window(&underlying, freeze_at, unfreeze_at, now)
+            .await
+            .unwrap();
+        scheduler
+            .schedule_window(&underlying, freeze_at, unfreeze_at, now)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn schedule_window_does_not_persist_half_a_window_when_unfreeze_insert_fails()
+     {
+        let harness = TestHarness::new().await;
+        let mut scheduler = FreezeScheduler::new(&harness.apalis_pool);
+        let now = Utc::now();
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+
+        sqlx::query(
+            r"
+            CREATE TRIGGER reject_unfreeze_job
+            BEFORE INSERT ON Jobs
+            WHEN NEW.idempotency_key LIKE 'unfreeze:%'
+            BEGIN
+                SELECT RAISE(ABORT, 'injected unfreeze enqueue failure');
+            END
+            ",
+        )
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+        let error = scheduler
+            .schedule_window(
+                &underlying,
+                now + ChronoDuration::hours(1),
+                now + ChronoDuration::hours(3),
+                now,
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(error, FreezeScheduleError::Push(_)));
+        let persisted_transitions: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key LIKE ?",
+        )
+        .bind("%:AAPL:%")
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(persisted_transitions, 0);
+    }
+}


### PR DESCRIPTION
## Motivation

Dividend freeze windows are known in advance (the ex-date), but today the `Freeze`/`Unfreeze` commands can only be fired by hand via the issuer CLI at the exact instants. An operator has to be at a keyboard at the right moment twice per corporate action, and a missed unfreeze leaves the asset gated longer than intended.

Implements [RAI-1045](https://linear.app/makeitrain/issue/RAI-1045/schedule-freezing-with-apalis).

## Solution

- `FreezeScheduler::schedule_window(underlying, freeze_at, unfreeze_at)` arms one window by enqueueing two durable apalis jobs (`ApplyFreezeTransition`), reusing the job infrastructure from the mint-recovery stack this PR sits on.
- The worker dispatches the exact same `TokenizedAssetCommand::Freeze`/`Unfreeze` the CLI does — only the trigger changes, so the mint gate and held-redemption hold/resume react identically.
- `POST /admin/freeze-schedules` (internal auth, documented in the OpenAPI spec) is the API to arm a window; the future Alpaca corporate-actions sourcing (RAI-1043) calls the same scheduler.
- The scheduler itself gates on the underlying having a listing (404 from the endpoint) — the `Underlying` commands succeed for any symbol, so an unchecked typo would arm a freeze that gates nothing while reporting success.
- Windows survive restarts (apalis persists the due time); re-arming the identical window while pending/running is a no-op (jobs idempotency-keyed by underlying + full scheduled instant, subseconds included); terminal rows (done/killed/out-of-retries) release their keys on re-arm so an infrastructure failure never permanently blocks a window.
- Startup resets orphaned `Running` freeze jobs and vacuums terminal rows, mirroring the mint jobs; transitions that died without applying are surfaced at ERROR before their rows are removed.
- Inverted and sub-second windows are 422 (apalis schedules at second granularity, so a sub-second window has no defined order), fully elapsed windows are rejected rather than flapping the asset, and an in-progress window freezes immediately.
- `JobQueue::push_scheduled_batch` adds the atomic `run_after` + idempotency-key enqueue path (batch entries are a named `ScheduledTask` struct); the drainer worker follows the existing `spawn_drainer_worker!` supervision pattern with the tracing target parameterized per domain.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs
