### PR TITLE
fix: refuse ambiguous prior burns

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2234,7 +2234,12 @@ on-chain, dispatches `RecordExistingBurn` → `ExistingBurnRecovered` event →
 `Completed` state. This handles the scenario where burns landed on-chain but
 weren't recorded (e.g. a crash between submit and confirmation). The completed
 transaction receipt must include its block number; recovery fails without
-emitting a permanent event when that proof is incomplete.
+emitting a permanent event when that proof is incomplete. A successfully mined
+receipt without a block number returns `500`. A replacement burn is authorized
+only after the prior transaction is confirmed reverted. Pending
+transactions, RPC failures, unknown outcomes, and legacy transaction IDs that
+cannot be verified on-chain return `422`, preserve the failed state and receipt
+reservation, and require manual intervention instead of risking a second burn.
 
 **Examples:**
 
@@ -2247,8 +2252,10 @@ emitting a permanent event when that proof is incomplete.
 - `200`: Recovery initiated
 - `404`: Aggregate not found
 - `409`: Aggregate already completed or closed (cannot recover)
-- `422`: Aggregate in a state that cannot be recovered, or Alpaca journal not
-  completed (for post-Alpaca redemption recovery)
+- `422`: Aggregate in a state that cannot be recovered, Alpaca journal not
+  completed, or prior burn not confirmed reverted (for post-Alpaca redemption
+  recovery)
+- `500`: A successfully mined burn receipt is missing its block number
 - `502`: Failed to poll Alpaca for journal status, or failed to execute the burn
   recovery (post-Alpaca recovery only)
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -299,9 +299,9 @@ async fn load_reprocess_context(
         (status = 409, description = "Redemption already completed"),
         (status = 422,
             description = "Cannot recover: Alpaca journal pending/rejected, \
-                Transaction burn still pending, or invalid aggregate state"),
+                prior burn not confirmed reverted, or invalid aggregate state"),
         (status = 502,
-            description = "Alpaca poll, Transaction lookup, or burn execution failed"),
+            description = "Alpaca poll or burn execution failed"),
         (status = 500, description = "Event load/deserialize or internal failure")
     ),
     security(("internal_api_key" = []))
@@ -586,15 +586,15 @@ enum PriorBurnDisposition {
     /// The prior burn already completed on-chain and was recorded; the caller
     /// should return this response directly.
     AlreadyRecorded(ReprocessResponse),
-    /// No conclusive prior burn — resume with this (possibly fallback) retry
-    /// `externalTxId`.
+    /// No prior burn exists, or the prior burn conclusively reverted; resume
+    /// with this (possibly fallback) retry `externalTxId`.
     ResumeWith(Option<BurnExternalTxId>),
 }
 
 /// Inspects the prior tx (if any) from a previous `BurningFailed` event to
-/// decide whether the on-chain burn already succeeded (record it), is still
-/// pending (cannot recover yet), or terminally failed (resume with a fresh
-/// replacement `externalTxId`).
+/// decide whether the on-chain burn already succeeded (record it), conclusively
+/// reverted (resume with a fresh replacement `externalTxId`), or remains
+/// ambiguous (require manual intervention).
 async fn inspect_prior_burn(
     store: &Store<Redemption>,
     vault_service: &Arc<dyn VaultService>,
@@ -663,37 +663,42 @@ async fn inspect_prior_burn(
                     .to_string(),
             }))
         }
