### PR TITLE
fix: preserve transaction ID variants on replay

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -240,6 +240,21 @@ initial request through journal confirmation to on-chain minting and callback.
   (carries tx details)
 - `MintRetryStarted` - Mint retry started during recovery
 
+Newly persisted transaction IDs use an explicitly tagged `hash` or `legacy`
+representation so replay preserves the original `TxId` variant, including a
+legacy ID whose text is valid 32-byte hex. Replay also accepts the historical
+flat-string representation; because those rows have no variant discriminator,
+32-byte hex flat strings retain the historical hash inference. Legacy
+`FireblocksSubmitted` events and their `fireblocks_tx_id` field replay as
+`MintTxSubmitted`.
+
+The tagged writer is a one-way persistence cutover. Deployment must stop event
+writers, back up the database, replace every service instance with the
+dual-format reader, and only then resume traffic. After the first tagged
+transaction ID is persisted, a binary that only understands flat strings must
+not be restored against that database; recovery is to roll forward with the
+dual-format reader or restore the pre-cutover backup.
+
 **Command -> Event Mappings:**
 
 | Command              | Events                  | Notes                                           |

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -115,7 +115,7 @@ pub(crate) struct StuckAggregate {
     /// `MintTxSubmitted` event. For redemptions, populated only on
     /// `BurnFailed` (the view carries it for that variant).
     #[serde(skip_serializing_if = "Option::is_none")]
-    tx_id: Option<TxId>,
+    tx_id: Option<String>,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -1254,7 +1254,7 @@ pub(crate) async fn list_stuck(
             underlying,
             quantity,
             tx_hash: mint_history.tx_hash,
-            tx_id: mint_history.tx_id,
+            tx_id: mint_history.tx_id.map(|tx_id| tx_id.to_string()),
         });
     }
 
@@ -1438,7 +1438,7 @@ fn stuck_redemption_entry(
         underlying,
         quantity,
         tx_hash,
-        tx_id,
+        tx_id: tx_id.map(|tx_id| tx_id.to_string()),
     })
 }
 
@@ -1776,7 +1776,7 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
-    use super::AggregateKind;
+    use super::{AggregateKind, StuckAggregate};
     use super::{
         AlpacaCalledData, PostAlpacaRecoveryInput, load_reprocess_context,
         recover_post_alpaca,
@@ -1994,6 +1994,36 @@ mod tests {
     }
 
     #[test]
+    fn stuck_aggregate_serializes_tx_id_as_documented_string() {
+        let cases = [
+            TxId::Hash(b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            )),
+            TxId::Legacy("07bdef3c-5314-4d1d-94f7-f3f346cd4c2f".to_string()),
+        ];
+
+        for tx_id in cases {
+            let expected = tx_id.to_string();
+            let entry = StuckAggregate {
+                aggregate_type: AggregateKind::Mint,
+                aggregate_id: "mint-id".to_string(),
+                tokenization_request_id: None,
+                state: "minting_failed".to_string(),
+                detail: "mint failed".to_string(),
+                timestamp: Utc::now(),
+                underlying: None,
+                quantity: None,
+                tx_hash: None,
+                tx_id: Some(expected.clone()),
+            };
+
+            let response = serde_json::to_value(entry).unwrap();
+
+            assert_eq!(response["tx_id"], expected);
+        }
+    }
+
+    #[test]
     fn failed_redemption_stuck_entry_uses_history_metadata() {
         let metadata = test_metadata();
         let tokenization_request_id = TokenizationRequestId::new("tok-red-1");
@@ -2028,7 +2058,7 @@ mod tests {
         assert_eq!(entry.underlying, Some(metadata.underlying));
         assert_eq!(entry.quantity, Some(metadata.quantity));
         assert_eq!(entry.tx_hash, Some(metadata.detected_tx_hash));
-        assert_eq!(entry.tx_id, Some(tx_id));
+        assert_eq!(entry.tx_id, Some(tx_id.to_string()));
         assert_eq!(entry.timestamp, failed_at);
     }
 
@@ -2070,7 +2100,7 @@ mod tests {
             Some(tokenization_request_id)
         );
         assert_eq!(entry.tx_hash, Some(metadata.detected_tx_hash));
-        assert_eq!(entry.tx_id, Some(tx_id));
+        assert_eq!(entry.tx_id, Some(tx_id.to_string()));
         assert_eq!(entry.underlying, Some(metadata.underlying));
         assert_eq!(entry.quantity, Some(metadata.quantity));
     }
