### PR TITLE
refactor: share per-network vault services

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -9,7 +9,6 @@ use rocket::serde::json::Json;
 use rocket::{get, post};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -35,7 +34,9 @@ use crate::redemption::{
     next_burn_retry_external_tx_id_from_history,
 };
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
-use crate::vault::{BurnVerification, TxId, VaultError, VaultService};
+use crate::vault::{
+    BurnVerification, NetworkVaultServices, TxId, VaultError, VaultService,
+};
 
 #[async_trait]
 pub(crate) trait RedemptionBurnRecovery: Send + Sync {
@@ -80,33 +81,6 @@ impl RedemptionBurnRecovery for BurnManager {
         )
         .await
     }
-}
-
-/// Per-network vault services held in Rocket managed state for mint confirm,
-/// admin recovery, and stuck triage. Mirrors the map the live redemption path
-/// threads through `RedemptionServices`/`BurnManager`, so those routes query
-/// the same signing backend as the flow that submitted the transaction.
-pub(crate) struct NetworkVaultServices(HashMap<Network, Arc<dyn VaultService>>);
-
-impl NetworkVaultServices {
-    pub(crate) fn new(
-        services: HashMap<Network, Arc<dyn VaultService>>,
-    ) -> Self {
-        Self(services)
-    }
-
-    pub(crate) fn get(
-        &self,
-        network: Network,
-    ) -> Result<&Arc<dyn VaultService>, UnconfiguredNetworkError> {
-        self.0.get(&network).ok_or(UnconfiguredNetworkError { network })
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-#[error("no vault service configured for network {network}")]
-pub(crate) struct UnconfiguredNetworkError {
-    network: Network,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, utoipa::ToSchema)]
@@ -419,7 +393,7 @@ pub(crate) async fn recover_redemption(
     // network must have a configured vault service before any recovery step
     // runs — otherwise fail closed with a 422.
     let vault_service =
-        vault_services.get(context.metadata.network).map_err(|error| {
+        vault_services.service(context.metadata.network).map_err(|error| {
             error!(target: "admin", aggregate_id = %aggregate_id,
                 error = %error,
                 "Cannot recover redemption on an unconfigured network"
@@ -1935,7 +1909,6 @@ mod tests {
     use rocket::http::Status;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
-    use std::collections::HashMap;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tracing::Level;
@@ -1965,11 +1938,12 @@ mod tests {
         RedemptionCommand, RedemptionEvent, RedemptionMetadata,
         RedemptionServices, RedemptionView,
     };
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        MultiBurnEntry, SendableTxWithHash, TxId, VaultService,
+        MultiBurnEntry, NetworkVaultServices, SendableTxWithHash, TxId,
+        VaultService,
     };
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
@@ -2006,11 +1980,12 @@ mod tests {
         }
     }
 
-    fn mock_network_vault_services() -> super::NetworkVaultServices {
-        super::NetworkVaultServices::new(HashMap::from([(
+    fn mock_network_vault_services() -> NetworkVaultServices {
+        NetworkVaultServices::with_single_vault(
             Network::Base,
+            ANVIL_CHAIN_ID,
             mock_vault_service(),
-        )]))
+        )
     }
 
     /// Configurable poll response for the test mock.

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1169,7 +1169,7 @@ pub(crate) async fn reprocess_mint(
         }
     };
 
-    let vault_service = vault_services.get(network).map_err(|error| {
+    let vault_service = vault_services.service(network).map_err(|error| {
         error!(target: "admin", aggregate_id = aggregate_id,
             error = %error,
             "Cannot reprocess mint on an unconfigured network"
@@ -3271,10 +3271,11 @@ mod tests {
             .manage(store)
             .manage(pool)
             .manage(alpaca)
-            .manage(super::NetworkVaultServices::new(HashMap::from([(
+            .manage(super::NetworkVaultServices::with_single_vault(
                 Network::Base,
+                crate::test_utils::ANVIL_CHAIN_ID,
                 vault_service,
-            )])))
+            ))
             .manage(burn_recovery)
             .mount("/", rocket::routes![super::recover_redemption])
     }

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -21,7 +21,10 @@ use crate::tokenized_asset::view::{
     TokenizedAssetViewError, list_enabled_assets,
 };
 use crate::vault::rain_meta::OaSchemaCache;
-use crate::vault::{VaultService, service::RealBlockchainService};
+use crate::vault::{
+    NetworkVault, NetworkVaultServices, VaultService,
+    service::RealBlockchainService,
+};
 use crate::wallet::{
     SignerConfig, SignerResolveError, local::resolve_local_signer,
     turnkey::resolve_turnkey_signer,
@@ -160,13 +163,23 @@ impl<P> ChainRegistry<P> {
         self.runtimes.keys().copied().collect()
     }
 
-    pub(crate) fn clone_vault_services(
-        &self,
-    ) -> HashMap<Network, Arc<dyn VaultService>> {
-        self.runtimes
-            .iter()
-            .map(|(network, runtime)| (*network, runtime.vault_service.clone()))
-            .collect()
+    /// Builds the shared per-network vault-service lookup handed to every
+    /// consumer that dispatches on-chain work by network.
+    pub(crate) fn network_vault_services(&self) -> NetworkVaultServices {
+        NetworkVaultServices::new(
+            self.runtimes
+                .iter()
+                .map(|(network, runtime)| {
+                    (
+                        *network,
+                        NetworkVault {
+                            service: runtime.vault_service.clone(),
+                            chain_id: runtime.chain_id,
+                        },
+                    )
+                })
+                .collect(),
+        )
     }
 
     pub(crate) fn runtimes(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use crate::tokenized_asset::{
     validate_no_cross_network_vault_collisions, view::list_enabled_assets,
 };
 use crate::underlying::Underlying;
+use crate::vault::NetworkVaultServices;
 use poll_checkpoint::load_receipt_backfill;
 
 pub mod account;
@@ -293,26 +294,21 @@ pub async fn initialize_rocket(
 
     let vault_service_for_rocket = base.vault_service.clone();
     let configured_networks = chain_registry.configured_networks();
+    let network_vault_services = chain_registry.network_vault_services();
 
     let AggregateCqrsSetup { mint_store, redemption_store } =
         setup_aggregate_cqrs(
             &pool,
             &receipt_inventory_store,
-            &chain_registry,
+            &network_vault_services,
             alpaca_service,
             bot_wallet,
         )
         .await?;
 
-    let chain_ids = chain_registry
-        .runtimes()
-        .map(|(network, runtime)| (*network, runtime.chain_id))
-        .collect();
-
     let managers = setup_redemption_managers(
         &config,
-        chain_registry.clone_vault_services(),
-        chain_ids,
+        network_vault_services.clone(),
         &redemption_store,
         &receipt_inventory_store,
         &pool,
@@ -451,9 +447,7 @@ pub async fn initialize_rocket(
         alpaca_service: rocket_alpaca,
         burn_recovery: managers.burn.clone()
             as Arc<dyn admin::RedemptionBurnRecovery>,
-        vault_services: admin::NetworkVaultServices::new(
-            chain_registry.clone_vault_services(),
-        ),
+        vault_services: network_vault_services,
         configured_networks,
     }))
 }
@@ -469,7 +463,7 @@ struct RocketState {
     redemption_store: Arc<Store<Redemption>>,
     alpaca_service: Arc<dyn AlpacaService>,
     burn_recovery: Arc<dyn admin::RedemptionBurnRecovery>,
-    vault_services: admin::NetworkVaultServices,
+    vault_services: NetworkVaultServices,
     configured_networks: ConfiguredNetworks,
 }
 
@@ -547,26 +541,18 @@ fn mount_api_docs(
     )
 }
 
-async fn setup_aggregate_cqrs<P>(
+async fn setup_aggregate_cqrs(
     pool: &Pool<Sqlite>,
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
-    chain_registry: &ChainRegistry<P>,
+    network_vault_services: &NetworkVaultServices,
     alpaca_service: Arc<dyn AlpacaService>,
     bot_wallet: Address,
-) -> Result<AggregateCqrsSetup, anyhow::Error>
-where
-    P: Provider + Clone,
-{
+) -> Result<AggregateCqrsSetup, anyhow::Error> {
     // Create MintServices with all dependencies
     let receipt_service =
         Arc::new(CqrsReceiptService::new(receipt_inventory_store.clone()));
-    let chain_ids = chain_registry
-        .runtimes()
-        .map(|(network, runtime)| (*network, runtime.chain_id))
-        .collect();
     let mint_services = MintServices::new(
-        chain_registry.clone_vault_services(),
-        chain_ids,
+        network_vault_services.clone(),
         alpaca_service,
         receipt_service,
         pool.clone(),
@@ -597,7 +583,7 @@ where
     // receipt_inventory_view at query time to compute available balance).
     prepare_event_sourced_startup::<Redemption>(pool).await?;
     let redemption_services =
-        RedemptionServices::new(chain_registry.clone_vault_services());
+        RedemptionServices::new(network_vault_services.clone());
     let redemption_store = StoreBuilder::<Redemption>::new(pool.clone())
         .with(Arc::new(RedemptionViewReactor::new(pool.clone())))
         .with(Arc::new(ReceiptBurnsViewReactor::new(pool.clone())))
@@ -705,8 +691,7 @@ async fn clear_canonical_projection_for_aggregate(
 
 fn setup_redemption_managers(
     config: &Config,
-    vault_services: HashMap<Network, Arc<dyn vault::VaultService>>,
-    chain_ids: HashMap<Network, u64>,
+    vault_services: NetworkVaultServices,
     redemption_store: &Arc<Store<Redemption>>,
     receipt_inventory_store: &Arc<Store<ReceiptInventory>>,
     pool: &Pool<Sqlite>,
@@ -729,7 +714,6 @@ fn setup_redemption_managers(
 
     let burn = Arc::new(BurnManager::new(
         vault_services,
-        chain_ids,
         pool.clone(),
         redemption_store.clone(),
         receipt_service,

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -7,13 +7,12 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
-use crate::admin::NetworkVaultServices;
 use crate::auth::IssuerAuth;
 use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, TokenizationRequestId,
     recovery::enqueue_scheduled_mint_recovery,
 };
-use crate::vault::VaultService;
+use crate::vault::{NetworkVaultServices, VaultService};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JournalConfirmationRequest {
@@ -112,8 +111,8 @@ pub(crate) async fn confirm_journal(
                 return rocket::http::Status::InternalServerError;
             };
 
-            let vault_service = match vault_services.get(network) {
-                Ok(vault) => vault.clone(),
+            let vault_service = match vault_services.service(network) {
+                Ok(vault_service) => vault_service.clone(),
                 Err(error) => {
                     error!(target: "mint",
                         issuer_request_id = %issuer_request_id,

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -2,7 +2,6 @@ use alloy::primitives::{Address, B256, address};
 use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use event_sorcery::{Store, StoreBuilder, test_store};
 use sqlx::sqlite::{SqliteJournalMode, SqlitePoolOptions};
-use std::collections::HashMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -11,7 +10,6 @@ use url::Url;
 use crate::account::{
     Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
 };
-use crate::admin::NetworkVaultServices;
 use crate::alpaca::mock::MockAlpacaService;
 use crate::alpaca::service::AlpacaConfig;
 use crate::auth::test_auth_config;
@@ -20,15 +18,19 @@ use crate::mint::{Mint, MintServices, Network, TokenSymbol, UnderlyingSymbol};
 use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
 use crate::test_utils::ANVIL_CHAIN_ID;
 use crate::tokenized_asset::{AssetKey, TokenizedAsset, TokenizedAssetCommand};
-use crate::vault::VaultService;
 use crate::vault::mock::MockVaultService;
+use crate::vault::{NetworkVaultServices, VaultService};
 use crate::wallet::SignerConfig;
 
 /// Wraps a single-network mock vault the way production Rocket state does.
 pub(crate) fn network_vault_services(
     vault: Arc<dyn VaultService>,
 ) -> NetworkVaultServices {
-    NetworkVaultServices::new(HashMap::from([(Network::Base, vault)]))
+    NetworkVaultServices::with_single_vault(
+        Network::Base,
+        ANVIL_CHAIN_ID,
+        vault,
+    )
 }
 
 pub(crate) fn test_config() -> Config {

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -10,7 +10,6 @@ use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use event_sorcery::{EventSourced, Table};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 use uuid::Uuid;
@@ -24,7 +23,8 @@ use crate::tokenized_asset::view::{
     TokenizedAssetViewError, TokenizedAssetViewFailure, find_vault,
 };
 use crate::vault::{
-    PreparedMintTx, ReceiptInformation, TxId, VaultError, VaultService,
+    NetworkVaultServices, PreparedMintTx, ReceiptInformation, TxId,
+    UnconfiguredNetworkError, VaultError, VaultService,
 };
 
 pub use api::MintResponse;
@@ -42,8 +42,7 @@ pub(crate) use view::{
 /// Mint side effects resolve [`VaultService`] per aggregate `network` via
 /// [`Self::vault_for`] ([RAI-1206]).
 pub(crate) struct MintServices {
-    vaults: HashMap<Network, Arc<dyn VaultService>>,
-    chain_ids: HashMap<Network, u64>,
+    vaults: NetworkVaultServices,
     pub(crate) alpaca: Arc<dyn AlpacaService>,
     pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) pool: Pool<Sqlite>,
@@ -52,14 +51,13 @@ pub(crate) struct MintServices {
 
 impl MintServices {
     pub(crate) fn new(
-        vaults: HashMap<Network, Arc<dyn VaultService>>,
-        chain_ids: HashMap<Network, u64>,
+        vaults: NetworkVaultServices,
         alpaca: Arc<dyn AlpacaService>,
         receipts: Arc<dyn ReceiptService>,
         pool: Pool<Sqlite>,
         bot: Address,
     ) -> Self {
-        Self { vaults, chain_ids, alpaca, receipts, pool, bot }
+        Self { vaults, alpaca, receipts, pool, bot }
     }
 
     pub(crate) fn with_single_vault(
@@ -72,8 +70,7 @@ impl MintServices {
         bot: Address,
     ) -> Self {
         Self::new(
-            HashMap::from([(network, vault)]),
-            HashMap::from([(network, chain_id)]),
+            NetworkVaultServices::with_single_vault(network, chain_id, vault),
             alpaca,
             receipts,
             pool,
@@ -85,19 +82,14 @@ impl MintServices {
         &self,
         network: Network,
     ) -> Result<u64, MintError> {
-        self.chain_ids
-            .get(&network)
-            .copied()
-            .ok_or(MintError::NetworkNotConfigured { network })
+        Ok(self.vaults.chain_id(network)?)
     }
 
     fn vault_for(
         &self,
         network: Network,
     ) -> Result<&Arc<dyn VaultService>, MintError> {
-        self.vaults
-            .get(&network)
-            .ok_or(MintError::NetworkNotConfigured { network })
+        Ok(self.vaults.service(network)?)
     }
 }
 
@@ -2415,6 +2407,12 @@ impl From<TokenizedAssetViewError> for MintError {
     }
 }
 
+impl From<UnconfiguredNetworkError> for MintError {
+    fn from(error: UnconfiguredNetworkError) -> Self {
+        Self::NetworkNotConfigured { network: error.network }
+    }
+}
+
 #[cfg(test)]
 pub(crate) mod tests {
     use alloy::primitives::{Address, B256, U256, address, b256, uint};
@@ -2452,8 +2450,8 @@ pub(crate) mod tests {
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-        PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx,
-        TxId, VaultError, VaultService,
+        NetworkVaultServices, PreparedMintTx, ReceiptInformation,
+        SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
     };
 
     pub(super) const VAULT: Address =
@@ -2842,8 +2840,7 @@ pub(crate) mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
         MintServices::new(
-            HashMap::new(),
-            HashMap::new(),
+            NetworkVaultServices::new(HashMap::new()),
             Arc::new(MockAlpacaService::new_success()),
             Arc::new(CqrsReceiptService::new(receipt_store)),
             pool,

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -2,7 +2,6 @@ use alloy::primitives::{Address, B256, U256};
 use cqrs_es::AggregateError;
 use event_sorcery::{LifecycleError, Store};
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
@@ -27,8 +26,9 @@ use crate::redemption::{
 use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
 use crate::vault::{
-    BurnTxStatus, BurnVerification, MultiBurnEntry, SendableTxWithHash, TxId,
-    VaultError, VaultService,
+    BurnTxStatus, BurnVerification, MultiBurnEntry, NetworkVaultServices,
+    SendableTxWithHash, TxId, UnconfiguredNetworkError, VaultError,
+    VaultService,
 };
 
 pub(crate) const MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS: u32 = 5;
@@ -69,10 +69,8 @@ pub(crate) enum RecoveryOutcome {
 /// On burn failure, the manager issues a `RecordBurnFailure` command to record the error.
 #[derive(Clone)]
 pub(crate) struct BurnManager {
-    /// Per-network vault services for balance queries and Fireblocks recovery.
-    vault_services: HashMap<Network, Arc<dyn VaultService>>,
-    /// Per-network EVM chain ids for receipt inventory aggregate keys.
-    chain_ids: HashMap<Network, u64>,
+    /// Per-network vault services and chain ids for recovery paths.
+    vaults: NetworkVaultServices,
     view_pool: Pool<Sqlite>,
     store: Arc<Store<Redemption>>,
     receipt_service: Arc<dyn ReceiptService>,
@@ -85,46 +83,34 @@ impl BurnManager {
     ///
     /// # Arguments
     ///
-    /// * `vault_services` - Per-network vault services for recovery paths
+    /// * `vaults` - Per-network vault services and chain ids for recovery paths
     /// * `view_pool` - Database pool for querying views
     /// * `store` - Event-sorcery store for dispatching commands and loading
     ///   aggregate state during recovery
     /// * `receipt_service` - Service for finding receipts to burn
     /// * `bot_wallet` - Bot's wallet address that owns both shares and receipts
-    /// * `chain_ids` - Per-network EVM chain ids for receipt inventory keys
     pub(crate) fn new(
-        vault_services: HashMap<Network, Arc<dyn VaultService>>,
-        chain_ids: HashMap<Network, u64>,
+        vaults: NetworkVaultServices,
         view_pool: Pool<Sqlite>,
         store: Arc<Store<Redemption>>,
         receipt_service: Arc<dyn ReceiptService>,
         bot_wallet: Address,
     ) -> Self {
-        Self {
-            vault_services,
-            chain_ids,
-            view_pool,
-            store,
-            receipt_service,
-            bot_wallet,
-            automatic_recovery_lock: Arc::new(Mutex::new(())),
-        }
+        Self { vaults, view_pool, store, receipt_service, bot_wallet }
     }
 
     fn vault_for(
         &self,
         network: Network,
-    ) -> Result<&Arc<dyn VaultService>, RedemptionError> {
-        self.vault_services
-            .get(&network)
-            .ok_or(RedemptionError::NetworkNotConfigured { network })
+    ) -> Result<&Arc<dyn VaultService>, UnconfiguredNetworkError> {
+        self.vaults.service(network)
     }
 
-    fn chain_id_for(&self, network: Network) -> Result<u64, RedemptionError> {
-        self.chain_ids
-            .get(&network)
-            .copied()
-            .ok_or(RedemptionError::NetworkNotConfigured { network })
+    fn chain_id_for(
+        &self,
+        network: Network,
+    ) -> Result<u64, UnconfiguredNetworkError> {
+        self.vaults.chain_id(network)
     }
 
     /// Terminalizes a redemption whose network has no configured vault
@@ -171,8 +157,11 @@ impl BurnManager {
         receipt_chain_id: u64,
     ) -> Self {
         Self {
-            vault_services: HashMap::from([(Network::Base, vault_service)]),
-            chain_ids: HashMap::from([(Network::Base, receipt_chain_id)]),
+            vaults: NetworkVaultServices::with_single_vault(
+                Network::Base,
+                receipt_chain_id,
+                vault_service,
+            ),
             view_pool,
             store,
             receipt_service,
@@ -288,7 +277,6 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         reason: String,
-        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<BurnVerification, BurnManagerError> {
         let redemption =
             self.store.load(issuer_request_id).await?.ok_or_else(|| {
@@ -299,11 +287,15 @@ impl BurnManager {
 
         let persisted_burn_tx = redemption.persisted_burn_tx()?;
         persisted_burn_tx.validate_for_owner(self.bot_wallet)?;
-        let acknowledged_unresolved_burn_tx_hash = redemption
-            .validate_force_complete_burn_hash(
-                burn_tx_hash,
-                acknowledged_unresolved_burn_tx_hash,
-            )?;
+        let persisted_burn_hash = persisted_burn_tx.hash;
+        if persisted_burn_hash != burn_tx_hash {
+            return Err(BurnManagerError::Redemption(
+                RedemptionError::BurnHashMismatch {
+                    expected: persisted_burn_hash,
+                    provided: burn_tx_hash,
+                },
+            ));
+        }
 
         let (underlying, network) = match &redemption {
             Redemption::Burning { metadata, .. }
@@ -323,6 +315,8 @@ impl BurnManager {
                 BurnManagerError::AssetNotFound { underlying, network },
             )?;
 
+        // Verify the burn actually landed on-chain before recording a terminal
+        // success — never trust the operator-supplied hash blindly.
         let verification = self
             .vault_for(network)?
             .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
@@ -330,8 +324,6 @@ impl BurnManager {
 
         info!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_tx_hash = ?burn_tx_hash,
-            persisted_burn_tx_hash = ?persisted_burn_tx.hash,
-            acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
             block_number = verification.block_number,
             shares_burned = %verification.shares_burned,
             "Force-completing stuck Burning redemption: burn verified on-chain"
@@ -345,7 +337,6 @@ impl BurnManager {
                     burn_tx_hash,
                     block_number: verification.block_number,
                     reason,
-                    acknowledged_unresolved_burn_tx_hash,
                 },
             )
             .await?;
@@ -905,8 +896,7 @@ impl BurnManager {
         external_tx_id: Option<BurnExternalTxId>,
         has_submitted: bool,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
-        let vault_service = self.vault_for(metadata.network)?;
-        let wallet_guard = vault_service.lock_wallet().await;
+        let wallet_guard = self.vault_service.lock_wallet().await;
         if !self
             .recovery_budget_available(issuer_request_id, Some(sendable_tx))
             .await?
@@ -919,7 +909,8 @@ impl BurnManager {
             return Ok(RecoveryOutcome::SkippedManualIntervention);
         }
 
-        let status = vault_service
+        let status = self
+            .vault_service
             .classify_burn_tx(self.bot_wallet, sendable_tx)
             .await?;
         let tx_id = sendable_tx.hash.into();
@@ -936,15 +927,10 @@ impl BurnManager {
                 .await;
         }
 
-        let action = match status {
-            BurnTxStatus::StillMineable => BurnRecoveryAction::Rebroadcast,
-            BurnTxStatus::ProvablyDead => BurnRecoveryAction::Replace,
-            BurnTxStatus::Mined | BurnTxStatus::Reverted => {
-                return Err(BurnManagerError::InvalidAggregateState {
-                    current_state: "terminal burn classification".to_string(),
-                });
-            }
-        };
+        let action = recovery_action_for_status(status)
+            .ok_or_else(terminal_classification_error)?;
+        let action_already_reserved =
+            pending_recovery == Some(PendingBurnRecovery::Reserved(action));
         let vault = find_vault(
             &self.view_pool,
             &metadata.underlying,
@@ -955,6 +941,14 @@ impl BurnManager {
             underlying: metadata.underlying.clone(),
             network: metadata.network,
         })?;
+        if !action_already_reserved
+            && !self
+                .recovery_budget_available(issuer_request_id, Some(sendable_tx))
+                .await?
+        {
+            drop(wallet_guard);
+            return Ok(RecoveryOutcome::SkippedManualIntervention);
+        }
         if status == BurnTxStatus::ProvablyDead {
             let unresolved_mint =
                 has_unresolved_mint_intent(&self.view_pool, None).await?;
@@ -1056,6 +1050,56 @@ impl BurnManager {
             "Automatic burn recovery action accepted"
         );
         Ok(RecoveryOutcome::Executed)
+    }
+
+    async fn submit_prepared_replacement(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        metadata: &RedemptionMetadata,
+        planned_burns: &[BurnRecord],
+        sendable_tx: &SendableTxWithHash,
+        external_tx_id: Option<BurnExternalTxId>,
+    ) -> Result<(), BurnManagerError> {
+        let vault = find_vault(
+            &self.view_pool,
+            &metadata.underlying,
+            &metadata.network,
+        )
+        .await?
+        .ok_or_else(|| BurnManagerError::AssetNotFound {
+            underlying: metadata.underlying.clone(),
+            network: metadata.network,
+        })?;
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::BurnTokens {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: recovery_burn_entries(planned_burns),
+                    dust_shares: sendable_tx.dust_shares,
+                    owner: self.bot_wallet,
+                    external_tx_id,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn exhausted_recovery_outcome(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<Option<RecoveryOutcome>, BurnManagerError> {
+        if !self.burn_recovery_budget(issuer_request_id).await?.exhausted {
+            return Ok(None);
+        }
+        debug!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            tx_hash = %sendable_tx.hash,
+            "Skipping burn with exhausted automatic recovery budget"
+        );
+        Ok(Some(RecoveryOutcome::SkippedManualIntervention))
     }
 
     async fn recover_single_burning(
@@ -1163,7 +1207,7 @@ impl BurnManager {
                 // verified burn tx) for landed burns, or `close` for ambiguous cases.
                 let vault_service = match self.vault_for(metadata.network) {
                     Ok(vault_service) => vault_service,
-                    Err(RedemptionError::NetworkNotConfigured { network }) => {
+                    Err(UnconfiguredNetworkError { network }) => {
                         return self
                             .record_burn_failure_for_unconfigured_network(
                                 issuer_request_id,
@@ -1174,7 +1218,6 @@ impl BurnManager {
                             .await
                             .map(|()| RecoveryOutcome::Executed);
                     }
-                    Err(err) => return Err(err.into()),
                 };
 
                 let on_chain_balance = vault_service
@@ -2201,6 +2244,8 @@ pub(crate) enum BurnManagerError {
     Cqrs(#[from] AggregateError<LifecycleError<Redemption>>),
     #[error("Redemption error: {0}")]
     Redemption(#[from] RedemptionError),
+    #[error(transparent)]
+    UnconfiguredNetwork(#[from] UnconfiguredNetworkError),
     #[error("Invalid aggregate state: {current_state}")]
     InvalidAggregateState { current_state: String },
     #[error("Quantity conversion error: {0}")]

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -96,7 +96,14 @@ impl BurnManager {
         receipt_service: Arc<dyn ReceiptService>,
         bot_wallet: Address,
     ) -> Self {
-        Self { vaults, view_pool, store, receipt_service, bot_wallet }
+        Self {
+            vaults,
+            view_pool,
+            store,
+            receipt_service,
+            bot_wallet,
+            automatic_recovery_lock: Arc::new(Mutex::new(())),
+        }
     }
 
     fn vault_for(
@@ -277,6 +284,7 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<BurnVerification, BurnManagerError> {
         let redemption =
             self.store.load(issuer_request_id).await?.ok_or_else(|| {
@@ -287,15 +295,11 @@ impl BurnManager {
 
         let persisted_burn_tx = redemption.persisted_burn_tx()?;
         persisted_burn_tx.validate_for_owner(self.bot_wallet)?;
-        let persisted_burn_hash = persisted_burn_tx.hash;
-        if persisted_burn_hash != burn_tx_hash {
-            return Err(BurnManagerError::Redemption(
-                RedemptionError::BurnHashMismatch {
-                    expected: persisted_burn_hash,
-                    provided: burn_tx_hash,
-                },
-            ));
-        }
+        let acknowledged_unresolved_burn_tx_hash = redemption
+            .validate_force_complete_burn_hash(
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash,
+            )?;
 
         let (underlying, network) = match &redemption {
             Redemption::Burning { metadata, .. }
@@ -315,8 +319,6 @@ impl BurnManager {
                 BurnManagerError::AssetNotFound { underlying, network },
             )?;
 
-        // Verify the burn actually landed on-chain before recording a terminal
-        // success — never trust the operator-supplied hash blindly.
         let verification = self
             .vault_for(network)?
             .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
@@ -324,6 +326,8 @@ impl BurnManager {
 
         info!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_tx_hash = ?burn_tx_hash,
+            persisted_burn_tx_hash = ?persisted_burn_tx.hash,
+            acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
             block_number = verification.block_number,
             shares_burned = %verification.shares_burned,
             "Force-completing stuck Burning redemption: burn verified on-chain"
@@ -337,6 +341,7 @@ impl BurnManager {
                     burn_tx_hash,
                     block_number: verification.block_number,
                     reason,
+                    acknowledged_unresolved_burn_tx_hash,
                 },
             )
             .await?;
@@ -896,7 +901,8 @@ impl BurnManager {
         external_tx_id: Option<BurnExternalTxId>,
         has_submitted: bool,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
-        let wallet_guard = self.vault_service.lock_wallet().await;
+        let vault_service = self.vault_for(metadata.network)?;
+        let wallet_guard = vault_service.lock_wallet().await;
         if !self
             .recovery_budget_available(issuer_request_id, Some(sendable_tx))
             .await?
@@ -909,8 +915,7 @@ impl BurnManager {
             return Ok(RecoveryOutcome::SkippedManualIntervention);
         }
 
-        let status = self
-            .vault_service
+        let status = vault_service
             .classify_burn_tx(self.bot_wallet, sendable_tx)
             .await?;
         let tx_id = sendable_tx.hash.into();
@@ -927,10 +932,15 @@ impl BurnManager {
                 .await;
         }
 
-        let action = recovery_action_for_status(status)
-            .ok_or_else(terminal_classification_error)?;
-        let action_already_reserved =
-            pending_recovery == Some(PendingBurnRecovery::Reserved(action));
+        let action = match status {
+            BurnTxStatus::StillMineable => BurnRecoveryAction::Rebroadcast,
+            BurnTxStatus::ProvablyDead => BurnRecoveryAction::Replace,
+            BurnTxStatus::Mined | BurnTxStatus::Reverted => {
+                return Err(BurnManagerError::InvalidAggregateState {
+                    current_state: "terminal burn classification".to_string(),
+                });
+            }
+        };
         let vault = find_vault(
             &self.view_pool,
             &metadata.underlying,
@@ -941,14 +951,6 @@ impl BurnManager {
             underlying: metadata.underlying.clone(),
             network: metadata.network,
         })?;
-        if !action_already_reserved
-            && !self
-                .recovery_budget_available(issuer_request_id, Some(sendable_tx))
-                .await?
-        {
-            drop(wallet_guard);
-            return Ok(RecoveryOutcome::SkippedManualIntervention);
-        }
         if status == BurnTxStatus::ProvablyDead {
             let unresolved_mint =
                 has_unresolved_mint_intent(&self.view_pool, None).await?;
@@ -1050,56 +1052,6 @@ impl BurnManager {
             "Automatic burn recovery action accepted"
         );
         Ok(RecoveryOutcome::Executed)
-    }
-
-    async fn submit_prepared_replacement(
-        &self,
-        issuer_request_id: &IssuerRedemptionRequestId,
-        metadata: &RedemptionMetadata,
-        planned_burns: &[BurnRecord],
-        sendable_tx: &SendableTxWithHash,
-        external_tx_id: Option<BurnExternalTxId>,
-    ) -> Result<(), BurnManagerError> {
-        let vault = find_vault(
-            &self.view_pool,
-            &metadata.underlying,
-            &metadata.network,
-        )
-        .await?
-        .ok_or_else(|| BurnManagerError::AssetNotFound {
-            underlying: metadata.underlying.clone(),
-            network: metadata.network,
-        })?;
-        self.store
-            .send(
-                issuer_request_id,
-                RedemptionCommand::BurnTokens {
-                    issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: recovery_burn_entries(planned_burns),
-                    dust_shares: sendable_tx.dust_shares,
-                    owner: self.bot_wallet,
-                    external_tx_id,
-                },
-            )
-            .await?;
-        Ok(())
-    }
-
-    async fn exhausted_recovery_outcome(
-        &self,
-        issuer_request_id: &IssuerRedemptionRequestId,
-        sendable_tx: &SendableTxWithHash,
-    ) -> Result<Option<RecoveryOutcome>, BurnManagerError> {
-        if !self.burn_recovery_budget(issuer_request_id).await?.exhausted {
-            return Ok(None);
-        }
-        debug!(target: "redemption",
-            issuer_request_id = %issuer_request_id,
-            tx_hash = %sendable_tx.hash,
-            "Skipping burn with exhausted automatic recovery budget"
-        );
-        Ok(Some(RecoveryOutcome::SkippedManualIntervention))
     }
 
     async fn recover_single_burning(

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -2230,7 +2230,6 @@ mod tests {
     use event_sorcery::{Store, StoreBuilder, test_store};
     use rust_decimal::Decimal;
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
-    use std::collections::HashMap;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
@@ -2262,8 +2261,8 @@ mod tests {
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        BurnTxStatus, MultiBurnEntry, ReceiptInformation, SendableTxWithHash,
-        TxId, VaultError, VaultService,
+        BurnTxStatus, MultiBurnEntry, NetworkVaultServices, ReceiptInformation,
+        SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
     const TEST_WALLET: Address =
@@ -6351,8 +6350,11 @@ mod tests {
         let blockchain_service: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
         let manager = BurnManager::new(
-            HashMap::from([(Network::Base, blockchain_service)]),
-            HashMap::from([(Network::Base, ANVIL_CHAIN_ID)]),
+            NetworkVaultServices::with_single_vault(
+                Network::Base,
+                ANVIL_CHAIN_ID,
+                blockchain_service,
+            ),
             harness.pool.clone(),
             harness.store.clone(),
             harness.receipt_service.clone(),
@@ -6405,8 +6407,11 @@ mod tests {
         let recovery_blockchain: Arc<dyn crate::vault::VaultService> =
             vault_mock.clone();
         let failing_manager = BurnManager::new(
-            HashMap::from([(Network::Base, recovery_blockchain)]),
-            HashMap::from([(Network::Base, ANVIL_CHAIN_ID)]),
+            NetworkVaultServices::with_single_vault(
+                Network::Base,
+                ANVIL_CHAIN_ID,
+                recovery_blockchain,
+            ),
             harness.pool.clone(),
             harness.store.clone(),
             settle_failing,

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -17,7 +17,6 @@ use chrono::{DateTime, Utc};
 use event_sorcery::{EventSourced, Nil};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
-use std::collections::HashMap;
 use std::sync::Arc;
 use tracing::warn;
 
@@ -188,8 +187,9 @@ impl std::fmt::Display for BurnExternalTxId {
 }
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{
-    BurnTxStatus, MultiBurnEntry, MultiBurnParams, SendableTxWithHash, TxId,
-    VaultError, VaultService,
+    BurnTxStatus, MultiBurnEntry, MultiBurnParams, NetworkVaultServices,
+    SendableTxWithHash, TxId, UnconfiguredNetworkError, VaultError,
+    VaultService,
 };
 
 pub(super) const fn default_redemption_network() -> Network {
@@ -198,11 +198,11 @@ pub(super) const fn default_redemption_network() -> Network {
 
 /// Per-network vault services for redemption command handling ([RAI-1207]).
 pub(crate) struct RedemptionServices {
-    vaults: HashMap<Network, Arc<dyn VaultService>>,
+    vaults: NetworkVaultServices,
 }
 
 impl RedemptionServices {
-    pub(crate) fn new(vaults: HashMap<Network, Arc<dyn VaultService>>) -> Self {
+    pub(crate) const fn new(vaults: NetworkVaultServices) -> Self {
         Self { vaults }
     }
 
@@ -211,16 +211,18 @@ impl RedemptionServices {
         network: Network,
         vault: Arc<dyn VaultService>,
     ) -> Self {
-        Self { vaults: HashMap::from([(network, vault)]) }
+        Self::new(NetworkVaultServices::with_single_vault(
+            network,
+            crate::test_utils::ANVIL_CHAIN_ID,
+            vault,
+        ))
     }
 
     fn vault_for(
         &self,
         network: Network,
     ) -> Result<&Arc<dyn VaultService>, RedemptionError> {
-        self.vaults
-            .get(&network)
-            .ok_or(RedemptionError::NetworkNotConfigured { network })
+        Ok(self.vaults.service(network)?)
     }
 }
 
@@ -1386,6 +1388,12 @@ pub(crate) enum RedemptionError {
     PreparingBurnTxFailed { message: String },
     #[error("network {network} is not configured")]
     NetworkNotConfigured { network: Network },
+}
+
+impl From<UnconfiguredNetworkError> for RedemptionError {
+    fn from(error: UnconfiguredNetworkError) -> Self {
+        Self::NetworkNotConfigured { network: error.network }
+    }
 }
 
 #[async_trait]

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -26,8 +26,13 @@ use crate::mint::{
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
 pub(crate) mod mock;
+pub(crate) mod network_services;
 pub(crate) mod rain_meta;
 pub(crate) mod service;
+
+pub(crate) use network_services::{
+    NetworkVault, NetworkVaultServices, UnconfiguredNetworkError,
+};
 
 /// Service abstraction for vault operations.
 ///

--- a/src/vault/network_services.rs
+++ b/src/vault/network_services.rs
@@ -60,7 +60,6 @@ impl NetworkVaultServices {
         self.get(network).map(|entry| entry.chain_id)
     }
 
-    #[cfg(test)]
     pub(crate) fn with_single_vault(
         network: Network,
         chain_id: u64,

--- a/src/vault/network_services.rs
+++ b/src/vault/network_services.rs
@@ -1,0 +1,106 @@
+//! Per-network vault service lookup, built once at startup and shared by
+//! every consumer that dispatches on-chain work by network (mint and
+//! redemption command handling, burn recovery, admin recovery/triage).
+//!
+//! Consolidates the previously-duplicated `HashMap<Network,
+//! Arc<dyn VaultService>>` + get-or-error copies so the lookup and its error
+//! cannot drift between consumers.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::tokenized_asset::Network;
+use crate::vault::VaultService;
+
+/// The signing backend and chain id serving one configured network.
+#[derive(Clone)]
+pub(crate) struct NetworkVault {
+    pub(crate) service: Arc<dyn VaultService>,
+    pub(crate) chain_id: u64,
+}
+
+/// Per-network [`NetworkVault`] entries, built once at startup from the
+/// chain registry and cloned into every consumer.
+#[derive(Clone)]
+pub(crate) struct NetworkVaultServices {
+    entries: Arc<HashMap<Network, NetworkVault>>,
+}
+
+/// A network has no configured vault service. Consumers convert this into
+/// their own domain error at the boundary.
+#[derive(Debug, thiserror::Error, Clone, Copy, PartialEq, Eq)]
+#[error("no vault service configured for network {network}")]
+pub(crate) struct UnconfiguredNetworkError {
+    pub(crate) network: Network,
+}
+
+impl NetworkVaultServices {
+    pub(crate) fn new(entries: HashMap<Network, NetworkVault>) -> Self {
+        Self { entries: Arc::new(entries) }
+    }
+
+    pub(crate) fn get(
+        &self,
+        network: Network,
+    ) -> Result<&NetworkVault, UnconfiguredNetworkError> {
+        self.entries.get(&network).ok_or(UnconfiguredNetworkError { network })
+    }
+
+    pub(crate) fn service(
+        &self,
+        network: Network,
+    ) -> Result<&Arc<dyn VaultService>, UnconfiguredNetworkError> {
+        self.get(network).map(|entry| &entry.service)
+    }
+
+    pub(crate) fn chain_id(
+        &self,
+        network: Network,
+    ) -> Result<u64, UnconfiguredNetworkError> {
+        self.get(network).map(|entry| entry.chain_id)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_single_vault(
+        network: Network,
+        chain_id: u64,
+        service: Arc<dyn VaultService>,
+    ) -> Self {
+        Self::new(HashMap::from([(
+            network,
+            NetworkVault { service, chain_id },
+        )]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::vault::mock::MockVaultService;
+
+    #[test]
+    fn configured_network_resolves_service_and_chain_id() {
+        let services = NetworkVaultServices::with_single_vault(
+            Network::Base,
+            8453,
+            Arc::new(MockVaultService::new_success()),
+        );
+
+        services.service(Network::Base).unwrap();
+        assert_eq!(services.chain_id(Network::Base).unwrap(), 8453);
+    }
+
+    #[test]
+    fn unconfigured_network_fails_closed() {
+        let services = NetworkVaultServices::with_single_vault(
+            Network::Base,
+            8453,
+            Arc::new(MockVaultService::new_success()),
+        );
+
+        assert!(matches!(
+            services.get(Network::Ethereum),
+            Err(UnconfiguredNetworkError { network: Network::Ethereum })
+        ));
+    }
+}


### PR DESCRIPTION
## Motivation

RAI-1313 follows up on the duplicated per-network vault lookup identified in [#215](https://github.com/ST0x-Technology/st0x.issuance/pull/215). Minting, redemption command handling, burn recovery, and admin recovery each maintained their own service lookup, while minting and burn recovery also kept a separate chain-id map that could drift from the selected signing service.

## Solution

Add one `NetworkVaultServices` registry built from `ChainRegistry` during startup. Each entry couples its `VaultService` with its chain ID, and the same registry is shared by `MintServices`, `RedemptionServices`, `BurnManager`, and Rocket admin state.

Unknown networks fail closed through one shared lookup error. Mint and redemption retain their existing persisted domain-error variants at their serialization boundaries.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Verified with:

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets --all-features -- -D clippy::all -D warnings`
- `cargo fmt --all -- --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Centralized vault and network configuration across minting, redemption, administration, and blockchain operations.
  * Added consistent handling for unconfigured networks, preserving clear request errors.
  * Simplified startup and service configuration by combining vault services with their chain IDs.
* **Bug Fixes**
  * Improved vault and chain selection reliability across supported network workflows.
* **Tests**
  * Updated coverage for configured and unconfigured network scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->