-        Err(e) => {
-            if matches!(e, VaultError::Reverted { .. }) {
-                // The terminally failed tx permanently reserves its
-                // externalTxId, so the replacement burn must never reuse the base
-                // id. When event history has no recorded retry id, fall back to
-                // retry-1 — mirror of the startup recovery path in BurnManager.
-                let retry_external_tx_id =
-                    burn_retry_external_tx_id.or_else(|| {
-                        Some(Redemption::retry_burn_external_tx_id_typed(
-                            detected_tx_hash,
-                            1,
-                        ))
-                    });
+        Err(VaultError::Reverted { .. }) => {
+            // The terminally failed tx permanently reserves its externalTxId,
+            // so the replacement burn must never reuse the base id. When event
+            // history has no recorded retry id, fall back to retry-1 — mirror
+            // of the startup recovery path in BurnManager.
+            let retry_external_tx_id =
+                burn_retry_external_tx_id.or_else(|| {
+                    Some(Redemption::retry_burn_external_tx_id_typed(
+                        detected_tx_hash,
+                        1,
+                    ))
+                });
 
-                info!(target: "admin", aggregate_id = %aggregate_id,
-                    tx_hash = %tx_id,
-                    retry_external_tx_id = ?retry_external_tx_id,
-                    "Transaction reverted onchain, proceeding with ResumeBurn"
-                );
-
-                return Ok(PriorBurnDisposition::ResumeWith(
-                    retry_external_tx_id,
-                ));
-            }
-
-            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                %tx_id,
-                error = %e,
-                "Failed to confirm previously submitted burn"
+            info!(target: "admin", aggregate_id = %aggregate_id,
+                tx_hash = %tx_id,
+                retry_external_tx_id = ?retry_external_tx_id,
+                "Transaction reverted onchain, proceeding with ResumeBurn"
             );
-            Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id))
+
+            Ok(PriorBurnDisposition::ResumeWith(retry_external_tx_id))
+        }
+        Err(VaultError::MissingBlockNumber { tx_hash }) => {
+            error!(target: "admin", aggregate_id = %aggregate_id,
+                %tx_hash,
+                "Completed burn transaction receipt is missing block number"
+            );
+            Err(Status::InternalServerError)
+        }
+        Err(error) => {
+            warn!(target: "admin", aggregate_id = %aggregate_id,
+                issuer_request_id = %issuer_request_id,
+                %tx_id,
+                error = %error,
+                "Prior burn outcome is ambiguous; manual intervention required"
+            );
+            Err(Status::UnprocessableEntity)
         }
     }
 }
