### PR TITLE
fix: persist mint transaction intent before broadcast

### DIFF
--- a/.sqlx/query-134efafc4cc1761e4e8ff26587d53d70e40e67f84f4b76c49dd091699d2ad9b2.json
+++ b/.sqlx/query-134efafc4cc1761e4e8ff26587d53d70e40e67f84f4b76c49dd091699d2ad9b2.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            view_id as \"view_id!: String\",\n            json_extract(payload, '$.Live') as \"live: String\"\n        FROM mint_view\n        WHERE json_extract(payload, '$.Live.Initiated')           IS NOT NULL\n           OR json_extract(payload, '$.Live.JournalConfirmed')    IS NOT NULL\n           OR json_extract(payload, '$.Live.JournalRejected')     IS NOT NULL\n           OR json_extract(payload, '$.Live.Minting')             IS NOT NULL\n           OR json_extract(payload, '$.Live.TxIntended')          IS NOT NULL\n           OR json_extract(payload, '$.Live.MintIntended')        IS NOT NULL\n           OR json_extract(payload, '$.Live.TxSubmitted')         IS NOT NULL\n           OR json_extract(payload, '$.Live.MintTxSubmitted')     IS NOT NULL\n           OR json_extract(payload, '$.Live.CallbackPending')     IS NOT NULL\n           OR json_extract(payload, '$.Live.MintingFailed')       IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "view_id!: String",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "mint_view",
+            "name": "view_id"
+          }
+        }
+      },
+      {
+        "name": "live: String",
+        "ordinal": 1,
+        "type_info": "Null",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      null
+    ]
+  },
+  "hash": "134efafc4cc1761e4e8ff26587d53d70e40e67f84f4b76c49dd091699d2ad9b2"
+}

--- a/.sqlx/query-e030dda9fb3c08a630cadc70bf36e9e3aebf2064dce5fa64ce8a69df934a6ad1.json
+++ b/.sqlx/query-e030dda9fb3c08a630cadc70bf36e9e3aebf2064dce5fa64ce8a69df934a6ad1.json
@@ -1,0 +1,33 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT\n            view_id as \"view_id!: String\",\n            json_extract(payload, '$.Live') as \"live: String\"\n        FROM mint_view\n        WHERE json_extract(payload, '$.Live.JournalConfirmed') IS NOT NULL\n           OR json_extract(payload, '$.Live.Minting') IS NOT NULL\n           OR json_extract(payload, '$.Live.TxIntended') IS NOT NULL\n           OR json_extract(payload, '$.Live.MintIntended') IS NOT NULL\n           OR json_extract(payload, '$.Live.TxSubmitted') IS NOT NULL\n           OR json_extract(payload, '$.Live.MintTxSubmitted') IS NOT NULL\n           OR json_extract(payload, '$.Live.MintingFailed') IS NOT NULL\n           OR json_extract(payload, '$.Live.CallbackPending') IS NOT NULL\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "view_id!: String",
+        "ordinal": 0,
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "mint_view",
+            "name": "view_id"
+          }
+        }
+      },
+      {
+        "name": "live: String",
+        "ordinal": 1,
+        "type_info": "Null",
+        "origin": "Expression"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      true,
+      null
+    ]
+  },
+  "hash": "e030dda9fb3c08a630cadc70bf36e9e3aebf2064dce5fa64ce8a69df934a6ad1"
+}

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,9 +191,14 @@ initial request through journal confirmation to on-chain minting and callback.
   `MintingStarted`. Intent is persisted before the network call so that a crash
   during submission leaves the aggregate in a recoverable `Minting` state rather
   than `JournalConfirmed` (which would lose track of the submission)
-- `SubmitMint { issuer_request_id }` - Submit the on-chain deposit to the
-  signing backend. Requires `Minting` state. Produces `MintTxSubmitted` on
-  success or `MintingFailed` on failure
+- `PrepareMint { issuer_request_id }` - Build and sign the exact on-chain
+  deposit transaction. Requires `Minting` state. Produces `MintTxIntended`,
+  which persists the raw transaction, hash, nonce, signing time, and stable
+  external transaction ID before any broadcast
+- `SubmitMint { issuer_request_id }` - Broadcast the exact transaction stored
+  by `MintTxIntended`. Requires `MintIntended` state. Produces
+  `MintTxSubmitted` on success. An uncertain broadcast failure leaves the
+  aggregate in `MintIntended`, so recovery rebroadcasts the same bytes
 - `ConfirmMint { issuer_request_id, tx_id }` - Confirm a previously submitted
   mint transaction. Re-fetches the on-chain receipt for the stored `tx_id` and
   produces `TokensMinted` or `MintingFailed`
@@ -201,7 +206,8 @@ initial request through journal confirmation to on-chain minting and callback.
   mint completion
 - `Recover { issuer_request_id, mode }` - Recover a mint stuck in an incomplete
   state. Startup recovery drives any mint in `JournalConfirmed`, `Minting`,
-  `MintingFailed`, or `CallbackPending` state; at runtime, live retry scheduling
+  `MintIntended`, `TxSubmitted`, `MintingFailed`, or `CallbackPending` state;
+  at runtime, live retry scheduling
   is triggered specifically when a mint lands in `MintingFailed` during the
   journal-confirmation flow. Both paths hand a mint that is waiting on a retry
   window to a background scheduled-recovery task, so retries fire on schedule
@@ -215,15 +221,20 @@ initial request through journal confirmation to on-chain minting and callback.
   an operator can retry after fixing the underlying cause. This prevents
   double-minting after crashes while ensuring terminal failures can be retried
   with new `externalTxId`s
+- `RecoverWalletStep { issuer_request_id, mode }` - Internal recovery variant
+  used only while the wallet lock is held. It performs the same recoverable
+  on-chain steps as `Recover`, but becomes a no-op if a concurrent transition
+  already reached `CallbackPending`; the next recovery iteration then sends
+  the callback without the wallet lock
 - `RecoverFromReceipt { issuer_request_id, tx_hash }` - Recover a mint that
-  failed during the minting step when an ITN receipt is discovered on-chain.
-  Triggered by the receipt monitor when it finds a Deposit event with a matching
-  `issuer_request_id` for a mint in `MintingFailed` state. Unlike `Recover`,
-  this command only accepts `MintingFailed` state where the non-failed
-  predecessor was `Minting` (meaning a transaction was actually submitted).
-  Rejects `JournalConfirmed` and `Minting` states because receipt discovery only
-  justifies recovery when the mint was marked as failed after submission. Emits
-  `ExistingMintRecovered` and proceeds to callback
+  failed during the minting step, or whose broadcast outcome was not persisted,
+  when an ITN receipt is discovered on-chain. Triggered by the receipt monitor
+  when it finds a Deposit event with a matching `issuer_request_id`. Accepts
+  `MintIntended`, because the persisted transaction may have been mined before
+  submission recording, and `MintingFailed` when the non-failed predecessor was
+  `Minting`. Rejects `JournalConfirmed` and `Minting` because neither state
+  proves a transaction was signed or submitted. Emits `ExistingMintRecovered`
+  and proceeds to callback
 
 **Events:**
 
@@ -231,6 +242,8 @@ initial request through journal confirmation to on-chain minting and callback.
 - `JournalConfirmed` - Alpaca journal transfer confirmed
 - `JournalRejected` - Alpaca journal transfer rejected (terminal)
 - `MintingStarted` - Mint intent recorded (aggregate moves to `Minting`)
+- `MintTxIntended` - Exact signed mint transaction persisted before broadcast
+  (carries raw bytes, hash, nonce, signing time, and external transaction ID)
 - `MintTxSubmitted` - Mint transaction submitted to signing backend (carries
   `external_tx_id` and `tx_id` — the on-chain tx hash — for crash recovery)
 - `TokensMinted` - On-chain mint succeeded (carries tx details)
@@ -263,48 +276,74 @@ dual-format reader or restore the pre-cutover backup.
 | `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                               |
 | `RejectJournal`      | `JournalRejected`       | Terminal failure                                |
 | `Deposit`            | `MintingStarted`        | Records intent (no network call)                |
-| `SubmitMint`         | See below               | Submits to signing backend                      |
+| `PrepareMint`        | `MintTxIntended`         | Persists exact signed tx before broadcast       |
+| `SubmitMint`         | `MintTxSubmitted`        | Broadcasts the persisted transaction            |
 | `ConfirmMint`        | See below               | Confirms submitted tx                           |
 | `SendCallback`       | `MintCompleted`         | Calls Alpaca callback                           |
 | `Recover`            | See below               | Checks receipt inventory                        |
-| `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt-triggered recovery from `MintingFailed` |
+| `RecoverWalletStep`  | See below               | Never sends callbacks while wallet-locked       |
+| `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt recovery from intended or failed state  |
 
-`Deposit` emits only `MintingStarted` (intent). The actual submission is handled
-by `SubmitMint`, which emits either `MintTxSubmitted` (success) or
-`MintingFailed` (failure). This two-step design persists intent before the
-network call, so a crash during submission leaves the aggregate in `Minting`
-state (recoverable) rather than `JournalConfirmed`.
+`Deposit` emits only `MintingStarted` (business intent). `PrepareMint` builds
+and signs the transaction, then persists the exact bytes and hash in
+`MintTxIntended`. Only `SubmitMint` may broadcast those persisted bytes. A
+crash before `MintTxIntended` cannot have broadcast anything; a crash after it
+causes recovery to rebroadcast or poll that same transaction, never prepare a
+second one. A crash after broadcast but before `MintTxSubmitted` therefore
+remains safe because rebroadcasting identical signed bytes is idempotent.
+Preparing, persisting, and initially broadcasting a mint transaction share one
+wallet critical section. Startup mint recovery processes its persisted intents
+in nonce order before mint states that may prepare a new transaction. Mint and
+redemption recovery run concurrently so persisted transactions from either
+domain can fill lower nonce gaps while higher transactions await confirmation.
+Live mint and burn preparation query the authoritative event log and are
+blocked while any other wallet intent remains unresolved; this safety check
+does not depend on a fallible read-model projection. Together these rules
+prevent two aggregate commands from signing the same wallet nonce without
+relying on in-memory nonce state that would be lost on restart.
+Each live burn attempt waits at most 30 seconds behind an earlier unresolved
+wallet intent. On timeout it prepares and broadcasts nothing, leaves the
+redemption recoverable, and defers the burn to recovery rather than occupying
+the live flow indefinitely.
+
+The issuer is a single-writer service: exactly one process may own a given
+SQLite event store and signing wallet at a time. Horizontal replicas sharing a
+wallet are unsupported because the wallet critical section is process-local.
+Deployments must terminate the old process before the replacement begins
+serving or recovering work.
 
 `ConfirmMint` re-fetches the on-chain receipt for the submitted `tx_id` and
 emits either `TokensMinted` (success) or `MintingFailed` (failure).
 
 `Recover` checks the receipt inventory for a receipt matching the
 `issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
-in `Minting` state, submits and emits `MintTxSubmitted` (or `MintingFailed` on
-failure). If in `TxSubmitted` (or `MintingFailed` with a known prior
-transaction), calls `ConfirmMint` with the stored `tx_id` to re-fetch the
-on-chain receipt. `TxSubmitted` means the signing backend accepted the
-submission and returned a transaction identifier; it does not mean the
-transaction succeeded on-chain. `ConfirmMint` waits for the receipt and emits
-`TokensMinted` for a successful transaction or `MintingFailed` for a reverted or
-otherwise failed transaction. Retry transactions use
+in `Minting` state, prepares and persists `MintTxIntended`. If in
+`MintIntended`, rebroadcasts the persisted raw transaction. If in `TxSubmitted`
+(or `MintingFailed` with a known prior transaction), calls `ConfirmMint` with
+the stored `tx_id` to re-fetch the on-chain receipt. `TxSubmitted` means the
+signing backend accepted the submission and returned a transaction identifier;
+it does not mean the transaction succeeded on-chain. `ConfirmMint` waits for
+the receipt and emits `TokensMinted` for a successful transaction or
+`MintingFailed` for a reverted or otherwise failed transaction. Retry
+transactions use
 `mint-{issuer_request_id}-retry-{n}` where automatic retries use n = 1..4 and
 the delay schedule is 1m, 10m, 30m, then 1h.
 
 The retry-delay/exhaustion schedule is driven by a `MintingFailed` attempt