@@ -3617,7 +3647,7 @@ mod tests {
         .expect("Burning view should produce a stuck entry");
         assert_eq!(entry.state, "Burning");
         assert_eq!(entry.detail, "Waiting for burn confirmation");
-        assert_eq!(entry.tx_id, Some(tx_id));
+        assert_eq!(entry.tx_id, Some(tx_id.to_string()));
     }
 
     #[test]

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -129,6 +129,58 @@ impl DomainEvent for MintEvent {
     }
 
     fn event_version(&self) -> String {
-        "1.0".to_string()
+        match self {
+            Self::MintTxSubmitted { .. } => "2.0".to_string(),
+            _ => "1.0".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn raw_fireblocks_submitted_event_replays_populated_legacy_tx_id() {
+        let raw_event = json!({
+            "FireblocksSubmitted": {
+                "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+                "external_tx_id": "mint-550e8400-e29b-41d4-a716-446655440000",
+                "fireblocks_tx_id": "07bdef3c-5314-4d1d-94f7-f3f346cd4c2f",
+                "submitted_at": "2026-07-14T12:00:00Z"
+            }
+        });
+
+        let event: MintEvent = serde_json::from_value(raw_event).unwrap();
+
+        assert!(matches!(
+            event,
+            MintEvent::MintTxSubmitted {
+                tx_id: TxId::Legacy(ref value),
+                ref external_tx_id,
+                ..
+            } if value == "07bdef3c-5314-4d1d-94f7-f3f346cd4c2f"
+                && external_tx_id
+                    == "mint-550e8400-e29b-41d4-a716-446655440000"
+        ));
+    }
+
+    #[test]
+    fn mint_tx_submitted_uses_tagged_tx_id_event_version() {
+        let event = MintEvent::MintTxSubmitted {
+            issuer_request_id: "550e8400-e29b-41d4-a716-446655440000"
+                .parse()
+                .unwrap(),
+            external_tx_id: "mint-550e8400-e29b-41d4-a716-446655440000"
+                .to_string(),
+            tx_id: TxId::Legacy(
+                "07bdef3c-5314-4d1d-94f7-f3f346cd4c2f".to_string(),
+            ),
+            submitted_at: Utc::now(),
+        };
+
+        assert_eq!(event.event_version(), "2.0");
     }
 }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1731,7 +1731,7 @@ impl EventSourced for Mint {
 
     const AGGREGATE_TYPE: &'static str = "Mint";
     const PROJECTION: Table = Table("mint_view");
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -291,7 +291,10 @@ impl DomainEvent for RedemptionEvent {
 
     fn event_version(&self) -> String {
         match self {
-            Self::TokensBurned(_) => "2.0".to_string(),
+            Self::TokensBurned(_)
+            | Self::BurningFailed { .. }
+            | Self::BurnTxSubmitted { .. }
+            | Self::ExistingBurnRecovered { .. } => "2.0".to_string(),
             _ => "1.0".to_string(),
         }
     }
@@ -395,7 +398,34 @@ mod tests {
         };
 
         assert_eq!(event.event_type(), "RedemptionEvent::BurningFailed");
-        assert_eq!(event.event_version(), "1.0");
+        assert_eq!(event.event_version(), "2.0");
+    }
+
+    #[test]
+    fn submitted_and_recovered_burns_use_tagged_tx_id_event_version() {
+        let submitted = RedemptionEvent::BurnTxSubmitted {
+            issuer_request_id: test_redemption_id(),
+            external_tx_id: BurnExternalTxId::from_string(
+                "burn-abcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                    .to_string(),
+            ),
+            tx_id: TxId::random(),
+            planned_burns: vec![],
+            submitted_at: Utc::now(),
+        };
+        let recovered = RedemptionEvent::ExistingBurnRecovered {
+            issuer_request_id: test_redemption_id(),
+            tx_id: TxId::random(),
+            tx_hash: b256!(
+                "0x1111111111111111111111111111111111111111111111111111111111111111"
+            ),
+            burns: vec![],
+            block_number: 1000,
+            recovered_at: Utc::now(),
+        };
+
+        assert_eq!(submitted.event_version(), "2.0");
+        assert_eq!(recovered.event_version(), "2.0");
     }
 
     #[test]

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -927,7 +927,7 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 2;
+    const SCHEMA_VERSION: u64 = 3;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -424,6 +424,27 @@ pub(crate) enum TxId {
     Legacy(String),
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+enum TaggedTxIdRef<'value> {
+    Hash(&'value B256),
+    Legacy(&'value str),
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum TaggedTxId {
+    Hash(B256),
+    Legacy(String),
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PersistedTxId {
+    Tagged(TaggedTxId),
+    Flat(String),
+}
+
 impl TxId {
     pub(crate) const fn to_hash(&self) -> Option<B256> {
         if let Self::Hash(hash) = self {
@@ -471,6 +492,7 @@ impl utoipa::ToSchema for TxId {
         "TxId".into()
     }
 }
+
 impl utoipa::PartialSchema for TxId {
     fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
         utoipa::openapi::ObjectBuilder::new()
@@ -488,7 +510,12 @@ impl Serialize for TxId {
         &self,
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.to_string())
+        match self {
+            Self::Hash(hash) => TaggedTxIdRef::Hash(hash).serialize(serializer),
+            Self::Legacy(value) => {
+                TaggedTxIdRef::Legacy(value).serialize(serializer)
+            }
+        }
     }
 }
 
@@ -496,19 +523,75 @@ impl<'de> Deserialize<'de> for TxId {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        s.parse().map_err(serde::de::Error::custom)
+        match PersistedTxId::deserialize(deserializer)? {
+            PersistedTxId::Tagged(TaggedTxId::Hash(hash)) => {
+                Ok(Self::Hash(hash))
+            }
+            PersistedTxId::Tagged(TaggedTxId::Legacy(value)) => {
+                Ok(Self::Legacy(value))
+            }
+            PersistedTxId::Flat(value) => {
+                value.parse().map_err(serde::de::Error::custom)
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::address;
+    use alloy::primitives::{address, b256};
     use chrono::Utc;
     use rust_decimal_macros::dec;
 
     use super::*;
     use crate::mint::{IssuerMintRequestId, Quantity, TokenizationRequestId};
+
+    #[test]
+    fn tx_id_tagged_persistence_roundtrips_variants() {
+        let legacy_uuid =
+            TxId::Legacy("07bdef3c-5314-4d1d-94f7-f3f346cd4c2f".to_string());
+        let legacy_hex = TxId::Legacy(
+            "1111111111111111111111111111111111111111111111111111111111111111"
+                .to_string(),
+        );
+        let hash = TxId::Hash(b256!(
+            "2222222222222222222222222222222222222222222222222222222222222222"
+        ));
+
+        let cases =
+            [(legacy_uuid, "legacy"), (legacy_hex, "legacy"), (hash, "hash")];
+
+        for (tx_id, expected_tag) in cases {
+            let serialized = serde_json::to_value(&tx_id).unwrap();
+            let roundtripped: TxId =
+                serde_json::from_value(serialized.clone()).unwrap();
+
+            assert_eq!(roundtripped, tx_id);
+            assert!(serialized.get(expected_tag).is_some());
+        }
+    }
+
+    #[test]
+    fn tx_id_deserializes_historical_flat_strings() {
+        let legacy: TxId =
+            serde_json::from_str(r#""07bdef3c-5314-4d1d-94f7-f3f346cd4c2f""#)
+                .unwrap();
+        let hash: TxId = serde_json::from_str(
+            r#""0x2222222222222222222222222222222222222222222222222222222222222222""#,
+        )
+        .unwrap();
+
+        assert_eq!(
+            legacy,
+            TxId::Legacy("07bdef3c-5314-4d1d-94f7-f3f346cd4c2f".to_string())
+        );
+        assert_eq!(
+            hash,
+            TxId::Hash(b256!(
+                "2222222222222222222222222222222222222222222222222222222222222222"
+            ))
+        );
+    }
 
     const TEST_OA_SCHEMA: &str =
         "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
@@ -801,21 +884,6 @@ mod tests {
         let original = TxId::Legacy("fb-tx-uuid-123".to_string());
         let roundtripped: TxId = original.to_string().parse().unwrap();
         assert_eq!(roundtripped, original);
-    }
-
-    #[test]
-    fn tx_id_serialize_hash_as_0x_hex_string() {
-        let tx_id = TxId::Hash(known_hash());
-        let json = serde_json::to_string(&tx_id).unwrap();
-        assert_eq!(json, format!("\"{HASH_HEX}\""));
-    }
-
-    #[test]
-    fn tx_id_serialize_legacy_as_raw_string() {
-        let raw = "fb-tx-uuid-123";
-        let tx_id = TxId::Legacy(raw.to_string());
-        let json = serde_json::to_string(&tx_id).unwrap();
-        assert_eq!(json, format!("\"{raw}\""));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`TxId` serialized both legacy backend IDs and on-chain hashes as flat strings. A 32-byte hex legacy ID came back as `Hash`, and the old `FireblocksSubmitted` event shape was only protected by aliases, not a raw replay test.

[RAI-1378](https://linear.app/makeitrain/issue/RAI-1378/guarantee-legacy-event-and-transaction-id-replay-stability)

## Solution

- persist new transaction IDs with explicit `hash` or `legacy` tags while still reading historical flat strings
- pin raw `FireblocksSubmitted` and `fireblocks_tx_id` replay with the production-era wire shape
- version the changed events and aggregate snapshots, while keeping `/admin/stuck` transaction IDs as strings
- document the one-way deployment and rollback cutover in the spec

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Verified with `cargo test --workspace`, strict Clippy, and rustfmt.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transaction IDs are now stored with their type preserved, improving replay accuracy.
  * Administrative stuck-transaction responses now return transaction IDs in a consistent string format.
  * Event history handling now distinguishes updated event formats from legacy records.

* **Bug Fixes**
  * Historical transaction records remain readable during migration.
  * Legacy Fireblocks transaction events are correctly interpreted during replay.

* **Documentation**
  * Added deployment guidance for safely migrating transaction ID storage, including backups and compatible readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->