@@ -1761,7 +1766,7 @@ mod tests {
     use alloy::consensus::{
         Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
     };
-    use alloy::primitives::{Address, Bloom, U256, address, b256};
+    use alloy::primitives::{Address, B256, Bloom, U256, address, b256};
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
     use chrono::Utc;
@@ -1785,9 +1790,13 @@ mod tests {
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
+    use crate::receipt_inventory::{
+        ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
+        Shares,
+    };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::{
-        IssuerRedemptionRequestId, Redemption, RedemptionCommand,
+        BurnRecord, IssuerRedemptionRequestId, Redemption, RedemptionCommand,
         RedemptionMetadata, RedemptionView,
     };
     use crate::test_utils::logs_contain_at;
@@ -1799,12 +1808,13 @@ mod tests {
         Arc::new(MockVaultService::new_success())
     }
 
-    fn checked_burn_receipt(block_number: Option<u64>) -> TransactionReceipt {
-        let transaction_hash = b256!(
-            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-        );
+    fn checked_burn_receipt(
+        transaction_hash: B256,
+        block_number: Option<u64>,
+        succeeded: bool,
+    ) -> TransactionReceipt {
         let consensus_receipt = Receipt {
-            status: Eip658Value::Eip658(true),
+            status: Eip658Value::Eip658(succeeded),
             cumulative_gas_used: 21_000,
             logs: Vec::new(),
         };
@@ -1885,6 +1895,47 @@ mod tests {
 
         fn force_calls(&self) -> usize {
             self.force_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    struct ReservationTrackingBurnRecovery {
+        calls: AtomicUsize,
+        receipt_inventory_store: Arc<Store<ReceiptInventory>>,
+        vault: Address,
+    }
+
+    impl ReservationTrackingBurnRecovery {
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl super::RedemptionBurnRecovery for ReservationTrackingBurnRecovery {
+        async fn execute_recovered_burn(
+            &self,
+            issuer_request_id: &IssuerRedemptionRequestId,
+        ) -> Result<super::RecoveryOutcome, super::BurnManagerError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            self.receipt_inventory_store
+                .send(
+                    &self.vault,
+                    ReceiptInventoryCommand::ReleaseBurn {
+                        redemption_issuer_request_id: issuer_request_id.clone(),
+                    },
+                )
+                .await
+                .expect("test recovery should release the reservation");
+            Ok(super::RecoveryOutcome::Executed)
+        }
+
+        async fn force_complete_burn(
+            &self,
+            _issuer_request_id: &IssuerRedemptionRequestId,
+            _burn_tx_hash: alloy::primitives::B256,
+            _reason: String,
+        ) -> Result<super::BurnVerification, super::BurnManagerError> {
+            unimplemented!("not used by redemption recovery route tests")
         }
     }
 
@@ -2353,8 +2404,15 @@ mod tests {
                 &alpaca_data,
             )),
         });
+        let prior_tx_id = TxId::random();
         let vault: Arc<dyn VaultService> =
-            Arc::new(MockVaultService::new_success().with_reverted_burn());
+            Arc::new(MockVaultService::new_success().with_checked_tx_receipt(
+                checked_burn_receipt(
+                    prior_tx_id.to_hash().unwrap(),
+                    Some(12_345),
+                    false,
+                ),
+            ));
 
         let result = recover_post_alpaca(
             &store,
@@ -2367,7 +2425,7 @@ mod tests {
                 metadata: metadata.clone(),
                 alpaca_data,
                 burning_failed: Some(BurningFailedData {
-                    tx_id: Some(TxId::random()),
+                    tx_id: Some(prior_tx_id),
                     planned_burns: vec![],
                 }),
                 burn_retry_external_tx_id: None,
@@ -2785,13 +2843,68 @@ mod tests {
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     error: "burn terminally failed".to_string(),
                     tx_id: Some(tx_id),
-                    planned_burns: vec![],
+                    planned_burns: vec![BurnRecord {
+                        receipt_id: U256::from(99),
+                        shares_burned: U256::from(100),
+                    }],
                 },
             )
             .await
             .expect("RecordBurnFailure failed");
 
         (metadata, alpaca_data)
+    }
+
+    async fn seed_receipt_reservation(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> (Arc<Store<ReceiptInventory>>, Address) {
+        let store = Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(U256::from(99)),
+                    balance: Shares::from(U256::from(100)),
+                    block_number: 12_345,
+                    tx_hash: b256!(
+                        "0xa4f500a4f500a4f500a4f500a4f500a4f500a4f500a4f500a4f500a4f500a4f5"
+                    ),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .expect("receipt discovery should succeed");
+
+        store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::ReserveBurn {
+                    redemption_issuer_request_id: issuer_request_id.clone(),
+                    burns: vec![BurnRecord {
+                        receipt_id: U256::from(99),
+                        shares_burned: U256::from(100),
+                    }],
+                },
+            )
+            .await
+            .expect("receipt reservation should succeed");
+
+        let inventory = store
+            .load(&vault)
+            .await
+            .expect("receipt inventory should load")
+            .expect("receipt inventory should exist");
+        assert_eq!(
+            inventory.reserved_redemptions(),
+            vec![issuer_request_id.clone()]
+        );
+
+        (store, vault)
     }
 
     #[traced_test]
@@ -2900,7 +3013,8 @@ mod tests {
         let pool = setup_pool().await;
         let store = setup_store(&pool);
         let tx_id = TxId::random();
-        let (metadata, alpaca_data) = setup_burn_failure(&store, tx_id).await;
+        let (metadata, alpaca_data) =
+            setup_burn_failure(&store, tx_id.clone()).await;
         let aggregate_id = metadata.issuer_request_id.to_string();
         let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
             response: PollResponse::Ok(redeem_response(
@@ -2909,10 +3023,10 @@ mod tests {
                 &alpaca_data,
             )),
         });
-        let vault_service: Arc<dyn VaultService> = Arc::new(
-            MockVaultService::new_success()
-                .with_checked_tx_receipt(checked_burn_receipt(None)),
-        );
+        let vault_service: Arc<dyn VaultService> =
+            Arc::new(MockVaultService::new_success().with_checked_tx_receipt(
+                checked_burn_receipt(tx_id.to_hash().unwrap(), None, true),
+            ));
         let burn_recovery = Arc::new(MockBurnRecovery::default());
         let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
             burn_recovery.clone();
@@ -2959,7 +3073,8 @@ mod tests {
         let pool = setup_pool().await;
         let store = setup_store(&pool);
         let tx_id = TxId::random();
-        let (metadata, alpaca_data) = setup_burn_failure(&store, tx_id).await;
+        let (metadata, alpaca_data) =
+            setup_burn_failure(&store, tx_id.clone()).await;
         let aggregate_id = metadata.issuer_request_id.to_string();
         let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
             response: PollResponse::Ok(redeem_response(
@@ -2968,10 +3083,14 @@ mod tests {
                 &alpaca_data,
             )),
         });
-        let vault_service: Arc<dyn VaultService> = Arc::new(
-            MockVaultService::new_success()
-                .with_checked_tx_receipt(checked_burn_receipt(Some(12_345))),
-        );
+        let vault_service: Arc<dyn VaultService> =
+            Arc::new(MockVaultService::new_success().with_checked_tx_receipt(
+                checked_burn_receipt(
+                    tx_id.to_hash().unwrap(),
+                    Some(12_345),
+                    true,
+                ),
+            ));
         let burn_recovery = Arc::new(MockBurnRecovery::default());
         let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
             burn_recovery.clone();
@@ -3019,6 +3138,229 @@ mod tests {
         assert!(logs_contain_at!(
             Level::INFO,
             &[&aggregate_id, "recording existing burn"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_refuses_ambiguous_prior_burns() {
+        let incomplete_revert_tx_id = TxId::random();
+        let mismatched_success_tx_id = TxId::random();
+        let mismatched_revert_tx_id = TxId::random();
+        let cases = [
+            (
+                "pending",
+                TxId::random(),
+                MockVaultService::new_success().with_pending_checked_tx(),
+            ),
+            (
+                "rpc_failed",
+                TxId::random(),
+                MockVaultService::new_success().with_rpc_checked_tx_error(),
+            ),
+            (
+                "unknown",
+                TxId::random(),
+                MockVaultService::new_success().with_invalid_checked_tx(),
+            ),
+            (
+                "legacy",
+                TxId::Legacy("legacy-fireblocks-id".to_string()),
+                MockVaultService::new_success().with_invalid_checked_tx(),
+            ),
+            (
+                "incomplete_revert",
+                incomplete_revert_tx_id.clone(),
+                MockVaultService::new_success().with_checked_tx_receipt(
+                    checked_burn_receipt(
+                        incomplete_revert_tx_id.to_hash().unwrap(),
+                        None,
+                        false,
+                    ),
+                ),
+            ),
+            (
+                "mismatched_success",
+                mismatched_success_tx_id,
+                MockVaultService::new_success().with_checked_tx_receipt(
+                    checked_burn_receipt(B256::ZERO, Some(12_345), true),
+                ),
+            ),
+            (
+                "mismatched_revert",
+                mismatched_revert_tx_id,
+                MockVaultService::new_success().with_checked_tx_receipt(
+                    checked_burn_receipt(B256::ZERO, Some(12_345), false),
+                ),
+            ),
+        ];
+
+        for (case, tx_id, vault_service) in cases {
+            let pool = setup_pool().await;
+            let store = setup_store(&pool);
+            let (metadata, alpaca_data) =
+                setup_burn_failure(&store, tx_id.clone()).await;
+            let aggregate_id = metadata.issuer_request_id.to_string();
+            let (receipt_inventory_store, vault) =
+                seed_receipt_reservation(&pool, &metadata.issuer_request_id)
+                    .await;
+            let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+                response: PollResponse::Ok(redeem_response(
+                    RedeemRequestStatus::Completed,
+                    &metadata,
+                    &alpaca_data,
+                )),
+            });
+            let vault_service: Arc<dyn VaultService> = Arc::new(vault_service);
+            let burn_recovery = Arc::new(ReservationTrackingBurnRecovery {
+                calls: AtomicUsize::new(0),
+                receipt_inventory_store: receipt_inventory_store.clone(),
+                vault,
+            });
+            let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+                burn_recovery.clone();
+            let rocket = post_alpaca_rocket(
+                store.clone(),
+                pool.clone(),
+                alpaca,
+                vault_service,
+                burn_recovery_state,
+            );
+
+            let (status, _body) = dispatch_recover_redemption(
+                rocket,
+                &metadata.issuer_request_id,
+            )
+            .await;
+
+            assert_eq!(status, Status::UnprocessableEntity, "case: {case}");
+            assert_eq!(burn_recovery.calls(), 0, "case: {case}");
+            let redemption =
+                store.load(&metadata.issuer_request_id).await.unwrap().unwrap();
+            assert!(
+                matches!(redemption, Redemption::Failed { .. }),
+                "case: {case}"
+            );
+            let context =
+                load_reprocess_context(&pool, &metadata.issuer_request_id)
+                    .await
+                    .unwrap();
+            let planned_burns = context.burning_failed.unwrap().planned_burns;
+            assert_eq!(planned_burns.len(), 1, "case: {case}");
+            let planned_burn = planned_burns.first().unwrap();
+            assert_eq!(planned_burn.receipt_id, U256::from(99));
+            assert_eq!(planned_burn.shares_burned, U256::from(100));
+            let receipt_inventory =
+                receipt_inventory_store.load(&vault).await.unwrap().unwrap();
+            assert_eq!(
+                receipt_inventory.reserved_redemptions(),
+                vec![metadata.issuer_request_id.clone()],
+                "case: {case}"
+            );
+            let advancing_events: i64 = sqlx::query_scalar(
+                "
+                SELECT COUNT(*)
+                FROM events
+                WHERE aggregate_type = 'Redemption'
+                  AND aggregate_id = ?
+                  AND event_type IN (
+                      'RedemptionEvent::BurnResumed',
+                      'RedemptionEvent::ExistingBurnRecovered'
+                  )
+                ",
+            )
+            .bind(&aggregate_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+            assert_eq!(advancing_events, 0, "case: {case}");
+            assert!(
+                logs_contain_at!(
+                    Level::WARN,
+                    &[&aggregate_id, "manual intervention"]
+                ),
+                "case: {case}"
+            );
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_replaces_only_confirmed_reverted_prior_burn() {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let tx_id = TxId::random();
+        let tx_hash = tx_id.to_hash().unwrap();
+        let (metadata, alpaca_data) =
+            setup_burn_failure(&store, tx_id.clone()).await;
+        let aggregate_id = metadata.issuer_request_id.to_string();
+        let (receipt_inventory_store, vault) =
+            seed_receipt_reservation(&pool, &metadata.issuer_request_id).await;
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let vault_service: Arc<dyn VaultService> =
+            Arc::new(MockVaultService::new_success().with_checked_tx_receipt(
+                checked_burn_receipt(tx_hash, Some(12_345), false),
+            ));
+        let burn_recovery = Arc::new(ReservationTrackingBurnRecovery {
+            calls: AtomicUsize::new(0),
+            receipt_inventory_store: receipt_inventory_store.clone(),
+            vault,
+        });
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+        let rocket = post_alpaca_rocket(
+            store.clone(),
+            pool.clone(),
+            alpaca,
+            vault_service,
+            burn_recovery_state,
+        );
+
+        let (status, body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(body.contains("executed burn"));
+        assert_eq!(burn_recovery.calls(), 1);
+        let redemption =
+            store.load(&metadata.issuer_request_id).await.unwrap().unwrap();
+        let Redemption::Burning { external_tx_id, .. } = redemption else {
+            panic!("expected Burning state, got {redemption:?}");
+        };
+        assert_eq!(
+            external_tx_id,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &metadata.detected_tx_hash,
+                1,
+            ))
+        );
+        let receipt_inventory =
+            receipt_inventory_store.load(&vault).await.unwrap().unwrap();
+        assert!(receipt_inventory.reserved_redemptions().is_empty());
+        let resumed_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnResumed'
+            ",
+        )
+        .bind(&aggregate_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(resumed_events, 1);
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&aggregate_id, "Transaction reverted onchain", "ResumeBurn"]
         ));
     }
 

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -3,7 +3,11 @@ use alloy::consensus::{
 };
 use alloy::eips::Encodable2718;
 use alloy::primitives::{Address, B256, Bytes, Signature, TxKind, U256, b256};
+#[cfg(test)]
+use alloy::providers::{PendingTransactionError, WatchTxError};
 use alloy::rpc::types::TransactionReceipt;
+#[cfg(test)]
+use alloy::transports::TransportErrorKind;
 use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -58,8 +62,7 @@ enum MockBehavior {
     InvalidPreparedMint,
 }
 
-/// Configured outcome for `verify_burn_tx` in tests, exercising the admin
-/// force-complete path's on-chain verification of an operator-supplied tx hash.
+/// Configured outcome for `verify_burn_tx` in tests.
 #[cfg(test)]
 #[derive(Clone)]
 enum MockVerifyBurn {
@@ -69,6 +72,19 @@ enum MockVerifyBurn {
     NotABurn,
     /// The tx reverted on-chain.
     Reverted,
+}
+
+#[cfg(test)]
+#[derive(Clone, Default)]
+enum MockCheckTxOutcome {
+    Receipt(Box<TransactionReceipt>),
+    /// The prior tx is still pending.
+    Pending,
+    /// The prior tx lookup failed at the RPC boundary.
+    Rpc,
+    /// The prior tx cannot be verified from its identifier or receipt.
+    #[default]
+    InvalidReceipt,
 }
 
 #[cfg(test)]
@@ -107,14 +123,14 @@ pub(crate) struct MockVaultService {
     #[cfg(test)]
     last_multi_burn_params: Arc<Mutex<Option<MultiBurnParams>>>,
     /// Outcome returned by `verify_burn_tx`. Defaults to a successful
-    /// verification, exercising the admin force-complete happy path.
+    /// verification, exercising the force-complete happy path.
     #[cfg(test)]
     verify_burn: Arc<Mutex<MockVerifyBurn>>,
     /// Signed tx returned by `prepare_tx` when local signing is configured.
     #[cfg(test)]
     prepared_tx: Arc<Mutex<Option<SendableTxWithHash>>>,
     #[cfg(test)]
-    checked_tx_receipt: Arc<Mutex<Option<TransactionReceipt>>>,
+    checked_tx_outcome: Arc<Mutex<MockCheckTxOutcome>>,
 }
 
 impl MockVaultService {
@@ -141,7 +157,9 @@ impl MockVaultService {
             #[cfg(test)]
             prepared_tx: Arc::new(Mutex::new(None)),
             #[cfg(test)]
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -161,7 +179,9 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -181,7 +201,9 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -201,7 +223,9 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -228,7 +252,9 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -248,7 +274,9 @@ impl MockVaultService {
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_receipt: Arc::new(Mutex::new(None)),
+            checked_tx_outcome: Arc::new(Mutex::new(
+                MockCheckTxOutcome::default(),
+            )),
         }
     }
 
@@ -336,6 +364,25 @@ impl MockVaultService {
         self
     }
 
+    #[cfg(test)]
+    pub(crate) fn with_pending_checked_tx(self) -> Self {
+        *self.checked_tx_outcome.lock().unwrap() = MockCheckTxOutcome::Pending;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_rpc_checked_tx_error(self) -> Self {
+        *self.checked_tx_outcome.lock().unwrap() = MockCheckTxOutcome::Rpc;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_invalid_checked_tx(self) -> Self {
+        *self.checked_tx_outcome.lock().unwrap() =
+            MockCheckTxOutcome::InvalidReceipt;
+        self
+    }
+
     /// Configures `find_existing_burn` to return the given [`SubmittedTx`],
     /// simulating a burn that was already submitted on-chain before the current
     /// process started (crash-safe idempotency recovery path).
@@ -353,7 +400,8 @@ impl MockVaultService {
         self,
         receipt: TransactionReceipt,
     ) -> Self {
-        *self.checked_tx_receipt.lock().unwrap() = Some(receipt);
+        *self.checked_tx_outcome.lock().unwrap() =
+            MockCheckTxOutcome::Receipt(Box::new(receipt));
         self
     }
 }
@@ -710,17 +758,35 @@ impl VaultService for MockVaultService {
         _tx_id: &TxId,
     ) -> Result<TransactionReceipt, VaultError> {
         #[cfg(test)]
-        let checked_tx_receipt =
-            self.checked_tx_receipt.lock().unwrap().clone();
+        let checked_tx_outcome =
+            self.checked_tx_outcome.lock().unwrap().clone();
         #[cfg(test)]
-        if let Some(receipt) = checked_tx_receipt {
-            return Ok(receipt);
-        }
-        #[cfg(test)]
-        if matches!(*self.verify_burn.lock().unwrap(), MockVerifyBurn::Reverted)
         {
-            return Err(VaultError::Reverted { tx_hash: B256::ZERO });
+            use super::classify_checked_receipt;
+
+            match checked_tx_outcome {
+                MockCheckTxOutcome::Receipt(receipt) => {
+                    let tx_hash =
+                        _tx_id.to_hash().ok_or(VaultError::InvalidReceipt)?;
+                    return classify_checked_receipt(tx_hash, *receipt);
+                }
+                MockCheckTxOutcome::Pending => {
+                    return Err(PendingTransactionError::TxWatcher(
+                        WatchTxError::Timeout,
+                    )
+                    .into());
+                }
+                MockCheckTxOutcome::Rpc => {
+                    return Err(VaultError::Rpc(
+                        TransportErrorKind::custom_str("mock RPC failure"),
+                    ));
+                }
+                MockCheckTxOutcome::InvalidReceipt => {
+                    return Err(VaultError::InvalidReceipt);
+                }
+            }
         }
+        #[cfg(not(test))]
         Err(VaultError::InvalidReceipt)
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -453,6 +453,9 @@ pub(crate) enum VaultError {
     /// Transaction receipt is missing required data
     #[error("Invalid receipt")]
     InvalidReceipt,
+    /// A transaction receipt was returned without proof of block inclusion.
+    #[error("Transaction receipt is missing a block number: {tx_hash:?}")]
+    MissingBlockNumber { tx_hash: B256 },
     /// Expected event (e.g., Deposit) not found in transaction logs
     #[error("Event not found in transaction: {tx_hash:?}")]
     EventNotFound { tx_hash: B256 },
@@ -502,6 +505,26 @@ pub(crate) enum VaultError {
     ),
     #[error(transparent)]
     SendableTxErr(#[from] Box<SendableTxErr<TransactionRequest>>),
+}
+
+fn classify_checked_receipt(
+    tx_hash: B256,
+    receipt: TransactionReceipt,
+) -> Result<TransactionReceipt, VaultError> {
+    if receipt.transaction_hash != tx_hash {
+        return Err(VaultError::InvalidReceipt);
+    }
+    if !receipt.status() {
+        if receipt.block_number.is_none() {
+            return Err(VaultError::InvalidReceipt);
+        }
+        return Err(VaultError::Reverted { tx_hash });
+    }
+    if receipt.block_number.is_none() {
+        return Err(VaultError::MissingBlockNumber { tx_hash });
+    }
+
+    Ok(receipt)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -21,7 +21,8 @@ use super::rain_meta::OaSchemaCache;
 use super::{
     BurnVerification, MintResult, MultiBurnResult, MultiBurnResultEntry,
     PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId,
-    VaultError, VaultService, WalletNonceGuard, verify_burn_in_receipt,
+    VaultError, VaultService, WalletNonceGuard, classify_checked_receipt,
+    verify_burn_in_receipt,
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
@@ -449,13 +450,7 @@ impl VaultService for RealBlockchainService {
         .get_receipt()
         .await?;
 
-        // A mined-but-reverted burn consumes no receipts, so it is a definitive
-        // failure distinct from an anomalous missing-Withdraw parse error.
-        if !receipt.status() {
-            return Err(VaultError::Reverted { tx_hash });
-        }
-
-        Ok(receipt)
+        classify_checked_receipt(tx_hash, receipt)
     }
 
     async fn lock_wallet(&self) -> WalletNonceGuard {
@@ -871,6 +866,121 @@ mod tests {
                 consensus_receipt,
                 Bloom::default(),
             )),
+        }
+    }
+
+    #[tokio::test]
+    async fn check_tx_rejects_reverted_receipt_without_block_number() {
+        let vault_address = test_vault_address();
+        let tx_hash = fixed_bytes!(
+            "0x7070707070707070707070707070707070707070707070707070707070707070"
+        );
+        let mut receipt = create_empty_receipt(vault_address, tx_hash);
+        receipt.block_hash = None;
+        receipt.block_number = None;
+        receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+            Receipt {
+                status: Eip658Value::Eip658(false),
+                cumulative_gas_used: 0x6100,
+                logs: vec![],
+            },
+            Bloom::default(),
+        ));
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.check_tx(&TxId::Hash(tx_hash)).await;
+
+        assert!(
+            matches!(result, Err(VaultError::InvalidReceipt)),
+            "unexpected check result: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_tx_rejects_successful_receipt_without_block_number() {
+        let vault_address = test_vault_address();
+        let tx_hash = fixed_bytes!(
+            "0x7272727272727272727272727272727272727272727272727272727272727272"
+        );
+        let mut receipt = create_empty_receipt(vault_address, tx_hash);
+        receipt.block_hash = None;
+        receipt.block_number = None;
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.check_tx(&TxId::Hash(tx_hash)).await;
+
+        assert!(
+            matches!(result, Err(VaultError::MissingBlockNumber { tx_hash: hash }) if hash == tx_hash),
+            "unexpected check result: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_tx_reports_mined_revert() {
+        let vault_address = test_vault_address();
+        let tx_hash = fixed_bytes!(
+            "0x7171717171717171717171717171717171717171717171717171717171717171"
+        );
+        let mut receipt = create_empty_receipt(vault_address, tx_hash);
+        receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+            Receipt {
+                status: Eip658Value::Eip658(false),
+                cumulative_gas_used: 0x6100,
+                logs: vec![],
+            },
+            Bloom::default(),
+        ));
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.check_tx(&TxId::Hash(tx_hash)).await;
+
+        assert!(
+            matches!(result, Err(VaultError::Reverted { tx_hash: hash }) if hash == tx_hash),
+            "unexpected check result: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn check_tx_rejects_mismatched_receipt_hash() {
+        let vault_address = test_vault_address();
+        let requested_tx_hash = fixed_bytes!(
+            "0x7272727272727272727272727272727272727272727272727272727272727272"
+        );
+        let receipt_tx_hash = fixed_bytes!(
+            "0x7373737373737373737373737373737373737373737373737373737373737373"
+        );
+
+        for succeeded in [true, false] {
+            let mut receipt =
+                create_empty_receipt(vault_address, receipt_tx_hash);
+            receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                Receipt {
+                    status: Eip658Value::Eip658(succeeded),
+                    cumulative_gas_used: 0x6100,
+                    logs: vec![],
+                },
+                Bloom::default(),
+            ));
+            let asserter = Asserter::new();
+            asserter.push_success(&receipt);
+            asserter.push_success(&receipt);
+            let service = create_service_with_asserter(asserter);
+
+            let result = service.check_tx(&TxId::Hash(requested_tx_hash)).await;
+
+            assert!(
+                matches!(result, Err(VaultError::InvalidReceipt)),
+                "succeeded: {succeeded}, unexpected check result: {result:?}"
+            );
         }
     }
 


### PR DESCRIPTION
## Motivation

Admin redemption recovery treated any prior burn lookup failure as permission to submit a replacement. Pending, unknown, RPC-failed, legacy, or inconsistent receipts could therefore risk a second burn.

## Solution

- only authorize replacement after an exact-hash, mined on-chain revert
- record already completed burns and refuse every ambiguous disposition with `422`
- preserve the failed state and receipt reservation when manual intervention is required
- cover pending, RPC, unknown, legacy, incomplete, mismatched, completed, and reverted outcomes through the recovery route

Linear: https://linear.app/makeitrain/issue/RAI-1377/refuse-ambiguous-prior-burns-in-admin-recovery

## Checks

- [x] added comprehensive test coverage for changes in logic
- [x] made this PR as small as possible
- [x] linked the relevant issue
- [x] `cargo test --workspace`
- [x] strict workspace Clippy
- [x] `cargo fmt --all -- --check`
- [x] four review-loop passes, final pass clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption recovery safeguards by requiring prior burns to be conclusively confirmed as reverted before replacement.
  * Ambiguous transaction outcomes—including pending transactions, lookup failures, invalid receipts, and unverifiable legacy transactions—now return HTTP 422 and preserve the failed state for manual intervention.
  * Strengthened transaction receipt validation to detect mismatched or incomplete receipt data.

* **Documentation**
  * Updated recovery guidance and HTTP 422 response descriptions to reflect the stricter recovery requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->