-counter that advances on every failure — including a submission that fails
-before the transaction lands (no `MintTxSubmitted` predecessor). In that case
-the `external_tx_id` is reused unchanged; the receipt backfiller's on-chain scan
-for existing deposits guards against double-minting, so resubmission stays
-idempotent, while the schedule still escalates and eventually exhausts. A
+counter. A transaction-preparation failure records `MintingFailed`; an
+uncertain broadcast failure instead preserves `MintIntended` and recovery
+rebroadcasts the exact same signed bytes without advancing the attempt. A
 running service keeps driving deferred retries via a background
 scheduled-recovery task (also spawned at startup and after a manual reprocess),
 rather than waiting for the next restart.
 
 `RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
-receipt for a mint in `MintingFailed` state (where the predecessor was
-`Minting`). Emits `ExistingMintRecovered`, transitioning to `CallbackPending`,
-then continues through the existing `SendCallback` -> `MintCompleted` flow.
+receipt for a mint in `MintIntended`, or in `MintingFailed` where the predecessor
+was `Minting`. It emits `ExistingMintRecovered`, transitions to
+`CallbackPending`, then continues through the existing `SendCallback` ->
+`MintCompleted` flow without rebroadcasting. Automated recovery persists the
+`CallbackPending` boundary before delivering the callback, so receipt polling
+and Alpaca requests do not hold the wallet transaction lock.
 
 ### Redemption Aggregate
 
@@ -1371,11 +1410,14 @@ stateDiagram-v2
     PendingJournal --> JournalConfirmed: ConfirmJournal
     PendingJournal --> JournalRejected: RejectJournal
     JournalConfirmed --> Minting: Deposit (MintingStarted)
-    Minting --> TxSubmitted: SubmitMint (MintTxSubmitted)
-    Minting --> MintingFailed: SubmitMint (MintingFailed)
+    Minting --> MintIntended: PrepareMint (MintTxIntended)
+    Minting --> MintingFailed: PrepareMint (MintingFailed)
+    MintIntended --> TxSubmitted: SubmitMint (MintTxSubmitted)
+    MintIntended --> MintIntended: SubmitMint uncertain failure (no event)
+    MintIntended --> CallbackPending: Recover or RecoverFromReceipt (ExistingMintRecovered)
     TxSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
     TxSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
-    MintingFailed --> TxSubmitted: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + MintTxSubmitted)
+    MintingFailed --> MintIntended: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + MintTxIntended)
     MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
     MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
     CallbackPending --> Completed: SendCallback

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,6 +1,5 @@
 use alloy::network::ReceiptResponse;
 use alloy::primitives::B256;
-use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::AggregateError;
@@ -19,9 +18,9 @@ use crate::alpaca::{
 };
 use crate::auth::InternalAuth;
 use crate::mint::{
-    IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
+    DriveOutcome, IssuerMintRequestId, Mint, MintCommand, MintEvent, MintView,
     TokenizationRequestId, find_by_issuer_request_id,
-    find_stuck as find_stuck_mints, recovery::enqueue_scheduled_mint_recovery,
+    find_stuck as find_stuck_mints, recover_mint_manually,
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -1010,13 +1009,13 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, store, pool, apalis_pool))]
+#[tracing::instrument(skip(_auth, store, vault_service, pool))]
 #[post("/admin/reprocess/mint/<aggregate_id>")]
 pub(crate) async fn reprocess_mint(
     _auth: InternalAuth,
     store: &rocket::State<Arc<Store<Mint>>>,
+    vault_service: &rocket::State<Arc<dyn VaultService>>,
     pool: &rocket::State<Pool<Sqlite>>,
-    apalis_pool: &rocket::State<ApalisSqlitePool>,
     aggregate_id: &str,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let issuer_request_id: IssuerMintRequestId = aggregate_id
@@ -1041,6 +1040,7 @@ pub(crate) async fn reprocess_mint(
                 MintView::JournalConfirmed { .. } => "JournalConfirmed",
                 MintView::JournalRejected { .. } => "JournalRejected",
                 MintView::Minting { .. } => "Minting",
+                MintView::MintIntended { .. } => "MintIntended",
                 MintView::MintTxSubmitted { .. } => "MintTxSubmitted",
                 MintView::CallbackPending { .. } => "CallbackPending",
                 MintView::MintingFailed { .. } => "MintingFailed",
@@ -1054,48 +1054,24 @@ pub(crate) async fn reprocess_mint(
         }
     };
 
-    store
-        .send(
-            &issuer_request_id,
-            MintCommand::Recover {
-                issuer_request_id: issuer_request_id.clone(),
-                mode: crate::mint::MintRecoveryMode::Manual,
-            },
-        )
-        .await
-        .map_err(|err| {
-            error!(target: "admin", aggregate_id = aggregate_id,
-                error = %err,
-                "Failed to reprocess mint"
-            );
-            match err {
-                AggregateError::UserError(_) => Status::UnprocessableEntity,
-                _ => Status::InternalServerError,
-            }
-        })?;
+    let outcome = recover_mint_manually(
+        store.inner().as_ref(),
+        vault_service.inner(),
+        issuer_request_id,
+    )
+    .await;
+    if !matches!(outcome, DriveOutcome::Done) {
+        error!(target: "admin", aggregate_id = aggregate_id,
+            ?outcome,
+            "Failed to drive manual mint recovery to completion"
+        );
+        return Err(Status::UnprocessableEntity);
+    }
 
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
         "Mint reprocessed successfully"
     );
-
-    // A single manual Recover advances the mint by one step (e.g. submits the
-    // next retry, leaving it in TxSubmitted). Enqueue a durable recovery
-    // job so it is driven to completion instead of stalling until the next
-    // restart or another manual reprocess.
-    enqueue_scheduled_mint_recovery(
-        pool.inner(),
-        apalis_pool.inner(),
-        issuer_request_id,
-    )
-    .await
-    .map_err(|error| {
-        error!(target: "admin", aggregate_id = aggregate_id,
-            error = %error,
-            "Failed to enqueue scheduled mint recovery after reprocess"
-        );
-        Status::InternalServerError
-    })?;
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Mint,
@@ -1619,6 +1595,17 @@ fn mint_view_summary(view: &MintView) -> Option<MintStuckSummary> {
             detail: "Deposit in progress".to_string(),
             timestamp: *minting_started_at,
         }),
+        MintView::MintIntended {
+            tokenization_request_id,
+            minting_started_at,
+            ..
+        } => Some(MintStuckSummary {
+            class: InProgress,
+            tokenization_request_id: Some(tokenization_request_id.clone()),
+            state: "MintIntended".to_string(),
+            detail: "Signed transaction awaiting broadcast".to_string(),
+            timestamp: *minting_started_at,
+        }),
         MintView::MintTxSubmitted {
             tokenization_request_id,
             minting_started_at,
@@ -1667,6 +1654,7 @@ fn mint_view_asset(
         | MintView::JournalConfirmed { underlying, quantity, .. }
         | MintView::JournalRejected { underlying, quantity, .. }
         | MintView::Minting { underlying, quantity, .. }
+        | MintView::MintIntended { underlying, quantity, .. }
         | MintView::MintTxSubmitted { underlying, quantity, .. }
         | MintView::MintingFailed { underlying, quantity, .. }
         | MintView::CallbackPending { underlying, quantity, .. } => {

--- a/src/alpaca/mock.rs
+++ b/src/alpaca/mock.rs
@@ -4,6 +4,7 @@ use chrono::Utc;
 use rust_decimal::Decimal;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 
 use super::{
     AlpacaError, AlpacaService, Fees, MintCallbackRequest, RedeemRequest,
@@ -29,6 +30,7 @@ pub(crate) struct MockAlpacaService {
     should_succeed: bool,
     #[cfg(test)]
     error_message: Option<String>,
+    callback_delay_ms: u64,
     call_count: Arc<AtomicUsize>,
 }
 
@@ -41,6 +43,7 @@ impl MockAlpacaService {
             should_succeed: true,
             #[cfg(test)]
             error_message: None,
+            callback_delay_ms: 0,
             call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
@@ -55,8 +58,16 @@ impl MockAlpacaService {
         Self {
             should_succeed: false,
             error_message: Some(error_message.into()),
+            callback_delay_ms: 0,
             call_count: Arc::new(AtomicUsize::new(0)),
         }
+    }
+
+    #[cfg(test)]
+    #[must_use]
+    pub(crate) const fn with_callback_delay(mut self, delay_ms: u64) -> Self {
+        self.callback_delay_ms = delay_ms;
+        self
     }
 
     /// Returns the number of times `send_mint_callback()` was called.
@@ -73,6 +84,10 @@ impl AlpacaService for MockAlpacaService {
         _request: MintCallbackRequest,
     ) -> Result<(), AlpacaError> {
         self.call_count.fetch_add(1, Ordering::Relaxed);
+        if self.callback_delay_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(self.callback_delay_ms))
+                .await;
+        }
 
         #[cfg(test)]
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
 use crate::mint::{
-    Mint, MintServices, find_all_recoverable_mints,
+    Mint, MintServices, MintView, find_all_recoverable_mints,
     recovery::{
         DriveOutcome, MintRecoveryHandler, MintRecoveryJob, MintRecoveryQueue,
         MintRecoveryWorkerId, enqueue_scheduled_mint_recovery,
@@ -339,6 +339,7 @@ pub async fn initialize_rocket(
         &pool,
         &apalis_pool,
         &mint_store,
+        &vault_service_for_rocket,
         &managers,
         &vaults,
     )
@@ -353,7 +354,11 @@ pub async fn initialize_rocket(
     // submission, Alpaca callback) for the same mint concurrently with the
     // re-scan. The only cost is that jobs enqueued by the re-scan start
     // draining moments later.
-    spawn_mint_recovery_worker(apalis_pool.clone(), mint_store.clone());
+    spawn_mint_recovery_worker(
+        apalis_pool.clone(),
+        mint_store.clone(),
+        vault_service_for_rocket.clone(),
+    );
 
     // Periodically re-enqueue recoverable mints that lost their recovery job
     // (e.g. an enqueue that failed during a transient SQLite outage at confirm
@@ -368,7 +373,11 @@ pub async fn initialize_rocket(
         bot_wallet,
         backfill_start_block: config.backfill_start_block,
         receipt_poll_interval: config.receipt_poll_interval,
-        handler: MintRecoveryHandler::new(mint_store.clone()),
+        handler: MintRecoveryHandler::new(
+            mint_store.clone(),
+            pool.clone(),
+            apalis_pool.clone(),
+        ),
     });
 
     {
@@ -677,6 +686,7 @@ async fn run_mint_recovery(
     pool: &Pool<Sqlite>,
     apalis_pool: &ApalisSqlitePool,
     mint_store: &Arc<Store<Mint>>,
+    vault_service: &Arc<dyn vault::VaultService>,
 ) {
     info!(target: "mint", "Running mint recovery");
 
@@ -707,7 +717,7 @@ async fn run_mint_recovery(
         );
     }
 
-    let recoverable_mints = match find_all_recoverable_mints(pool).await {
+    let mut recoverable_mints = match find_all_recoverable_mints(pool).await {
         Ok(mints) => mints,
         Err(err) => {
             error!(target: "mint", error = %err, "Failed to query recoverable mints");
@@ -720,6 +730,14 @@ async fn run_mint_recovery(
         return;
     }
 
+    // Persisted, unbroadcast intents reserve concrete wallet nonces. Recover
+    // them in nonce order before any state that may prepare a fresh
+    // transaction, so a restart cannot sign a replacement at the same nonce.
+    recoverable_mints.sort_by_key(|(_, view)| match view {
+        MintView::MintIntended { prepared_tx, .. } => (0, prepared_tx.nonce),
+        _ => (1, 0),
+    });
+
     let count = recoverable_mints.len();
     debug!(target: "mint", count, "Recovering mints");
 
@@ -730,7 +748,9 @@ async fn run_mint_recovery(
         // — waiting on a retry window, or a transient failure — hand the mint
         // to a background scheduled-recovery task so it keeps progressing while
         // the service runs instead of waiting for the next restart.
-        match recover_mint(mint_store, issuer_request_id.clone()).await {
+        match recover_mint(mint_store, vault_service, issuer_request_id.clone())
+            .await
+        {
             DriveOutcome::RetryNotDue | DriveOutcome::Failed => {
                 if let Err(error) = enqueue_scheduled_mint_recovery(
                     pool,
@@ -815,18 +835,25 @@ async fn run_recovery_with_timeout(
     pool: &Pool<Sqlite>,
     apalis_pool: &ApalisSqlitePool,
     mint_store: &Arc<Store<Mint>>,
+    vault_service: &Arc<dyn vault::VaultService>,
     managers: &RedemptionManagers,
     vaults: &[Address],
 ) {
     let recovery = async {
-        run_mint_recovery(pool, apalis_pool, mint_store).await;
-        run_redemption_recovery(
-            &managers.redeem_call,
-            &managers.journal,
-            &managers.burn,
-            vaults,
-        )
-        .await;
+        tokio::join!(
+            Box::pin(run_mint_recovery(
+                pool,
+                apalis_pool,
+                mint_store,
+                vault_service,
+            )),
+            Box::pin(run_redemption_recovery(
+                &managers.redeem_call,
+                &managers.journal,
+                &managers.burn,
+                vaults,
+            )),
+        );
     };
 
     match tokio::time::timeout(RECOVERY_TIMEOUT, recovery).await {
@@ -1275,17 +1302,20 @@ const MINT_RECOVERY_WORKER_RESTART_BACKOFF: Duration = Duration::from_secs(5);
 fn spawn_mint_recovery_worker(
     apalis_pool: ApalisSqlitePool,
     mint_store: Arc<Store<Mint>>,
+    vault_service: Arc<dyn vault::VaultService>,
 ) {
     tokio::spawn(async move {
         loop {
             let apalis_pool = apalis_pool.clone();
             let mint_store = mint_store.clone();
+            let vault_service = vault_service.clone();
             let monitor = Monitor::new().register(move |_worker_index| {
                 // A fresh worker id per registration is load-bearing for crash
                 // recovery — see [`MintRecoveryWorkerId`].
                 WorkerBuilder::new(MintRecoveryWorkerId::new().to_string())
                     .backend(MintRecoveryQueue::new(&apalis_pool))
                     .data(mint_store.clone())
+                    .data(vault_service.clone())
                     .build(MintRecoveryJob::run)
             });
 

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -3,6 +3,7 @@ use event_sorcery::Store;
 use rocket::{post, serde::json::Json};
 use serde::Deserialize;
 use sqlx::{Pool, Sqlite};
+use std::fmt::Debug;
 use std::sync::Arc;
 use tracing::{error, info, warn};
 
@@ -11,6 +12,7 @@ use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, TokenizationRequestId,
     recovery::enqueue_scheduled_mint_recovery,
 };
+use crate::vault::VaultService;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct JournalConfirmationRequest {
@@ -27,7 +29,7 @@ pub(crate) enum JournalStatus {
     Rejected,
 }
 
-#[tracing::instrument(skip(_auth, mint_store, pool, apalis_pool), fields(
+#[tracing::instrument(skip(_auth, mint_store, vault_service, pool, apalis_pool), fields(
     tokenization_request_id = %request.tokenization_request_id.0,
     issuer_request_id = %request.issuer_request_id,
     status = ?request.status
@@ -36,6 +38,7 @@ pub(crate) enum JournalStatus {
 pub(crate) async fn confirm_journal(
     _auth: IssuerAuth,
     mint_store: &rocket::State<Arc<Store<Mint>>>,
+    vault_service: &rocket::State<Arc<dyn VaultService>>,
     pool: &rocket::State<Pool<Sqlite>>,
     apalis_pool: &rocket::State<ApalisSqlitePool>,
     request: Json<JournalConfirmationRequest>,
@@ -114,10 +117,12 @@ pub(crate) async fn confirm_journal(
             }
 
             let mint_store = mint_store.inner().clone();
+            let vault_service = vault_service.inner().clone();
             let pool = pool.inner().clone();
             let apalis_pool = apalis_pool.inner().clone();
             rocket::tokio::spawn(process_journal_completion(
                 mint_store,
+                vault_service,
                 pool,
                 apalis_pool,
                 issuer_request_id,
@@ -128,11 +133,12 @@ pub(crate) async fn confirm_journal(
     rocket::http::Status::Ok
 }
 
-#[tracing::instrument(skip(mint_store, pool, apalis_pool), fields(
+#[tracing::instrument(skip(mint_store, vault_service, pool, apalis_pool), fields(
     issuer_request_id = %issuer_request_id
 ))]
 async fn process_journal_completion(
     mint_store: Arc<Store<Mint>>,
+    vault_service: Arc<dyn VaultService>,
     pool: Pool<Sqlite>,
     apalis_pool: ApalisSqlitePool,
     issuer_request_id: IssuerMintRequestId,
@@ -157,7 +163,54 @@ async fn process_journal_completion(
         return;
     }
 
-    // Step 2: Submit mint transaction (SubmitMint → TxSubmitted).
+    // The shared wallet lock spans preparation, durable event persistence,
+    // and initial broadcast. The real provider reads the pending chain nonce
+    // while this guard is held, so a failed signing/event append cannot consume
+    // a process-local nonce and concurrent wallet operations cannot prepare a
+    // replacement before the exact intent is durable.
+    let wallet_guard = vault_service.lock_wallet().await;
+
+    // Step 2: Prepare and persist the exact signed transaction before any
+    // broadcast (PrepareMint → MintIntended).
+    if let Err(err) = mint_store
+        .send(
+            &issuer_request_id,
+            MintCommand::PrepareMint {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+        )
+        .await
+    {
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = ?err,
+            "PrepareMint command failed — scheduling recovery"
+        );
+        schedule_recovery(&pool, &apalis_pool, &issuer_request_id).await;
+        return;
+    }
+
+    let Some(prepared) = prepared_mint_after_load(
+        mint_store.load(&issuer_request_id).await,
+        &pool,
+        &apalis_pool,
+        &issuer_request_id,
+    )
+    .await
+    else {
+        return;
+    };
+
+    if !matches!(prepared, Mint::TxIntended { .. }) {
+        if matches!(prepared, Mint::MintingFailed { .. }) {
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint preparation failed — scheduling automatic recovery"
+            );
+            schedule_recovery(&pool, &apalis_pool, &issuer_request_id).await;
+        }
+        return;
+    }
+
+    // Step 3: Broadcast only the persisted transaction.
     if let Err(err) = mint_store
         .send(
             &issuer_request_id,
@@ -167,14 +220,16 @@ async fn process_journal_completion(
         )
         .await
     {
-        error!(target: "mint", issuer_request_id = %issuer_request_id,
+        warn!(target: "mint", issuer_request_id = %issuer_request_id,
             error = ?err,
-            "SubmitMint command failed"
+            "SubmitMint command failed — keeping persisted intent for recovery"
         );
+        schedule_recovery(&pool, &apalis_pool, &issuer_request_id).await;
         return;
     }
+    drop(wallet_guard);
 
-    // Step 3: Load the tx_id from the aggregate and confirm
+    // Step 4: Load the tx_id from the aggregate and confirm.
     let mint = match mint_store.load(&issuer_request_id).await {
         Ok(Some(mint)) => mint,
         Ok(None) => {
@@ -217,21 +272,8 @@ async fn process_journal_completion(
                     %state,
                     "Mint submission failed — scheduling automatic recovery"
                 );
-                if let Err(error) = enqueue_scheduled_mint_recovery(
-                    &pool,
-                    &apalis_pool,
-                    issuer_request_id.clone(),
-                )
-                .await
-                {
-                    // Reconciler re-enqueues recoverable mints, so a failed
-                    // enqueue here delays recovery rather than losing it:
-                    // degraded-but-continuing (WARN), not unrecoverable (ERROR).
-                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                        error = %error,
-                        "Failed to enqueue scheduled mint recovery"
-                    );
-                }
+                schedule_recovery(&pool, &apalis_pool, &issuer_request_id)
+                    .await;
             }
             Mint::CallbackPending { .. } | Mint::Completed { .. } => {
                 info!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -271,21 +313,7 @@ async fn process_journal_completion(
             warn!(target: "mint", issuer_request_id = %issuer_request_id,
                 "Mint confirmation failed — scheduling automatic recovery"
             );
-            if let Err(error) = enqueue_scheduled_mint_recovery(
-                &pool,
-                &apalis_pool,
-                issuer_request_id.clone(),
-            )
-            .await
-            {
-                // Reconciler re-enqueues recoverable mints, so a failed
-                // enqueue here delays recovery rather than losing it:
-                // degraded-but-continuing (WARN), not unrecoverable (ERROR).
-                warn!(target: "mint", issuer_request_id = %issuer_request_id,
-                    error = %error,
-                    "Failed to enqueue scheduled mint recovery"
-                );
-            }
+            schedule_recovery(&pool, &apalis_pool, &issuer_request_id).await;
             return;
         }
         Mint::CallbackPending { .. } => {}
@@ -321,6 +349,52 @@ async fn process_journal_completion(
     }
 }
 
+async fn prepared_mint_after_load<LoadError: Debug>(
+    result: Result<Option<Mint>, LoadError>,
+    pool: &Pool<Sqlite>,
+    apalis_pool: &ApalisSqlitePool,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Option<Mint> {
+    match result {
+        Ok(Some(mint)) => Some(mint),
+        Ok(None) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint aggregate not found after PrepareMint"
+            );
+            None
+        }
+        Err(error) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = ?error,
+                "Failed to load aggregate after PrepareMint — scheduling recovery"
+            );
+            schedule_recovery(pool, apalis_pool, issuer_request_id).await;
+            None
+        }
+    }
+}
+
+async fn schedule_recovery(
+    pool: &Pool<Sqlite>,
+    apalis_pool: &ApalisSqlitePool,
+    issuer_request_id: &IssuerMintRequestId,
+) {
+    if let Err(error) = enqueue_scheduled_mint_recovery(
+        pool,
+        apalis_pool,
+        issuer_request_id.clone(),
+    )
+    .await
+    {
+        // The reconciler re-enqueues recoverable mints, so this delays
+        // recovery rather than losing it: degraded but continuing.
+        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = %error,
+            "Failed to enqueue scheduled mint recovery"
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
@@ -332,17 +406,143 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
-    use super::confirm_journal;
+    use super::{
+        confirm_journal, prepared_mint_after_load, process_journal_completion,
+    };
     use crate::auth::FailedAuthRateLimiter;
     use crate::mint::api::test_utils::{
         TestAccountAndAsset, TestHarness, test_config,
     };
     use crate::mint::{
-        IssuerMintRequestId, MintCommand, MintView, Quantity,
+        IssuerMintRequestId, Mint, MintCommand, MintView, Quantity,
         TokenizationRequestId, view::find_by_issuer_request_id,
     };
     use crate::test_utils::log_count_at;
+    use crate::vault::VaultService;
     use crate::vault::mock::MockVaultService;
+
+    #[traced_test]
+    #[tokio::test]
+    async fn prepared_mint_load_failure_enqueues_recovery() {
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, apalis_pool, .. } = harness;
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let prepared = prepared_mint_after_load(
+            Err::<Option<Mint>, _>("transient load failure"),
+            &pool,
+            &apalis_pool,
+            &issuer_request_id,
+        )
+        .await;
+
+        assert!(prepared.is_none());
+        let aggregate_id = issuer_request_id.to_string();
+        let enqueued = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key = ?",
+        )
+        .bind(&aggregate_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(enqueued, 1);
+        assert_eq!(
+            log_count_at!(
+                Level::ERROR,
+                &[
+                    "Failed to load aggregate after PrepareMint — scheduling recovery",
+                    &issuer_request_id.to_string(),
+                ]
+            ),
+            1,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn concurrent_mints_share_the_wallet_preparation_lock() {
+        let vault = Arc::new(MockVaultService::new_success().with_delay(500));
+        let harness = TestHarness::new_with_mint_vault(vault.clone()).await;
+        let TestAccountAndAsset {
+            client_id, underlying, token, network, ..
+        } = harness.setup_account_and_asset().await;
+        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let first_id = IssuerMintRequestId::random();
+        let second_id = IssuerMintRequestId::random();
+
+        for (issuer_request_id, request_id) in [
+            (first_id.clone(), "concurrent-first"),
+            (second_id.clone(), "concurrent-second"),
+        ] {
+            mint_store
+                .send(
+                    &issuer_request_id,
+                    MintCommand::Initiate {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tokenization_request_id: TokenizationRequestId::new(
+                            request_id,
+                        ),
+                        quantity: Quantity::new(Decimal::from(100)),
+                        underlying: underlying.clone(),
+                        token: token.clone(),
+                        network: network.clone(),
+                        client_id,
+                        wallet: address!(
+                            "0x1234567890abcdef1234567890abcdef12345678"
+                        ),
+                    },
+                )
+                .await
+                .unwrap();
+            mint_store
+                .send(
+                    &issuer_request_id,
+                    MintCommand::ConfirmJournal {
+                        issuer_request_id: issuer_request_id.clone(),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let initial_guard = vault.lock_wallet().await;
+        let first = tokio::spawn(process_journal_completion(
+            mint_store.clone(),
+            vault.clone(),
+            pool.clone(),
+            apalis_pool.clone(),
+            first_id.clone(),
+        ));
+        let second = tokio::spawn(process_journal_completion(
+            mint_store.clone(),
+            vault.clone(),
+            pool,
+            apalis_pool,
+            second_id.clone(),
+        ));
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(vault.get_call_count(), 0);
+        drop(initial_guard);
+        tokio::time::sleep(Duration::from_millis(650)).await;
+        assert_eq!(
+            vault.get_call_count(),
+            1,
+            "only one concurrent mint may prepare while the shared guard is held"
+        );
+
+        first.await.unwrap();
+        second.await.unwrap();
+        assert_eq!(vault.get_call_count(), 2);
+        assert!(matches!(
+            mint_store.load(&first_id).await.unwrap(),
+            Some(Mint::Completed { .. })
+        ));
+        assert!(matches!(
+            mint_store.load(&second_id).await.unwrap(),
+            Some(Mint::Completed { .. })
+        ));
+    }
 
     #[tokio::test]
     async fn test_confirm_journal_completed_returns_ok() {
@@ -351,7 +551,7 @@ mod tests {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
 
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-ok-test");
@@ -378,6 +578,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool)
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -411,7 +612,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -439,6 +640,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool)
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -473,7 +675,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -501,6 +703,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -560,7 +763,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -591,6 +794,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -646,7 +850,9 @@ mod tests {
         assert_eq!(
             log_count_at!(
                 Level::WARN,
-                &["Mint submission failed — scheduling automatic recovery"]
+                &[
+                    "SubmitMint command failed — keeping persisted intent for recovery"
+                ]
             ),
             1,
             "the submission-failure path must log the scheduling of recovery"
@@ -670,7 +876,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -701,6 +907,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -769,7 +976,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -797,6 +1004,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -850,7 +1058,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -878,6 +1086,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -929,7 +1138,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let tokenization_request_id =
@@ -957,6 +1166,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool.clone())
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -1012,7 +1222,7 @@ mod tests {
         let TestAccountAndAsset {
             client_id, underlying, token, network, ..
         } = harness.setup_account_and_asset().await;
-        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } = harness;
 
         let issuer_request_id = IssuerMintRequestId::random();
         let correct_tokenization_request_id =
@@ -1042,6 +1252,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool)
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -1072,7 +1283,7 @@ mod tests {
     #[tokio::test]
     async fn test_confirm_journal_for_nonexistent_mint_returns_internal_server_error()
      {
-        let TestHarness { pool, apalis_pool, mint_store, .. } =
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } =
             TestHarness::new().await;
 
         let rocket = rocket::build()
@@ -1081,6 +1292,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool)
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)
@@ -1110,7 +1322,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_confirm_journal_without_auth_returns_401() {
-        let TestHarness { pool, apalis_pool, mint_store, .. } =
+        let TestHarness { pool, apalis_pool, mint_store, vault, .. } =
             TestHarness::new().await;
 
         let rocket = rocket::build()
@@ -1119,6 +1331,7 @@ mod tests {
             .manage(mint_store)
             .manage(pool)
             .manage(apalis_pool)
+            .manage(vault)
             .mount("/", routes![confirm_journal]);
 
         let client = rocket::local::asynchronous::Client::tracked(rocket)

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -50,6 +50,7 @@ pub(crate) struct TestHarness {
     pub(crate) account_store: Arc<Store<Account>>,
     pub(crate) asset_store: Arc<Store<TokenizedAsset>>,
     pub(crate) mint_store: Arc<Store<Mint>>,
+    pub(crate) vault: Arc<dyn VaultService>,
 }
 
 impl TestHarness {
@@ -114,7 +115,7 @@ impl TestHarness {
 
         let bot = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
         let mint_services = MintServices {
-            vault,
+            vault: vault.clone(),
             alpaca: Arc::new(MockAlpacaService::new_success()),
             pool: pool.clone(),
             bot,
@@ -139,7 +140,14 @@ impl TestHarness {
             .await
             .expect("Failed to create apalis pool");
 
-        Self { pool, apalis_pool, account_store, asset_store, mint_store }
+        Self {
+            pool,
+            apalis_pool,
+            account_store,
+            asset_store,
+            mint_store,
+            vault,
+        }
     }
 }
 

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -43,11 +43,16 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
     },
 
+    /// Builds and signs the exact mint transaction, then persists it before
+    /// any broadcast.
+    PrepareMint {
+        issuer_request_id: IssuerMintRequestId,
+    },
+
     /// Submits the on-chain deposit (minting) transaction to the signing backend.
     ///
-    /// Requires `Minting` state (set by prior `Deposit` command). Performs vault
-    /// lookup, builds receipt info, and calls `submit_mint()`. Produces
-    /// `TxSubmitted` on success or `MintingFailed` on failure.
+    /// Requires `MintIntended` state (set by prior `PrepareMint` command) and
+    /// broadcasts only the persisted signed bytes.
     SubmitMint {
         issuer_request_id: IssuerMintRequestId,
     },
@@ -78,6 +83,14 @@ pub(crate) enum MintCommand {
     /// For mints in `CallbackPending` state:
     /// - Retries sending the callback
     Recover {
+        issuer_request_id: IssuerMintRequestId,
+        mode: MintRecoveryMode,
+    },
+
+    /// Runs only recovery work that is safe while holding the wallet lock.
+    /// If the mint concurrently advances to callback delivery, this command
+    /// becomes a no-op so the next recovery iteration can send it unlocked.
+    RecoverWalletStep {
         issuer_request_id: IssuerMintRequestId,
         mode: MintRecoveryMode,
     },

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
 
-use crate::vault::TxId;
+use crate::vault::{PreparedMintTx, TxId};
 
 use super::{
     ClientId, IssuerMintRequestId, Network, Quantity, TokenSymbol,
@@ -35,6 +35,12 @@ pub(crate) enum MintEvent {
     MintingStarted {
         issuer_request_id: IssuerMintRequestId,
         started_at: DateTime<Utc>,
+    },
+    /// Exact signed transaction persisted before any broadcast.
+    MintTxIntended {
+        issuer_request_id: IssuerMintRequestId,
+        prepared_tx: PreparedMintTx,
+        intended_at: DateTime<Utc>,
     },
     TokensMinted {
         issuer_request_id: IssuerMintRequestId,
@@ -107,6 +113,9 @@ impl DomainEvent for MintEvent {
             }
             Self::MintingStarted { .. } => {
                 "MintEvent::MintingStarted".to_string()
+            }
+            Self::MintTxIntended { .. } => {
+                "MintEvent::MintTxIntended".to_string()
             }
             Self::TokensMinted { .. } => "MintEvent::TokensMinted".to_string(),
             Self::MintingFailed { .. } => {

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -18,14 +18,18 @@ use crate::alpaca::{AlpacaService, MintCallbackRequest};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptService, Shares,
 };
+use crate::redemption::has_unresolved_burn_intent;
 use crate::tokenized_asset::view::find_vault_by_underlying;
-use crate::vault::{ReceiptInformation, TxId, VaultError, VaultService};
+use crate::vault::{
+    PreparedMintTx, ReceiptInformation, TxId, VaultError, VaultService,
+};
 
 pub use api::MintResponse;
 
 pub(crate) use api::{confirm_journal, initiate_mint};
 pub(crate) use cmd::{MintCommand, MintRecoveryMode};
 pub(crate) use event::MintEvent;
+pub(crate) use recovery::{DriveOutcome, recover_mint_manually};
 pub(crate) use view::{
     MintView, find_all_recoverable_mints, find_by_issuer_request_id, find_stuck,
 };
@@ -37,6 +41,41 @@ pub(crate) struct MintServices {
     pub(crate) receipts: Arc<dyn ReceiptService>,
     pub(crate) pool: Pool<Sqlite>,
     pub(crate) bot: Address,
+}
+
+pub(crate) async fn has_unresolved_mint_intent(
+    pool: &Pool<Sqlite>,
+    excluding: Option<&IssuerMintRequestId>,
+) -> Result<bool, sqlx::Error> {
+    let excluding = excluding.map(ToString::to_string).unwrap_or_default();
+    let exists = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM events AS intent
+            WHERE intent.aggregate_type = 'Mint'
+              AND intent.event_type = 'MintEvent::MintTxIntended'
+              AND intent.aggregate_id != ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM events AS later
+                  WHERE later.aggregate_type = intent.aggregate_type
+                    AND later.aggregate_id = intent.aggregate_id
+                    AND later.sequence > intent.sequence
+                    AND later.event_type IN (
+                        'MintEvent::MintTxSubmitted',
+                        'MintEvent::TokensMinted',
+                        'MintEvent::ExistingMintRecovered'
+                    )
+              )
+        )
+        ",
+    )
+    .bind(excluding)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists)
 }
 
 pub(crate) use crate::account::ClientId;
@@ -141,6 +180,21 @@ pub(crate) enum Mint {
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
     },
+    /// Exact signed transaction persisted before broadcast.
+    TxIntended {
+        issuer_request_id: IssuerMintRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        quantity: Quantity,
+        underlying: UnderlyingSymbol,
+        token: TokenSymbol,
+        network: Network,
+        client_id: ClientId,
+        wallet: Address,
+        initiated_at: DateTime<Utc>,
+        journal_confirmed_at: DateTime<Utc>,
+        minting_started_at: DateTime<Utc>,
+        prepared_tx: PreparedMintTx,
+    },
     /// Transaction submitted to signing backend, awaiting on-chain confirmation.
     /// The `tx_id` enables recovery: on restart, the bot resumes
     /// polling this transaction instead of resubmitting (which would double-mint).
@@ -156,6 +210,7 @@ pub(crate) enum Mint {
         initiated_at: DateTime<Utc>,
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
+        prepared_tx: Option<PreparedMintTx>,
         external_tx_id: String,
         tx_id: TxId,
     },
@@ -276,6 +331,7 @@ impl Mint {
             Self::JournalConfirmed { .. } => "JournalConfirmed",
             Self::JournalRejected { .. } => "JournalRejected",
             Self::Minting { .. } => "Minting",
+            Self::TxIntended { .. } => "MintIntended",
             Self::TxSubmitted { .. } => "TxSubmitted",
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
@@ -364,6 +420,7 @@ impl Mint {
             return match self {
                 Self::JournalConfirmed { .. }
                 | Self::Minting { .. }
+                | Self::TxIntended { .. }
                 | Self::TxSubmitted { .. }
                 | Self::CallbackPending { .. } => AutomaticRetryDecision::Ready,
                 _ => AutomaticRetryDecision::NotRecoverable,
@@ -395,6 +452,7 @@ impl Mint {
             | Self::JournalConfirmed { tokenization_request_id, .. }
             | Self::JournalRejected { tokenization_request_id, .. }
             | Self::Minting { tokenization_request_id, .. }
+            | Self::TxIntended { tokenization_request_id, .. }
             | Self::TxSubmitted { tokenization_request_id, .. }
             | Self::CallbackPending { tokenization_request_id, .. }
             | Self::MintingFailed { tokenization_request_id, .. }
@@ -484,9 +542,8 @@ impl Mint {
         }])
     }
 
-    /// Submits the on-chain mint transaction to the signing backend.
-    /// Requires `Minting` state (set by prior `Deposit` command).
-    async fn handle_submit_mint(
+    /// Builds and signs the exact mint transaction without broadcasting it.
+    async fn handle_prepare_mint(
         &self,
         services: &MintServices,
         issuer_request_id: IssuerMintRequestId,
@@ -508,7 +565,7 @@ impl Mint {
 
         Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
 
-        let event = Self::execute_mint_submission(
+        let event = Self::execute_mint_preparation(
             services,
             MintSubmissionInput {
                 issuer_request_id,
@@ -526,9 +583,9 @@ impl Mint {
         Ok(vec![event])
     }
 
-    /// Shared submission logic: vault lookup, receipt info, submit_mint call.
-    /// Returns a single `TxSubmitted` or `MintingFailed` event.
-    async fn execute_mint_submission(
+    /// Shared preparation logic: vault lookup, receipt info, and signing.
+    /// Returns a persisted exact intent or a pre-broadcast failure.
+    async fn execute_mint_preparation(
         services: &MintServices,
         input: MintSubmissionInput<'_>,
     ) -> Result<MintEvent, MintError> {
@@ -542,6 +599,21 @@ impl Mint {
             receipt_note,
             external_tx_id,
         } = input;
+
+        let unresolved_mint = has_unresolved_mint_intent(
+            &services.pool,
+            Some(&issuer_request_id),
+        )
+        .await
+        .map_err(|error| MintError::AssetView { message: error.to_string() })?;
+        let unresolved_burn =
+            has_unresolved_burn_intent(&services.pool, None).await.map_err(
+                |error| MintError::AssetView { message: error.to_string() },
+            )?;
+        if unresolved_mint || unresolved_burn {
+            return Err(MintError::PendingWalletIntent);
+        }
+
         let vault = find_vault_by_underlying(&services.pool, underlying)
             .await
             .map_err(|e| MintError::AssetView { message: e.to_string() })?
@@ -566,7 +638,7 @@ impl Mint {
 
         match services
             .vault
-            .submit_mint(
+            .prepare_mint_tx(
                 vault,
                 assets,
                 services.bot,
@@ -576,20 +648,35 @@ impl Mint {
             )
             .await
         {
-            Ok(submitted) => {
+            Ok(prepared_tx) => {
+                if let Err(err) = prepared_tx.validate() {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Mint transaction preparation returned an invalid signed envelope"
+                    );
+
+                    return Ok(MintEvent::MintingFailed {
+                        issuer_request_id,
+                        error: err.to_string(),
+                        failed_at: now,
+                    });
+                }
+
                 info!(
                     target: "mint",
                     issuer_request_id = %issuer_request_id,
-                    external_tx_id = %submitted.external_tx_id,
-                    tx_id = %submitted.tx_id,
-                    "Mint transaction submitted to signing backend"
+                    external_tx_id = %prepared_tx.external_tx_id,
+                    tx_hash = %prepared_tx.hash,
+                    nonce = prepared_tx.nonce,
+                    "Mint transaction intent prepared"
                 );
 
-                Ok(MintEvent::MintTxSubmitted {
+                Ok(MintEvent::MintTxIntended {
                     issuer_request_id,
-                    external_tx_id: submitted.external_tx_id,
-                    tx_id: submitted.tx_id,
-                    submitted_at: now,
+                    prepared_tx,
+                    intended_at: now,
                 })
             }
             Err(err) => {
@@ -597,7 +684,7 @@ impl Mint {
                     target: "mint",
                     issuer_request_id = %issuer_request_id,
                     error = %err,
-                    "Mint submission failed"
+                    "Mint transaction preparation failed"
                 );
 
                 Ok(MintEvent::MintingFailed {
@@ -607,6 +694,63 @@ impl Mint {
                 })
             }
         }
+    }
+
+    /// Broadcasts only the exact signed transaction persisted by
+    /// `MintTxIntended`. A broadcast error is returned without an event so the
+    /// aggregate remains recoverable in `MintIntended`.
+    async fn handle_submit_mint(
+        &self,
+        services: &MintServices,
+        issuer_request_id: IssuerMintRequestId,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let Self::TxIntended {
+            issuer_request_id: expected_id,
+            prepared_tx,
+            ..
+        } = self
+        else {
+            return Err(MintError::NotInMintIntendedState {
+                current_state: self.state_name().to_string(),
+            });
+        };
+
+        Self::validate_issuer_request_id(expected_id, &issuer_request_id)?;
+
+        let submitted = match services.vault.submit_mint(prepared_tx).await {
+            Ok(submitted) => submitted,
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %prepared_tx.hash,
+                    error = %error,
+                    "Persisted mint transaction broadcast failed; keeping intent for recovery"
+                );
+                return Err(MintError::Vault { message: error.to_string() });
+            }
+        };
+
+        if submitted.tx_id != TxId::from(prepared_tx.hash)
+            || submitted.external_tx_id != prepared_tx.external_tx_id
+        {
+            return Err(MintError::SubmittedTransactionMismatch);
+        }
+
+        info!(
+            target: "mint",
+            issuer_request_id = %issuer_request_id,
+            external_tx_id = %submitted.external_tx_id,
+            tx_id = %submitted.tx_id,
+            "Persisted mint transaction broadcast"
+        );
+
+        Ok(vec![MintEvent::MintTxSubmitted {
+            issuer_request_id,
+            external_tx_id: submitted.external_tx_id,
+            tx_id: submitted.tx_id,
+            submitted_at: Utc::now(),
+        }])
     }
 
     /// Confirms a previously submitted mint transaction by polling the backend.
@@ -799,6 +943,30 @@ impl Mint {
                 // Recover again, which hits the Minting arm to submit.
                 self.handle_deposit(issuer_request_id)
             }
+            Self::TxIntended { underlying, .. } => {
+                let vault =
+                    find_vault_by_underlying(&services.pool, underlying)
+                        .await
+                        .map_err(|error| MintError::AssetView {
+                            message: error.to_string(),
+                        })?
+                        .ok_or_else(|| MintError::AssetNotFound {
+                            underlying: underlying.clone(),
+                        })?;
+
+                if let Some(deposit_events) =
+                    Self::recover_from_existing_receipt(
+                        services,
+                        &vault,
+                        &issuer_request_id,
+                    )
+                    .await?
+                {
+                    Ok(deposit_events)
+                } else {
+                    self.handle_submit_mint(services, issuer_request_id).await
+                }
+            }
             Self::TxSubmitted { tx_id, .. } => {
                 let deposit_events = self
                     .handle_confirm_mint(
@@ -807,12 +975,7 @@ impl Mint {
                         tx_id.clone(),
                     )
                     .await?;
-                self.advance_through_callback(
-                    services,
-                    issuer_request_id,
-                    deposit_events,
-                )
-                .await
+                Ok(deposit_events)
             }
             Self::MintingFailed { .. } => {
                 // Preserve the previous tx so recovery can
@@ -829,12 +992,7 @@ impl Mint {
                         mode,
                     )
                     .await?;
-                self.advance_through_callback(
-                    services,
-                    issuer_request_id,
-                    deposit_events,
-                )
-                .await
+                Ok(deposit_events)
             }
             Self::Minting { .. } => {
                 let deposit_events = self
@@ -846,12 +1004,7 @@ impl Mint {
                         mode,
                     )
                     .await?;
-                self.advance_through_callback(
-                    services,
-                    issuer_request_id,
-                    deposit_events,
-                )
-                .await
+                Ok(deposit_events)
             }
             Self::CallbackPending { .. } => {
                 self.handle_send_callback(services, issuer_request_id).await
@@ -860,6 +1013,22 @@ impl Mint {
                 current_state: self.state_name().to_string(),
             }),
         }
+    }
+
+    async fn handle_recover_wallet_step(
+        &self,
+        services: &MintServices,
+        issuer_request_id: IssuerMintRequestId,
+        mode: MintRecoveryMode,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        if matches!(self, Self::CallbackPending { .. }) {
+            debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Deferring callback from wallet-locked recovery step"
+            );
+            return Ok(vec![]);
+        }
+
+        self.handle_recover(services, issuer_request_id, mode).await
     }
 
     /// Handles recovery triggered by receipt discovery. Only accepts
@@ -878,6 +1047,28 @@ impl Mint {
         tx_hash: TxHash,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
+            Self::TxIntended { underlying, .. } => {
+                let vault =
+                    find_vault_by_underlying(&services.pool, underlying)
+                        .await
+                        .map_err(|error| MintError::AssetView {
+                            message: error.to_string(),
+                        })?
+                        .ok_or_else(|| MintError::AssetNotFound {
+                            underlying: underlying.clone(),
+                        })?;
+                let deposit_events = Self::recover_from_existing_receipt(
+                    services,
+                    &vault,
+                    &issuer_request_id,
+                )
+                .await?
+                .ok_or_else(|| MintError::ReceiptNotFound {
+                    issuer_request_id: issuer_request_id.clone(),
+                })?;
+
+                Ok(deposit_events)
+            }
             Self::MintingFailed { .. }
                 if matches!(
                     self.non_failed_predecessor(),
@@ -895,76 +1086,12 @@ impl Mint {
                         MintRecoveryMode::Manual,
                     )
                     .await?;
-                self.advance_through_callback(
-                    services,
-                    issuer_request_id,
-                    deposit_events,
-                )
-                .await
+                Ok(deposit_events)
             }
             _ => Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
             }),
         }
-    }
-
-    /// If `deposit_events` contain a successful deposit (`TokensMinted` or
-    /// `ExistingMintRecovered`), advance through `CallbackPending` by
-    /// sending the Alpaca callback in the same command execution and
-    /// return the combined event list. Otherwise return `deposit_events`
-    /// unchanged.
-    ///
-    /// Keeps recovery atomic: a single `Recover` command takes the
-    /// aggregate from a stuck pre-callback state straight to `Completed`,
-    /// so the aggregate never lingers in `CallbackPending` between
-    /// commands and so any recovery entry-point (admin reprocess, the
-    /// boot-time loop, or receipt-discovery handler) picks up the same
-    /// advancing behavior.
-    async fn advance_through_callback(
-        &self,
-        services: &MintServices,
-        issuer_request_id: IssuerMintRequestId,
-        deposit_events: Vec<MintEvent>,
-    ) -> Result<Vec<MintEvent>, MintError> {
-        let deposit_succeeded = deposit_events.iter().any(|event| {
-            matches!(
-                event,
-                MintEvent::TokensMinted { .. }
-                    | MintEvent::ExistingMintRecovered { .. }
-            )
-        });
-
-        if !deposit_succeeded {
-            return Ok(deposit_events);
-        }
-
-        let mut intermediate = self.clone();
-        for event in &deposit_events {
-            intermediate.apply_event(event.clone());
-        }
-
-        // If callback delivery fails after a successful on-chain deposit,
-        // preserve the deposit events so the aggregate advances to
-        // CallbackPending. The next recovery picks up from there instead
-        // of re-running the deposit path.
-        let callback_events = match intermediate
-            .handle_send_callback(services, issuer_request_id.clone())
-            .await
-        {
-            Ok(events) => events,
-            Err(err) => {
-                warn!(
-                    target: "mint",
-                    issuer_request_id = %issuer_request_id,
-                    error = %err,
-                    "Callback failed after successful deposit; \
-                     keeping mint in CallbackPending"
-                );
-                return Ok(deposit_events);
-            }
-        };
-
-        Ok(deposit_events.into_iter().chain(callback_events).collect())
     }
 
     async fn handle_recover_incomplete(
@@ -1214,19 +1341,19 @@ impl Mint {
         });
         input.external_tx_id = external_tx_id;
 
-        let submission_event =
-            Self::execute_mint_submission(services, input).await?;
+        let preparation_event =
+            Self::execute_mint_preparation(services, input).await?;
 
-        // Only record MintRetryStarted alongside a *successful* submission.
-        // execute_mint_submission returns Ok(MintingFailed) when the backend
-        // rejects the submission; emitting MintRetryStarted in that case would
+        // Only record MintRetryStarted alongside a successfully persisted
+        // transaction intent. Preparation failures emit MintingFailed;
+        // emitting MintRetryStarted in that case would
         // move the aggregate MintingFailed -> Minting, discarding the
         // TxSubmitted predecessor (its tx_id and the retry
         // counter derived from external_tx_id). Re-emitting only the failure
         // keeps the predecessor chain intact for the next retry.
         let retry_event = matches!(
-            (retrying_failed_mint, &submission_event),
-            (true, MintEvent::MintTxSubmitted { .. })
+            (retrying_failed_mint, &preparation_event),
+            (true, MintEvent::MintTxIntended { .. })
         )
         .then(|| MintEvent::MintRetryStarted {
             issuer_request_id,
@@ -1236,7 +1363,7 @@ impl Mint {
 
         Ok(retry_event
             .into_iter()
-            .chain(std::iter::once(submission_event))
+            .chain(std::iter::once(preparation_event))
             .collect())
     }
 
@@ -1375,6 +1502,62 @@ impl Mint {
         tx_id: TxId,
         _submitted_at: DateTime<Utc>,
     ) {
+        let prepared_tx = match self {
+            Self::TxIntended { prepared_tx, .. } => Some(prepared_tx.clone()),
+            Self::Minting { .. } => None,
+            _ => return,
+        };
+
+        let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            minting_started_at,
+        }
+        | Self::TxIntended {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            minting_started_at,
+            ..
+        }) = self.clone()
+        else {
+            return;
+        };
+
+        *self = Self::TxSubmitted {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            minting_started_at,
+            prepared_tx,
+            external_tx_id,
+            tx_id,
+        };
+    }
+
+    fn apply_mint_intended(&mut self, prepared_tx: PreparedMintTx) {
         let Self::Minting {
             issuer_request_id,
             tokenization_request_id,
@@ -1392,7 +1575,7 @@ impl Mint {
             return;
         };
 
-        *self = Self::TxSubmitted {
+        *self = Self::TxIntended {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -1404,8 +1587,7 @@ impl Mint {
             initiated_at,
             journal_confirmed_at,
             minting_started_at,
-            external_tx_id,
-            tx_id,
+            prepared_tx,
         };
     }
 
@@ -1419,6 +1601,19 @@ impl Mint {
         minted_at: DateTime<Utc>,
     ) {
         let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::TxIntended {
             issuer_request_id,
             tokenization_request_id,
             quantity,
@@ -1618,6 +1813,19 @@ impl Mint {
             journal_confirmed_at,
             ..
         }
+        | Self::TxIntended {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            journal_confirmed_at,
+            ..
+        }
         | Self::TxSubmitted {
             issuer_request_id,
             tokenization_request_id,
@@ -1731,7 +1939,7 @@ impl EventSourced for Mint {
 
     const AGGREGATE_TYPE: &'static str = "Mint";
     const PROJECTION: Table = Table("mint_view");
-    const SCHEMA_VERSION: u64 = 3;
+    const SCHEMA_VERSION: u64 = 4;
 
     // Snapshots are disabled: the pre-migration wiring never wrote snapshots,
     // and event-sorcery hardwires snapshot-every-N with no off switch, so
@@ -1812,8 +2020,13 @@ impl EventSourced for Mint {
                     current_state: "Uninitialized".to_string(),
                 })
             }
-            MintCommand::SubmitMint { .. } => {
+            MintCommand::PrepareMint { .. } => {
                 Err(MintError::NotInMintingState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::SubmitMint { .. } => {
+                Err(MintError::NotInMintIntendedState {
                     current_state: "Uninitialized".to_string(),
                 })
             }
@@ -1828,6 +2041,7 @@ impl EventSourced for Mint {
                 })
             }
             MintCommand::Recover { .. }
+            | MintCommand::RecoverWalletStep { .. }
             | MintCommand::RecoverFromReceipt { .. }
             | MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
                 current_state: "Uninitialized".to_string(),
@@ -1878,6 +2092,9 @@ impl EventSourced for Mint {
             MintCommand::Deposit { issuer_request_id } => {
                 self.handle_deposit(issuer_request_id)
             }
+            MintCommand::PrepareMint { issuer_request_id } => {
+                self.handle_prepare_mint(services, issuer_request_id).await
+            }
             MintCommand::SubmitMint { issuer_request_id } => {
                 self.handle_submit_mint(services, issuer_request_id).await
             }
@@ -1890,6 +2107,14 @@ impl EventSourced for Mint {
             }
             MintCommand::Recover { issuer_request_id, mode } => {
                 self.handle_recover(services, issuer_request_id, mode).await
+            }
+            MintCommand::RecoverWalletStep { issuer_request_id, mode } => {
+                self.handle_recover_wallet_step(
+                    services,
+                    issuer_request_id,
+                    mode,
+                )
+                .await
             }
             MintCommand::RecoverFromReceipt { issuer_request_id, tx_hash } => {
                 self.handle_recover_from_receipt(
@@ -1944,6 +2169,11 @@ impl Mint {
             MintEvent::MintingStarted { issuer_request_id: _, started_at } => {
                 self.apply_minting_started(started_at);
             }
+            MintEvent::MintTxIntended {
+                issuer_request_id: _,
+                prepared_tx,
+                intended_at: _,
+            } => self.apply_mint_intended(prepared_tx),
             MintEvent::TokensMinted {
                 issuer_request_id: _,
                 tx_hash,
@@ -2031,6 +2261,8 @@ pub(crate) enum MintError {
     },
     #[error("Mint not in Minting state. Current state: {current_state}")]
     NotInMintingState { current_state: String },
+    #[error("Mint not in MintIntended state. Current state: {current_state}")]
+    NotInMintIntendedState { current_state: String },
     #[error(
         "Mint not in Minting or MintingFailed state. Current state: {current_state}"
     )]
@@ -2047,6 +2279,10 @@ pub(crate) enum MintError {
         "Transaction ID mismatch. Expected: {expected}, provided: {provided}"
     )]
     TxIdMismatch { expected: TxId, provided: TxId },
+    #[error(
+        "Vault returned transaction metadata that differs from mint intent"
+    )]
+    SubmittedTransactionMismatch,
     #[error("Asset not found for underlying: {underlying}")]
     AssetNotFound { underlying: UnderlyingSymbol },
     #[error("Quantity conversion: {message}")]
@@ -2057,6 +2293,12 @@ pub(crate) enum MintError {
     Alpaca { message: String },
     #[error("Receipt lookup: {message}")]
     ReceiptLookup { message: String },
+    #[error("No receipt found for mint {issuer_request_id}")]
+    ReceiptNotFound { issuer_request_id: IssuerMintRequestId },
+    #[error(
+        "Cannot prepare a new mint while another wallet intent is unresolved"
+    )]
+    PendingWalletIntent,
     #[error("Vault: {message}")]
     Vault { message: String },
 }
@@ -2085,6 +2327,7 @@ pub(crate) mod tests {
         MintCommand, MintError, MintEvent, MintRecoveryMode, MintServices,
         MintView, Network, Quantity, TokenSymbol, TokenizationRequestId,
         UnderlyingSymbol, find_by_issuer_request_id,
+        has_unresolved_mint_intent,
     };
     use crate::alpaca::mock::MockAlpacaService;
     use crate::prepare_event_sourced_startup;
@@ -2094,8 +2337,8 @@ pub(crate) mod tests {
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
         BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-        ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId, VaultError,
-        VaultService,
+        PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx,
+        TxId, VaultError, VaultService,
     };
 
     pub(super) const VAULT: Address =
@@ -2122,7 +2365,7 @@ pub(crate) mod tests {
 
     #[async_trait]
     impl VaultService for TerminalFailedMintVault {
-        async fn submit_mint(
+        async fn prepare_mint_tx(
             &self,
             _vault: Address,
             _assets: U256,
@@ -2130,13 +2373,23 @@ pub(crate) mod tests {
             _user: Address,
             _receipt_info: ReceiptInformation,
             external_tx_id: Option<String>,
-        ) -> Result<SubmittedTx, VaultError> {
+        ) -> Result<PreparedMintTx, VaultError> {
             let external_tx_id =
                 external_tx_id.unwrap_or_else(|| "mint-base".to_string());
             *self.submitted_external_tx_id.lock().unwrap() =
                 Some(external_tx_id.clone());
 
-            Ok(SubmittedTx { external_tx_id, tx_id: TxId::random() })
+            Ok(PreparedMintTx::valid_for_test(1, external_tx_id))
+        }
+
+        async fn submit_mint(
+            &self,
+            prepared_tx: &PreparedMintTx,
+        ) -> Result<SubmittedTx, VaultError> {
+            Ok(SubmittedTx {
+                external_tx_id: prepared_tx.external_tx_id.clone(),
+                tx_id: prepared_tx.hash.into(),
+            })
         }
 
         async fn confirm_mint(
@@ -2200,7 +2453,7 @@ pub(crate) mod tests {
 
     #[async_trait]
     impl VaultService for RetrySubmitFailsVault {
-        async fn submit_mint(
+        async fn prepare_mint_tx(
             &self,
             _vault: Address,
             _assets: U256,
@@ -2208,6 +2461,13 @@ pub(crate) mod tests {
             _user: Address,
             _receipt_info: ReceiptInformation,
             _external_tx_id: Option<String>,
+        ) -> Result<PreparedMintTx, VaultError> {
+            Err(VaultError::InvalidReceipt)
+        }
+
+        async fn submit_mint(
+            &self,
+            _prepared_tx: &PreparedMintTx,
         ) -> Result<SubmittedTx, VaultError> {
             Err(VaultError::InvalidReceipt)
         }
@@ -2504,6 +2764,7 @@ pub(crate) mod tests {
             MintEvent::JournalConfirmed { .. }
             | MintEvent::JournalRejected { .. }
             | MintEvent::MintingStarted { .. }
+            | MintEvent::MintTxIntended { .. }
             | MintEvent::MintTxSubmitted { .. }
             | MintEvent::TokensMinted { .. }
             | MintEvent::MintingFailed { .. }
@@ -3329,6 +3590,15 @@ pub(crate) mod tests {
     /// flow can be driven end to end and the resulting `MintView` inspected via
     /// the view query helpers.
     async fn setup_projected_mint_store() -> (Arc<Store<Mint>>, Pool<Sqlite>) {
+        setup_projected_mint_store_with_vault(Arc::new(
+            MockVaultService::new_success(),
+        ))
+        .await
+    }
+
+    async fn setup_projected_mint_store_with_vault(
+        vault: Arc<dyn VaultService>,
+    ) -> (Arc<Store<Mint>>, Pool<Sqlite>) {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect(":memory:")
@@ -3360,7 +3630,7 @@ pub(crate) mod tests {
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
         let services = MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
+            vault,
             alpaca: Arc::new(MockAlpacaService::new_success()),
             receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
             pool: pool.clone(),
@@ -3374,6 +3644,157 @@ pub(crate) mod tests {
                 .unwrap();
 
         (mint_store, pool)
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn prepare_mint_rejects_invalid_signed_envelope() {
+        let (store, pool) = setup_projected_mint_store_with_vault(Arc::new(
+            MockVaultService::new_invalid_prepared_mint(),
+        ))
+        .await;
+        let data = TestMintData::new();
+
+        for command in [
+            MintCommand::Initiate {
+                issuer_request_id: data.issuer_request_id.clone(),
+                tokenization_request_id: data.tokenization_request_id.clone(),
+                quantity: data.quantity.clone(),
+                underlying: data.underlying.clone(),
+                token: data.token.clone(),
+                network: data.network.clone(),
+                client_id: data.client_id,
+                wallet: data.wallet,
+            },
+            MintCommand::ConfirmJournal {
+                issuer_request_id: data.issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: data.issuer_request_id.clone(),
+            },
+            MintCommand::PrepareMint {
+                issuer_request_id: data.issuer_request_id.clone(),
+            },
+        ] {
+            store.send(&data.issuer_request_id, command).await.unwrap();
+        }
+
+        let mint = store.load(&data.issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "invalid prepared envelope must fail the mint, got {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            count_events_of_type(
+                &pool,
+                &data.issuer_request_id,
+                "MintEvent::MintTxIntended"
+            )
+            .await,
+            0,
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                &data.issuer_request_id.to_string(),
+                "Mint transaction preparation returned an invalid signed envelope"
+            ]
+        ));
+    }
+
+    #[tokio::test]
+    async fn durable_intent_is_detected_without_a_projection_row() {
+        let (_store, pool) = setup_projected_mint_store().await;
+        let pending_id = IssuerMintRequestId::random();
+        let pending_id_string = pending_id.to_string();
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, 1, 'MintEvent::MintTxIntended', '4.0', '{}', '{}')
+            ",
+        )
+        .bind(&pending_id_string)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            has_unresolved_mint_intent(
+                &pool,
+                Some(&IssuerMintRequestId::random()),
+            )
+            .await
+            .unwrap(),
+            "the event store must remain authoritative when projection writes fail"
+        );
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, 2, 'MintEvent::MintClosed', '4.0', '{}', '{}')
+            ",
+        )
+        .bind(&pending_id_string)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            has_unresolved_mint_intent(
+                &pool,
+                Some(&IssuerMintRequestId::random()),
+            )
+            .await
+            .unwrap(),
+            "closing a mint must not release signed bytes that can still land"
+        );
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, 3, 'MintEvent::MintTxSubmitted', '4.0', '{}', '{}')
+            ",
+        )
+        .bind(pending_id_string)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            !has_unresolved_mint_intent(
+                &pool,
+                Some(&IssuerMintRequestId::random()),
+            )
+            .await
+            .unwrap(),
+            "an explicit transaction-resolution event must release the wallet-intent gate"
+        );
     }
 
     /// Regression: pre-event-sorcery snapshot payloads (`{"Completed": ...}`)
@@ -3820,7 +4241,26 @@ pub(crate) mod tests {
             .await
             .unwrap();
 
-        // SubmitMint does the network call (emits TxSubmitted)
+        // PrepareMint signs and persists the exact transaction before any
+        // broadcast (emits MintTxIntended).
+        store
+            .send(
+                &data.issuer_request_id,
+                MintCommand::PrepareMint {
+                    issuer_request_id: data.issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let Some(Mint::TxIntended { prepared_tx, .. }) =
+            store.load(&data.issuer_request_id).await.unwrap()
+        else {
+            panic!("Expected MintIntended state after PrepareMint");
+        };
+        assert!(!prepared_tx.tx.is_empty());
+
+        // SubmitMint broadcasts only the persisted transaction.
         store
             .send(
                 &data.issuer_request_id,
@@ -3868,7 +4308,7 @@ pub(crate) mod tests {
             "Expected Completed state"
         );
 
-        // The split flow must emit exactly these six events in order.
+        // The split flow must emit exactly these seven events in order.
         let event_types: Vec<String> = sqlx::query_scalar(
             "
             SELECT event_type
@@ -3890,11 +4330,12 @@ pub(crate) mod tests {
                 "MintEvent::Initiated",
                 "MintEvent::JournalConfirmed",
                 "MintEvent::MintingStarted",
+                "MintEvent::MintTxIntended",
                 "MintEvent::MintTxSubmitted",
                 "MintEvent::TokensMinted",
                 "MintEvent::MintCompleted",
             ],
-            "Expected 6 events in the split flow, in order"
+            "Expected 7 events in the split flow, in order"
         );
 
         let view = find_by_issuer_request_id(&pool, &data.issuer_request_id)
@@ -3924,6 +4365,152 @@ pub(crate) mod tests {
         assert!(view_completed_at >= view_minted_at);
         assert!(view_minted_at >= view_journal_confirmed_at);
         assert!(view_journal_confirmed_at >= view_initiated_at);
+    }
+
+    fn persisted_mint_intent_events(
+        issuer_request_id: &IssuerMintRequestId,
+        prepared_tx: PreparedMintTx,
+    ) -> Vec<MintEvent> {
+        let now = Utc::now();
+        vec![
+            MintEvent::Initiated {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("tok-123"),
+                quantity: Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::Base,
+                client_id: ClientId::new(),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                initiated_at: now,
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: now,
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: now,
+            },
+            MintEvent::MintTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx,
+                intended_at: now,
+            },
+        ]
+    }
+
+    fn test_prepared_mint_tx(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> PreparedMintTx {
+        PreparedMintTx::valid_for_test(17, format!("mint-{issuer_request_id}"))
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn restart_rebroadcasts_persisted_mint_without_preparing_another_tx()
+    {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id.to_string(),
+                persisted_mint_intent_events(
+                    &issuer_request_id,
+                    prepared_tx.clone(),
+                ),
+            )
+            .await;
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        let Mint::TxSubmitted { prepared_tx: Some(replayed_tx), tx_id, .. } =
+            mint
+        else {
+            panic!("Expected TxSubmitted with its persisted transaction");
+        };
+        assert_eq!(replayed_tx, prepared_tx);
+        assert_eq!(tx_id, TxId::from(prepared_tx.hash));
+        assert_eq!(vault.get_call_count(), 0, "recovery must not re-prepare");
+        assert_eq!(
+            count_events_of_type(
+                &fixture.pool,
+                &issuer_request_id,
+                "MintEvent::MintTxIntended",
+            )
+            .await,
+            1,
+            "restart recovery must retain the single persisted intent"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[
+                "Persisted mint transaction broadcast",
+                &prepared_tx.hash.to_string()
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn uncertain_broadcast_failure_keeps_exact_mint_intent() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared_tx = test_prepared_mint_tx(&issuer_request_id);
+        let vault = Arc::new(MockVaultService::new_submit_failure());
+        let fixture = MintTestFixture::new_with_vault(vault.clone()).await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id.to_string(),
+                persisted_mint_intent_events(
+                    &issuer_request_id,
+                    prepared_tx.clone(),
+                ),
+            )
+            .await;
+
+        let result = fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await;
+        assert!(result.is_err());
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(
+            mint,
+            Mint::TxIntended {
+                prepared_tx: ref stored,
+                ..
+            } if stored == &prepared_tx
+        ));
+        assert_eq!(vault.get_call_count(), 0, "failure must not re-prepare");
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                "Persisted mint transaction broadcast failed",
+                &prepared_tx.hash.to_string(),
+            ]
+        ));
     }
 
     #[test]
@@ -3969,6 +4556,18 @@ pub(crate) mod tests {
             vault.submitted_external_tx_id(),
             Some(format!("mint-{issuer_request_id}-retry-1"))
         );
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
 
         let Some(Mint::TxSubmitted { external_tx_id, .. }) =
             fixture.mint_store.load(&issuer_request_id).await.unwrap()
@@ -4087,6 +4686,18 @@ pub(crate) mod tests {
             Some(format!("mint-{issuer_request_id}-retry-5"))
         );
 
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Manual,
+                },
+            )
+            .await
+            .unwrap();
+
         let mint = fixture
             .mint_store
             .load(&issuer_request_id)
@@ -4113,7 +4724,7 @@ pub(crate) mod tests {
                 Level::INFO,
                 &[
                     test,
-                    "Mint transaction submitted to signing backend",
+                    "Persisted mint transaction broadcast",
                     expected_external.as_str(),
                 ]
             ),

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -18,17 +18,24 @@ use super::{
     MintRecoveryMode, find_all_recoverable_mints,
 };
 use crate::receipt_inventory::ItnReceiptHandler;
+use crate::vault::VaultService;
 
 /// Production handler that triggers mint recovery when an ITN receipt is
 /// discovered by the receipt monitor.
 #[derive(Clone)]
 pub(crate) struct MintRecoveryHandler {
     mint_store: Arc<Store<Mint>>,
+    pool: Pool<Sqlite>,
+    apalis_pool: SqlitePool,
 }
 
 impl MintRecoveryHandler {
-    pub(crate) const fn new(mint_store: Arc<Store<Mint>>) -> Self {
-        Self { mint_store }
+    pub(crate) const fn new(
+        mint_store: Arc<Store<Mint>>,
+        pool: Pool<Sqlite>,
+        apalis_pool: SqlitePool,
+    ) -> Self {
+        Self { mint_store, pool, apalis_pool }
     }
 }
 
@@ -40,14 +47,48 @@ impl ItnReceiptHandler for MintRecoveryHandler {
         tx_hash: TxHash,
     ) {
         let mint_store = self.mint_store.clone();
+        let pool = self.pool.clone();
+        let apalis_pool = self.apalis_pool.clone();
         tokio::spawn(async move {
-            drive_recovery(&mint_store, issuer_request_id, |id| {
-                MintCommand::RecoverFromReceipt {
-                    issuer_request_id: id,
-                    tx_hash,
+            let result = mint_store
+                .send(
+                    &issuer_request_id,
+                    MintCommand::RecoverFromReceipt {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tx_hash,
+                    },
+                )
+                .await;
+            match result {
+                Ok(()) => {
+                    if let Err(error) = enqueue_scheduled_mint_recovery(
+                        &pool,
+                        &apalis_pool,
+                        issuer_request_id.clone(),
+                    )
+                    .await
+                    {
+                        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                            %error,
+                            "Failed to enqueue receipt-triggered mint recovery"
+                        );
+                    }
                 }
-            })
-            .await;
+                Err(AggregateError::UserError(LifecycleError::Apply(
+                    MintError::NotRecoverable { current_state },
+                ))) => {
+                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                        current_state,
+                        "Receipt discovery ignored for current mint state"
+                    );
+                }
+                Err(error) => {
+                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                        %error,
+                        "Receipt-triggered mint recovery failed"
+                    );
+                }
+            }
         });
     }
 }
@@ -69,12 +110,57 @@ pub(crate) enum DriveOutcome {
 /// Drives a mint through recovery to completion using `MintCommand::Recover`.
 pub(crate) async fn recover_mint(
     mint_store: &Store<Mint>,
+    vault_service: &Arc<dyn VaultService>,
     issuer_request_id: IssuerMintRequestId,
 ) -> DriveOutcome {
-    drive_recovery(mint_store, issuer_request_id, |id| MintCommand::Recover {
-        issuer_request_id: id,
-        mode: MintRecoveryMode::Automatic,
-    })
+    drive_recovery(
+        mint_store,
+        vault_service,
+        issuer_request_id,
+        recovery_step_requires_wallet,
+        |_, id, wallet_locked| {
+            if wallet_locked {
+                MintCommand::RecoverWalletStep {
+                    issuer_request_id: id,
+                    mode: MintRecoveryMode::Automatic,
+                }
+            } else {
+                MintCommand::Recover {
+                    issuer_request_id: id,
+                    mode: MintRecoveryMode::Automatic,
+                }
+            }
+        },
+    )
+    .await
+}
+
+/// Drives an operator-requested recovery, holding the shared wallet lock only
+/// for transitions that may prepare or broadcast a transaction.
+pub(crate) async fn recover_mint_manually(
+    mint_store: &Store<Mint>,
+    vault_service: &Arc<dyn VaultService>,
+    issuer_request_id: IssuerMintRequestId,
+) -> DriveOutcome {
+    drive_recovery(
+        mint_store,
+        vault_service,
+        issuer_request_id,
+        recovery_step_requires_wallet,
+        |_, id, wallet_locked| {
+            if wallet_locked {
+                MintCommand::RecoverWalletStep {
+                    issuer_request_id: id,
+                    mode: MintRecoveryMode::Manual,
+                }
+            } else {
+                MintCommand::Recover {
+                    issuer_request_id: id,
+                    mode: MintRecoveryMode::Manual,
+                }
+            }
+        },
+    )
     .await
 }
 
@@ -119,9 +205,11 @@ impl MintRecoveryJob {
     pub(crate) async fn run(
         self,
         mint_store: Data<Arc<Store<Mint>>>,
+        vault_service: Data<Arc<dyn VaultService>>,
     ) -> Result<(), AbortError> {
         match recover_mint_until_automatic_budget_exhausted(
             &mint_store,
+            &vault_service,
             &self.issuer_request_id,
             SCHEDULED_RECOVERY_BACKOFF,
         )
@@ -510,6 +598,7 @@ enum RecoveryConclusion {
 
 async fn recover_mint_until_automatic_budget_exhausted(
     mint_store: &Store<Mint>,
+    vault_service: &Arc<dyn VaultService>,
     issuer_request_id: &IssuerMintRequestId,
     backoff: Duration,
 ) -> RecoveryConclusion {
@@ -557,7 +646,12 @@ async fn recover_mint_until_automatic_budget_exhausted(
 
         match mint.automatic_retry_decision(Utc::now()) {
             AutomaticRetryDecision::Ready => {
-                match recover_mint(mint_store, issuer_request_id.clone()).await
+                match recover_mint(
+                    mint_store,
+                    vault_service,
+                    issuer_request_id.clone(),
+                )
+                .await
                 {
                     DriveOutcome::Done => {
                         return RecoveryConclusion::Resolved;
@@ -654,13 +748,52 @@ const MAX_RECOVERY_ATTEMPTS: usize = 10;
 /// spinning if a command returns `Ok(())` without advancing state.
 async fn drive_recovery(
     mint_store: &Store<Mint>,
+    vault_service: &Arc<dyn VaultService>,
     issuer_request_id: IssuerMintRequestId,
-    make_command: impl Fn(IssuerMintRequestId) -> MintCommand,
+    requires_wallet: impl Fn(&Mint) -> bool,
+    make_command: impl Fn(Option<&Mint>, IssuerMintRequestId, bool) -> MintCommand,
 ) -> DriveOutcome {
     for attempt in 1..=MAX_RECOVERY_ATTEMPTS {
+        let mut loaded_mint = match mint_store.load(&issuer_request_id).await {
+            Ok(mint) => mint,
+            Err(err) => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Failed to load mint before recovery step"
+                );
+                return DriveOutcome::Failed;
+            }
+        };
+
+        let mut wallet_guard = None;
+        if loaded_mint.as_ref().is_some_and(&requires_wallet) {
+            wallet_guard = vault_service.lock_wallet().await;
+            loaded_mint = match mint_store.load(&issuer_request_id).await {
+                Ok(mint) => mint,
+                Err(err) => {
+                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Failed to reload mint under wallet lock before recovery step"
+                    );
+                    return DriveOutcome::Failed;
+                }
+            };
+            if !loaded_mint.as_ref().is_some_and(&requires_wallet) {
+                drop(wallet_guard.take());
+            }
+        }
+
         let result = mint_store
-            .send(&issuer_request_id, make_command(issuer_request_id.clone()))
+            .send(
+                &issuer_request_id,
+                make_command(
+                    loaded_mint.as_ref(),
+                    issuer_request_id.clone(),
+                    wallet_guard.is_some(),
+                ),
+            )
             .await;
+        drop(wallet_guard);
 
         match result {
             Ok(()) => {
@@ -715,6 +848,16 @@ async fn drive_recovery(
     DriveOutcome::Failed
 }
 
+const fn recovery_step_requires_wallet(mint: &Mint) -> bool {
+    !matches!(
+        mint,
+        Mint::JournalRejected { .. }
+            | Mint::CallbackPending { .. }
+            | Mint::Completed { .. }
+            | Mint::Closed { .. }
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::{address, b256, uint};
@@ -722,10 +865,12 @@ mod tests {
     use event_sorcery::{StoreBuilder, test_store};
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tracing::Level;
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::alpaca::AlpacaService;
     use crate::alpaca::mock::MockAlpacaService;
     use crate::mint::api::test_utils::{TestAccountAndAsset, TestHarness};
     use crate::mint::tests::{BOT, VAULT};
@@ -737,10 +882,12 @@ mod tests {
         CqrsReceiptService, ReceiptId, ReceiptInventory,
         ReceiptInventoryCommand, ReceiptSource, Shares,
     };
-    use crate::test_utils::log_count_at;
+    use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{TokenizedAsset, TokenizedAssetCommand};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{ReceiptInformation, TxId, VaultService};
+    use crate::vault::{
+        PreparedMintTx, ReceiptInformation, TxId, VaultService,
+    };
 
     /// Builds a real event-sorcery [`Store<Mint>`] backed by an in-memory
     /// SQLite pool, wired with the same services the production recovery flow
@@ -751,6 +898,7 @@ mod tests {
         mint_store: Arc<Store<Mint>>,
         receipt_store: Arc<Store<ReceiptInventory>>,
         pool: sqlx::SqlitePool,
+        vault: Arc<dyn VaultService>,
     }
 
     impl MintRecoveryFixture {
@@ -760,6 +908,17 @@ mod tests {
         }
 
         async fn new_with_vault(vault: Arc<dyn VaultService>) -> Self {
+            Self::new_with_services(
+                vault,
+                Arc::new(MockAlpacaService::new_success()),
+            )
+            .await
+        }
+
+        async fn new_with_services(
+            vault: Arc<dyn VaultService>,
+            alpaca: Arc<dyn AlpacaService>,
+        ) -> Self {
             let pool = SqlitePoolOptions::new()
                 .max_connections(1)
                 .connect(":memory:")
@@ -791,8 +950,8 @@ mod tests {
                 Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
 
             let services = MintServices {
-                vault,
-                alpaca: Arc::new(MockAlpacaService::new_success()),
+                vault: vault.clone(),
+                alpaca,
                 receipts: Arc::new(CqrsReceiptService::new(
                     receipt_store.clone(),
                 )),
@@ -803,7 +962,7 @@ mod tests {
             let mint_store =
                 Arc::new(test_store::<Mint>(pool.clone(), services));
 
-            Self { mint_store, receipt_store, pool }
+            Self { mint_store, receipt_store, pool, vault }
         }
 
         /// Seeds the event store with raw `Mint` events, putting the aggregate
@@ -815,41 +974,49 @@ mod tests {
             issuer_request_id: &IssuerMintRequestId,
             events: Vec<MintEvent>,
         ) {
-            let aggregate_id = issuer_request_id.to_string();
+            seed_mint_events(&self.pool, issuer_request_id, events).await;
+        }
+    }
 
-            for (offset, event) in events.into_iter().enumerate() {
-                let sequence = i64::try_from(offset).unwrap() + 1;
-                let payload = serde_json::to_value(&event).unwrap();
-                let variant = payload
-                    .as_object()
-                    .and_then(|map| map.keys().next())
-                    .expect("MintEvent serializes as an externally-tagged enum")
-                    .clone();
-                let event_type = format!("MintEvent::{variant}");
-                let payload_str = payload.to_string();
+    async fn seed_mint_events(
+        pool: &Pool<Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        events: Vec<MintEvent>,
+    ) {
+        let aggregate_id = issuer_request_id.to_string();
 
-                sqlx::query(
-                    "
-                    INSERT INTO events (
-                        aggregate_type,
-                        aggregate_id,
-                        sequence,
-                        event_type,
-                        event_version,
-                        payload,
-                        metadata
-                    )
-                    VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
-                    ",
+        for (offset, event) in events.into_iter().enumerate() {
+            let sequence = i64::try_from(offset).unwrap() + 1;
+            let payload = serde_json::to_value(&event).unwrap();
+            let variant = payload
+                .as_object()
+                .and_then(|map| map.keys().next())
+                .expect("MintEvent serializes as an externally-tagged enum")
+                .clone();
+            let event_type = format!("MintEvent::{variant}");
+            let payload_str = payload.to_string();
+
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
                 )
-                .bind(&aggregate_id)
-                .bind(sequence)
-                .bind(&event_type)
-                .bind(&payload_str)
-                .execute(&self.pool)
-                .await
-                .unwrap();
-            }
+                VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(&aggregate_id)
+            .bind(sequence)
+            .bind(&event_type)
+            .bind(&payload_str)
+            .execute(pool)
+            .await
+            .unwrap();
         }
     }
 
@@ -888,6 +1055,14 @@ mod tests {
         ]
     }
 
+    fn journal_confirmed_events(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = minting_events(issuer_request_id);
+        events.pop();
+        events
+    }
+
     fn tx_submitted_events(
         issuer_request_id: &IssuerMintRequestId,
     ) -> Vec<MintEvent> {
@@ -899,6 +1074,22 @@ mod tests {
             external_tx_id: format!("mint-{issuer_request_id}"),
             tx_id: TxId::random(),
             submitted_at: now,
+        });
+
+        events
+    }
+
+    fn mint_intended_events(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = minting_events(issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: Utc::now(),
         });
 
         events
@@ -956,8 +1147,26 @@ mod tests {
     async fn setup_with_receipt_and_events(
         events: Vec<MintEvent>,
     ) -> MintRecoveryFixture {
+        setup_with_receipt_and_events_and_vault(
+            events,
+            Arc::new(MockVaultService::new_success()),
+        )
+        .await
+    }
+
+    async fn setup_with_receipt_and_events_and_vault(
+        events: Vec<MintEvent>,
+        vault: Arc<dyn VaultService>,
+    ) -> MintRecoveryFixture {
+        let fixture = MintRecoveryFixture::new_with_vault(vault).await;
+        setup_fixture_with_receipt_and_events(fixture, events).await
+    }
+
+    async fn setup_fixture_with_receipt_and_events(
+        fixture: MintRecoveryFixture,
+        events: Vec<MintEvent>,
+    ) -> MintRecoveryFixture {
         let issuer_request_id = test_issuer_request_id();
-        let fixture = MintRecoveryFixture::new().await;
 
         let receipt_info = ReceiptInformation::new(
             TokenizationRequestId::new("tok-123"),
@@ -1003,8 +1212,12 @@ mod tests {
         let events = minting_failed_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
 
-        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
-            .await;
+        recover_mint(
+            fixture.mint_store.as_ref(),
+            &fixture.vault,
+            issuer_request_id.clone(),
+        )
+        .await;
 
         let mint =
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
@@ -1019,12 +1232,48 @@ mod tests {
             log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
             1,
         );
-        // A single Recover command advances MintingFailed → CallbackPending
-        // → Completed atomically via advance_through_callback, so the
-        // drive_recovery loop only needs one successful step.
+        // Receipt recovery and callback delivery are separate durable steps,
+        // so the wallet guard is released before the Alpaca request.
         assert_eq!(
             log_count_at!(Level::DEBUG, &[test, "Recovery step succeeded"]),
-            1,
+            2,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn mint_intended_with_receipt_recovers_without_rebroadcast() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = mint_intended_events(&issuer_request_id);
+        let vault = Arc::new(MockVaultService::new_submit_failure());
+        let fixture =
+            setup_with_receipt_and_events_and_vault(events, vault.clone())
+                .await;
+
+        recover_mint(
+            fixture.mint_store.as_ref(),
+            &fixture.vault,
+            issuer_request_id.clone(),
+        )
+        .await;
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Completed { .. }),
+            "receipt proof must complete MintIntended, got {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "receipt-first recovery must not prepare a replacement transaction"
+        );
+        assert!(
+            log_count_at!(
+                Level::INFO,
+                &["Found existing receipt, recording recovery"]
+            ) > 0
         );
     }
 
@@ -1034,9 +1283,19 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
         let events = callback_pending_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
+        let wallet_guard = fixture.vault.lock_wallet().await;
 
-        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
-            .await;
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            recover_mint(
+                fixture.mint_store.as_ref(),
+                &fixture.vault,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await
+        .expect("callback-only recovery must not wait for the wallet lock");
+        drop(wallet_guard);
 
         let mint =
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
@@ -1057,13 +1316,11 @@ mod tests {
         );
     }
 
-    /// A single `Recover` command on a mint stuck in `Minting` must reach
-    /// `Completed` in one execution when an on-chain receipt is already
-    /// present — the deposit event and the callback must be committed
-    /// together so the aggregate never lingers in `CallbackPending`.
+    /// Recovery from `Minting` persists the receipt proof before delivering
+    /// the callback in a second command.
     #[traced_test]
     #[tokio::test]
-    async fn single_recover_command_from_minting_reaches_completed() {
+    async fn minting_receipt_recovery_persists_before_callback() {
         let issuer_request_id = test_issuer_request_id();
         let events = minting_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
@@ -1084,21 +1341,37 @@ mod tests {
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state after one Recover, got: {}",
+            matches!(mint, Mint::CallbackPending { .. }),
+            "Expected CallbackPending after receipt recovery, got: {}",
             mint.state_name()
         );
-        let test = "single_recover_command_from_minting_reaches_completed";
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        let completed =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(completed, Mint::Completed { .. }));
+        let test = "minting_receipt_recovery_persists_before_callback";
         assert_eq!(
             log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
             1,
         );
     }
 
-    /// Same invariant for the `MintingFailed` starting state.
+    /// The same durable boundary applies from `MintingFailed`.
     #[traced_test]
     #[tokio::test]
-    async fn single_recover_command_from_minting_failed_reaches_completed() {
+    async fn failed_mint_receipt_recovery_persists_before_callback() {
         let issuer_request_id = test_issuer_request_id();
         let events = minting_failed_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
@@ -1119,30 +1392,42 @@ mod tests {
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state after one Recover, got: {}",
+            matches!(mint, Mint::CallbackPending { .. }),
+            "Expected CallbackPending after receipt recovery, got: {}",
             mint.state_name()
         );
-        let test =
-            "single_recover_command_from_minting_failed_reaches_completed";
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        let completed =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(completed, Mint::Completed { .. }));
+        let test = "failed_mint_receipt_recovery_persists_before_callback";
         assert_eq!(
             log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
             1,
         );
     }
 
-    /// Same invariant for the `TxSubmitted` starting state — the
-    /// mock vault's `confirm_mint` succeeds, so `TokensMinted` and
-    /// `MintCompleted` must be emitted in one command.
+    /// Same invariant for the `TxSubmitted` starting state.
     #[traced_test]
     #[tokio::test]
-    async fn single_recover_command_from_tx_submitted_reaches_completed() {
+    async fn tx_submitted_recovery_persists_before_callback() {
         let issuer_request_id = test_issuer_request_id();
         let events = tx_submitted_events(&issuer_request_id);
         // No pre-existing receipt — the mock confirm path produces TokensMinted.
         let fixture = MintRecoveryFixture::new().await;
         fixture.seed_mint_events(&issuer_request_id, events).await;
-
         fixture
             .mint_store
             .send(
@@ -1159,15 +1444,126 @@ mod tests {
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
 
         assert!(
-            matches!(mint, Mint::Completed { .. }),
-            "Expected Completed state after one Recover, got: {}",
+            matches!(mint, Mint::CallbackPending { .. }),
+            "Expected CallbackPending after one Recover, got: {}",
             mint.state_name()
         );
-        let test = "single_recover_command_from_tx_submitted_reaches_completed";
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .unwrap();
+
+        let completed =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(completed, Mint::Completed { .. }));
+        let test = "tx_submitted_recovery_persists_before_callback";
         assert_eq!(
             log_count_at!(Level::INFO, &[test, "Alpaca callback succeeded"]),
             1,
         );
+    }
+
+    /// Receipt-monitor recovery must durably record the receipt before making
+    /// the Alpaca callback.
+    #[traced_test]
+    #[tokio::test]
+    async fn receipt_command_persists_recovery_before_callback() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = minting_failed_events(&issuer_request_id);
+        let fixture = setup_with_receipt_and_events(events).await;
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecoverFromReceipt {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tx_hash: b256!(
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    ),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "Expected CallbackPending after receipt command, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    "receipt_command_persists_recovery_before_callback",
+                    "Alpaca callback succeeded"
+                ]
+            ),
+            0,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn receipt_discovery_does_not_send_callback_from_callback_pending() {
+        let issuer_request_id = test_issuer_request_id();
+        let harness = TestHarness::new().await;
+        let TestHarness { pool, apalis_pool, mint_store, .. } = harness;
+        seed_mint_events(
+            &pool,
+            &issuer_request_id,
+            callback_pending_events(&issuer_request_id),
+        )
+        .await;
+        let handler = MintRecoveryHandler::new(
+            mint_store.clone(),
+            pool.clone(),
+            apalis_pool,
+        );
+
+        handler
+            .on_itn_receipt_discovered(
+                issuer_request_id.clone(),
+                b256!(
+                    "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                ),
+            )
+            .await;
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !logs_contain_at!(
+                Level::DEBUG,
+                &[
+                    "receipt_discovery_does_not_send_callback_from_callback_pending",
+                    "Receipt discovery ignored for current mint state",
+                ]
+            ) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("receipt-triggered recovery should finish");
+
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::CallbackPending { .. }));
+        let queued: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM Jobs WHERE idempotency_key = ?",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(queued, 0);
     }
 
     #[traced_test]
@@ -1177,8 +1573,12 @@ mod tests {
         let events = completed_events(&issuer_request_id);
         let fixture = setup_with_receipt_and_events(events).await;
 
-        recover_mint(fixture.mint_store.as_ref(), issuer_request_id.clone())
-            .await;
+        recover_mint(
+            fixture.mint_store.as_ref(),
+            &fixture.vault,
+            issuer_request_id.clone(),
+        )
+        .await;
 
         let mint =
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
@@ -1192,6 +1592,251 @@ mod tests {
         let test = "completed_mint_returns_cleanly";
         assert_eq!(
             log_count_at!(Level::INFO, &[test, "Mint recovery complete"]),
+            1,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn journal_confirmed_recovery_waits_for_wallet_lock() {
+        let issuer_request_id = test_issuer_request_id();
+        let events = journal_confirmed_events(&issuer_request_id);
+        let fixture = setup_with_receipt_and_events(events).await;
+        let wallet_guard = fixture.vault.lock_wallet().await;
+
+        let blocked = tokio::time::timeout(
+            Duration::from_millis(100),
+            recover_mint(
+                fixture.mint_store.as_ref(),
+                &fixture.vault,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await;
+
+        assert!(blocked.is_err(), "recovery must wait for the wallet lock");
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::JournalConfirmed { .. }),
+            "recovery must not advance toward signing without the wallet lock"
+        );
+
+        drop(wallet_guard);
+        recover_mint(
+            fixture.mint_store.as_ref(),
+            &fixture.vault,
+            issuer_request_id.clone(),
+        )
+        .await;
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Completed { .. }));
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    "journal_confirmed_recovery_waits_for_wallet_lock",
+                    "Mint recovery complete",
+                ]
+            ),
+            1,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn recovery_reloads_state_and_releases_obsolete_wallet_lock() {
+        let issuer_request_id = test_issuer_request_id();
+        let vault = Arc::new(MockVaultService::new_success());
+        let alpaca =
+            Arc::new(MockAlpacaService::new_success().with_callback_delay(500));
+        let fixture = MintRecoveryFixture::new_with_services(
+            vault.clone(),
+            alpaca.clone(),
+        )
+        .await;
+        let fixture = setup_fixture_with_receipt_and_events(
+            fixture,
+            minting_events(&issuer_request_id),
+        )
+        .await;
+        let wallet_guard = fixture.vault.lock_wallet().await;
+        let mint_store = fixture.mint_store.clone();
+        let recovery_vault = fixture.vault.clone();
+        let recovery_id = issuer_request_id.clone();
+        let recovery = tokio::spawn(async move {
+            recover_mint(mint_store.as_ref(), &recovery_vault, recovery_id)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while vault.get_wallet_lock_call_count() < 2 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("recovery must begin waiting for the wallet lock");
+
+        fixture
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Recover {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            )
+            .await
+            .expect("concurrent receipt recovery should advance the mint");
+        drop(wallet_guard);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while alpaca.get_call_count() == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("callback must start after the aggregate reload");
+
+        let available_guard = tokio::time::timeout(
+            Duration::from_millis(100),
+            fixture.vault.lock_wallet(),
+        )
+        .await
+        .expect("callback delivery must not retain the obsolete wallet lock");
+        drop(available_guard);
+
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), recovery)
+                .await
+                .expect("recovery should finish after callback delivery")
+                .expect("recovery task should not panic"),
+            DriveOutcome::Done,
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Completed { .. }));
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    "recovery_reloads_state_and_releases_obsolete_wallet_lock",
+                    "Mint recovery complete",
+                ]
+            ),
+            1,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn wallet_recovery_step_defers_concurrent_callback_state() {
+        let issuer_request_id = test_issuer_request_id();
+        let vault = Arc::new(MockVaultService::new_success());
+        let alpaca =
+            Arc::new(MockAlpacaService::new_success().with_callback_delay(500));
+        let fixture =
+            MintRecoveryFixture::new_with_services(vault, alpaca.clone()).await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id,
+                callback_pending_events(&issuer_request_id),
+            )
+            .await;
+
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            fixture.mint_store.send(
+                &issuer_request_id,
+                MintCommand::RecoverWalletStep {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mode: MintRecoveryMode::Automatic,
+                },
+            ),
+        )
+        .await
+        .expect("wallet recovery step must not call Alpaca")
+        .expect("callback deferral should be a successful no-op");
+
+        assert_eq!(alpaca.get_call_count(), 0);
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::CallbackPending { .. }));
+        assert_eq!(
+            log_count_at!(
+                Level::DEBUG,
+                &[
+                    "wallet_recovery_step_defers_concurrent_callback_state",
+                    "Deferring callback from wallet-locked recovery step",
+                ]
+            ),
+            1,
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn wallet_recovery_noop_converges_on_next_unlocked_iteration() {
+        let issuer_request_id = test_issuer_request_id();
+        let vault = Arc::new(MockVaultService::new_success());
+        let alpaca = Arc::new(MockAlpacaService::new_success());
+        let fixture =
+            MintRecoveryFixture::new_with_services(vault, alpaca.clone()).await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id,
+                callback_pending_events(&issuer_request_id),
+            )
+            .await;
+        let classifications = Arc::new(AtomicUsize::new(0));
+        let classifier_calls = classifications.clone();
+
+        let outcome = drive_recovery(
+            fixture.mint_store.as_ref(),
+            &fixture.vault,
+            issuer_request_id.clone(),
+            move |_| classifier_calls.fetch_add(1, Ordering::Relaxed) < 2,
+            |_, id, wallet_locked| {
+                if wallet_locked {
+                    MintCommand::RecoverWalletStep {
+                        issuer_request_id: id,
+                        mode: MintRecoveryMode::Automatic,
+                    }
+                } else {
+                    MintCommand::Recover {
+                        issuer_request_id: id,
+                        mode: MintRecoveryMode::Automatic,
+                    }
+                }
+            },
+        )
+        .await;
+
+        assert_eq!(outcome, DriveOutcome::Done);
+        assert_eq!(alpaca.get_call_count(), 1);
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Completed { .. }));
+        assert_eq!(
+            log_count_at!(
+                Level::DEBUG,
+                &[
+                    "wallet_recovery_noop_converges_on_next_unlocked_iteration",
+                    "Deferring callback from wallet-locked recovery step",
+                ]
+            ),
+            1,
+        );
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    "wallet_recovery_noop_converges_on_next_unlocked_iteration",
+                    "Mint recovery complete",
+                ]
+            ),
             1,
         );
     }
@@ -1217,6 +1862,7 @@ mod tests {
         // Second pass: retry window not yet elapsed → RetryNotDue.
         let outcome = recover_mint(
             fixture.mint_store.as_ref(),
+            &fixture.vault,
             issuer_request_id.clone(),
         )
         .await;
@@ -1276,6 +1922,7 @@ mod tests {
 
         let outcome = recover_mint(
             fixture.mint_store.as_ref(),
+            &fixture.vault,
             issuer_request_id.clone(),
         )
         .await;
@@ -1324,8 +1971,10 @@ mod tests {
         // Recover command fails with AssetNotFound → DriveOutcome::Failed.
         let receipt_store =
             Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        let vault: Arc<dyn VaultService> =
+            Arc::new(MockVaultService::new_success());
         let services = MintServices {
-            vault: Arc::new(MockVaultService::new_success()),
+            vault: vault.clone(),
             alpaca: Arc::new(MockAlpacaService::new_success()),
             receipts: Arc::new(CqrsReceiptService::new(receipt_store)),
             pool: pool.clone(),
@@ -1383,6 +2032,7 @@ mod tests {
         // Zero backoff so the test does not sleep.
         recover_mint_until_automatic_budget_exhausted(
             mint_store.as_ref(),
+            &vault,
             &issuer_request_id,
             Duration::ZERO,
         )
@@ -1586,7 +2236,10 @@ mod tests {
         let issuer_request_id = test_issuer_request_id();
 
         let result = MintRecoveryJob { issuer_request_id }
-            .run(Data::new(fixture.mint_store.clone()))
+            .run(
+                Data::new(fixture.mint_store.clone()),
+                Data::new(fixture.vault.clone()),
+            )
             .await;
 
         assert!(
@@ -1629,7 +2282,10 @@ mod tests {
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
         let error = MintRecoveryJob { issuer_request_id }
-            .run(Data::new(fixture.mint_store.clone()))
+            .run(
+                Data::new(fixture.mint_store.clone()),
+                Data::new(fixture.vault.clone()),
+            )
             .await
             .expect_err("an exhausted mint must abort, not resolve");
 

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -1,31 +1,26 @@
 use alloy::primitives::{Address, B256, U256};
 use chrono::{DateTime, Utc};
+use event_sorcery::{Projection, ProjectionError};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
-use uuid::Uuid;
 
 use super::{
-    ClientId, IssuerMintRequestId, Network, Quantity, TokenSymbol,
+    ClientId, IssuerMintRequestId, Mint, Network, Quantity, TokenSymbol,
     TokenizationRequestId, UnderlyingSymbol,
 };
+use crate::vault::{PreparedMintTx, TxId};
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MintViewError {
-    #[error("Database error: {0}")]
-    Database(#[from] sqlx::Error),
+    #[error("Projection error: {0}")]
+    Projection(#[from] ProjectionError<Mint>),
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
-    #[error("UUID parse error: {0}")]
-    Uuid(#[from] uuid::Error),
 }
 
-/// Read model for a mint, projected from the `mint_view` table.
+/// Query-oriented representation of a live `Mint` projection.
 ///
-/// `mint_view` stores the event-sorcery `Lifecycle<Mint>` payload
-/// (`{"Live": {...}}`). The `find_*` queries extract the `$.Live` sub-object —
-/// which is one of the live `Mint` variants — and deserialize it into this
-/// enum, which mirrors those variants field-for-field. `NotFound` is the
-/// query-miss sentinel and is never a deserialize target.
+/// `NotFound` is the query-miss sentinel and is never a deserialize target.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub(crate) enum MintView {
     #[default]
@@ -79,7 +74,22 @@ pub(crate) enum MintView {
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
     },
-    #[serde(alias = "FireblocksSubmitted")]
+    #[serde(alias = "TxIntended")]
+    MintIntended {
+        issuer_request_id: IssuerMintRequestId,
+        tokenization_request_id: TokenizationRequestId,
+        quantity: Quantity,
+        underlying: UnderlyingSymbol,
+        token: TokenSymbol,
+        network: Network,
+        client_id: ClientId,
+        wallet: Address,
+        initiated_at: DateTime<Utc>,
+        journal_confirmed_at: DateTime<Utc>,
+        minting_started_at: DateTime<Utc>,
+        prepared_tx: PreparedMintTx,
+    },
+    #[serde(alias = "FireblocksSubmitted", alias = "TxSubmitted")]
     MintTxSubmitted {
         issuer_request_id: IssuerMintRequestId,
         tokenization_request_id: TokenizationRequestId,
@@ -93,7 +103,7 @@ pub(crate) enum MintView {
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
         external_tx_id: String,
-        tx_id: String,
+        tx_id: TxId,
     },
     CallbackPending {
         issuer_request_id: IssuerMintRequestId,
@@ -154,6 +164,10 @@ pub(crate) enum MintView {
 }
 
 impl MintView {
+    fn from_mint(mint: Mint) -> Result<Self, serde_json::Error> {
+        serde_json::from_value(serde_json::to_value(mint)?)
+    }
+
     #[cfg(test)]
     pub(crate) const fn state_name(&self) -> &'static str {
         match self {
@@ -162,6 +176,7 @@ impl MintView {
             Self::JournalConfirmed { .. } => "JournalConfirmed",
             Self::JournalRejected { .. } => "JournalRejected",
             Self::Minting { .. } => "Minting",
+            Self::MintIntended { .. } => "MintIntended",
             Self::MintTxSubmitted { .. } => "MintTxSubmitted",
             Self::CallbackPending { .. } => "CallbackPending",
             Self::MintingFailed { .. } => "MintingFailed",
@@ -175,25 +190,12 @@ pub(crate) async fn find_by_issuer_request_id(
     pool: &Pool<Sqlite>,
     issuer_request_id: &IssuerMintRequestId,
 ) -> Result<Option<MintView>, MintViewError> {
-    let issuer_request_id_str = issuer_request_id.to_string();
-    let row = sqlx::query!(
-        r#"
-        SELECT json_extract(payload, '$.Live') as "live: String"
-        FROM mint_view
-        WHERE view_id = ?
-        "#,
-        issuer_request_id_str
-    )
-    .fetch_optional(pool)
-    .await?;
-
-    let Some(live) = row.and_then(|row| row.live) else {
-        return Ok(None);
-    };
-
-    let view: MintView = serde_json::from_str(&live)?;
-
-    Ok(Some(view))
+    Projection::<Mint>::sqlite(pool.clone())
+        .load(issuer_request_id)
+        .await?
+        .map(MintView::from_mint)
+        .transpose()
+        .map_err(Into::into)
 }
 
 /// Finds all mints that need recovery (not in terminal states).
@@ -202,28 +204,28 @@ pub(crate) async fn find_by_issuer_request_id(
 pub(crate) async fn find_all_recoverable_mints(
     pool: &Pool<Sqlite>,
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
-    let rows = sqlx::query!(
-        r#"
-        SELECT
-            view_id as "view_id!: String",
-            json_extract(payload, '$.Live') as "live: String"
-        FROM mint_view
-        WHERE json_extract(payload, '$.Live.JournalConfirmed') IS NOT NULL
-           OR json_extract(payload, '$.Live.Minting') IS NOT NULL
-           OR json_extract(payload, '$.Live.MintTxSubmitted') IS NOT NULL
-           OR json_extract(payload, '$.Live.MintingFailed') IS NOT NULL
-           OR json_extract(payload, '$.Live.CallbackPending') IS NOT NULL
-        "#
-    )
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .filter_map(|row| row.live.map(|live| (row.view_id, live)))
-        .map(|(view_id, live)| {
-            let view: MintView = serde_json::from_str(&live)?;
-            let id = Uuid::parse_str(&view_id)?;
-            Ok((IssuerMintRequestId::new(id), view))
+    Projection::<Mint>::sqlite(pool.clone())
+        .load_all()
+        .await?
+        .into_iter()
+        .map(|(issuer_request_id, mint)| {
+            MintView::from_mint(mint)
+                .map(|view| (issuer_request_id, view))
+                .map_err(Into::into)
+        })
+        .filter(|result| {
+            matches!(
+                result,
+                Ok((
+                    _,
+                    MintView::JournalConfirmed { .. }
+                        | MintView::Minting { .. }
+                        | MintView::MintIntended { .. }
+                        | MintView::MintTxSubmitted { .. }
+                        | MintView::MintingFailed { .. }
+                        | MintView::CallbackPending { .. }
+                ))
+            ) || result.is_err()
         })
         .collect()
 }
@@ -239,30 +241,30 @@ pub(crate) async fn find_all_recoverable_mints(
 pub(crate) async fn find_stuck(
     pool: &Pool<Sqlite>,
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
-    let rows = sqlx::query!(
-        r#"
-        SELECT
-            view_id as "view_id!: String",
-            json_extract(payload, '$.Live') as "live: String"
-        FROM mint_view
-        WHERE json_extract(payload, '$.Live.Initiated')           IS NOT NULL
-           OR json_extract(payload, '$.Live.JournalConfirmed')    IS NOT NULL
-           OR json_extract(payload, '$.Live.JournalRejected')     IS NOT NULL
-           OR json_extract(payload, '$.Live.Minting')             IS NOT NULL
-           OR json_extract(payload, '$.Live.MintTxSubmitted')     IS NOT NULL
-           OR json_extract(payload, '$.Live.CallbackPending')     IS NOT NULL
-           OR json_extract(payload, '$.Live.MintingFailed')       IS NOT NULL
-        "#
-    )
-    .fetch_all(pool)
-    .await?;
-
-    rows.into_iter()
-        .filter_map(|row| row.live.map(|live| (row.view_id, live)))
-        .map(|(view_id, live)| {
-            let view: MintView = serde_json::from_str(&live)?;
-            let id = Uuid::parse_str(&view_id)?;
-            Ok((IssuerMintRequestId::new(id), view))
+    Projection::<Mint>::sqlite(pool.clone())
+        .load_all()
+        .await?
+        .into_iter()
+        .map(|(issuer_request_id, mint)| {
+            MintView::from_mint(mint)
+                .map(|view| (issuer_request_id, view))
+                .map_err(Into::into)
+        })
+        .filter(|result| {
+            matches!(
+                result,
+                Ok((
+                    _,
+                    MintView::Initiated { .. }
+                        | MintView::JournalConfirmed { .. }
+                        | MintView::JournalRejected { .. }
+                        | MintView::Minting { .. }
+                        | MintView::MintIntended { .. }
+                        | MintView::MintTxSubmitted { .. }
+                        | MintView::CallbackPending { .. }
+                        | MintView::MintingFailed { .. }
+                ))
+            ) || result.is_err()
         })
         .collect()
 }
@@ -281,19 +283,50 @@ mod tests {
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
     use crate::vault::mock::MockVaultService;
 
-    /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given live
-    /// `Mint` variant. The projection stores `{"Live": {"<Variant>": {...}}}`,
-    /// which the `find_*` query helpers read via `$.Live`; serializing a
-    /// `MintView` (which mirrors the live `Mint` variants field-for-field)
-    /// produces the `{"<Variant>": {...}}` body, so wrapping it under `Live`
-    /// reproduces exactly what the running projection would write.
+    /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given
+    /// query view. The adjusted variants reproduce the production `Mint`
+    /// serialization rather than the query-oriented `MintView` names.
     async fn insert_mint_view(
         pool: &Pool<Sqlite>,
         issuer_request_id: &IssuerMintRequestId,
         view: &MintView,
     ) {
         let view_id = issuer_request_id.to_string();
-        let live = serde_json::to_value(view).unwrap();
+        let mut live = serde_json::to_value(view).unwrap();
+        let variants = live.as_object_mut().unwrap();
+
+        if let Some(mut fields) = variants.remove("MintIntended") {
+            variants.insert("TxIntended".to_owned(), fields.take());
+        }
+
+        if let Some(mut fields) = variants.remove("MintTxSubmitted") {
+            fields
+                .as_object_mut()
+                .unwrap()
+                .insert("prepared_tx".to_owned(), serde_json::Value::Null);
+            variants.insert("TxSubmitted".to_owned(), fields.take());
+        }
+
+        if let Some(fields) = variants.get_mut("MintingFailed") {
+            let fields = fields.as_object_mut().unwrap();
+            let predecessor = serde_json::json!({
+                "JournalConfirmed": {
+                    "issuer_request_id": fields["issuer_request_id"],
+                    "tokenization_request_id": fields["tokenization_request_id"],
+                    "quantity": fields["quantity"],
+                    "underlying": fields["underlying"],
+                    "token": fields["token"],
+                    "network": fields["network"],
+                    "client_id": fields["client_id"],
+                    "wallet": fields["wallet"],
+                    "initiated_at": fields["initiated_at"],
+                    "journal_confirmed_at": fields["journal_confirmed_at"],
+                }
+            });
+            fields.insert("attempts".to_owned(), serde_json::json!(1));
+            fields.insert("failed_from".to_owned(), predecessor);
+        }
+
         let payload =
             serde_json::to_string(&serde_json::json!({ "Live": live }))
                 .unwrap();
@@ -443,7 +476,7 @@ mod tests {
         pool: &Pool<Sqlite>,
     ) -> Vec<IssuerMintRequestId> {
         let now = Utc::now();
-        let fields: Vec<_> = (0..5).map(|_| test_mint_fields()).collect();
+        let fields: Vec<_> = (0..6).map(|_| test_mint_fields()).collect();
 
         let views: Vec<MintView> = vec![
             MintView::JournalConfirmed {
@@ -475,7 +508,7 @@ mod tests {
                 journal_confirmed_at: now,
                 minting_started_at: now,
             },
-            MintView::MintTxSubmitted {
+            MintView::MintIntended {
                 issuer_request_id: fields[2].issuer_request_id.clone(),
                 tokenization_request_id: fields[2]
                     .tokenization_request_id
@@ -489,10 +522,9 @@ mod tests {
                 initiated_at: fields[2].initiated_at,
                 journal_confirmed_at: now,
                 minting_started_at: now,
-                external_tx_id: "mint-base".to_string(),
-                tx_id: "fb-1".to_string(),
+                prepared_tx: PreparedMintTx::default(),
             },
-            MintView::MintingFailed {
+            MintView::MintTxSubmitted {
                 issuer_request_id: fields[3].issuer_request_id.clone(),
                 tokenization_request_id: fields[3]
                     .tokenization_request_id
@@ -505,10 +537,11 @@ mod tests {
                 wallet: fields[3].wallet,
                 initiated_at: fields[3].initiated_at,
                 journal_confirmed_at: now,
-                error: "Transaction reverted".to_string(),
-                failed_at: now,
+                minting_started_at: now,
+                external_tx_id: "mint-base".to_string(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
             },
-            MintView::CallbackPending {
+            MintView::MintingFailed {
                 issuer_request_id: fields[4].issuer_request_id.clone(),
                 tokenization_request_id: fields[4]
                     .tokenization_request_id
@@ -520,6 +553,22 @@ mod tests {
                 client_id: fields[4].client_id,
                 wallet: fields[4].wallet,
                 initiated_at: fields[4].initiated_at,
+                journal_confirmed_at: now,
+                error: "Transaction reverted".to_string(),
+                failed_at: now,
+            },
+            MintView::CallbackPending {
+                issuer_request_id: fields[5].issuer_request_id.clone(),
+                tokenization_request_id: fields[5]
+                    .tokenization_request_id
+                    .clone(),
+                quantity: fields[5].quantity.clone(),
+                underlying: fields[5].underlying.clone(),
+                token: fields[5].token.clone(),
+                network: fields[5].network.clone(),
+                client_id: fields[5].client_id,
+                wallet: fields[5].wallet,
+                initiated_at: fields[5].initiated_at,
                 journal_confirmed_at: now,
                 tx_hash: b256!(
                     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
@@ -590,7 +639,7 @@ mod tests {
 
         let results = find_all_recoverable_mints(&pool).await.unwrap();
 
-        assert_eq!(results.len(), 5, "Expected 5 recoverable mints");
+        assert_eq!(results.len(), 6, "Expected 6 recoverable mints");
 
         let result_ids: Vec<_> =
             results.iter().map(|(id, _)| id.clone()).collect();
@@ -605,6 +654,7 @@ mod tests {
             results.iter().map(|(_, view)| view.state_name()).collect();
         assert!(state_names.contains(&"JournalConfirmed"));
         assert!(state_names.contains(&"Minting"));
+        assert!(state_names.contains(&"MintIntended"));
         assert!(state_names.contains(&"MintTxSubmitted"));
         assert!(state_names.contains(&"MintingFailed"));
         assert!(state_names.contains(&"CallbackPending"));
@@ -712,8 +762,8 @@ mod tests {
 
         assert_eq!(
             results.len(),
-            7,
-            "Expected 7 non-terminal mints, got ids: {result_ids:?}"
+            8,
+            "Expected 8 non-terminal mints, got ids: {result_ids:?}"
         );
         for id in &recoverable_ids {
             assert!(result_ids.contains(id), "Should include {id}");
@@ -738,6 +788,7 @@ mod tests {
         assert!(state_names.contains(&"JournalConfirmed"));
         assert!(state_names.contains(&"JournalRejected"));
         assert!(state_names.contains(&"Minting"));
+        assert!(state_names.contains(&"MintIntended"));
         assert!(state_names.contains(&"MintTxSubmitted"));
         assert!(state_names.contains(&"MintingFailed"));
         assert!(state_names.contains(&"CallbackPending"));

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -3,6 +3,7 @@ use cqrs_es::AggregateError;
 use event_sorcery::{LifecycleError, Store};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
+use std::time::Duration;
 use tracing::{debug, error, info, warn};
 
 use super::view::{
@@ -13,12 +14,14 @@ use super::{
     RedemptionError, RedemptionEvent,
     next_burn_retry_external_tx_id_from_history,
 };
-use crate::mint::QuantityConversionError;
+use crate::mint::{QuantityConversionError, has_unresolved_mint_intent};
 use crate::receipt_inventory::{
     BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
     Shares,
 };
-use crate::redemption::{BurnRecord, RedemptionMetadata};
+use crate::redemption::{
+    BurnRecord, RedemptionMetadata, has_unresolved_burn_intent,
+};
 use crate::tokenized_asset::UnderlyingSymbol;
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
@@ -26,6 +29,8 @@ use crate::tokenized_asset::view::{
 use crate::vault::{
     BurnVerification, MultiBurnEntry, TxId, VaultError, VaultService,
 };
+
+const WALLET_INTENT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Outcome of recovering a single redemption stuck in a burning state.
 ///
@@ -1096,8 +1101,59 @@ impl BurnManager {
         plan: BurnPlan,
         external_tx_id: Option<BurnExternalTxId>,
     ) -> Result<(), BurnManagerError> {
+        self.execute_burn_with_wallet_intent_timeout(
+            issuer_request_id,
+            vault,
+            plan,
+            external_tx_id,
+            WALLET_INTENT_WAIT_TIMEOUT,
+        )
+        .await
+    }
+
+    async fn execute_burn_with_wallet_intent_timeout(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        vault: Address,
+        plan: BurnPlan,
+        external_tx_id: Option<BurnExternalTxId>,
+        wait_timeout: Duration,
+    ) -> Result<(), BurnManagerError> {
         let execution = BurnExecutionPlan::new(vault, &plan, external_tx_id);
-        let wallet_guard = self.vault_service.lock_wallet().await;
+        let wallet_guard = if let Ok(result) = tokio::time::timeout(wait_timeout, async {
+            loop {
+                let wallet_guard = self.vault_service.lock_wallet().await;
+                let unresolved_mint =
+                    has_unresolved_mint_intent(&self.view_pool, None).await?;
+                let unresolved_burn = has_unresolved_burn_intent(
+                    &self.view_pool,
+                    Some(issuer_request_id),
+                )
+                .await?;
+                if !unresolved_mint && !unresolved_burn {
+                    return Ok::<_, BurnManagerError>(wallet_guard);
+                }
+
+                drop(wallet_guard);
+                debug!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    "Waiting for an earlier wallet intent before preparing burn"
+                );
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        })
+        .await {
+            result?
+        } else {
+            warn!(target: "redemption",
+                issuer_request_id = %issuer_request_id,
+                wait_ms = wait_timeout.as_millis(),
+                "Deferring burn after wallet-intent wait deadline"
+            );
+            return Err(BurnManagerError::WalletIntentWaitTimeout {
+                issuer_request_id: issuer_request_id.clone(),
+            });
+        };
         if !self.is_burn_execution_current(issuer_request_id).await? {
             return Ok(());
         }
@@ -1613,6 +1669,10 @@ pub(crate) enum BurnManagerError {
     SharesOverflow,
     #[error("Receipt reservation error: {0}")]
     ReceiptRegistration(#[from] ReceiptRegistrationError),
+    #[error(
+        "Timed out waiting to prepare burn for redemption {issuer_request_id} behind an earlier wallet intent"
+    )]
+    WalletIntentWaitTimeout { issuer_request_id: IssuerRedemptionRequestId },
 }
 
 #[cfg(test)]
@@ -1623,6 +1683,7 @@ mod tests {
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
+    use std::time::Duration;
     use tracing_test::traced_test;
 
     use super::{
@@ -1927,6 +1988,108 @@ mod tests {
                 .is_empty(),
             "successful burn must leave no dangling reservation"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn burn_wait_for_earlier_wallet_intent_is_bounded() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        harness.add_asset(&underlying, vault).await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(42_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        let unresolved_mint_id = IssuerMintRequestId::random().to_string();
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                ?,
+                1,
+                'MintEvent::MintTxIntended',
+                '4.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .bind(unresolved_mint_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        let plan = manager
+            .plan_burn(
+                &issuer_request_id,
+                vault,
+                &underlying,
+                uint!(100_000000000000000000_U256),
+                U256::ZERO,
+            )
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            manager.execute_burn_with_wallet_intent_timeout(
+                &issuer_request_id,
+                vault,
+                plan,
+                None,
+                Duration::from_millis(100),
+            ),
+        )
+        .await
+        .expect("wallet-intent wait must return before its deadline");
+
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::WalletIntentWaitTimeout {
+                issuer_request_id: blocked_id,
+            }) if blocked_id == issuer_request_id
+        ));
+        assert_eq!(vault_mock.get_multi_burn_call_count(), 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &[
+                "Deferring burn after wallet-intent wait deadline",
+                &issuer_request_id.to_string(),
+                "wait_ms=100",
+            ]
+        ));
+        let aggregate = store
+            .load(&issuer_request_id)
+            .await
+            .unwrap()
+            .expect("redemption should still exist");
+        assert!(matches!(aggregate, Redemption::Burning { .. }));
     }
 
     #[traced_test]

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -16,6 +16,7 @@ use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use event_sorcery::{EventSourced, Nil};
 use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use tracing::warn;
 
@@ -24,6 +25,36 @@ use crate::mint::TokenizationRequestId;
 use crate::redemption::burn_manager::{
     extract_tx_hash, is_pending_burn_confirmation, should_release_reserved_burn,
 };
+
+pub(crate) async fn has_unresolved_burn_intent(
+    pool: &Pool<Sqlite>,
+    excluding: Option<&IssuerRedemptionRequestId>,
+) -> Result<bool, sqlx::Error> {
+    let excluding = excluding.map(ToString::to_string).unwrap_or_default();
+    let exists = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM events AS intent
+            WHERE intent.aggregate_type = 'Redemption'
+              AND intent.event_type = 'RedemptionEvent::BurnIntended'
+              AND intent.aggregate_id != ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM events AS later
+                  WHERE later.aggregate_type = intent.aggregate_type
+                    AND later.aggregate_id = intent.aggregate_id
+                    AND later.sequence > intent.sequence
+              )
+        )
+        ",
+    )
+    .bind(excluding)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists)
+}
 
 /// Issuer request ID for redemption operations.
 ///

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -1,4 +1,8 @@
-use alloy::primitives::{Address, B256, Bytes, U256, b256};
+use alloy::consensus::{
+    SignableTransaction, Transaction, TxEnvelope, TxLegacy,
+};
+use alloy::eips::Encodable2718;
+use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256, b256};
 use alloy::rpc::types::TransactionReceipt;
 use async_trait::async_trait;
 use std::sync::Arc;
@@ -7,8 +11,8 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 
 use super::{
     BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-    MultiBurnResultEntry, ReceiptInformation, SubmittedTx, VaultError,
-    VaultService,
+    MultiBurnResultEntry, PreparedMintTx, ReceiptInformation, SubmittedTx,
+    VaultError, VaultService, WalletNonceGuard,
 };
 use crate::redemption::BurnExternalTxId;
 use crate::vault::{SendableTxWithHash, TxId};
@@ -50,6 +54,8 @@ enum MockBehavior {
     /// where signed-tx preparation fails before the tx is stored in the event.
     #[cfg(test)]
     PrepareTxFails,
+    #[cfg(test)]
+    InvalidPreparedMint,
 }
 
 /// Configured outcome for `verify_burn_tx` in tests, exercising the admin
@@ -85,6 +91,9 @@ impl Default for MockVerifyBurn {
 pub(crate) struct MockVaultService {
     behavior: MockBehavior,
     mint_delay_ms: u64,
+    wallet_nonce_lock: Arc<tokio::sync::Mutex<()>>,
+    #[cfg(test)]
+    wallet_lock_call_count: Arc<AtomicUsize>,
     call_count: Arc<AtomicUsize>,
     multi_burn_call_count: Arc<AtomicUsize>,
     /// Cached MintResult from submit_mint for retrieval in confirm_mint.
@@ -112,6 +121,9 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::Success,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            #[cfg(test)]
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -134,6 +146,8 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::Failure,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -151,6 +165,8 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::SubmitFailure,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -168,6 +184,8 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::ConfirmRevert,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -192,6 +210,8 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::SubmitRevert,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -209,6 +229,8 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::PrepareTxFails,
             mint_delay_ms: 0,
+            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
+            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
             call_count: Arc::new(AtomicUsize::new(0)),
             multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
             pending_mint_result: Arc::new(Mutex::new(None)),
@@ -222,6 +244,13 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
+    pub(crate) fn new_invalid_prepared_mint() -> Self {
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::InvalidPreparedMint;
+        service
+    }
+
+    #[cfg(test)]
     #[must_use]
     pub(crate) const fn with_delay(mut self, delay_ms: u64) -> Self {
         self.mint_delay_ms = delay_ms;
@@ -231,6 +260,11 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn get_call_count(&self) -> usize {
         self.call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_wallet_lock_call_count(&self) -> usize {
+        self.wallet_lock_call_count.load(Ordering::Relaxed)
     }
 
     #[cfg(test)]
@@ -250,6 +284,7 @@ impl MockVaultService {
 
     #[cfg(test)]
     pub(crate) fn reset(&self) {
+        self.wallet_lock_call_count.store(0, Ordering::Relaxed);
         self.call_count.store(0, Ordering::Relaxed);
         self.multi_burn_call_count.store(0, Ordering::Relaxed);
         *self.last_call.lock().unwrap() = None;
@@ -327,7 +362,7 @@ fn default_multi_burn_result(dust_shares: U256) -> MultiBurnResult {
 #[async_trait]
 impl VaultService for MockVaultService {
     #[cfg_attr(not(test), allow(unused_variables))]
-    async fn submit_mint(
+    async fn prepare_mint_tx(
         &self,
         vault: Address,
         assets: U256,
@@ -335,12 +370,7 @@ impl VaultService for MockVaultService {
         _user: Address,
         receipt_info: ReceiptInformation,
         external_tx_id: Option<String>,
-    ) -> Result<SubmittedTx, VaultError> {
-        #[cfg(test)]
-        if matches!(self.behavior, MockBehavior::SubmitFailure) {
-            return Err(VaultError::InvalidReceipt);
-        }
-
+    ) -> Result<PreparedMintTx, VaultError> {
         if self.mint_delay_ms > 0 {
             tokio::time::sleep(tokio::time::Duration::from_millis(
                 self.mint_delay_ms,
@@ -370,11 +400,24 @@ impl VaultService for MockVaultService {
             }
         };
 
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce: 1,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(vault),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let envelope = TxEnvelope::from(transaction.into_signed(signature));
+        let tx_hash = *envelope.tx_hash();
+
         *self
             .pending_mint_result
             .lock()
             .expect("pending_mint_result mutex poisoned") = Some(MintResult {
-            tx_hash: MOCK_MINT_TX_HASH,
+            tx_hash,
             receipt_id: U256::from(1),
             shares_minted: assets,
             gas_used: 21000,
@@ -382,10 +425,38 @@ impl VaultService for MockVaultService {
             receipt_info_bytes,
         });
 
-        Ok(SubmittedTx {
+        #[cfg(test)]
+        let persisted_hash =
+            if matches!(self.behavior, MockBehavior::InvalidPreparedMint) {
+                B256::ZERO
+            } else {
+                tx_hash
+            };
+        #[cfg(not(test))]
+        let persisted_hash = tx_hash;
+
+        Ok(PreparedMintTx {
+            tx: envelope.encoded_2718(),
+            hash: persisted_hash,
+            nonce: envelope.nonce(),
+            signed_at: chrono::Utc::now(),
             external_tx_id: external_tx_id
                 .unwrap_or_else(|| "mock-mint".to_string()),
-            tx_id: MOCK_MINT_TX_HASH.into(),
+        })
+    }
+
+    async fn submit_mint(
+        &self,
+        prepared_tx: &PreparedMintTx,
+    ) -> Result<SubmittedTx, VaultError> {
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitFailure) {
+            return Err(VaultError::InvalidReceipt);
+        }
+
+        Ok(SubmittedTx {
+            external_tx_id: prepared_tx.external_tx_id.clone(),
+            tx_id: prepared_tx.hash.into(),
         })
     }
 
@@ -436,7 +507,10 @@ impl VaultService for MockVaultService {
             MockBehavior::ConfirmRevert
             | MockBehavior::ConfirmPending
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails => Err(VaultError::InvalidReceipt),
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
+                Err(VaultError::InvalidReceipt)
+            }
         }
     }
 
@@ -552,7 +626,9 @@ impl VaultService for MockVaultService {
             // PrepareTxFails never reaches confirm (fails before submit);
             // if somehow called, return the cached result.
             #[cfg(test)]
-            MockBehavior::SubmitRevert | MockBehavior::PrepareTxFails => {
+            MockBehavior::SubmitRevert
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
                 let result = self
                     .pending_burn_result
                     .lock()
@@ -622,6 +698,12 @@ impl VaultService for MockVaultService {
         }
         Err(VaultError::InvalidReceipt)
     }
+
+    async fn lock_wallet(&self) -> WalletNonceGuard {
+        #[cfg(test)]
+        self.wallet_lock_call_count.fetch_add(1, Ordering::Relaxed);
+        Some(self.wallet_nonce_lock.clone().lock_owned().await)
+    }
 }
 
 #[cfg(test)]
@@ -673,8 +755,8 @@ mod tests {
             address!("0x1111111111111111111111111111111111111111");
         let receipt_info = test_receipt_info();
 
-        let submitted = mock
-            .submit_mint(
+        let prepared = mock
+            .prepare_mint_tx(
                 vault,
                 assets,
                 bot_wallet,
@@ -684,6 +766,7 @@ mod tests {
             )
             .await
             .unwrap();
+        let submitted = mock.submit_mint(&prepared).await.unwrap();
 
         assert_eq!(submitted.external_tx_id, "mock-mint");
 
@@ -706,8 +789,8 @@ mod tests {
         let receipt_info = test_receipt_info();
 
         // Submit always succeeds
-        let submitted = mock
-            .submit_mint(
+        let prepared = mock
+            .prepare_mint_tx(
                 vault,
                 assets,
                 bot_wallet,
@@ -717,6 +800,7 @@ mod tests {
             )
             .await
             .unwrap();
+        let submitted = mock.submit_mint(&prepared).await.unwrap();
 
         // Confirm returns the failure
         let result = mock.confirm_mint(&submitted.tx_id).await;
@@ -734,7 +818,7 @@ mod tests {
 
         assert_eq!(mock.get_call_count(), 0);
 
-        mock.submit_mint(
+        mock.prepare_mint_tx(
             vault,
             assets,
             bot_wallet,
@@ -759,7 +843,7 @@ mod tests {
 
         assert!(mock.get_last_call().is_none());
 
-        mock.submit_mint(
+        mock.prepare_mint_tx(
             vault,
             assets,
             bot_wallet,
@@ -795,7 +879,7 @@ mod tests {
         let receipt_info = test_receipt_info();
 
         let start = tokio::time::Instant::now();
-        mock.submit_mint(
+        mock.prepare_mint_tx(
             vault,
             assets,
             bot_wallet,
@@ -820,7 +904,7 @@ mod tests {
             address!("0x1111111111111111111111111111111111111111");
         let receipt_info = test_receipt_info();
 
-        mock.submit_mint(
+        mock.prepare_mint_tx(
             vault,
             assets,
             bot_wallet,
@@ -915,8 +999,8 @@ mod tests {
     #[tokio::test]
     async fn test_submit_mint_failure() {
         let mock = MockVaultService::new_submit_failure();
-        let result = mock
-            .submit_mint(
+        let prepared = mock
+            .prepare_mint_tx(
                 test_vault(),
                 U256::from(1000),
                 test_receiver(),
@@ -924,7 +1008,9 @@ mod tests {
                 test_receipt_info(),
                 None,
             )
-            .await;
+            .await
+            .unwrap();
+        let result = mock.submit_mint(&prepared).await;
 
         assert!(
             matches!(result, Err(VaultError::InvalidReceipt)),

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,5 +1,13 @@
+#[cfg(test)]
+use alloy::consensus::{SignableTransaction, TxLegacy};
+use alloy::consensus::{Transaction, TxEnvelope};
+use alloy::eips::Decodable2718;
+#[cfg(test)]
+use alloy::eips::Encodable2718;
 use alloy::hex::decode;
-use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
+#[cfg(test)]
+use alloy::primitives::{Signature, TxKind};
 use alloy::providers::SendableTxErr;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use async_trait::async_trait;
@@ -23,15 +31,14 @@ pub(crate) mod service;
 /// services or mocks for testing.
 #[async_trait]
 pub(crate) trait VaultService: Send + Sync {
-    /// Submits a mint transaction (deposit + share transfer) to the signing backend.
+    /// Builds and signs a mint transaction without broadcasting it.
     ///
-    /// Encodes the multicall calldata and submits it via the backend. Returns a
-    /// [`SubmittedTx`] whose `tx_id` is persisted in a CQRS event so that `confirm_mint`
-    /// can resume polling after a restart.
+    /// The returned bytes and hash must be persisted before calling
+    /// [`VaultService::submit_mint`].
     ///
     /// Uses a deterministic `external_tx_id` so that resubmitting the same mint
     /// after a crash triggers transaction duplicate rejection instead of a double-mint.
-    async fn submit_mint(
+    async fn prepare_mint_tx(
         &self,
         vault: Address,
         assets: U256,
@@ -39,6 +46,14 @@ pub(crate) trait VaultService: Send + Sync {
         user: Address,
         receipt_info: ReceiptInformation,
         external_tx_id: Option<String>,
+    ) -> Result<PreparedMintTx, VaultError>;
+
+    /// Broadcasts the exact signed mint transaction that was persisted before
+    /// this call. Repeated calls must rebroadcast the same bytes rather than
+    /// prepare a replacement transaction.
+    async fn submit_mint(
+        &self,
+        prepared_tx: &PreparedMintTx,
     ) -> Result<SubmittedTx, VaultError>;
 
     /// Confirms a previously submitted mint transaction.
@@ -132,6 +147,63 @@ pub(crate) trait VaultService: Send + Sync {
 }
 
 pub(crate) type WalletNonceGuard = Option<tokio::sync::OwnedMutexGuard<()>>;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub(crate) struct PreparedMintTx {
+    pub(crate) tx: Vec<u8>,
+    pub(crate) hash: FixedBytes<32>,
+    pub(crate) nonce: u64,
+    pub(crate) signed_at: DateTime<Utc>,
+    pub(crate) external_tx_id: String,
+}
+
+impl PreparedMintTx {
+    /// Verifies that the redundant persisted identity fields describe the
+    /// exact signed envelope bytes.
+    pub(crate) fn validate(&self) -> Result<(), VaultError> {
+        let envelope = TxEnvelope::decode_2718_exact(&self.tx)?;
+        let decoded_hash = *envelope.tx_hash();
+        if decoded_hash != self.hash {
+            return Err(VaultError::PreparedMintHashMismatch {
+                expected: self.hash,
+                decoded: decoded_hash,
+            });
+        }
+
+        let decoded_nonce = envelope.nonce();
+        if decoded_nonce != self.nonce {
+            return Err(VaultError::PreparedMintNonceMismatch {
+                expected: self.nonce,
+                decoded: decoded_nonce,
+            });
+        }
+
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn valid_for_test(nonce: u64, external_tx_id: String) -> Self {
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let envelope = TxEnvelope::from(transaction.into_signed(signature));
+
+        Self {
+            tx: envelope.encoded_2718(),
+            hash: *envelope.tx_hash(),
+            nonce: envelope.nonce(),
+            signed_at: Utc::now(),
+            external_tx_id,
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct SendableTxWithHash {
@@ -395,6 +467,20 @@ pub(crate) enum VaultError {
     /// The operator-supplied hash cannot terminalize the redemption.
     #[error("Transaction is not a burn of the expected shares: {tx_hash:?}")]
     NotABurn { tx_hash: B256 },
+    #[error(
+        "Node returned transaction hash {returned:?} for persisted transaction {expected:?}"
+    )]
+    BroadcastHashMismatch { expected: B256, returned: B256 },
+    #[error(
+        "Persisted mint transaction hash {expected:?} does not match decoded hash {decoded:?}"
+    )]
+    PreparedMintHashMismatch { expected: B256, decoded: B256 },
+    #[error(
+        "Persisted mint transaction nonce {expected} does not match decoded nonce {decoded}"
+    )]
+    PreparedMintNonceMismatch { expected: u64, decoded: u64 },
+    #[error(transparent)]
+    Eip2718(#[from] alloy::eips::eip2718::Eip2718Error),
     /// Contract call error
     #[error(transparent)]
     Contract(#[from] alloy::contract::Error),

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -20,8 +20,8 @@ use tracing::debug;
 use super::rain_meta::OaSchemaCache;
 use super::{
     BurnVerification, MintResult, MultiBurnResult, MultiBurnResultEntry,
-    ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId, VaultError,
-    VaultService, WalletNonceGuard, verify_burn_in_receipt,
+    PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId,
+    VaultError, VaultService, WalletNonceGuard, verify_burn_in_receipt,
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
@@ -47,11 +47,10 @@ pub type RealBlockchainServiceProvider = FillProvider<
 /// for testing.
 ///
 /// **Crash-safe idempotency:**
-/// - **Mints**: handled at the application layer — the receipt backfiller runs at
-///   startup before recovery, scans the chain for `Deposit` events, and populates
-///   the receipt inventory by `issuer_request_id`. `recover_from_existing_receipt`
-///   finds the existing deposit and emits `ExistingMintRecovered`, preventing a
-///   double-mint.
+/// - **Mints**: `prepare_mint_tx()` returns exact signed bytes and their hash for
+///   persistence before `submit_mint()` broadcasts them. Recovery rebroadcasts
+///   or polls that same transaction; receipt backfill remains a second line of
+///   defense for transactions that already mined.
 /// - **Burns**: through `prepare_burn_tx()` which prepares a signed transaction
 ///   whose hash commits to the complete encoded transaction, including its
 ///   assigned nonce. On startup recovery, the exact persisted transaction is
@@ -85,7 +84,7 @@ impl RealBlockchainService {
 
 #[async_trait]
 impl VaultService for RealBlockchainService {
-    async fn submit_mint(
+    async fn prepare_mint_tx(
         &self,
         vault: Address,
         assets: U256,
@@ -93,7 +92,10 @@ impl VaultService for RealBlockchainService {
         user: Address,
         receipt_info: ReceiptInformation,
         external_tx_id: Option<String>,
-    ) -> Result<SubmittedTx, VaultError> {
+    ) -> Result<PreparedMintTx, VaultError> {
+        let external_tx_id = external_tx_id.unwrap_or_else(|| {
+            format!("mint-{}", receipt_info.issuer_request_id)
+        });
         let oa_schema = self.oa_schema_cache.get(vault).await;
         let receipt_info_bytes = receipt_info.encode(oa_schema.as_deref())?;
 
@@ -116,21 +118,62 @@ impl VaultService for RealBlockchainService {
         let transfer_call =
             vault_contract.transfer(user, shares).calldata().clone();
 
-        // Execute both operations atomically via multicall
-        let wallet_guard = self.wallet_nonce_lock.clone().lock_owned().await;
-        let pending_tx = vault_contract
+        let transaction = vault_contract
             .multicall(vec![deposit_call, transfer_call])
-            .send()
-            .await?;
-        drop(wallet_guard);
+            .into_transaction_request();
+        let envelope = self
+            .provider
+            .fill(transaction)
+            .await?
+            .try_into_envelope()
+            .map_err(Box::new)?;
+        let prepared_tx = PreparedMintTx {
+            nonce: envelope.nonce(),
+            hash: *envelope.tx_hash(),
+            tx: envelope.encoded_2718(),
+            signed_at: Utc::now(),
+            external_tx_id,
+        };
+        prepared_tx.validate()?;
 
-        let tx_id = TxId::from(*pending_tx.tx_hash());
+        Ok(prepared_tx)
+    }
+
+    async fn submit_mint(
+        &self,
+        prepared_tx: &PreparedMintTx,
+    ) -> Result<SubmittedTx, VaultError> {
+        prepared_tx.validate()?;
+
+        match self.provider.send_raw_transaction(&prepared_tx.tx).await {
+            Ok(pending_tx) => {
+                let returned = *pending_tx.tx_hash();
+                if returned != prepared_tx.hash {
+                    return Err(VaultError::BroadcastHashMismatch {
+                        expected: prepared_tx.hash,
+                        returned,
+                    });
+                }
+            }
+            Err(error) => {
+                if self
+                    .provider
+                    .get_transaction_by_hash(prepared_tx.hash)
+                    .await?
+                    .is_none()
+                {
+                    return Err(error.into());
+                }
+
+                debug!(target: "vault", tx_hash = %prepared_tx.hash,
+                    "Mint broadcast errored but the node holds the persisted transaction"
+                );
+            }
+        }
 
         Ok(SubmittedTx {
-            external_tx_id: external_tx_id.unwrap_or_else(|| {
-                format!("mint-{}", receipt_info.issuer_request_id)
-            }),
-            tx_id,
+            external_tx_id: prepared_tx.external_tx_id.clone(),
+            tx_id: prepared_tx.hash.into(),
         })
     }
 
@@ -423,8 +466,10 @@ impl VaultService for RealBlockchainService {
 #[cfg(test)]
 mod tests {
     use alloy::consensus::{
-        Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
+        Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Transaction,
+        TxEnvelope,
     };
+    use alloy::eips::Decodable2718;
     use alloy::network::EthereumWallet;
     use alloy::primitives::{
         Address, B256, Bloom, Bytes, IntoLogData, U256, address, b256,
@@ -448,7 +493,7 @@ mod tests {
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
         MultiBurnEntry, MultiBurnParams, ReceiptInformation,
-        SendableTxWithHash, VaultError, VaultService,
+        SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
     const TEST_OA_SCHEMA: &str =
@@ -539,6 +584,8 @@ mod tests {
         let user_wallet =
             address!("0x2222222222222222222222222222222222222222");
         let receipt_info = test_receipt_info();
+        let expected_external_tx_id =
+            format!("mint-{}", receipt_info.issuer_request_id);
         let vault_address = test_vault_address();
 
         let tx_hash = fixed_bytes!(
@@ -583,7 +630,7 @@ mod tests {
         let receipt_with_bloom =
             ReceiptWithBloom::new(consensus_receipt, Bloom::default());
 
-        let receipt = TransactionReceipt {
+        let mut receipt = TransactionReceipt {
             transaction_hash: tx_hash,
             transaction_index: Some(0),
             block_hash: Some(fixed_bytes!(
@@ -621,10 +668,6 @@ mod tests {
         asserter.push_success(&100_000_u64);
         asserter.push_success(&1_000_000_000_u64);
         asserter.push_success(&0u64);
-        asserter.push_success(&tx_hash);
-        asserter.push_success(&receipt);
-        asserter.push_success(&receipt);
-
         let signer = PrivateKeySigner::random();
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
@@ -633,14 +676,14 @@ mod tests {
             .with_simple_nonce_management()
             .filler(ChainIdFiller::default())
             .wallet(EthereumWallet::from(signer))
-            .connect_mocked_client(asserter);
+            .connect_mocked_client(asserter.clone());
         let service = RealBlockchainService::new(
             provider,
             Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
         );
 
-        let submitted = service
-            .submit_mint(
+        let prepared = service
+            .prepare_mint_tx(
                 vault_address,
                 assets,
                 bot_wallet,
@@ -650,14 +693,48 @@ mod tests {
             )
             .await;
 
-        assert!(submitted.is_ok(), "Expected Ok but got: {submitted:?}");
-        let submitted = submitted.unwrap();
+        assert!(prepared.is_ok(), "Expected Ok but got: {prepared:?}");
+        let prepared = prepared.unwrap();
+        assert!(!prepared.tx.is_empty());
+        assert_eq!(prepared.external_tx_id, expected_external_tx_id);
+        let decoded = TxEnvelope::decode_2718(&mut prepared.tx.as_slice())
+            .expect("prepared mint must contain a valid EIP-2718 transaction");
+        assert_eq!(decoded.nonce(), prepared.nonce);
+        assert_eq!(*decoded.tx_hash(), prepared.hash);
+
+        let mut malformed = prepared.clone();
+        malformed.tx = vec![0x02];
+        assert!(matches!(
+            service.submit_mint(&malformed).await,
+            Err(VaultError::Eip2718(_))
+        ));
+
+        let mut wrong_hash = prepared.clone();
+        wrong_hash.hash = B256::ZERO;
+        assert!(matches!(
+            service.submit_mint(&wrong_hash).await,
+            Err(VaultError::PreparedMintHashMismatch { .. })
+        ));
+
+        let mut wrong_nonce = prepared.clone();
+        wrong_nonce.nonce = prepared.nonce + 1;
+        assert!(matches!(
+            service.submit_mint(&wrong_nonce).await,
+            Err(VaultError::PreparedMintNonceMismatch { .. })
+        ));
+
+        receipt.transaction_hash = prepared.hash;
+        asserter.push_success(&prepared.hash);
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let submitted = service.submit_mint(&prepared).await.unwrap();
+        assert_eq!(submitted.tx_id, TxId::from(prepared.hash));
 
         let result = service.confirm_mint(&submitted.tx_id).await;
 
         assert!(result.is_ok(), "Expected Ok but got: {result:?}");
         let mint_result = result.unwrap();
-        assert_eq!(mint_result.tx_hash, tx_hash);
+        assert_eq!(mint_result.tx_hash, prepared.hash);
         assert_eq!(mint_result.receipt_id, receipt_id);
         assert_eq!(mint_result.shares_minted, shares);
         assert_eq!(mint_result.gas_used, 0x5208);
@@ -686,7 +763,7 @@ mod tests {
         let receipt_with_bloom =
             ReceiptWithBloom::new(consensus_receipt, Bloom::default());
 
-        let receipt = TransactionReceipt {
+        let mut receipt = TransactionReceipt {
             transaction_hash: tx_hash,
             transaction_index: Some(0),
             block_hash: Some(fixed_bytes!(
@@ -723,10 +800,6 @@ mod tests {
         asserter.push_success(&100_000_u64);
         asserter.push_success(&1_000_000_000_u64);
         asserter.push_success(&0u64);
-        asserter.push_success(&tx_hash);
-        asserter.push_success(&receipt);
-        asserter.push_success(&receipt);
-
         let signer = PrivateKeySigner::random();
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
@@ -735,14 +808,14 @@ mod tests {
             .with_simple_nonce_management()
             .filler(ChainIdFiller::default())
             .wallet(EthereumWallet::from(signer))
-            .connect_mocked_client(asserter);
+            .connect_mocked_client(asserter.clone());
         let service = RealBlockchainService::new(
             provider,
             Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
         );
 
-        let submitted = service
-            .submit_mint(
+        let prepared = service
+            .prepare_mint_tx(
                 vault_address,
                 assets,
                 bot_wallet,
@@ -752,8 +825,13 @@ mod tests {
             )
             .await;
 
-        assert!(submitted.is_ok(), "Expected Ok but got: {submitted:?}");
-        let submitted = submitted.unwrap();
+        assert!(prepared.is_ok(), "Expected Ok but got: {prepared:?}");
+        let prepared = prepared.unwrap();
+        receipt.transaction_hash = prepared.hash;
+        asserter.push_success(&prepared.hash);
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let submitted = service.submit_mint(&prepared).await.unwrap();
 
         let result = service.confirm_mint(&submitted.tx_id).await;
 

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -337,16 +337,18 @@ async fn test_mint_recovery_after_view_deletion()
     Ok(())
 }
 
-/// Tests recovery from `Minting` state when the on-chain mint already succeeded.
+/// Tests restart recovery from `MintIntended` after the exact transaction
+/// broadcast and mined but before submission was durably recorded.
 ///
 /// Scenario:
 /// 1. Complete a mint normally (creates on-chain receipt)
-/// 2. Roll back event store to `Minting` state (delete TokensMinted and later events)
+/// 2. Roll back the event store to `MintIntended` (keep the persisted raw tx)
 /// 3. Restart service — views are cleared and rebuilt repopulates from rolled-back events
 /// 4. Recovery detects the existing receipt via receipt inventory and records
 ///    mint success without re-minting
+#[tracing_test::traced_test]
 #[tokio::test]
-async fn test_mint_recovery_from_minting_state_when_receipt_exists()
+async fn test_mint_recovery_from_intended_state_when_receipt_exists()
 -> Result<(), Box<dyn std::error::Error>> {
     let _recovery_test_guard = recovery_test_guard().await;
 
@@ -396,23 +398,30 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
         &user_provider,
     );
     let shares_before = harness::wait_for_shares(&vault, user_wallet).await?;
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
 
-    drop(client1);
+    client1.terminate().await;
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        1,
+        "the first service must finish exactly one callback before restart"
+    );
 
     let query_pool =
         SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
 
-    // Roll back to Minting state: keep events 1-3 (Initiated, JournalConfirmed, MintingStarted)
+    // Keep the exact persisted intent but remove MintTxSubmitted and every
+    // later event, reproducing a crash after broadcast and mining.
     let aggregate_id = issuer_request_id.clone();
-    sqlx::query!(
-        r#"
+    sqlx::query(
+        r"
         DELETE FROM events
         WHERE aggregate_type = 'Mint'
           AND aggregate_id = ?
-          AND sequence > 3
-        "#,
-        aggregate_id
+          AND sequence > 4
+        ",
     )
+    .bind(&aggregate_id)
     .execute(&query_pool)
     .await?;
 
@@ -427,44 +436,28 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
     .fetch_one(&query_pool)
     .await?;
     assert_eq!(
-        event_count.count, 3,
-        "Expected exactly 3 events (Initiated, JournalConfirmed, MintingStarted)"
+        event_count.count, 4,
+        "Expected the lifecycle prefix through MintTxIntended"
     );
 
     query_pool.close().await;
 
     // Restart — views are cleared and rebuilt repopulates from events, recovery
-    // finds the Minting mint and checks for an existing receipt.
+    // finds the MintIntended mint and checks the backfilled receipt before
+    // attempting another broadcast.
     let (config2, _mock_subgraph2) =
         harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
     let rocket2 = initialize_rocket(config2).await?;
     let _client2 =
         rocket::local::asynchronous::Client::tracked(rocket2).await?;
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
-
-    let query_pool2 =
-        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
-
-    let final_event_count = sqlx::query!(
-        r#"
-        SELECT COUNT(*) as "count!: i32"
-        FROM events
-        WHERE aggregate_type = 'Mint' AND aggregate_id = ?
-        "#,
-        aggregate_id
-    )
-    .fetch_one(&query_pool2)
-    .await?;
-
-    // Recovery should have added TokensMinted event (recognizing the existing receipt)
-    // and possibly MintCompleted after callback
-    assert!(
-        final_event_count.count > 3,
-        "Recovery should have processed the Minting mint and added events. \
-         Expected >3 events, found {}. Recovery for Minting state not implemented.",
-        final_event_count.count
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        2,
+        "restart recovery must deliver exactly one additional callback"
     );
+    assert!(logs_contain("Found existing receipt, recording recovery"));
 
     // Verify the user still has the same shares (no double mint)
     let shares_after = vault.balanceOf(user_wallet).call().await?;
@@ -472,8 +465,6 @@ async fn test_mint_recovery_from_minting_state_when_receipt_exists()
         shares_after, shares_before,
         "User should have same shares (no double mint)"
     );
-
-    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     Ok(())
 }

--- a/tests/redemption_dust.rs
+++ b/tests/redemption_dust.rs
@@ -316,7 +316,7 @@ async fn test_redemption_returns_dust_to_user()
         "Minted shares should match expected amount"
     );
 
-    mint_callback_mock.assert();
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
     let user_provider = create_provider()
@@ -415,7 +415,7 @@ async fn test_redemption_no_dust_when_9_decimals()
     let expected_shares = U256::from(123_456_789_000_000_000_u64);
     assert_eq!(minted_shares, expected_shares);
 
-    mint_callback_mock.assert();
+    harness::wait_for_mock_hit(&mint_callback_mock).await?;
 
     let user_wallet_instance = EthereumWallet::from(user_signer);
     let user_provider = create_provider()


### PR DESCRIPTION
## Motivation

- A crash after broadcasting a mint but before appending `MintTxSubmitted` loses the exact transaction and can submit a second mint for the same journal.
- Finishes [RAI-1379](https://linear.app/makeitrain/issue/RAI-1379/persist-mint-transaction-intent-before-broadcast).

## Solution

- Adds `MintTxIntended` with the signed EIP-2718 bytes, hash, nonce, signing time, and external transaction ID, persisted before `submit_mint`.
- Recovery checks receipts first, validates and rebroadcasts the same persisted envelope, and persists `CallbackPending` before calling Alpaca. Receipt discovery never sends the callback independently.
- Serializes mint and burn preparation with one wallet lock and keeps the event-log nonce reservation active until an explicit transaction-resolution event.
- Loads mint state through typed event-sorcery projections instead of parsing view JSON with raw SQL.
- Keeps legacy submitted events replayable and updates admin/view handling for the new state.
- Documents the single-writer deployment invariant for a SQLite store and signing wallet.

## Checks

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Tested with `cargo test --workspace`, strict workspace clippy, formatting, SQLx metadata validation, restart recovery E2E, malformed-envelope rejection, concurrent wallet-lock coverage, and callback/nonce-reservation race regressions.