### PR TITLE
feat: add lifecycle notification foundation

### DIFF
--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -81,7 +81,7 @@ pub(crate) enum IssuerRedemptionRequestId {
 
 impl IssuerRedemptionRequestId {
     #[must_use]
-    pub(crate) const fn new(tx_hash: TxHash) -> Self {
+    pub const fn new(tx_hash: TxHash) -> Self {
         Self::Full(tx_hash)
     }
 


### PR DESCRIPTION
## Motivation

Advances [RAI-1044](https://linear.app/makeitrain/issue/RAI-1044/issuance-bot-telegram-notifications-for-corporate-actions-lifecycle). Dividends V1 needs an operator-visible lifecycle channel without allowing Telegram availability to control financial workflow success.

## Solution

- Define typed lifecycle notification variants and redacted, quantity-free message templates
- Add all-or-none Telegram configuration validation with optional forum-topic support
- Provide Telegram, no-op, and capturing notifier implementations behind one lifecycle notifier boundary
- Bound delivery attempts, remove token-bearing URLs from request errors, and treat delivery as best-effort after durable state succeeds
- Add the durable notification job and runtime wiring used by the corporate-action and held-redemption call-site PRs above this branch
- Cover configuration, template rendering, Telegram success/rejection, secret redaction, and non-propagating delivery failures

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs