### PR TITLE
feat: recover persisted burn transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,6 +195,7 @@ checksum = "9d4769c6ffddca380b0070d71c8b7f30bed375543fe76bb2f74ec0acf4b7cd16"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
+ "k256",
  "serde",
  "thiserror",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ alloy = { version = "1.0.41", features = [
   "pubsub",
   "node-bindings",
   "rand",
+  "k256",
 ] }
 rust_decimal = { version = "1.39.0", features = ["serde"] }
 tokio = { workspace = true, features = ["time"] }

--- a/SPEC.md
+++ b/SPEC.md
@@ -372,6 +372,16 @@ on-chain transfer through calling Alpaca to burning tokens.
   `BurnTxSubmitted` on success
 - `ConfirmBurn { tx_id, dust_shares }` - Confirm a previously submitted burn
   transaction. Produces `TokensBurned` on success
+- `RecordBurnRecoveryAttempt` - Persist one automatic recovery action before
+  its external side effect
+- `RecordBurnPreparationRecoveryAttempt` - Persist one automatic retry before
+  resuming a failed redemption that has no signed burn transaction
+- `ReplaceDeadBurn` - Re-check that the persisted transaction is provably dead,
+  then sign and persist a replacement at a fresh nonce
+- `RecordBurnRecoveryExhausted` - Persist that the redemption-wide automatic
+  recovery budget is spent
+- `RecordBurnPreparationRecoveryExhausted` - Persist exhaustion when repeated
+  burn preparation failures never produced a transaction identity
 - `RecordBurnFailure` - Record on-chain burn failure (from `Burning` or
   `BurnSubmitted` state). Carries optional `tx_id` and `planned_burns` for
   recovery
@@ -402,15 +412,16 @@ on-chain transfer through calling Alpaca to burning tokens.
   the on-chain burn does not wait for a service restart.
 - `CloseRedemption { issuer_request_id, reason }` - Admin-close a redemption
   that cannot be automatically recovered, recording an operator `reason`. Valid
-  from `Failed`, `Burning`, or `BurnSubmitted`. This is the honest terminal path
-  for a redemption whose burn cannot or should not be re-submitted and is
+  from `Failed`, `Burning`, `BurnIntended`, or `BurnSubmitted`. This is the
+  honest terminal path for a redemption whose burn cannot or should not be re-submitted and is
   **not** verifiable on-chain (e.g. a `Failed -> Burning` recovery regression
   where no burn ever landed, or an ambiguous case pending off-chain
   reconciliation). A held receipt reservation is **left in place** (the
   conservative policy for `Closed`), since an ambiguous burn may still have
   landed. Emits `RedemptionClosed`.
 - `ForceCompleteBurn { issuer_request_id, burn_tx_hash, block_number, reason }` -
-  Admin-terminalize a redemption stuck in `Burning`/`BurnSubmitted` whose burn
+  Admin-terminalize a redemption stuck in
+  `BurnIntended`/`BurnSubmitted` whose persisted exact burn transaction
   **already landed on-chain** but was never recorded (e.g. the bot crashed
   between the burn and `TokensBurned`). The admin layer verifies the
   operator-supplied `burn_tx_hash` on-chain first — the receipt must have
@@ -418,8 +429,11 @@ on-chain transfer through calling Alpaca to burning tokens.
   vault's shares — then records the proving tx hash and block number. The
   receipt reservation is settled (mirror reduced) just like a normal burn
   completion. Emits `BurnForceCompleted`, transitioning to `Completed`.
-  Ambiguous cases with no verifiable on-chain burn are **not** force-completed;
-  ops use `CloseRedemption` (or reconcile first) instead.
+  The persisted bytes must decode with matching hash and nonce and recover the
+  configured bot wallet as signer; the supplied hash must then equal that exact
+  transaction hash. Legacy or pre-intent states without a trustworthy
+  persisted transaction are **not** force-completed; ops use `CloseRedemption`
+  after off-chain reconciliation instead.
 
 **Events:**
 
@@ -436,11 +450,25 @@ on-chain transfer through calling Alpaca to burning tokens.
   definitive terminal/reverted failure it is released.
 - `BurnIntended` - Persists the exact signed raw transaction and its hash before
   any broadcast attempt. A prepared transaction is immutable: live execution and
-  recovery may only broadcast those persisted bytes, never sign a replacement
-  while its outcome is unknown. Recovery re-broadcasts the same bytes before
-  confirming the stored hash. If the broadcast outcome remains ambiguous, the
-  redemption stays in `BurnIntended` with its receipt reservation held for
-  operator resolution.
+  recovery may only broadcast those persisted bytes while they can still land.
+  Recovery classifies the hash before acting. A fresh transaction may be signed
+  only when the old transaction is provably dead under the replacement predicate
+  below. If the RPC result is uncertain, the redemption stays unresolved with
+  its receipt reservation held.
+- `BurnRecoveryAttempted` - Records one accepted automatic recovery action for
+  the persisted transaction, including its hash, nonce, action, and timestamp.
+  These events form the durable redemption-wide recovery budget across process
+  restarts.
+- `BurnPreparationRecoveryAttempted` - Records an automatic retry before a
+  failed redemption without a signed burn transaction resumes preparation.
+  These attempts share the same redemption-wide budget.
+- `BurnRecoveryExhausted` - Records that the automatic recovery budget is spent,
+  including the latest hash, nonce, attempt count, and timestamp. It leaves the
+  aggregate unresolved and the receipt reservation held for operator recovery.
+  Its first persistence emits the single actionable operator error; later
+  periodic passes observe the marker and perform no RPC or signing side effects.
+- `BurnPreparationRecoveryExhausted` - Records the same durable stop when
+  repeated preparation failures never produced a burn hash and nonce.
 - `TokensBurned` - On-chain burn succeeded, redemption complete (terminal
   success). Payload contains `burns: Vec<BurnRecord>` where each `BurnRecord`
   has `receipt_id` and `shares_burned`, supporting multi-receipt burns when a
@@ -451,9 +479,10 @@ on-chain transfer through calling Alpaca to burning tokens.
 - `RedemptionClosed` - Admin-closed redemption (terminal). Carries the operator
   `reason` and `closed_at`. Closed redemptions do not appear in stuck queries.
 - `BurnForceCompleted` - Admin-recorded terminal success for a stuck
-  `Burning`/`BurnSubmitted` redemption whose burn was verified on-chain. Carries
-  the proving `burn_tx_hash`, `block_number`, operator `reason`, and
-  `completed_at`. Transitions to `Completed` (terminal success).
+  `BurnIntended`/`BurnSubmitted` redemption whose persisted exact burn was
+  verified on-chain. Carries the proving `burn_tx_hash`, `block_number`,
+  operator `reason`, and `completed_at`. Transitions to `Completed` (terminal
+  success).
 - `Reprocessed` - Redemption reset to `Detected` state for reprocessing. Carries
   the original `RedemptionMetadata`, the previous state name, and a timestamp.
   Used for audit trail — shows when and from what state a manual reprocess was
@@ -476,12 +505,67 @@ on-chain transfer through calling Alpaca to burning tokens.
 | `IntendBurn`            | `BurnIntended`           | Persist exact signed tx before broadcasting   |
 | `BurnTokens`            | `BurnTxSubmitted`        | Submits to signing backend                    |
 | `ConfirmBurn`           | `TokensBurned`           | Confirms burn, terminal success               |
+| `RecordBurnRecoveryAttempt` | `BurnRecoveryAttempted` | Reserve one durable automatic recovery action |
+| `RecordBurnPreparationRecoveryAttempt` | `BurnPreparationRecoveryAttempted` | Reserve a retry before burn preparation |
+| `ReplaceDeadBurn`       | `BurnIntended`            | Re-check dead predicate, then persist replacement |
+| `RecordBurnRecoveryExhausted` | `BurnRecoveryExhausted` | Stop automatic recovery durably          |
+| `RecordBurnPreparationRecoveryExhausted` | `BurnPreparationRecoveryExhausted` | Stop preparation retries durably |
 | `RecordBurnFailure`     | `BurningFailed`          | Records failure with optional tx metadata     |
 | `RecordExistingBurn`    | `ExistingBurnRecovered`  | Recovery from Failed with known tx            |
 | `Reprocess`             | `Reprocessed`            | Reset to Detected for reprocessing            |
 | `ResumeBurn`            | `BurnResumed`            | Resume to Burning for post-Alpaca recovery    |
-| `CloseRedemption`       | `RedemptionClosed`       | Admin close from Failed/Burning/BurnSubmitted |
+| `CloseRedemption`       | `RedemptionClosed`       | Admin close an unresolved redemption        |
 | `ForceCompleteBurn`     | `BurnForceCompleted`     | Admin terminalize a verified-on-chain burn    |
+
+Burn transaction recovery runs once during startup and every five minutes while
+the service is running. Before any recovery side effect, the issuer classifies
+the latest persisted signed transaction `(H, N)` for wallet `W` in this order:
+
+1. A receipt for `H` with a block number and successful status is **mined** and
+   is confirmed and recorded; no transaction is signed or re-broadcast.
+2. A receipt for `H` with a block number and failed status is **reverted**. The
+   nonce is consumed and the failed attempt is recorded before any later retry.
+3. With no receipt, if the finalized account nonce for `W` is at
+   most `N`, the transaction is **still mineable**. Recovery may only
+   re-broadcast the exact persisted bytes, producing the same hash `H`.
+4. With no receipt, if the finalized account nonce for `W` is
+   greater than `N`, the transaction is **provably dead** and can never land.
+   Only this case permits signing a replacement at a fresh nonce. The
+   replacement preserves the persisted transaction's destination, value, and
+   calldata exactly; only its nonce, gas limit, and fee fields are regenerated.
+   Its fresh nonce is the authoritative pending account nonce so it cannot
+   collide with another live transaction from the signing wallet.
+
+Equivalently, the exact replacement predicate is
+`receipt(H) = None AND finalized_nonce(W) > N`. Receipt lookup is evaluated
+before the nonce comparison. A latest-but-unfinalized nonce advance is not proof
+of death because a reorganization can remove it. A missing block number,
+mismatched receipt hash, provider error, timeout, signer that differs from `W`,
+or any other identity/RPC uncertainty is unclassified and fails closed: the old
+transaction remains live, no replacement is signed, and its reservation remains
+held. Same-nonce fee replacement is not supported.
+
+Automatic recovery is capped at five accepted recovery actions across the
+redemption's complete event history, including preparation retries,
+re-broadcasts, and fresh-nonce replacements. The initial live submission is not
+a recovery action. Once the budget is exhausted, `BurnRecoveryExhausted` or
+`BurnPreparationRecoveryExhausted` is persisted once and automatic recovery
+stops. An accepted action is resumed after restart without consuming
+another budget slot until its side effect is complete: an accepted re-broadcast
+resubmits the same bytes, and a persisted replacement intent is submitted as
+the continuation of the action that created it only while it remains mineable.
+If its nonce became finalized while the service was down, signing a further
+replacement requires another budgeted action. Classification and confirmation
+of a transaction produced by the fifth action remain allowed because they do
+not create another side effect. If that transaction is still non-terminal or
+provably dead, the history check persists exhaustion before accepting any
+further action. A failed fifth replacement preparation retains the preceding
+exact transaction identity long enough to persist exhaustion safely. An
+exhausted persisted intent cannot
+be re-armed through the admin recover endpoint: the operator must force-complete
+a verified landed burn or close only after off-chain reconciliation. At every
+point there is at most one transaction hash that can still land for a
+redemption.
 
 ### Account Aggregate
 
@@ -1771,10 +1855,14 @@ stateDiagram-v2
     AlpacaCalled --> Burning: ConfirmAlpacaComplete
     AlpacaCalled --> Failed: RecordAlpacaFailure / MarkFailed
     Burning --> Completed: RecordBurnSuccess
+    Burning --> BurnIntended: IntendBurn
     Burning --> BurnSubmitted: BurnTokens (BurnTxSubmitted)
     Burning --> Failed: RecordBurnFailure / MarkFailed
-    Burning --> Completed: ForceCompleteBurn (admin, verified on-chain)
     Burning --> Closed: CloseRedemption (admin)
+    BurnIntended --> BurnSubmitted: BurnTokens (BurnTxSubmitted)
+    BurnIntended --> BurnIntended: ReplaceDeadBurn / recovery annotations
+    BurnIntended --> Completed: ForceCompleteBurn (admin, verified on-chain)
+    BurnIntended --> Closed: CloseRedemption (admin)
     BurnSubmitted --> Completed: ConfirmBurn (TokensBurned)
     BurnSubmitted --> Failed: RecordBurnFailure / MarkFailed
     BurnSubmitted --> Completed: ForceCompleteBurn (admin, verified on-chain)

--- a/docs/ops-recovery-guide.md
+++ b/docs/ops-recovery-guide.md
@@ -44,6 +44,13 @@ Redemption recovery covers redemptions in `Detected`
 (`recover_stuck_reservations`). This runs with a **30-second timeout** before
 the HTTP server starts accepting requests.
 
+Persisted burn transactions are also reconciled every five minutes. Recovery
+confirms mined transactions, re-broadcasts the exact signed bytes while a
+transaction can still land, and signs a fresh-nonce replacement only after the
+old hash is provably dead. After five durable automatic actions across the
+redemption's lifetime, it logs `Automatic burn recovery exhausted` once with
+the request ID, transaction hash, nonce, and required operator action.
+
 - If recovery completes within 30 seconds, everything is handled automatically.
 - If recovery times out (e.g., the RPC is slow or unavailable), the remaining
   stuck transactions are left for manual intervention via the admin endpoints

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -24,7 +24,8 @@ use crate::mint::{
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
-    BurnManager, BurnManagerError, RecoveryOutcome,
+    BurnManager, BurnManagerError, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+    RecoveryOutcome,
 };
 use crate::redemption::{
     BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, RedemptionCommand,
@@ -42,9 +43,9 @@ pub(crate) trait RedemptionBurnRecovery: Send + Sync {
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Result<RecoveryOutcome, BurnManagerError>;
 
-    /// Terminalizes a redemption stuck in `Burning`/`BurnSubmitted` whose burn
-    /// already landed on-chain, after verifying `burn_tx_hash` against the
-    /// chain. Returns the on-chain verification for the admin response.
+    /// Terminalizes a redemption whose persisted exact burn already landed
+    /// on-chain, after binding and verifying `burn_tx_hash` against the chain.
+    /// Returns the on-chain verification for the admin response.
     async fn force_complete_burn(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
@@ -147,6 +148,7 @@ struct ReprocessContext {
     /// Replacement externalTxId for a retry burn, when event
     /// history shows a prior accepted burn or an unaccepted retry attempt.
     burn_retry_external_tx_id: Option<BurnExternalTxId>,
+    burn_recovery_exhausted: bool,
 }
 
 /// Loads all events for a redemption and extracts:
@@ -268,12 +270,38 @@ async fn load_reprocess_context(
             );
             Status::InternalServerError
         })?;
+    let burn_recovery_exhausted = events.iter().any(|event| {
+        matches!(
+            event,
+            RedemptionEvent::BurnRecoveryExhausted { .. }
+                | RedemptionEvent::BurnPreparationRecoveryExhausted { .. }
+        )
+    }) || events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                RedemptionEvent::BurnRecoveryAttempted { .. }
+                    | RedemptionEvent::BurnPreparationRecoveryAttempted { .. }
+            )
+        })
+        .count()
+        >= usize::try_from(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS).map_err(
+            |error| {
+                error!(target: "admin", aggregate_id = %aggregate_id_str,
+                    %error,
+                    "Burn recovery limit does not fit this platform"
+                );
+                Status::InternalServerError
+            },
+        )?;
 
     Ok(ReprocessContext {
         metadata,
         alpaca_called,
         burning_failed,
         burn_retry_external_tx_id,
+        burn_recovery_exhausted,
     })
 }
 
@@ -328,6 +356,13 @@ pub(crate) async fn recover_redemption(
 
     let context =
         load_reprocess_context(pool.inner(), &issuer_request_id).await?;
+
+    if context.burn_recovery_exhausted {
+        warn!(target: "admin", aggregate_id = %aggregate_id,
+            "Refusing to re-arm a redemption with exhausted automatic burn recovery"
+        );
+        return Err(Status::UnprocessableEntity);
+    }
 
     let Some(alpaca_data) = context.alpaca_called else {
         // Pre-Alpaca failure: safe to reset to Detected and re-call Alpaca.
@@ -1766,7 +1801,7 @@ mod tests {
     use alloy::consensus::{
         Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
     };
-    use alloy::primitives::{Address, B256, Bloom, U256, address, b256};
+    use alloy::primitives::{Address, B256, Bloom, Bytes, U256, address, b256};
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
     use chrono::Utc;
@@ -1779,7 +1814,9 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
-    use super::{AggregateKind, StuckAggregate};
+    use super::{
+        AggregateKind, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS, StuckAggregate,
+    };
     use super::{
         AlpacaCalledData, PostAlpacaRecoveryInput, load_reprocess_context,
         recover_post_alpaca,
@@ -1796,13 +1833,15 @@ mod tests {
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::{
-        BurnRecord, IssuerRedemptionRequestId, Redemption, RedemptionCommand,
-        RedemptionMetadata, RedemptionView,
+        BurnRecord, BurnRecoveryAction, IssuerRedemptionRequestId, Redemption,
+        RedemptionCommand, RedemptionEvent, RedemptionMetadata, RedemptionView,
     };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{MultiBurnEntry, TxId, VaultService};
+    use crate::vault::{
+        MultiBurnEntry, SendableTxWithHash, TxId, VaultService,
+    };
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
@@ -2205,6 +2244,13 @@ mod tests {
     fn setup_store(pool: &sqlx::Pool<sqlx::Sqlite>) -> Arc<Store<Redemption>> {
         let vault_service: Arc<dyn VaultService> =
             Arc::new(MockVaultService::new_success());
+        setup_store_with_vault(pool, vault_service)
+    }
+
+    fn setup_store_with_vault(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        vault_service: Arc<dyn VaultService>,
+    ) -> Arc<Store<Redemption>> {
         Arc::new(test_store::<Redemption>(pool.clone(), vault_service))
     }
 
@@ -3284,6 +3330,131 @@ mod tests {
         }
     }
 
+    async fn assert_endpoint_refuses_exhausted_burn_recovery(
+        with_marker: bool,
+    ) {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let tx_id = TxId::random();
+        let tx_hash = tx_id.to_hash().unwrap();
+        let (metadata, alpaca_data) = setup_burn_failure(&store, tx_id).await;
+        let aggregate_id = metadata.issuer_request_id.to_string();
+        let annotations = if with_marker {
+            vec![RedemptionEvent::BurnRecoveryExhausted {
+                issuer_request_id: metadata.issuer_request_id.clone(),
+                tx_hash,
+                nonce: 4,
+                attempts: MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+                exhausted_at: Utc::now(),
+            }]
+        } else {
+            (0..MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS)
+                .map(|_| RedemptionEvent::BurnRecoveryAttempted {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    tx_hash,
+                    nonce: 4,
+                    action: BurnRecoveryAction::Rebroadcast,
+                    attempted_at: Utc::now(),
+                })
+                .collect()
+        };
+        for annotation in annotations {
+            let event_type = match annotation {
+                RedemptionEvent::BurnRecoveryAttempted { .. } => {
+                    "RedemptionEvent::BurnRecoveryAttempted"
+                }
+                RedemptionEvent::BurnRecoveryExhausted { .. } => {
+                    "RedemptionEvent::BurnRecoveryExhausted"
+                }
+                _ => unreachable!(),
+            };
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                SELECT
+                    'Redemption',
+                    ?,
+                    COALESCE(MAX(sequence), 0) + 1,
+                    ?,
+                    '1.0',
+                    ?,
+                    '{}'
+                FROM events
+                WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+                ",
+            )
+            .bind(&aggregate_id)
+            .bind(event_type)
+            .bind(serde_json::to_string(&annotation).unwrap())
+            .bind(&aggregate_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+        let rocket = post_alpaca_rocket(
+            store,
+            pool.clone(),
+            alpaca,
+            mock_vault_service(),
+            burn_recovery_state,
+        );
+
+        let (status, _body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(burn_recovery.calls(), 0);
+        let resumed_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnResumed'
+            ",
+        )
+        .bind(&aggregate_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(resumed_events, 0);
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[&aggregate_id, "exhausted automatic burn recovery"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_refuses_marked_exhausted_burn_recovery() {
+        assert_endpoint_refuses_exhausted_burn_recovery(true).await;
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_refuses_count_only_exhausted_burn_recovery() {
+        assert_endpoint_refuses_exhausted_burn_recovery(false).await;
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn endpoint_replaces_only_confirmed_reverted_prior_burn() {
@@ -3708,8 +3879,37 @@ mod tests {
     #[tokio::test]
     async fn test_endpoint_force_complete_records_verified_burn() {
         let pool = setup_pool().await;
-        let store = setup_store(&pool);
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_service: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let store = setup_store_with_vault(&pool, vault_service);
         let metadata = setup_burning(&store).await;
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: U256::from(42),
+                        burn_shares: U256::from(17),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: persisted_tx.signer_for_test(),
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn failed");
 
         // In production `force_complete_burn` appends `BurnForceCompleted` before
         // the endpoint reads the prior state; the mock can't, so append it here
@@ -3720,7 +3920,7 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::ForceCompleteBurn {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    burn_tx_hash: alloy::primitives::B256::ZERO,
+                    burn_tx_hash: persisted_tx.hash,
                     block_number: 45_989_009,
                     reason: "burn confirmed on-chain".to_string(),
                 },
@@ -3733,17 +3933,20 @@ mod tests {
             burn_recovery.clone();
 
         let rocket = force_complete_rocket(pool, burn_recovery_state);
-        let body = r#"{"burn_tx_hash":"0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf","reason":"burn confirmed on-chain"}"#;
+        let body = format!(
+            r#"{{"burn_tx_hash":"{:#x}","reason":"burn confirmed on-chain"}}"#,
+            persisted_tx.hash
+        );
 
         let (status, body) =
-            dispatch_force_complete(rocket, &metadata.issuer_request_id, body)
+            dispatch_force_complete(rocket, &metadata.issuer_request_id, &body)
                 .await;
 
         assert_eq!(status, Status::Ok);
         // Response reports the proven block and the true previous state.
         assert!(body.contains("Force-completed"), "body: {body}");
         assert!(body.contains("45989009"), "body: {body}");
-        assert!(body.contains("Burning"), "body: {body}");
+        assert!(body.contains("BurnIntended"), "body: {body}");
         assert_eq!(burn_recovery.force_calls(), 1);
         assert!(logs_contain_at!(Level::INFO, &["Redemption force-completed"]));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ use sqlx::sqlite::{
 use sqlx::{Pool, Sqlite};
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::{sync::Arc, time::Duration};
+use std::{future::Future, sync::Arc, time::Duration};
 use tokio::time::MissedTickBehavior;
 use tracing::{debug, error, info, trace, warn};
 
@@ -350,7 +350,7 @@ pub async fn initialize_rocket(
     // synchronous startup re-scan above finishes, so a mint is never driven by
     // two recovery drivers at once: the re-scan reads recoverable mints
     // independently of the Jobs table, so a worker draining a leftover job
-    // from t=0 would execute the same external side effects (Fireblocks
+    // from t=0 would execute the same external side effects (transaction
     // submission, Alpaca callback) for the same mint concurrently with the
     // re-scan. The only cost is that jobs enqueued by the re-scan start
     // draining moments later.
@@ -365,6 +365,7 @@ pub async fn initialize_rocket(
     // time), so a stranded mint is picked up promptly at startup and then once
     // per interval instead of waiting for the next process restart.
     spawn_mint_recovery_reconciler(pool.clone(), apalis_pool.clone());
+    spawn_burn_recovery_reconciler(managers.burn.clone());
 
     spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
         pool: pool.clone(),
@@ -779,6 +780,7 @@ async fn run_mint_recovery(
 
 /// Interval between periodic mint-recovery reconciliation passes.
 const MINT_RECOVERY_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
+const BURN_RECOVERY_RECONCILE_INTERVAL: Duration = Duration::from_secs(300);
 
 /// Periodically re-enqueues recoverable mints that lack a recovery job, closing
 /// the window where a mint whose enqueue failed (a transient SQLite outage at
@@ -797,6 +799,29 @@ fn spawn_mint_recovery_reconciler(
     });
 }
 
+async fn run_burn_recovery_reconciler<Recover, RecoveryFuture>(
+    interval: Duration,
+    mut recover: Recover,
+) where
+    Recover: FnMut() -> RecoveryFuture,
+    RecoveryFuture: Future<Output = ()>,
+{
+    loop {
+        tokio::time::sleep(interval).await;
+        recover().await;
+    }
+}
+
+fn spawn_burn_recovery_reconciler(burn: Arc<BurnManager>) {
+    tokio::spawn(async move {
+        run_burn_recovery_reconciler(BURN_RECOVERY_RECONCILE_INTERVAL, || {
+            let burn = burn.clone();
+            async move { burn.recover_unresolved_burns().await }
+        })
+        .await;
+    });
+}
+
 async fn run_redemption_recovery(
     redeem_call: &RedeemCallManager,
     journal: &JournalManager,
@@ -807,8 +832,7 @@ async fn run_redemption_recovery(
 
     redeem_call.recover_detected_redemptions().await;
     journal.recover_alpaca_called_redemptions().await;
-    burn.recover_burning_redemptions().await;
-    burn.recover_burn_failed_redemptions().await;
+    burn.recover_unresolved_burns().await;
     // Runs last, after the recovery passes above have re-confirmed in-flight
     // burns. It only SETTLES reservations whose redemption confirmed
     // (Completed) but whose settlement was missed; ambiguous/in-flight
@@ -1362,12 +1386,55 @@ mod tests {
     use rust_decimal::Decimal;
     use std::collections::HashMap;
     use std::str::FromStr;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+    use tokio::sync::Notify;
 
     use super::{
-        Environment, Quantity, QuantityConversionError, ReceiptContractAddress,
-        VaultAddress, cached_receipt_contract, mount_api_docs,
-        next_receipt_backfill_block,
+        BURN_RECOVERY_RECONCILE_INTERVAL, Environment, Quantity,
+        QuantityConversionError, ReceiptContractAddress, VaultAddress,
+        cached_receipt_contract, mount_api_docs, next_receipt_backfill_block,
+        run_burn_recovery_reconciler,
     };
+
+    #[tokio::test]
+    async fn burn_recovery_reconciler_repeats_after_each_interval() {
+        assert_eq!(BURN_RECOVERY_RECONCILE_INTERVAL, Duration::from_secs(300));
+        let calls = Arc::new(AtomicUsize::new(0));
+        let two_calls = Arc::new(Notify::new());
+        let task_calls = calls.clone();
+        let task_two_calls = two_calls.clone();
+        let task = tokio::spawn(run_burn_recovery_reconciler(
+            Duration::from_millis(20),
+            move || {
+                let task_calls = task_calls.clone();
+                let task_two_calls = task_two_calls.clone();
+                async move {
+                    if task_calls.fetch_add(1, Ordering::SeqCst) + 1 == 2 {
+                        task_two_calls.notify_one();
+                    }
+                }
+            },
+        ));
+
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(5),
+                two_calls.notified()
+            )
+            .await
+            .is_err(),
+            "reconciler must not run before its interval"
+        );
+
+        tokio::time::timeout(Duration::from_secs(1), two_calls.notified())
+            .await
+            .expect("reconciler should run more than once");
+        task.abort();
+
+        assert!(calls.load(Ordering::SeqCst) >= 2);
+    }
 
     /// The receipt-contract cache must resolve once on-chain and serve every
     /// subsequent call from memory — a receipt contract is immutable per vault,

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -4,14 +4,15 @@ use event_sorcery::{LifecycleError, Store};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
 use super::view::{
     RedemptionView, RedemptionViewError, find_burn_failed, find_burning,
 };
 use super::{
-    BurnExternalTxId, IssuerRedemptionRequestId, Redemption, RedemptionCommand,
-    RedemptionError, RedemptionEvent,
+    BurnExternalTxId, BurnRecoveryAction, IssuerRedemptionRequestId,
+    Redemption, RedemptionCommand, RedemptionError, RedemptionEvent,
     next_burn_retry_external_tx_id_from_history,
 };
 use crate::mint::{QuantityConversionError, has_unresolved_mint_intent};
@@ -27,10 +28,53 @@ use crate::tokenized_asset::view::{
     TokenizedAssetViewError, find_vault_by_underlying,
 };
 use crate::vault::{
-    BurnVerification, MultiBurnEntry, TxId, VaultError, VaultService,
+    BurnTxStatus, BurnVerification, MultiBurnEntry, SendableTxWithHash, TxId,
+    VaultError, VaultService,
 };
 
 const WALLET_INTENT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
+pub(crate) const MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS: u32 = 5;
+
+#[derive(Debug, Clone, Copy)]
+struct BurnRecoveryBudget {
+    attempts: u32,
+    exhausted: bool,
+    last_transaction: Option<(B256, u64)>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingBurnRecovery {
+    Reserved(BurnRecoveryAction),
+    ReplacementPrepared,
+}
+
+fn recovery_burn_entries(planned_burns: &[BurnRecord]) -> Vec<MultiBurnEntry> {
+    planned_burns
+        .iter()
+        .map(|burn| MultiBurnEntry {
+            receipt_id: burn.receipt_id,
+            burn_shares: burn.shares_burned,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        })
+        .collect()
+}
+
+const fn recovery_action_for_status(
+    status: BurnTxStatus,
+) -> Option<BurnRecoveryAction> {
+    match status {
+        BurnTxStatus::StillMineable => Some(BurnRecoveryAction::Rebroadcast),
+        BurnTxStatus::ProvablyDead => Some(BurnRecoveryAction::Replace),
+        BurnTxStatus::Mined | BurnTxStatus::Reverted => None,
+    }
+}
+
+fn terminal_classification_error() -> BurnManagerError {
+    BurnManagerError::InvalidAggregateState {
+        current_state: "terminal burn classification".to_string(),
+    }
+}
 
 /// Outcome of recovering a single redemption stuck in a burning state.
 ///
@@ -59,6 +103,7 @@ pub(crate) enum RecoveryOutcome {
 /// handler calls the vault service to perform the actual burn operation.
 ///
 /// On burn failure, the manager issues a `RecordBurnFailure` command to record the error.
+#[derive(Clone)]
 pub(crate) struct BurnManager {
     /// Used only for balance queries during recovery (not for burns - those go through aggregate)
     vault_service: Arc<dyn VaultService>,
@@ -66,6 +111,7 @@ pub(crate) struct BurnManager {
     store: Arc<Store<Redemption>>,
     receipt_service: Arc<dyn ReceiptService>,
     bot_wallet: Address,
+    automatic_recovery_lock: Arc<Mutex<()>>,
 }
 
 impl BurnManager {
@@ -86,7 +132,23 @@ impl BurnManager {
         receipt_service: Arc<dyn ReceiptService>,
         bot_wallet: Address,
     ) -> Self {
-        Self { vault_service, view_pool, store, receipt_service, bot_wallet }
+        Self {
+            vault_service,
+            view_pool,
+            store,
+            receipt_service,
+            bot_wallet,
+            automatic_recovery_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Runs one complete automatic recovery pass for every unresolved burn
+    /// state. Startup and the periodic reconciler share this entry point so a
+    /// reverted transaction that advances from `Burning` to `BurnFailed` is
+    /// retried in the same pass.
+    pub(crate) async fn recover_unresolved_burns(&self) {
+        self.recover_burning_redemptions().await;
+        self.recover_burn_failed_redemptions().await;
     }
 
     /// Recovers redemptions stuck in the `Burning` state at startup.
@@ -94,7 +156,7 @@ impl BurnManager {
     /// Queries the view for all redemptions in `Burning` state and resumes
     /// the burn process for each. This handles cases where the bot crashed
     /// after Alpaca journal completion but before burn was executed.
-    pub(crate) async fn recover_burning_redemptions(&self) {
+    async fn recover_burning_redemptions(&self) {
         let stuck_redemptions = match find_burning(&self.view_pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
@@ -128,7 +190,7 @@ impl BurnManager {
     ///
     /// Queries the view for all redemptions where burn failed and retries
     /// the burn process for each using metadata preserved in the view.
-    pub(crate) async fn recover_burn_failed_redemptions(&self) {
+    async fn recover_burn_failed_redemptions(&self) {
         let failed_redemptions = match find_burn_failed(&self.view_pool).await {
             Ok(redemptions) => redemptions,
             Err(err) => {
@@ -178,9 +240,10 @@ impl BurnManager {
     /// completion would. Returns the on-chain verification so the caller can
     /// report the proven block number and burned shares.
     ///
-    /// Ambiguous cases with no verifiable on-chain burn fail here (`NotABurn`)
-    /// and must be resolved via `CloseRedemption` (or off-chain reconciliation)
-    /// instead — they are never silently force-completed.
+    /// The supplied hash must match this redemption's non-empty persisted exact
+    /// transaction before on-chain verification. Ambiguous or legacy states
+    /// without that identity must be resolved via `CloseRedemption` after
+    /// off-chain reconciliation — they are never silently force-completed.
     pub(crate) async fn force_complete_burn(
         &self,
         issuer_request_id: &IssuerRedemptionRequestId,
@@ -193,6 +256,18 @@ impl BurnManager {
                     current_state: "Uninitialized".to_string(),
                 }
             })?;
+
+        let persisted_burn_tx = redemption.persisted_burn_tx()?;
+        persisted_burn_tx.validate_for_owner(self.bot_wallet)?;
+        let persisted_burn_hash = persisted_burn_tx.hash;
+        if persisted_burn_hash != burn_tx_hash {
+            return Err(BurnManagerError::Redemption(
+                RedemptionError::BurnHashMismatch {
+                    expected: persisted_burn_hash,
+                    provided: burn_tx_hash,
+                },
+            ));
+        }
 
         let underlying = match &redemption {
             Redemption::Burning { metadata, .. }
@@ -368,6 +443,26 @@ impl BurnManager {
             return Ok(());
         };
 
+        let replacement_already_reserved =
+            self.failed_replacement_already_reserved(issuer_request_id).await?;
+        let preparation_already_reserved =
+            self.failed_preparation_already_reserved(issuer_request_id).await?;
+        let recovery_allowed = if replacement_already_reserved
+            || preparation_already_reserved
+        {
+            true
+        } else if tx_id.is_none() {
+            self.reserve_preparation_recovery_attempt(issuer_request_id).await?
+        } else {
+            self.recovery_budget_available(issuer_request_id, None).await?
+        };
+        if !recovery_allowed {
+            debug!(target: "redemption", issuer_request_id = %issuer_request_id,
+                "Skipping BurnFailed redemption with exhausted automatic recovery budget"
+            );
+            return Ok(());
+        }
+
         let vault = find_vault_by_underlying(&self.view_pool, underlying)
             .await?
             .ok_or_else(|| BurnManagerError::AssetNotFound {
@@ -485,6 +580,61 @@ impl BurnManager {
         Ok(())
     }
 
+    async fn failed_replacement_already_reserved(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<bool, BurnManagerError> {
+        let aggregate_id = issuer_request_id.to_string();
+        let payloads = sqlx::query_scalar::<_, String>(
+            "
+            SELECT payload
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+            ORDER BY sequence DESC
+            LIMIT 2
+            ",
+        )
+        .bind(aggregate_id)
+        .fetch_all(&self.view_pool)
+        .await?;
+        let events = payloads
+            .iter()
+            .map(|payload| serde_json::from_str::<RedemptionEvent>(payload))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(matches!(
+            events.as_slice(),
+            [
+                RedemptionEvent::BurningFailed { .. },
+                RedemptionEvent::BurnRecoveryAttempted {
+                    action: BurnRecoveryAction::Replace,
+                    ..
+                }
+            ]
+        ))
+    }
+
+    async fn failed_preparation_already_reserved(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<bool, BurnManagerError> {
+        let latest_event = sqlx::query_scalar::<_, String>(
+            "
+            SELECT event_type
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+            ORDER BY sequence DESC
+            LIMIT 1
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_optional(&self.view_pool)
+        .await?;
+
+        Ok(latest_event.as_deref()
+            == Some("RedemptionEvent::BurnPreparationRecoveryAttempted"))
+    }
+
     /// Recovers a BurnFailed redemption that has a previously submitted
     /// transaction. Tries to confirm the existing transaction rather than resubmitting.
     async fn recover_burn_failed_with_existing_tx(
@@ -585,7 +735,7 @@ impl BurnManager {
         tx_id: &TxId,
         dust_shares: U256,
         planned_burns: &[BurnRecord],
-        recovery_state: BurnRecoveryState,
+        has_submitted: bool,
     ) -> Result<RecoveryOutcome, BurnManagerError> {
         let vault =
             find_vault_by_underlying(&self.view_pool, &metadata.underlying)
@@ -594,7 +744,7 @@ impl BurnManager {
                     underlying: metadata.underlying.clone(),
                 })?;
 
-        if recovery_state == BurnRecoveryState::Submitted {
+        if has_submitted {
             info!(target: "redemption", issuer_request_id = %issuer_request_id,
                 tx_id = %tx_id,
                 "Recovering BurnSubmitted redemption - confirming existing transaction"
@@ -635,7 +785,7 @@ impl BurnManager {
                     ..
                 },
             ))) => {
-                if recovery_state == BurnRecoveryState::Submitted {
+                if has_submitted {
                     warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                         error = %err,
                         "Burn confirmation failed during recovery"
@@ -648,6 +798,9 @@ impl BurnManager {
                 }
 
                 if release_reservation {
+                    let exact_recovery = self
+                        .reserve_replacement_after_revert(issuer_request_id)
+                        .await?;
                     // Release before terminalizing the redemption. A crash
                     // after this idempotent release leaves the aggregate in
                     // its recoverable state, so the same transaction is
@@ -655,19 +808,26 @@ impl BurnManager {
                     // reservation because burning-state recovery would no
                     // longer revisit the aggregate.
                     self.release_reserved_burn(vault, issuer_request_id).await;
+                    self.store
+                        .send(
+                            issuer_request_id,
+                            RedemptionCommand::RecordBurnFailure {
+                                issuer_request_id: issuer_request_id.clone(),
+                                error: err.clone(),
+                                tx_id: exact_recovery
+                                    .is_none()
+                                    .then(|| tx_id.clone()),
+                                planned_burns: planned_burns.to_vec(),
+                            },
+                        )
+                        .await?;
+                } else {
+                    warn!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tx_id = %tx_id,
+                        "Burn confirmation remains uncertain; keeping persisted transaction recoverable"
+                    );
                 }
-
-                self.store
-                    .send(
-                        issuer_request_id,
-                        RedemptionCommand::RecordBurnFailure {
-                            issuer_request_id: issuer_request_id.clone(),
-                            error: err.clone(),
-                            tx_id: Some(tx_id.clone()),
-                            planned_burns: planned_burns.to_vec(),
-                        },
-                    )
-                    .await?;
 
                 Err(BurnManagerError::Redemption(RedemptionError::Vault {
                     message: err,
@@ -677,6 +837,266 @@ impl BurnManager {
             }
             Err(err) => Err(err.into()),
         }
+    }
+
+    async fn recover_persisted_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        metadata: &RedemptionMetadata,
+        planned_burns: &[BurnRecord],
+        sendable_tx: &SendableTxWithHash,
+        external_tx_id: Option<BurnExternalTxId>,
+        has_submitted: bool,
+    ) -> Result<RecoveryOutcome, BurnManagerError> {
+        let wallet_guard = self.vault_service.lock_wallet().await;
+        let current = self.store.load(issuer_request_id).await?;
+        let persisted_burn_matches = match &current {
+            Some(Redemption::BurnIntended {
+                sendable_tx: current_tx, ..
+            }) => !has_submitted && current_tx == sendable_tx,
+            Some(Redemption::BurnSubmitted {
+                sendable_tx: current_tx, ..
+            }) => has_submitted && current_tx == sendable_tx,
+            _ => false,
+        };
+        if !persisted_burn_matches {
+            debug!(target: "redemption",
+                issuer_request_id = %issuer_request_id,
+                expected_tx_hash = %sendable_tx.hash,
+                current_state = current
+                    .as_ref()
+                    .map_or("Missing", aggregate_state_name),
+                "Skipping stale persisted burn recovery"
+            );
+            drop(wallet_guard);
+            return Ok(RecoveryOutcome::AlreadyAdvanced);
+        }
+
+        let pending_recovery = self
+            .pending_recovery_action(issuer_request_id, sendable_tx)
+            .await?;
+        if let Some(outcome) = self
+            .exhausted_recovery_outcome(issuer_request_id, sendable_tx)
+            .await?
+        {
+            drop(wallet_guard);
+            return Ok(outcome);
+        }
+
+        let status = self
+            .vault_service
+            .classify_burn_tx(self.bot_wallet, sendable_tx)
+            .await?;
+        let tx_id = sendable_tx.hash.into();
+        if matches!(status, BurnTxStatus::Mined | BurnTxStatus::Reverted) {
+            drop(wallet_guard);
+            return self
+                .recover_single_burning_shared_inner(
+                    issuer_request_id,
+                    metadata,
+                    &tx_id,
+                    sendable_tx.dust_shares,
+                    planned_burns,
+                    has_submitted,
+                )
+                .await;
+        }
+        if pending_recovery == Some(PendingBurnRecovery::ReplacementPrepared)
+            && status == BurnTxStatus::StillMineable
+        {
+            self.submit_prepared_replacement(
+                issuer_request_id,
+                metadata,
+                planned_burns,
+                sendable_tx,
+                external_tx_id,
+            )
+            .await?;
+            drop(wallet_guard);
+            info!(target: "redemption",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %sendable_tx.hash,
+                "Submitted persisted replacement from reserved recovery action"
+            );
+            return Ok(RecoveryOutcome::Executed);
+        }
+
+        let action = recovery_action_for_status(status)
+            .ok_or_else(terminal_classification_error)?;
+        let action_already_reserved =
+            pending_recovery == Some(PendingBurnRecovery::Reserved(action));
+        let vault =
+            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+                .await?
+                .ok_or_else(|| BurnManagerError::AssetNotFound {
+                    underlying: metadata.underlying.clone(),
+                })?;
+        if !action_already_reserved
+            && !self
+                .recovery_budget_available(issuer_request_id, Some(sendable_tx))
+                .await?
+        {
+            drop(wallet_guard);
+            return Ok(RecoveryOutcome::SkippedManualIntervention);
+        }
+        if status == BurnTxStatus::ProvablyDead {
+            let unresolved_mint =
+                has_unresolved_mint_intent(&self.view_pool, None).await?;
+            let unresolved_burn = has_unresolved_burn_intent(
+                &self.view_pool,
+                Some(issuer_request_id),
+            )
+            .await?;
+            if unresolved_mint || unresolved_burn {
+                drop(wallet_guard);
+                debug!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %sendable_tx.hash,
+                    "Deferring dead burn replacement behind another persisted wallet intent"
+                );
+                return Ok(RecoveryOutcome::SkippedManualIntervention);
+            }
+        }
+        if !action_already_reserved
+            && !self
+                .reserve_recovery_attempt(
+                    issuer_request_id,
+                    sendable_tx,
+                    action,
+                )
+                .await?
+        {
+            drop(wallet_guard);
+            return Ok(RecoveryOutcome::SkippedManualIntervention);
+        }
+        if action_already_reserved {
+            info!(target: "redemption",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %sendable_tx.hash,
+                action = ?action,
+                "Resuming reserved burn recovery action"
+            );
+        }
+
+        let burns = recovery_burn_entries(planned_burns);
+        let command = match status {
+            BurnTxStatus::StillMineable => RedemptionCommand::BurnTokens {
+                issuer_request_id: issuer_request_id.clone(),
+                vault,
+                burns,
+                dust_shares: sendable_tx.dust_shares,
+                owner: self.bot_wallet,
+                external_tx_id,
+            },
+            BurnTxStatus::ProvablyDead => RedemptionCommand::ReplaceDeadBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                owner: self.bot_wallet,
+            },
+            BurnTxStatus::Mined | BurnTxStatus::Reverted => {
+                return Err(BurnManagerError::InvalidAggregateState {
+                    current_state: "terminal burn classification".to_string(),
+                });
+            }
+        };
+        let command_result = self.store.send(issuer_request_id, command).await;
+        if matches!(
+            command_result,
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                RedemptionError::BurnReplacementPreparationFailed { .. }
+            )))
+        ) && action == BurnRecoveryAction::Replace
+            && !self
+                .recovery_budget_available(issuer_request_id, Some(sendable_tx))
+                .await?
+        {
+            drop(wallet_guard);
+            return Ok(RecoveryOutcome::SkippedManualIntervention);
+        }
+        command_result?;
+
+        if status == BurnTxStatus::ProvablyDead {
+            let Some(Redemption::BurnIntended {
+                planned_burns,
+                sendable_tx,
+                external_tx_id,
+                ..
+            }) = self.store.load(issuer_request_id).await?
+            else {
+                return Err(BurnManagerError::InvalidAggregateState {
+                    current_state: "expected replacement BurnIntended"
+                        .to_string(),
+                });
+            };
+            let replacement_burns = recovery_burn_entries(&planned_burns);
+            self.store
+                .send(
+                    issuer_request_id,
+                    RedemptionCommand::BurnTokens {
+                        issuer_request_id: issuer_request_id.clone(),
+                        vault,
+                        burns: replacement_burns,
+                        dust_shares: sendable_tx.dust_shares,
+                        owner: self.bot_wallet,
+                        external_tx_id,
+                    },
+                )
+                .await?;
+        }
+        drop(wallet_guard);
+
+        info!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            tx_hash = %sendable_tx.hash,
+            action = ?action,
+            "Automatic burn recovery action accepted"
+        );
+        Ok(RecoveryOutcome::Executed)
+    }
+
+    async fn submit_prepared_replacement(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        metadata: &RedemptionMetadata,
+        planned_burns: &[BurnRecord],
+        sendable_tx: &SendableTxWithHash,
+        external_tx_id: Option<BurnExternalTxId>,
+    ) -> Result<(), BurnManagerError> {
+        let vault =
+            find_vault_by_underlying(&self.view_pool, &metadata.underlying)
+                .await?
+                .ok_or_else(|| BurnManagerError::AssetNotFound {
+                    underlying: metadata.underlying.clone(),
+                })?;
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::BurnTokens {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: recovery_burn_entries(planned_burns),
+                    dust_shares: sendable_tx.dust_shares,
+                    owner: self.bot_wallet,
+                    external_tx_id,
+                },
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn exhausted_recovery_outcome(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<Option<RecoveryOutcome>, BurnManagerError> {
+        if !self.burn_recovery_budget(issuer_request_id).await?.exhausted {
+            return Ok(None);
+        }
+        debug!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            tx_hash = %sendable_tx.hash,
+            "Skipping burn with exhausted automatic recovery budget"
+        );
+        Ok(Some(RecoveryOutcome::SkippedManualIntervention))
     }
 
     async fn recover_single_burning(
@@ -694,19 +1114,39 @@ impl BurnManager {
             // Already submitted to tx but never confirmed — resume polling
             Redemption::BurnSubmitted {
                 metadata,
-                tx_id,
-                dust_quantity,
                 planned_burns,
+                sendable_tx,
+                external_tx_id,
                 ..
             } => {
-                let dust_shares = dust_quantity.to_u256_with_18_decimals()?;
-                self.recover_single_burning_shared_inner(
+                if sendable_tx == &SendableTxWithHash::default() {
+                    let Redemption::BurnSubmitted {
+                        tx_id, dust_quantity, ..
+                    } = &aggregate
+                    else {
+                        return Err(BurnManagerError::InvalidAggregateState {
+                            current_state: aggregate_state_name(&aggregate)
+                                .to_string(),
+                        });
+                    };
+                    return self
+                        .recover_single_burning_shared_inner(
+                            issuer_request_id,
+                            metadata,
+                            tx_id,
+                            dust_quantity.to_u256_with_18_decimals()?,
+                            planned_burns,
+                            true,
+                        )
+                        .await;
+                }
+                self.recover_persisted_burn(
                     issuer_request_id,
                     metadata,
-                    tx_id,
-                    dust_shares,
                     planned_burns,
-                    BurnRecoveryState::Submitted,
+                    sendable_tx,
+                    Some(external_tx_id.clone()),
+                    true,
                 )
                 .await
             }
@@ -718,68 +1158,13 @@ impl BurnManager {
                 external_tx_id,
                 ..
             } => {
-                let vault = find_vault_by_underlying(
-                    &self.view_pool,
-                    &metadata.underlying,
-                )
-                .await?
-                .ok_or_else(|| {
-                    BurnManagerError::AssetNotFound {
-                        underlying: metadata.underlying.clone(),
-                    }
-                })?;
-                let dust_shares = sendable_tx.dust_shares;
-                let tx_id = TxId::Hash(sendable_tx.hash);
-
-                info!(target: "redemption",
-                    issuer_request_id = %issuer_request_id,
-                    tx_hash = %sendable_tx.hash,
-                    "Recovering BurnIntended redemption - re-broadcasting persisted transaction"
-                );
-
-                let burns = planned_burns
-                    .iter()
-                    .map(|burn| MultiBurnEntry {
-                        receipt_id: burn.receipt_id,
-                        burn_shares: burn.shares_burned,
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    })
-                    .collect();
-                let wallet_guard = self.vault_service.lock_wallet().await;
-                let submit_result = self
-                    .store
-                    .send(
-                        issuer_request_id,
-                        RedemptionCommand::BurnTokens {
-                            issuer_request_id: issuer_request_id.clone(),
-                            vault,
-                            burns,
-                            dust_shares,
-                            owner: self.bot_wallet,
-                            external_tx_id: external_tx_id.clone(),
-                        },
-                    )
-                    .await;
-                drop(wallet_guard);
-
-                if let Err(error) = submit_result {
-                    warn!(target: "redemption",
-                        issuer_request_id = %issuer_request_id,
-                        tx_hash = %sendable_tx.hash,
-                        error = %error,
-                        "Persisted burn transaction re-broadcast failed; keeping BurnIntended for recovery"
-                    );
-                    return Err(error.into());
-                }
-
-                self.recover_single_burning_shared_inner(
+                self.recover_persisted_burn(
                     issuer_request_id,
                     metadata,
-                    &tx_id,
-                    dust_shares,
                     planned_burns,
-                    BurnRecoveryState::Intended,
+                    sendable_tx,
+                    external_tx_id.clone(),
+                    false,
                 )
                 .await
             }
@@ -1011,6 +1396,294 @@ impl BurnManager {
             detected_tx_hash,
             events.iter(),
         )?)
+    }
+
+    async fn burn_recovery_budget(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<BurnRecoveryBudget, BurnManagerError> {
+        let aggregate_id = issuer_request_id.to_string();
+        let payloads = sqlx::query_scalar::<_, String>(
+            "
+            SELECT payload
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type IN (
+                  'RedemptionEvent::BurnRecoveryAttempted',
+                  'RedemptionEvent::BurnPreparationRecoveryAttempted',
+                  'RedemptionEvent::BurnRecoveryExhausted',
+                  'RedemptionEvent::BurnPreparationRecoveryExhausted'
+              )
+            ORDER BY sequence
+            ",
+        )
+        .bind(aggregate_id)
+        .fetch_all(&self.view_pool)
+        .await?;
+
+        let mut budget = BurnRecoveryBudget {
+            attempts: 0,
+            exhausted: false,
+            last_transaction: None,
+        };
+        for payload in payloads {
+            match serde_json::from_str::<RedemptionEvent>(&payload)? {
+                RedemptionEvent::BurnRecoveryAttempted {
+                    tx_hash,
+                    nonce,
+                    ..
+                } => {
+                    budget.attempts =
+                        budget.attempts.checked_add(1).ok_or_else(|| {
+                            BurnManagerError::RecoveryAttemptOverflow {
+                                issuer_request_id: issuer_request_id.clone(),
+                            }
+                        })?;
+                    budget.last_transaction = Some((tx_hash, nonce));
+                }
+                RedemptionEvent::BurnPreparationRecoveryAttempted {
+                    ..
+                } => {
+                    budget.attempts =
+                        budget.attempts.checked_add(1).ok_or_else(|| {
+                            BurnManagerError::RecoveryAttemptOverflow {
+                                issuer_request_id: issuer_request_id.clone(),
+                            }
+                        })?;
+                }
+                RedemptionEvent::BurnRecoveryExhausted {
+                    tx_hash,
+                    nonce,
+                    ..
+                } => {
+                    budget.exhausted = true;
+                    budget.last_transaction = Some((tx_hash, nonce));
+                }
+                RedemptionEvent::BurnPreparationRecoveryExhausted {
+                    ..
+                } => {
+                    budget.exhausted = true;
+                }
+                _ => {}
+            }
+        }
+
+        Ok(budget)
+    }
+
+    async fn pending_recovery_action(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<Option<PendingBurnRecovery>, BurnManagerError> {
+        let payloads = sqlx::query_scalar::<_, String>(
+            "
+            SELECT payload
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type IN (
+                  'RedemptionEvent::BurnRecoveryAttempted',
+                  'RedemptionEvent::BurnRecoveryExhausted',
+                  'RedemptionEvent::BurnIntended',
+                  'RedemptionEvent::BurnTxSubmitted',
+                  'RedemptionEvent::BurningFailed'
+              )
+            ORDER BY sequence DESC
+            LIMIT 2
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_all(&self.view_pool)
+        .await?;
+        let events = payloads
+            .iter()
+            .map(|payload| serde_json::from_str::<RedemptionEvent>(payload))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(match events.as_slice() {
+            [
+                RedemptionEvent::BurnRecoveryAttempted {
+                    tx_hash,
+                    nonce,
+                    action,
+                    ..
+                },
+                ..,
+            ] if *tx_hash == sendable_tx.hash
+                && *nonce == sendable_tx.nonce =>
+            {
+                Some(PendingBurnRecovery::Reserved(*action))
+            }
+            [
+                RedemptionEvent::BurnIntended {
+                    sendable_tx: replacement, ..
+                },
+                RedemptionEvent::BurnRecoveryAttempted {
+                    action: BurnRecoveryAction::Replace,
+                    ..
+                },
+            ] if replacement == sendable_tx => {
+                Some(PendingBurnRecovery::ReplacementPrepared)
+            }
+            _ => None,
+        })
+    }
+
+    async fn recovery_budget_available(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        current_transaction: Option<&SendableTxWithHash>,
+    ) -> Result<bool, BurnManagerError> {
+        let _guard = self.automatic_recovery_lock.lock().await;
+        let budget = self.burn_recovery_budget(issuer_request_id).await?;
+        if budget.exhausted {
+            return Ok(false);
+        }
+        if budget.attempts < MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS {
+            return Ok(true);
+        }
+
+        let transaction = current_transaction
+            .map(|transaction| (transaction.hash, transaction.nonce))
+            .or(budget.last_transaction);
+        if let Some((tx_hash, nonce)) = transaction {
+            self.persist_recovery_exhaustion(
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                budget.attempts,
+            )
+            .await?;
+        } else {
+            self.persist_preparation_recovery_exhaustion(
+                issuer_request_id,
+                budget.attempts,
+            )
+            .await?;
+        }
+        Ok(false)
+    }
+
+    async fn reserve_preparation_recovery_attempt(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<bool, BurnManagerError> {
+        let _guard = self.automatic_recovery_lock.lock().await;
+        let budget = self.burn_recovery_budget(issuer_request_id).await?;
+        if budget.exhausted {
+            return Ok(false);
+        }
+        if budget.attempts >= MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS {
+            self.persist_preparation_recovery_exhaustion(
+                issuer_request_id,
+                budget.attempts,
+            )
+            .await?;
+            return Ok(false);
+        }
+        let attempt = budget.attempts.checked_add(1).ok_or_else(|| {
+            BurnManagerError::RecoveryAttemptOverflow {
+                issuer_request_id: issuer_request_id.clone(),
+            }
+        })?;
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::RecordBurnPreparationRecoveryAttempt {
+                    issuer_request_id: issuer_request_id.clone(),
+                    attempt,
+                },
+            )
+            .await?;
+        Ok(true)
+    }
+
+    async fn reserve_recovery_attempt(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: &SendableTxWithHash,
+        action: BurnRecoveryAction,
+    ) -> Result<bool, BurnManagerError> {
+        let _guard = self.automatic_recovery_lock.lock().await;
+        let budget = self.burn_recovery_budget(issuer_request_id).await?;
+        if budget.exhausted {
+            return Ok(false);
+        }
+        if budget.attempts >= MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS {
+            self.persist_recovery_exhaustion(
+                issuer_request_id,
+                sendable_tx.hash,
+                sendable_tx.nonce,
+                budget.attempts,
+            )
+            .await?;
+            return Ok(false);
+        }
+
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::RecordBurnRecoveryAttempt {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tx_hash: sendable_tx.hash,
+                    nonce: sendable_tx.nonce,
+                    action,
+                },
+            )
+            .await?;
+        Ok(true)
+    }
+
+    async fn persist_recovery_exhaustion(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        attempts: u32,
+    ) -> Result<(), BurnManagerError> {
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::RecordBurnRecoveryExhausted {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tx_hash,
+                    nonce,
+                    attempts,
+                },
+            )
+            .await?;
+        error!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            tx_hash = %tx_hash,
+            nonce,
+            attempts,
+            operator_action = "inspect the transaction; force-complete a verified landed burn, otherwise close after reconciliation",
+            "Automatic burn recovery exhausted"
+        );
+        Ok(())
+    }
+
+    async fn persist_preparation_recovery_exhaustion(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        attempts: u32,
+    ) -> Result<(), BurnManagerError> {
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::RecordBurnPreparationRecoveryExhausted {
+                    issuer_request_id: issuer_request_id.clone(),
+                    attempts,
+                },
+            )
+            .await?;
+        error!(target: "redemption",
+            issuer_request_id = %issuer_request_id,
+            attempts,
+            operator_action = "inspect repeated burn preparation failures before manual recovery",
+            "Automatic burn preparation recovery exhausted"
+        );
+        Ok(())
     }
 
     async fn plan_burn(
@@ -1422,23 +2095,34 @@ impl BurnManager {
                     "Burn confirmation failed"
                 );
                 if release_reservation {
+                    let exact_recovery = self
+                        .reserve_replacement_after_revert(issuer_request_id)
+                        .await?;
                     self.release_before_terminal_failure(
                         execution.vault,
                         issuer_request_id,
                     )
                     .await;
+                    self.store
+                        .send(
+                            issuer_request_id,
+                            RedemptionCommand::RecordBurnFailure {
+                                issuer_request_id: issuer_request_id.clone(),
+                                error: message.clone(),
+                                tx_id: exact_recovery
+                                    .is_none()
+                                    .then(|| tx_id.clone()),
+                                planned_burns: execution.planned_burns.clone(),
+                            },
+                        )
+                        .await?;
+                } else {
+                    warn!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tx_id = %tx_id,
+                        "Burn confirmation remains uncertain; periodic recovery will retry"
+                    );
                 }
-                self.store
-                    .send(
-                        issuer_request_id,
-                        RedemptionCommand::RecordBurnFailure {
-                            issuer_request_id: issuer_request_id.clone(),
-                            error: message.clone(),
-                            tx_id: Some(tx_id),
-                            planned_burns: execution.planned_burns.clone(),
-                        },
-                    )
-                    .await?;
 
                 Err(BurnManagerError::Redemption(RedemptionError::Vault {
                     message,
@@ -1460,6 +2144,31 @@ impl BurnManager {
         // Recording failure first could strand the reservation because
         // burning-state recovery would no longer revisit the aggregate.
         self.release_reserved_burn(vault, issuer_request_id).await;
+    }
+
+    /// Reserves the recovery action that may sign a fresh transaction after a
+    /// proven revert. `None` means this is a legacy state without trustworthy
+    /// persisted bytes, so automatic replacement must remain disabled.
+    async fn reserve_replacement_after_revert(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Result<Option<bool>, BurnManagerError> {
+        let Some(redemption) = self.store.load(issuer_request_id).await? else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: "Uninitialized".to_string(),
+            });
+        };
+        let Ok(sendable_tx) = redemption.persisted_burn_tx() else {
+            return Ok(None);
+        };
+
+        self.reserve_recovery_attempt(
+            issuer_request_id,
+            sendable_tx,
+            BurnRecoveryAction::Replace,
+        )
+        .await
+        .map(Some)
     }
 
     /// Reserves planned burns, retrying a bounded number of times on an
@@ -1595,12 +2304,6 @@ impl BurnExecutionPlan {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum BurnRecoveryState {
-    Intended,
-    Submitted,
-}
-
 const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
     match aggregate {
         Redemption::Detected { .. } => "Detected",
@@ -1673,6 +2376,8 @@ pub(crate) enum BurnManagerError {
         "Timed out waiting to prepare burn for redemption {issuer_request_id} behind an earlier wallet intent"
     )]
     WalletIntentWaitTimeout { issuer_request_id: IssuerRedemptionRequestId },
+    #[error("Burn recovery attempt counter overflowed for {issuer_request_id}")]
+    RecoveryAttemptOverflow { issuer_request_id: IssuerRedemptionRequestId },
 }
 
 #[cfg(test)]
@@ -1681,34 +2386,36 @@ mod tests {
     use chrono::Utc;
     use event_sorcery::{Store, StoreBuilder, test_store};
     use rust_decimal::Decimal;
-    use sqlx::sqlite::SqlitePoolOptions;
+    use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use std::sync::Arc;
     use std::time::Duration;
     use tracing_test::traced_test;
 
     use super::{
-        BurnManager, BurnManagerError, RecoveryOutcome, Redemption,
-        RedemptionCommand, should_release_reserved_burn,
+        BurnManager, BurnManagerError, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+        RecoveryOutcome, Redemption, RedemptionCommand,
+        should_release_reserved_burn,
     };
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Network, Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
-        CqrsReceiptService, ReceiptId, ReceiptInventory,
+        BurnTrackingError, CqrsReceiptService, ReceiptId, ReceiptInventory,
         ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::view::{RedemptionViewReactor, find_burn_failed};
     use crate::redemption::{
-        BurnRecord, IssuerRedemptionRequestId, RedemptionError,
+        BurnRecord, BurnRecoveryAction, IssuerRedemptionRequestId,
+        RedemptionError,
     };
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
         TokenSymbol, TokenizedAsset, TokenizedAssetCommand, UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        MultiBurnEntry, ReceiptInformation, SendableTxWithHash, TxId,
-        VaultError, VaultService,
+        BurnTxStatus, MultiBurnEntry, ReceiptInformation, SendableTxWithHash,
+        TxId, VaultError, VaultService,
     };
 
     const TEST_WALLET: Address =
@@ -1776,6 +2483,13 @@ mod tests {
                 .await
                 .expect("Failed to create in-memory database");
 
+            Self::with_pool(vault_mock, pool).await
+        }
+
+        async fn with_pool(
+            vault_mock: Arc<MockVaultService>,
+            pool: SqlitePool,
+        ) -> Self {
             sqlx::migrate!("./migrations")
                 .run(&pool)
                 .await
@@ -1927,6 +2641,56 @@ mod tests {
         issuer_request_id: &IssuerRedemptionRequestId,
     ) -> Redemption {
         store.load(issuer_request_id).await.unwrap().unwrap()
+    }
+
+    async fn persist_test_burn_intent(
+        store: &Store<Redemption>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        vault: Address,
+        owner: Address,
+    ) {
+        store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(42_U256),
+                        burn_shares: uint!(17_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("persisted burn intent should succeed");
+    }
+
+    async fn record_test_recovery_attempts(
+        store: &Store<Redemption>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: &SendableTxWithHash,
+        action: BurnRecoveryAction,
+        count: u32,
+    ) {
+        for _ in 0..count {
+            store
+                .send(
+                    issuer_request_id,
+                    RedemptionCommand::RecordBurnRecoveryAttempt {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tx_hash: sendable_tx.hash,
+                        nonce: sendable_tx.nonce,
+                        action,
+                    },
+                )
+                .await
+                .expect("recovery attempt should persist");
+        }
     }
 
     #[tokio::test]
@@ -2095,14 +2859,21 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_force_complete_burn_records_verified_burn() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
         let vault_mock = Arc::new(
             MockVaultService::new_success()
-                .with_verified_burn(45_989_009, uint!(17_U256)),
+                .with_verified_burn(45_989_009, uint!(17_U256))
+                .with_prepared_tx(persisted_tx.clone()),
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let underlying = UnderlyingSymbol::new("AAPL");
         harness.add_asset(&underlying, vault).await;
 
@@ -2113,13 +2884,12 @@ mod tests {
             pool.clone(),
             store.clone(),
             receipt_service.clone(),
-            TEST_WALLET,
+            owner,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-
         // Seed a held reservation so the test fails if force-complete stops
         // settling inventory after terminalizing the aggregate.
         harness
@@ -2145,10 +2915,9 @@ mod tests {
             vec![issuer_request_id.clone()],
             "reservation should be held before force-complete"
         );
+        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
 
-        let burn_tx_hash = b256!(
-            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-        );
+        let burn_tx_hash = persisted_tx.hash;
 
         let verification = manager
             .force_complete_burn(
@@ -2190,12 +2959,21 @@ mod tests {
 
     #[tokio::test]
     async fn test_force_complete_burn_rejects_unverifiable_burn() {
-        let vault_mock =
-            Arc::new(MockVaultService::new_success().with_unverifiable_burn());
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_unverifiable_burn()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let underlying = UnderlyingSymbol::new("AAPL");
         harness.add_asset(&underlying, vault).await;
 
@@ -2206,19 +2984,18 @@ mod tests {
             pool.clone(),
             store.clone(),
             receipt_service.clone(),
-            TEST_WALLET,
+            owner,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
 
         let result = manager
             .force_complete_burn(
                 &issuer_request_id,
-                b256!(
-                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-                ),
+                persisted_tx.hash,
                 "operator hash is not a burn".to_string(),
             )
             .await;
@@ -2229,22 +3006,31 @@ mod tests {
         ));
 
         // An unverifiable hash must NOT terminalize — the redemption stays
-        // Burning for manual reconciliation.
+        // BurnIntended for manual reconciliation.
         let updated = load_aggregate(store, &issuer_request_id).await;
         assert!(
-            matches!(updated, Redemption::Burning { .. }),
-            "Expected Burning state, got {updated:?}"
+            matches!(updated, Redemption::BurnIntended { .. }),
+            "Expected BurnIntended state, got {updated:?}"
         );
     }
 
     #[tokio::test]
     async fn test_force_complete_burn_rejects_reverted_tx() {
-        let vault_mock =
-            Arc::new(MockVaultService::new_success().with_reverted_burn());
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_reverted_burn()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
-        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let underlying = UnderlyingSymbol::new("AAPL");
         harness.add_asset(&underlying, vault).await;
 
@@ -2255,19 +3041,18 @@ mod tests {
             pool.clone(),
             store.clone(),
             receipt_service.clone(),
-            TEST_WALLET,
+            owner,
         );
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
 
         let result = manager
             .force_complete_burn(
                 &issuer_request_id,
-                b256!(
-                    "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-                ),
+                persisted_tx.hash,
                 "operator hash reverted".to_string(),
             )
             .await;
@@ -2279,9 +3064,48 @@ mod tests {
 
         let updated = load_aggregate(store, &issuer_request_id).await;
         assert!(
-            matches!(updated, Redemption::Burning { .. }),
-            "Expected Burning state, got {updated:?}"
+            matches!(updated, Redemption::BurnIntended { .. }),
+            "Expected BurnIntended state, got {updated:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_rejects_burning_without_persisted_hash() {
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burn(45_989_009, uint!(17_U256)),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                B256::random(),
+                "another redemption's verified burn".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::Redemption(
+                RedemptionError::PersistedBurnHashUnavailable
+            ))
+        ));
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::Burning { .. }
+        ));
     }
 
     #[tokio::test]
@@ -2593,7 +3417,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_handle_burning_started_with_blockchain_failure() {
+    async fn test_handle_burning_started_with_ambiguous_failure_stays_recoverable()
+     {
         let vault_mock = Arc::new(MockVaultService::new_failure());
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
@@ -2644,13 +3469,9 @@ mod tests {
 
         let updated_aggregate = load_aggregate(store, &issuer_request_id).await;
 
-        let Redemption::Failed { reason, .. } = updated_aggregate else {
-            panic!("Expected Failed state, got {updated_aggregate:?}");
-        };
-
         assert!(
-            reason.contains("Invalid receipt"),
-            "Expected error message to contain 'Invalid receipt', got: {reason}"
+            matches!(updated_aggregate, Redemption::BurnSubmitted { .. }),
+            "ambiguous confirmation must remain recoverable, got {updated_aggregate:?}"
         );
 
         // The confirmation failed with an ambiguous (non-terminal) error, so
@@ -2663,7 +3484,7 @@ mod tests {
                 .await
                 .unwrap()
                 .contains(&issuer_request_id),
-            "ambiguous burn failure must retain the reservation"
+            "ambiguous confirmation must retain the reservation"
         );
     }
 
@@ -3929,36 +4750,623 @@ mod tests {
 
     /// Recovery must re-broadcast the exact persisted transaction before
     /// confirming it, covering a crash after persistence but before broadcast.
+    async fn exhaust_restarted_recovery_budget(
+        manager: &BurnManager,
+        vault_mock: &MockVaultService,
+        receipt_service: &Arc<dyn ReceiptService>,
+        pool: &SqlitePool,
+        vault: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        transactions: (SendableTxWithHash, &SendableTxWithHash),
+    ) {
+        let (prepared_tx, replacement_tx) = transactions;
+        vault_mock.set_burn_tx_status(BurnTxStatus::StillMineable);
+
+        for _ in 0..3 {
+            assert!(matches!(
+                manager.recover_single_burning(issuer_request_id).await,
+                Ok(RecoveryOutcome::Executed)
+            ));
+        }
+        let classifications_at_cap =
+            vault_mock.burn_classification_call_count();
+        let replacements_at_cap =
+            vault_mock.replacement_preparation_call_count();
+        assert!(matches!(
+            manager.recover_single_burning(issuer_request_id).await,
+            Ok(RecoveryOutcome::SkippedManualIntervention)
+        ));
+        assert_eq!(
+            vault_mock.burn_classification_call_count(),
+            classifications_at_cap + 1,
+            "the fifth result must be classified before exhaustion is persisted"
+        );
+        assert_eq!(
+            vault_mock.replacement_preparation_call_count(),
+            replacements_at_cap,
+            "reaching the durable cap must not sign another transaction"
+        );
+        assert!(matches!(
+            manager.recover_single_burning(issuer_request_id).await,
+            Ok(RecoveryOutcome::SkippedManualIntervention)
+        ));
+        let classifications_after_exhaustion = classifications_at_cap + 1;
+        assert_eq!(
+            vault_mock.burn_classification_call_count(),
+            classifications_after_exhaustion,
+            "persisted exhaustion must skip classification RPCs"
+        );
+        assert_eq!(
+            vault_mock.replacement_preparation_call_count(),
+            replacements_at_cap,
+            "persisted exhaustion must skip replacement signing"
+        );
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            5,
+            "only five automatic recovery broadcasts are allowed"
+        );
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .expect("exhausted reservation query should succeed")
+                .contains(issuer_request_id),
+            "exhaustion must keep the receipt reservation held"
+        );
+        assert_eq!(
+            vault_mock.submitted_burn_txs(),
+            vec![
+                prepared_tx,
+                replacement_tx.clone(),
+                replacement_tx.clone(),
+                replacement_tx.clone(),
+                replacement_tx.clone(),
+            ]
+        );
+        let aggregate_id = issuer_request_id.to_string();
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(aggregate_id)
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion event count should load");
+        assert_eq!(exhaustion_events, 1);
+        assert_eq!(
+            log_count_at!(
+                tracing::Level::ERROR,
+                &[
+                    "Automatic burn recovery exhausted",
+                    &replacement_tx.hash.to_string(),
+                    "operator_action",
+                    "force-complete",
+                ]
+            ),
+            1,
+            "recovery exhaustion must emit one actionable error"
+        );
+    }
+
     #[traced_test]
     #[tokio::test]
-    async fn test_recover_burn_intended_rebroadcasts_persisted_transaction() {
-        let prepared_hash = b256!(
-            "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+    async fn persisted_burn_recovery_revalidates_state_under_wallet_lock() {
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
         );
-        let vault_mock =
-            Arc::new(MockVaultService::new_success().with_prepared_tx(
-                SendableTxWithHash {
-                    tx: vec![],
-                    hash: prepared_hash,
-                    nonce: 0,
-                    signed_at: Utc::now(),
-                    dust_shares: U256::ZERO,
-                },
-            ));
+        let vault_mock = Arc::new(
+            MockVaultService::new_wallet_lock_blocked()
+                .with_burn_tx_status(BurnTxStatus::StillMineable)
+                .with_prepared_tx(prepared_tx),
+        );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
-
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
+            .await;
 
-        let blockchain_service: Arc<dyn VaultService> = vault_mock.clone();
+        let stale = load_aggregate(store, &issuer_request_id).await;
+        let Redemption::BurnIntended {
+            metadata,
+            planned_burns,
+            sendable_tx,
+            external_tx_id,
+            ..
+        } = &stale
+        else {
+            panic!("expected persisted burn intent");
+        };
         let manager = BurnManager::new(
-            blockchain_service,
+            vault_mock.clone(),
             pool.clone(),
             store.clone(),
             receipt_service.clone(),
             TEST_WALLET,
         );
+        let recovery_manager = manager.clone();
+        let recovery_id = issuer_request_id.clone();
+        let recovery_metadata = metadata.clone();
+        let recovery_planned_burns = planned_burns.clone();
+        let recovery_sendable_tx = sendable_tx.clone();
+        let recovery_external_tx_id = external_tx_id.clone();
+        let persisted_owner = sendable_tx.signer_for_test();
+        let recovery = tokio::spawn(async move {
+            recovery_manager
+                .recover_persisted_burn(
+                    &recovery_id,
+                    &recovery_metadata,
+                    &recovery_planned_burns,
+                    &recovery_sendable_tx,
+                    recovery_external_tx_id,
+                    false,
+                )
+                .await
+        });
+        vault_mock.wait_for_wallet_lock_attempt().await;
+
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            1,
+            vault,
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        vault_mock.set_burn_tx_status(BurnTxStatus::ProvablyDead);
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::ReplaceDeadBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    owner: persisted_owner,
+                },
+            )
+            .await
+            .expect("concurrent replacement should persist a new transaction");
+        let classification_calls_after_replacement =
+            vault_mock.burn_classification_call_count();
+        vault_mock.release_wallet_lock();
+        let outcome = recovery
+            .await
+            .expect("recovery task should join")
+            .expect("stale recovery should be a safe no-op");
+
+        assert_eq!(outcome, RecoveryOutcome::AlreadyAdvanced);
+        assert_eq!(
+            vault_mock.burn_classification_call_count(),
+            classification_calls_after_replacement
+        );
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == replacement_tx
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Skipping stale persisted burn recovery", "BurnIntended"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn persisted_burn_confirmation_releases_wallet_lock() {
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_confirm_pending_blocked()
+                .with_burn_tx_status(BurnTxStatus::Mined)
+                .with_prepared_tx(prepared_tx),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
+            .await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let recovery_manager = manager.clone();
+        let recovery_id = issuer_request_id.clone();
+        let recovery = tokio::spawn(async move {
+            recovery_manager.recover_single_burning(&recovery_id).await
+        });
+
+        vault_mock.wait_for_burn_confirmation().await;
+        assert!(!recovery.is_finished());
+        let wallet_guard = tokio::time::timeout(
+            Duration::from_millis(50),
+            vault_mock.lock_wallet(),
+        )
+        .await
+        .expect("slow confirmation must not retain the wallet lock");
+        drop(wallet_guard);
+        vault_mock.release_burn_confirmation();
+
+        assert!(recovery.await.expect("recovery task should join").is_err());
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &[
+                "Recovering BurnIntended redemption",
+                "checking existing transaction"
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn restart_resumes_fifth_reserved_rebroadcast() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault,
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::StillMineable)
+                .with_prepared_tx(prepared_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
+            .await;
+        record_test_recovery_attempts(
+            store,
+            &issuer_request_id,
+            &prepared_tx,
+            BurnRecoveryAction::Rebroadcast,
+            MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+        )
+        .await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        let outcome = manager
+            .recover_single_burning(&issuer_request_id)
+            .await
+            .expect("reserved rebroadcast should resume");
+
+        assert_eq!(outcome, RecoveryOutcome::Executed);
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![prepared_tx]);
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnSubmitted { .. }
+        ));
+        vault_mock.set_burn_tx_status(BurnTxStatus::Mined);
+        let confirmation_outcome = manager
+            .recover_single_burning(&issuer_request_id)
+            .await
+            .expect("submitted fifth action should still be confirmed");
+        assert_eq!(confirmation_outcome, RecoveryOutcome::ExistingBurnRecorded);
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion count should load");
+        assert_eq!(exhaustion_events, 0);
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Resuming reserved burn recovery action", "Rebroadcast"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn restart_submits_fifth_prepared_replacement_without_new_attempt() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault,
+            Bytes::from_static(&[0x55, 0x66, 0x77]),
+        );
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            1,
+            vault,
+            Bytes::from_static(&[0x55, 0x66, 0x77]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        record_test_recovery_attempts(
+            store,
+            &issuer_request_id,
+            &persisted_tx,
+            BurnRecoveryAction::Replace,
+            MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+        )
+        .await;
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::ReplaceDeadBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    owner,
+                },
+            )
+            .await
+            .expect("replacement intent should persist before simulated crash");
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == replacement_tx
+        ));
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        vault_mock.set_burn_tx_status(BurnTxStatus::StillMineable);
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+
+        let outcome = manager
+            .recover_single_burning(&issuer_request_id)
+            .await
+            .expect("persisted replacement should submit after restart");
+
+        assert_eq!(outcome, RecoveryOutcome::Executed);
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![replacement_tx]);
+        let recovery_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("recovery attempt count should load");
+        assert_eq!(
+            recovery_attempts,
+            i64::from(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS)
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Submitted persisted replacement from reserved recovery action"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn fifth_prepared_replacement_consumed_while_down_is_exhausted() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault,
+            Bytes::from_static(&[0x11, 0x22, 0x33]),
+        );
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            1,
+            vault,
+            Bytes::from_static(&[0x11, 0x22, 0x33]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        record_test_recovery_attempts(
+            store,
+            &issuer_request_id,
+            &persisted_tx,
+            BurnRecoveryAction::Replace,
+            MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+        )
+        .await;
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::ReplaceDeadBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    owner,
+                },
+            )
+            .await
+            .expect("replacement intent should persist before simulated crash");
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+
+        let outcome = manager
+            .recover_single_burning(&issuer_request_id)
+            .await
+            .expect("consumed fifth replacement should exhaust recovery");
+
+        assert_eq!(outcome, RecoveryOutcome::SkippedManualIntervention);
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == replacement_tx
+        ));
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion count should load");
+        assert_eq!(exhaustion_events, 1);
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Automatic burn recovery exhausted", "attempts=5"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn fifth_replacement_preparation_failure_persists_exhaustion() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault,
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(prepared_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
+            .await;
+        record_test_recovery_attempts(
+            store,
+            &issuer_request_id,
+            &prepared_tx,
+            BurnRecoveryAction::Replace,
+            MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
+        )
+        .await;
+        vault_mock.reset();
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        assert_eq!(
+            manager
+                .recover_single_burning(&issuer_request_id)
+                .await
+                .expect("fifth preparation failure should exhaust recovery"),
+            RecoveryOutcome::SkippedManualIntervention
+        );
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 1);
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == prepared_tx
+        ));
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion count should load");
+        assert_eq!(exhaustion_events, 1);
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["Automatic burn recovery exhausted", "attempts=5"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_burn_intended_rebroadcasts_persisted_transaction() {
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        let recovery_owner = prepared_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::StillMineable)
+                .with_prepared_tx(prepared_tx.clone()),
+        );
+        let temp_dir =
+            tempfile::tempdir().expect("temp directory should exist");
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            temp_dir.path().join("burn-restart.db").display()
+        );
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("file-backed database should connect");
+        let harness = TestHarness::with_pool(vault_mock.clone(), pool).await;
+        let TestHarness { store, receipt_service, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
 
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
@@ -3986,8 +5394,734 @@ mod tests {
             .await
             .expect("seeding reservation should succeed");
 
-        // Drive to BurnIntended { sendable_tx: Some(...) } by sending IntendBurn;
-        // the mock returns the configured prepared tx from prepare_tx.
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: recovery_owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn should succeed");
+
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(aggregate, Redemption::BurnIntended { .. }),
+            "Expected BurnIntended with sendable_tx, got {aggregate:?}"
+        );
+        assert_eq!(
+            vault_mock.burn_preparation_call_count(),
+            1,
+            "the signed transaction must be prepared before the restart"
+        );
+
+        let restarted_pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(&database_url)
+            .await
+            .expect("restart should reconnect to the same database");
+        let restarted_store =
+            StoreBuilder::<Redemption>::new(restarted_pool.clone())
+                .with(Arc::new(RedemptionViewReactor::new(
+                    restarted_pool.clone(),
+                )))
+                .build(vault_mock.clone())
+                .await
+                .expect("restart should rebuild the redemption store");
+        let restarted_receipt_store = Arc::new(test_store::<ReceiptInventory>(
+            restarted_pool.clone(),
+            (),
+        ));
+        let restarted_receipt_service: Arc<dyn ReceiptService> =
+            Arc::new(CqrsReceiptService::new(restarted_receipt_store));
+        let replayed =
+            load_aggregate(&restarted_store, &issuer_request_id).await;
+        assert!(matches!(
+            replayed,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == prepared_tx
+        ));
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            restarted_pool.clone(),
+            restarted_store.clone(),
+            restarted_receipt_service.clone(),
+            recovery_owner,
+        );
+        let result = manager.recover_single_burning(&issuer_request_id).await;
+
+        assert!(matches!(result, Ok(RecoveryOutcome::Executed)));
+
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "recovery must broadcast the persisted transaction exactly once"
+        );
+        assert_eq!(
+            vault_mock.burn_preparation_call_count(),
+            1,
+            "restart recovery must not prepare or re-sign the transaction"
+        );
+        assert_eq!(
+            vault_mock.replacement_preparation_call_count(),
+            0,
+            "still-mineable recovery must not prepare a replacement"
+        );
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![prepared_tx.clone()]);
+
+        let updated =
+            load_aggregate(&restarted_store, &issuer_request_id).await;
+        assert!(matches!(updated, Redemption::BurnSubmitted { .. }));
+
+        assert!(
+            restarted_receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "reservation remains held until a later pass observes a receipt"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Automatic burn recovery action accepted", "Rebroadcast"]
+        ));
+
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            1,
+            vault,
+            Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef]),
+        );
+        vault_mock.set_burn_tx_status(BurnTxStatus::ProvablyDead);
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::Executed)
+        ));
+        assert!(
+            restarted_receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .expect("restart reservation query should succeed")
+                .contains(&issuer_request_id),
+            "replacement must keep the persisted receipt reservation"
+        );
+        let contender = IssuerRedemptionRequestId::random();
+        let availability = restarted_receipt_service
+            .for_burn(
+                vault,
+                &contender,
+                Shares::new(uint!(1_U256)),
+                Shares::ZERO,
+            )
+            .await;
+        assert!(matches!(
+            availability,
+            Err(BurnTrackingError::InsufficientBalance { available, .. })
+                if available == Shares::ZERO
+        ));
+        exhaust_restarted_recovery_budget(
+            &manager,
+            &vault_mock,
+            &restarted_receipt_service,
+            &restarted_pool,
+            vault,
+            &issuer_request_id,
+            (prepared_tx, &replacement_tx),
+        )
+        .await;
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn concurrent_recovery_persists_exhaustion_once() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
+        for _ in 0..(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS - 1) {
+            store
+                .send(
+                    &issuer_request_id,
+                    RedemptionCommand::RecordBurnRecoveryAttempt {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tx_hash: persisted_tx.hash,
+                        nonce: persisted_tx.nonce,
+                        action: BurnRecoveryAction::Rebroadcast,
+                    },
+                )
+                .await
+                .expect("recovery attempt should persist");
+        }
+
+        let first_manager = manager.clone();
+        let second_manager = manager.clone();
+        let (first, second) = tokio::join!(
+            first_manager.reserve_recovery_attempt(
+                &issuer_request_id,
+                &persisted_tx,
+                BurnRecoveryAction::Rebroadcast,
+            ),
+            second_manager.reserve_recovery_attempt(
+                &issuer_request_id,
+                &persisted_tx,
+                BurnRecoveryAction::Rebroadcast,
+            ),
+        );
+
+        assert!(matches!(
+            (first, second),
+            (Ok(true), Ok(false)) | (Ok(false), Ok(true))
+        ));
+        assert_eq!(vault_mock.burn_classification_call_count(), 0);
+        let recovery_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("recovery attempt count should load");
+        assert_eq!(recovery_attempts, 5);
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion event count should load");
+        assert_eq!(exhaustion_events, 1);
+        let issuer_request_id_text = issuer_request_id.to_string();
+        assert_eq!(
+            log_count_at!(
+                tracing::Level::ERROR,
+                &["Automatic burn recovery exhausted", &issuer_request_id_text,]
+            ),
+            1
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_provably_dead_burn_replaces_and_broadcasts_fresh_tx()
+    {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let recovery_owner = old_tx.signer_for_test();
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            5,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(old_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            recovery_owner,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: recovery_owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("old burn intent should persist");
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::Executed)
+        ));
+        assert_eq!(
+            vault_mock.submitted_burn_txs(),
+            vec![replacement_tx.clone()]
+        );
+        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        assert!(matches!(
+            aggregate,
+            Redemption::BurnSubmitted { sendable_tx, .. }
+                if sendable_tx == replacement_tx
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Automatic burn recovery action accepted", "Replace"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn provably_dead_replacement_waits_for_another_wallet_intent() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let owner = old_tx.signer_for_test();
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            5,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(old_tx),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                'blocking-mint',
+                1,
+                'MintEvent::MintTxIntended',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(pool)
+        .await
+        .expect("blocking mint intent should seed");
+
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::SkippedManualIntervention)
+        ));
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 0);
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        let recovery_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("recovery attempt count should load");
+        assert_eq!(recovery_attempts, 0);
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Deferring dead burn replacement",
+                &issuer_request_id.to_string(),
+            ]
+        ));
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                'blocking-mint',
+                2,
+                'MintEvent::MintTxSubmitted',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(pool)
+        .await
+        .expect("blocking mint intent should resolve");
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                'blocking-redemption',
+                1,
+                'RedemptionEvent::BurnIntended',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(pool)
+        .await
+        .expect("blocking burn intent should seed");
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::SkippedManualIntervention)
+        ));
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 0);
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                'blocking-redemption',
+                2,
+                'RedemptionEvent::BurnTxSubmitted',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(pool)
+        .await
+        .expect("blocking burn intent should resolve");
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::Executed)
+        ));
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 1);
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![replacement_tx]);
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_rejects_another_redemptions_burn_hash() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burn(45_989_009, uint!(17_U256))
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        harness.discover_receipt(vault, uint!(42_U256), uint!(17_U256)).await;
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(42_U256),
+                    shares_burned: uint!(17_U256),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(42_U256),
+                        burn_shares: uint!(17_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
+        let other_redemption_hash = B256::random();
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                other_redemption_hash,
+                "wrong redemption".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::Redemption(
+                RedemptionError::BurnHashMismatch { expected, provided }
+            )) if expected == persisted_tx.hash && provided == other_redemption_hash
+        ));
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn force_complete_rejects_unvalidated_persisted_transaction_identity()
+    {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let mut persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let decoded_hash = persisted_tx.hash;
+        persisted_tx.hash = B256::random();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burn(45_989_009, uint!(17_U256))
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("malformed historical burn intent should replay");
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                persisted_tx.hash,
+                "untrusted persisted identity".to_string(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::Vault(
+                VaultError::PreparedBurnHashMismatch { expected, decoded }
+            )) if expected == persisted_tx.hash && decoded == decoded_hash
+        ));
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recovery_classification_uncertainty_fails_closed() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_classification_failure()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(99_U256),
+                    shares_burned: uint!(100_000000000000000000_U256),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
         store
             .send(
                 &issuer_request_id,
@@ -4006,53 +6140,252 @@ mod tests {
                 },
             )
             .await
-            .expect("IntendBurn should succeed");
+            .expect("burn intent should persist");
 
-        let aggregate = load_aggregate(store, &issuer_request_id).await;
+        manager.recover_burning_redemptions().await;
+
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == persisted_tx
+        ));
         assert!(
-            matches!(aggregate, Redemption::BurnIntended { .. }),
-            "Expected BurnIntended with sendable_tx, got {aggregate:?}"
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id)
         );
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        let attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("attempt count should load");
+        assert_eq!(attempts, 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Failed to recover Burning redemption"]
+        ));
+    }
 
-        let result = manager.recover_single_burning(&issuer_request_id).await;
-
-        assert!(
-            matches!(result, Ok(RecoveryOutcome::ExistingBurnRecorded)),
-            "Expected ExistingBurnRecorded, got {result:?}"
+    #[traced_test]
+    #[tokio::test]
+    async fn test_missing_vault_does_not_consume_recovery_budget() {
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xca, 0xfe]),
         );
-
-        assert_eq!(
-            vault_mock.get_multi_burn_call_count(),
-            1,
-            "recovery must broadcast the persisted transaction exactly once"
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::StillMineable)
+                .with_prepared_tx(persisted_tx),
         );
-
-        let updated = load_aggregate(store, &issuer_request_id).await;
-        assert!(
-            matches!(updated, Redemption::Completed { .. }),
-            "Expected Completed after recovery, got {updated:?}"
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
         );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault: address!(
+                        "0xcccccccccccccccccccccccccccccccccccccccc"
+                    ),
+                    burns: vec![],
+                    dust_shares: U256::ZERO,
+                    owner: TEST_WALLET,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
 
+        manager.recover_burning_redemptions().await;
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+        let attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("attempt count should load");
+        assert_eq!(attempts, 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Failed to recover Burning redemption", "Asset not found"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn reverted_persisted_burn_is_retried_by_the_failed_recovery_pass() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_confirm_revert()
+                .with_burn_tx_status(BurnTxStatus::Reverted)
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(99_U256),
+                    shares_burned: uint!(100_000000000000000000_U256),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(99_U256),
+                        burn_shares: uint!(100_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: TEST_WALLET,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
+
+        for _ in 0..(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS - 1) {
+            store
+                .send(
+                    &issuer_request_id,
+                    RedemptionCommand::RecordBurnRecoveryAttempt {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tx_hash: persisted_tx.hash,
+                        nonce: persisted_tx.nonce,
+                        action: BurnRecoveryAction::Rebroadcast,
+                    },
+                )
+                .await
+                .expect("prior recovery attempt should persist");
+        }
+
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            5,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+        manager.recover_unresolved_burns().await;
+
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::Failed { .. }
+        ));
         assert!(
             receipt_service
                 .reserved_redemptions(vault)
                 .await
                 .unwrap()
                 .is_empty(),
-            "reservation must be settled after confirmed burn"
+            "the confirmed-reverted replacement must release its reservation"
         );
+        let attempts_after_revert: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("attempt count should load");
+        assert_eq!(
+            attempts_after_revert,
+            i64::from(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS)
+        );
+        let exhaustion_events: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("exhaustion event count should load");
+        assert_eq!(exhaustion_events, 1);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["BurnIntended confirmation failed during recovery"]
+        ));
 
-        assert!(logs_contain_at!(
-            tracing::Level::INFO,
-            &[
-                "Recovering BurnIntended redemption",
-                "re-broadcasting persisted transaction",
-            ]
-        ));
-        assert!(logs_contain_at!(
-            tracing::Level::INFO,
-            &["Burn confirmed successfully during recovery"]
-        ));
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![replacement_tx]);
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "the failed-state pass must submit the scheduled fresh replacement"
+        );
     }
 
     /// An ambiguous local broadcast failure must retain both the persisted
@@ -4273,6 +6606,84 @@ mod tests {
             tracing::Level::WARN,
             &["Preparing signed burn tx failed"]
         ));
+
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::RecordBurnPreparationRecoveryAttempt {
+                    issuer_request_id: issuer_request_id.clone(),
+                    attempt: 1,
+                },
+            )
+            .await
+            .expect("preparation attempt should survive a simulated restart");
+        manager.recover_burn_failed_redemptions().await;
+        let reserved_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type =
+                  'RedemptionEvent::BurnPreparationRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("reserved preparation attempt count should load");
+        assert_eq!(
+            reserved_attempts, 1,
+            "restart must resume the reserved attempt without another slot"
+        );
+
+        for _ in 0..=MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS {
+            manager.recover_burn_failed_redemptions().await;
+        }
+
+        assert_eq!(
+            vault_mock.burn_preparation_call_count(),
+            usize::try_from(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS).unwrap() + 1,
+            "the live attempt plus five recovery attempts may prepare"
+        );
+        let preparation_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type =
+                  'RedemptionEvent::BurnPreparationRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("preparation attempt count should load");
+        let preparation_exhausted: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+              AND event_type =
+                  'RedemptionEvent::BurnPreparationRecoveryExhausted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .expect("preparation exhaustion count should load");
+        assert_eq!(
+            preparation_attempts,
+            i64::from(MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS)
+        );
+        assert_eq!(preparation_exhausted, 1);
+        assert_eq!(
+            log_count_at!(
+                tracing::Level::ERROR,
+                &["Automatic burn preparation recovery exhausted"]
+            ),
+            1,
+            "preparation exhaustion must emit one actionable error"
+        );
     }
 
     /// Tests that recovery from `BurnSubmitted` state (crash between submit
@@ -4280,7 +6691,20 @@ mod tests {
     /// submitting a new one.
     #[tokio::test]
     async fn test_recover_burn_submitted_confirms_existing_transaction() {
-        let vault_mock = Arc::new(MockVaultService::new_success());
+        let prepared_hash = b256!(
+            "0x2323232323232323232323232323232323232323232323232323232323232323"
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::Mined)
+                .with_prepared_tx(SendableTxWithHash {
+                    tx: vec![1, 2, 3],
+                    hash: prepared_hash,
+                    nonce: 3,
+                    signed_at: Utc::now(),
+                    dust_shares: U256::ZERO,
+                }),
+        );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
 
@@ -4490,7 +6914,7 @@ mod tests {
     /// burn may still have landed. The GC must LEAVE it rather than release it —
     /// releasing would over-credit inventory and risk a duplicate burn.
     #[tokio::test]
-    async fn test_recover_stuck_reservations_leaves_failed() {
+    async fn test_recover_stuck_reservations_leaves_ambiguous_submitted() {
         let vault_mock = Arc::new(MockVaultService::new_failure());
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
@@ -4514,7 +6938,7 @@ mod tests {
             )
             .await;
 
-        // Drive the redemption to Failed (the failing mock fails the burn).
+        // Drive the redemption to an ambiguously submitted burn.
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let aggregate = create_test_redemption_in_burning_state(
             &harness.store,
@@ -4526,7 +6950,7 @@ mod tests {
             .await;
         assert!(matches!(
             load_aggregate(&harness.store, &issuer_request_id).await,
-            Redemption::Failed { .. }
+            Redemption::BurnSubmitted { .. }
         ));
 
         seed_stuck_reservation(

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -136,4 +136,28 @@ pub(crate) enum RedemptionCommand {
         #[serde(default)]
         external_tx_id: Option<BurnExternalTxId>,
     },
+    RecordBurnRecoveryAttempt {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        action: super::BurnRecoveryAction,
+    },
+    RecordBurnPreparationRecoveryAttempt {
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempt: u32,
+    },
+    RecordBurnRecoveryExhausted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        attempts: u32,
+    },
+    RecordBurnPreparationRecoveryExhausted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempts: u32,
+    },
+    ReplaceDeadBurn {
+        issuer_request_id: IssuerRedemptionRequestId,
+        owner: Address,
+    },
 }

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -241,6 +241,30 @@ pub(crate) enum RedemptionEvent {
         sendable_tx: SendableTxWithHash,
         planned_burns: Vec<BurnRecord>,
     },
+    BurnRecoveryAttempted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        action: super::BurnRecoveryAction,
+        attempted_at: DateTime<Utc>,
+    },
+    BurnPreparationRecoveryAttempted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempt: u32,
+        attempted_at: DateTime<Utc>,
+    },
+    BurnRecoveryExhausted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        attempts: u32,
+        exhausted_at: DateTime<Utc>,
+    },
+    BurnPreparationRecoveryExhausted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempts: u32,
+        exhausted_at: DateTime<Utc>,
+    },
 }
 
 impl DomainEvent for RedemptionEvent {
@@ -285,6 +309,18 @@ impl DomainEvent for RedemptionEvent {
             }
             Self::BurnIntended { .. } => {
                 "RedemptionEvent::BurnIntended".to_string()
+            }
+            Self::BurnRecoveryAttempted { .. } => {
+                "RedemptionEvent::BurnRecoveryAttempted".to_string()
+            }
+            Self::BurnPreparationRecoveryAttempted { .. } => {
+                "RedemptionEvent::BurnPreparationRecoveryAttempted".to_string()
+            }
+            Self::BurnRecoveryExhausted { .. } => {
+                "RedemptionEvent::BurnRecoveryExhausted".to_string()
+            }
+            Self::BurnPreparationRecoveryExhausted { .. } => {
+                "RedemptionEvent::BurnPreparationRecoveryExhausted".to_string()
             }
         }
     }

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -45,6 +45,12 @@ pub(crate) async fn has_unresolved_burn_intent(
                   WHERE later.aggregate_type = intent.aggregate_type
                     AND later.aggregate_id = intent.aggregate_id
                     AND later.sequence > intent.sequence
+                    AND later.event_type NOT IN (
+                        'RedemptionEvent::BurnRecoveryAttempted',
+                        'RedemptionEvent::BurnPreparationRecoveryAttempted',
+                        'RedemptionEvent::BurnRecoveryExhausted',
+                        'RedemptionEvent::BurnPreparationRecoveryExhausted'
+                    )
               )
         )
         ",
@@ -180,8 +186,10 @@ impl std::fmt::Display for BurnExternalTxId {
     }
 }
 use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
-use crate::vault::{MultiBurnEntry, MultiBurnParams, VaultService};
-use crate::vault::{SendableTxWithHash, TxId, VaultError};
+use crate::vault::{
+    BurnTxStatus, MultiBurnEntry, MultiBurnParams, SendableTxWithHash, TxId,
+    VaultError, VaultService,
+};
 
 pub(crate) use cmd::RedemptionCommand;
 pub(crate) use event::{BurnRecord, RedemptionEvent, TokensBurnedData};
@@ -227,6 +235,10 @@ pub(crate) enum Redemption {
         alpaca_journal_completed_at: DateTime<Utc>,
         #[serde(default)]
         external_tx_id: Option<BurnExternalTxId>,
+        /// Exact transaction from a failed attempt whose identity is retained
+        /// while a reserved replacement is prepared.
+        #[serde(default)]
+        prior_burn_tx: Option<SendableTxWithHash>,
     },
     /// Burn transaction submitted to signing backend, awaiting on-chain confirmation.
     BurnSubmitted {
@@ -239,6 +251,8 @@ pub(crate) enum Redemption {
         external_tx_id: BurnExternalTxId,
         tx_id: TxId,
         planned_burns: Vec<event::BurnRecord>,
+        #[serde(default)]
+        sendable_tx: SendableTxWithHash,
     },
     Completed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -249,6 +263,10 @@ pub(crate) enum Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
         failed_at: DateTime<Utc>,
+        /// Exact prior transaction used to validate durable recovery
+        /// exhaustion after replacement preparation fails.
+        #[serde(default)]
+        prior_burn_tx: Option<SendableTxWithHash>,
     },
     Closed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -270,6 +288,12 @@ pub(crate) enum Redemption {
         #[serde(default)]
         sendable_tx: SendableTxWithHash,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum BurnRecoveryAction {
+    Rebroadcast,
+    Replace,
 }
 
 /// Input parameters for the BurnTokens command handler.
@@ -330,7 +354,8 @@ impl Redemption {
             Self::Detected { metadata }
             | Self::AlpacaCalled { metadata, .. }
             | Self::Burning { metadata, .. }
-            | Self::BurnSubmitted { metadata, .. } => Some(metadata),
+            | Self::BurnSubmitted { metadata, .. }
+            | Self::BurnIntended { metadata, .. } => Some(metadata),
             _ => None,
         }
     }
@@ -438,9 +463,11 @@ impl Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         input: BurnInput,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let Self::BurnIntended { metadata, sendable_tx, .. } = self else {
+        let (Self::BurnIntended { metadata, sendable_tx, .. }
+        | Self::BurnSubmitted { metadata, sendable_tx, .. }) = self
+        else {
             return Err(RedemptionError::InvalidState {
-                expected: "BurnIntended".to_string(),
+                expected: "BurnIntended or BurnSubmitted".to_string(),
                 found: self.state_name().to_string(),
             });
         };
@@ -684,7 +711,7 @@ impl Redemption {
     }
 
     /// Admin-closes a redemption that cannot be auto-recovered. Valid from
-    /// `Failed`, `Burning`, or `BurnSubmitted` — the honest terminal path for a
+    /// `Failed`, `Burning`, `BurnIntended`, or `BurnSubmitted` — the honest terminal path for a
     /// redemption whose burn cannot/should not be re-submitted and is not
     /// verifiable on-chain. Widening beyond `Failed` covers redemptions stuck in
     /// `Burning` (including the `Failed -> Burning` recovery regression, which
@@ -698,6 +725,7 @@ impl Redemption {
             self,
             Self::Failed { .. }
                 | Self::Burning { .. }
+                | Self::BurnIntended { .. }
                 | Self::BurnSubmitted { .. }
         ) {
             return Err(match self {
@@ -705,7 +733,8 @@ impl Redemption {
                     RedemptionError::AlreadyCompleted { issuer_request_id }
                 }
                 _ => RedemptionError::InvalidState {
-                    expected: "Failed, Burning, or BurnSubmitted".to_string(),
+                    expected: "Failed, Burning, BurnIntended, or BurnSubmitted"
+                        .to_string(),
                     found: self.state_name().to_string(),
                 },
             });
@@ -746,6 +775,13 @@ impl Redemption {
                         .to_string(),
                     found: self.state_name().to_string(),
                 },
+            });
+        }
+        let persisted_burn_hash = self.persisted_burn_hash()?;
+        if persisted_burn_hash != burn_tx_hash {
+            return Err(RedemptionError::BurnHashMismatch {
+                expected: persisted_burn_hash,
+                provided: burn_tx_hash,
             });
         }
 
@@ -830,6 +866,7 @@ impl Redemption {
             called_at: *called_at,
             alpaca_journal_completed_at,
             external_tx_id: None,
+            prior_burn_tx: None,
         };
     }
 
@@ -883,6 +920,210 @@ impl Redemption {
         Ok(vec![RedemptionEvent::BurnIntended {
             issuer_request_id,
             sendable_tx,
+            planned_burns,
+        }])
+    }
+
+    const fn current_sendable_tx(&self) -> Option<&SendableTxWithHash> {
+        match self {
+            Self::BurnIntended { sendable_tx, .. }
+            | Self::BurnSubmitted { sendable_tx, .. } => Some(sendable_tx),
+            _ => None,
+        }
+    }
+
+    fn persisted_burn_hash(&self) -> Result<B256, RedemptionError> {
+        Ok(self.persisted_burn_tx()?.hash)
+    }
+
+    fn persisted_burn_tx(
+        &self,
+    ) -> Result<&SendableTxWithHash, RedemptionError> {
+        self.current_sendable_tx()
+            .filter(|sendable_tx| !sendable_tx.tx.is_empty())
+            .ok_or(RedemptionError::PersistedBurnHashUnavailable)
+    }
+
+    fn verify_recovery_transaction(
+        &self,
+        tx_hash: B256,
+        nonce: u64,
+    ) -> Result<(), RedemptionError> {
+        let sendable_tx = self.current_sendable_tx().ok_or_else(|| {
+            RedemptionError::InvalidState {
+                expected: "BurnIntended or BurnSubmitted".to_string(),
+                found: self.state_name().to_string(),
+            }
+        })?;
+        if sendable_tx.hash != tx_hash || sendable_tx.nonce != nonce {
+            return Err(RedemptionError::RecoveryTransactionMismatch {
+                expected_hash: sendable_tx.hash,
+                expected_nonce: sendable_tx.nonce,
+                provided_hash: tx_hash,
+                provided_nonce: nonce,
+            });
+        }
+        Ok(())
+    }
+
+    fn handle_record_burn_recovery_attempt(
+        &self,
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        action: BurnRecoveryAction,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        self.verify_recovery_transaction(tx_hash, nonce)?;
+        Ok(vec![RedemptionEvent::BurnRecoveryAttempted {
+            issuer_request_id,
+            tx_hash,
+            nonce,
+            action,
+            attempted_at: Utc::now(),
+        }])
+    }
+
+    fn handle_record_burn_preparation_recovery_attempt(
+        &self,
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempt: u32,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        if !matches!(self, Self::Failed { .. }) {
+            return Err(RedemptionError::InvalidState {
+                expected: "Failed".to_string(),
+                found: self.state_name().to_string(),
+            });
+        }
+        Ok(vec![RedemptionEvent::BurnPreparationRecoveryAttempted {
+            issuer_request_id,
+            attempt,
+            attempted_at: Utc::now(),
+        }])
+    }
+
+    fn handle_record_burn_recovery_exhausted(
+        &self,
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        nonce: u64,
+        attempts: u32,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        self.verify_recovery_exhaustion_transaction(tx_hash, nonce)?;
+        Ok(vec![RedemptionEvent::BurnRecoveryExhausted {
+            issuer_request_id,
+            tx_hash,
+            nonce,
+            attempts,
+            exhausted_at: Utc::now(),
+        }])
+    }
+
+    fn handle_record_burn_preparation_recovery_exhausted(
+        &self,
+        issuer_request_id: IssuerRedemptionRequestId,
+        attempts: u32,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        if !matches!(self, Self::Failed { .. }) {
+            return Err(RedemptionError::InvalidState {
+                expected: "Failed".to_string(),
+                found: self.state_name().to_string(),
+            });
+        }
+        Ok(vec![RedemptionEvent::BurnPreparationRecoveryExhausted {
+            issuer_request_id,
+            attempts,
+            exhausted_at: Utc::now(),
+        }])
+    }
+
+    fn verify_recovery_exhaustion_transaction(
+        &self,
+        tx_hash: B256,
+        nonce: u64,
+    ) -> Result<(), RedemptionError> {
+        let sendable_tx = self.current_sendable_tx().or(match self {
+            Self::Burning { prior_burn_tx, .. }
+            | Self::Failed { prior_burn_tx, .. } => prior_burn_tx.as_ref(),
+            _ => None,
+        });
+        let sendable_tx =
+            sendable_tx.ok_or_else(|| RedemptionError::InvalidState {
+                expected: "state with an exact recovery transaction"
+                    .to_string(),
+                found: self.state_name().to_string(),
+            })?;
+        if sendable_tx.hash != tx_hash || sendable_tx.nonce != nonce {
+            return Err(RedemptionError::RecoveryTransactionMismatch {
+                expected_hash: sendable_tx.hash,
+                expected_nonce: sendable_tx.nonce,
+                provided_hash: tx_hash,
+                provided_nonce: nonce,
+            });
+        }
+        Ok(())
+    }
+
+    async fn handle_replace_dead_burn(
+        &self,
+        services: &Arc<dyn VaultService>,
+        issuer_request_id: IssuerRedemptionRequestId,
+        owner: Address,
+    ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
+        let sendable_tx = self.current_sendable_tx().ok_or_else(|| {
+            RedemptionError::InvalidState {
+                expected: "BurnIntended or BurnSubmitted".to_string(),
+                found: self.state_name().to_string(),
+            }
+        })?;
+        if services.classify_burn_tx(owner, sendable_tx).await.map_err(
+            |_| RedemptionError::BurnRecoveryClassificationFailed {
+                tx_hash: sendable_tx.hash,
+                nonce: sendable_tx.nonce,
+            },
+        )? != BurnTxStatus::ProvablyDead
+        {
+            return Err(RedemptionError::BurnReplacementNotSafe {
+                tx_hash: sendable_tx.hash,
+                nonce: sendable_tx.nonce,
+            });
+        }
+
+        let planned_burns = match self {
+            Self::BurnIntended { planned_burns, .. }
+            | Self::BurnSubmitted { planned_burns, .. } => {
+                planned_burns.clone()
+            }
+            _ => Vec::new(),
+        };
+        let replacement = services
+            .prepare_replacement_burn_tx(owner, sendable_tx)
+            .await
+            .map_err(|_| RedemptionError::BurnReplacementPreparationFailed {
+                tx_hash: sendable_tx.hash,
+                nonce: sendable_tx.nonce,
+            })?;
+        replacement
+            .validate_replacement_for_owner(sendable_tx, owner)
+            .map_err(|_| RedemptionError::BurnReplacementValidationFailed {
+                previous_hash: sendable_tx.hash,
+                previous_nonce: sendable_tx.nonce,
+                replacement_hash: replacement.hash,
+                replacement_nonce: replacement.nonce,
+            })?;
+        if replacement.nonce <= sendable_tx.nonce
+            || replacement.hash == sendable_tx.hash
+        {
+            return Err(RedemptionError::BurnReplacementNotFresh {
+                previous_hash: sendable_tx.hash,
+                previous_nonce: sendable_tx.nonce,
+                replacement_hash: replacement.hash,
+                replacement_nonce: replacement.nonce,
+            });
+        }
+
+        Ok(vec![RedemptionEvent::BurnIntended {
+            issuer_request_id,
+            sendable_tx: replacement,
             planned_burns,
         }])
     }
@@ -940,6 +1181,51 @@ pub(crate) enum RedemptionError {
     #[error("Burn confirmation remains pending for {tx_id}: {message}")]
     BurnConfirmationPending { tx_id: TxId, message: String },
     #[error(
+        "Burn hash mismatch: expected persisted hash {expected:?}, provided {provided:?}"
+    )]
+    BurnHashMismatch { expected: B256, provided: B256 },
+    #[error(
+        "Force-completion requires a non-empty exact transaction persisted for this redemption"
+    )]
+    PersistedBurnHashUnavailable,
+    #[error(
+        "Recovery transaction mismatch: expected {expected_hash:?}/{expected_nonce}, provided {provided_hash:?}/{provided_nonce}"
+    )]
+    RecoveryTransactionMismatch {
+        expected_hash: B256,
+        expected_nonce: u64,
+        provided_hash: B256,
+        provided_nonce: u64,
+    },
+    #[error(
+        "Burn transaction {tx_hash:?} at nonce {nonce} can still land; replacement refused"
+    )]
+    BurnReplacementNotSafe { tx_hash: B256, nonce: u64 },
+    #[error("Failed to classify persisted burn {tx_hash:?} at nonce {nonce}")]
+    BurnRecoveryClassificationFailed { tx_hash: B256, nonce: u64 },
+    #[error(
+        "Failed to prepare replacement for burn {tx_hash:?} at nonce {nonce}"
+    )]
+    BurnReplacementPreparationFailed { tx_hash: B256, nonce: u64 },
+    #[error(
+        "Burn replacement {replacement_hash:?}/{replacement_nonce} failed validation against {previous_hash:?}/{previous_nonce}"
+    )]
+    BurnReplacementValidationFailed {
+        previous_hash: B256,
+        previous_nonce: u64,
+        replacement_hash: B256,
+        replacement_nonce: u64,
+    },
+    #[error(
+        "Burn replacement {replacement_hash:?}/{replacement_nonce} is not fresh relative to {previous_hash:?}/{previous_nonce}"
+    )]
+    BurnReplacementNotFresh {
+        previous_hash: B256,
+        previous_nonce: u64,
+        replacement_hash: B256,
+        replacement_nonce: u64,
+    },
+    #[error(
         "Burn retry attempt counter overflowed for external tx id: {latest_external_tx_id}"
     )]
     RetryAttemptOverflow { latest_external_tx_id: BurnExternalTxId },
@@ -958,7 +1244,7 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 3;
+    const SCHEMA_VERSION: u64 = 4;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {
@@ -1044,6 +1330,20 @@ impl EventSourced for Redemption {
                     expected:
                         "Burning or BurnIntended without a signed transaction"
                             .to_string(),
+                    found: "Uninitialized".to_string(),
+                })
+            }
+            RedemptionCommand::RecordBurnRecoveryAttempt { .. }
+            | RedemptionCommand::RecordBurnPreparationRecoveryAttempt {
+                ..
+            }
+            | RedemptionCommand::RecordBurnRecoveryExhausted { .. }
+            | RedemptionCommand::RecordBurnPreparationRecoveryExhausted {
+                ..
+            }
+            | RedemptionCommand::ReplaceDeadBurn { .. } => {
+                Err(RedemptionError::InvalidState {
+                    expected: "BurnIntended or BurnSubmitted".to_string(),
                     found: "Uninitialized".to_string(),
                 })
             }
@@ -1225,6 +1525,50 @@ impl EventSourced for Redemption {
                 )
                 .await
             }
+            RedemptionCommand::RecordBurnRecoveryAttempt {
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                action,
+            } => self.handle_record_burn_recovery_attempt(
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                action,
+            ),
+            RedemptionCommand::RecordBurnPreparationRecoveryAttempt {
+                issuer_request_id,
+                attempt,
+            } => self.handle_record_burn_preparation_recovery_attempt(
+                issuer_request_id,
+                attempt,
+            ),
+            RedemptionCommand::RecordBurnRecoveryExhausted {
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                attempts,
+            } => self.handle_record_burn_recovery_exhausted(
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                attempts,
+            ),
+            RedemptionCommand::RecordBurnPreparationRecoveryExhausted {
+                issuer_request_id,
+                attempts,
+            } => self.handle_record_burn_preparation_recovery_exhausted(
+                issuer_request_id,
+                attempts,
+            ),
+            RedemptionCommand::ReplaceDeadBurn { issuer_request_id, owner } => {
+                self.handle_replace_dead_burn(
+                    services,
+                    issuer_request_id,
+                    owner,
+                )
+                .await
+            }
         }
     }
 }
@@ -1276,6 +1620,10 @@ impl Redemption {
             RedemptionEvent::BurnIntended { .. } => {
                 self.apply_burn_intended_event(event);
             }
+            RedemptionEvent::BurnRecoveryAttempted { .. }
+            | RedemptionEvent::BurnPreparationRecoveryAttempted { .. }
+            | RedemptionEvent::BurnRecoveryExhausted { .. }
+            | RedemptionEvent::BurnPreparationRecoveryExhausted { .. } => {}
         }
     }
 
@@ -1320,6 +1668,12 @@ impl Redemption {
     }
 
     fn apply_failure_event(&mut self, event: RedemptionEvent) {
+        let prior_burn_tx =
+            self.current_sendable_tx().cloned().or_else(|| match self {
+                Self::Burning { prior_burn_tx, .. }
+                | Self::Failed { prior_burn_tx, .. } => prior_burn_tx.clone(),
+                _ => None,
+            });
         let (issuer_request_id, reason, failed_at) = match event {
             RedemptionEvent::AlpacaCallFailed {
                 issuer_request_id,
@@ -1340,7 +1694,12 @@ impl Redemption {
             _ => return,
         };
 
-        *self = Self::Failed { issuer_request_id, reason, failed_at };
+        *self = Self::Failed {
+            issuer_request_id,
+            reason,
+            failed_at,
+            prior_burn_tx,
+        };
     }
 
     fn apply_burn_submitted_event(&mut self, event: RedemptionEvent) {
@@ -1376,6 +1735,9 @@ impl Redemption {
             return;
         };
 
+        let sendable_tx =
+            self.current_sendable_tx().cloned().unwrap_or_default();
+
         *self = Self::BurnSubmitted {
             metadata,
             tokenization_request_id,
@@ -1386,10 +1748,15 @@ impl Redemption {
             external_tx_id,
             tx_id,
             planned_burns,
+            sendable_tx,
         };
     }
 
     fn apply_burn_resumed_event(&mut self, event: RedemptionEvent) {
+        let prior_burn_tx = match self {
+            Self::Failed { prior_burn_tx, .. } => prior_burn_tx.clone(),
+            _ => None,
+        };
         let RedemptionEvent::BurnResumed {
             issuer_request_id,
             underlying,
@@ -1428,6 +1795,7 @@ impl Redemption {
             called_at,
             alpaca_journal_completed_at,
             external_tx_id,
+            prior_burn_tx,
         };
     }
 
@@ -1488,7 +1856,56 @@ impl Redemption {
             return;
         };
 
-        let (Self::Burning {
+        let transition = match self.clone() {
+            Self::Burning {
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                external_tx_id,
+                ..
+            }
+            | Self::BurnIntended {
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                external_tx_id,
+                ..
+            } => Some((
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                external_tx_id,
+            )),
+            Self::BurnSubmitted {
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                external_tx_id,
+                ..
+            } => Some((
+                metadata,
+                tokenization_request_id,
+                alpaca_quantity,
+                dust_quantity,
+                called_at,
+                alpaca_journal_completed_at,
+                Some(external_tx_id),
+            )),
+            _ => None,
+        };
+        let Some((
             metadata,
             tokenization_request_id,
             alpaca_quantity,
@@ -1496,17 +1913,7 @@ impl Redemption {
             called_at,
             alpaca_journal_completed_at,
             external_tx_id,
-        }
-        | Self::BurnIntended {
-            metadata,
-            tokenization_request_id,
-            alpaca_quantity,
-            dust_quantity,
-            called_at,
-            alpaca_journal_completed_at,
-            external_tx_id,
-            ..
-        }) = self.clone()
+        )) = transition
         else {
             return;
         };
@@ -1527,28 +1934,84 @@ impl Redemption {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{B256, TxHash, U256, address, b256, uint};
+    use alloy::primitives::{
+        Address, B256, Bytes, TxHash, U256, address, b256, uint,
+    };
     use chrono::Utc;
+    use cqrs_es::DomainEvent;
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
+    use tracing_test::traced_test;
 
     use super::{
-        BurnExternalTxId, BurnRecord, IssuerRedemptionRequestId, Redemption,
-        RedemptionCommand, RedemptionError, RedemptionEvent,
-        RedemptionMetadata, TokensBurnedData, TxId,
+        BurnExternalTxId, BurnRecord, BurnRecoveryAction,
+        IssuerRedemptionRequestId, Redemption, RedemptionCommand,
+        RedemptionError, RedemptionEvent, RedemptionMetadata, TokensBurnedData,
+        has_unresolved_burn_intent,
         next_burn_retry_external_tx_id_from_history,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::prepare_event_sourced_startup;
+    use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{MultiBurnEntry, SendableTxWithHash, VaultService};
+    use crate::vault::{
+        BurnTxStatus, MultiBurnEntry, SendableTxWithHash, TxId, VaultService,
+    };
 
     fn mock_services() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
+    }
+
+    #[tokio::test]
+    async fn recovery_annotations_keep_the_wallet_intent_gate_closed() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+        let aggregate_id = IssuerRedemptionRequestId::random().to_string();
+
+        for (sequence, event_type) in [
+            (1, "RedemptionEvent::BurnIntended"),
+            (2, "RedemptionEvent::BurnRecoveryAttempted"),
+            (3, "RedemptionEvent::BurnRecoveryExhausted"),
+        ] {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, '1.0', '{}', '{}')
+                ",
+            )
+            .bind(&aggregate_id)
+            .bind(sequence)
+            .bind(event_type)
+            .execute(&pool)
+            .await
+            .expect("test event should insert");
+        }
+
+        assert!(
+            has_unresolved_burn_intent(&pool, None)
+                .await
+                .expect("intent query should succeed"),
+            "recovery bookkeeping must not permit another wallet transaction"
+        );
     }
 
     #[test]
@@ -1559,7 +2022,7 @@ mod tests {
         let events = [RedemptionEvent::BurnTxSubmitted {
             issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
             external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
-            tx_id: TxId::Legacy("fb-1".to_string()),
+            tx_id: TxId::random(),
             planned_burns: vec![],
             submitted_at: Utc::now(),
         }];
@@ -1592,7 +2055,7 @@ mod tests {
                     detected_tx_hash,
                 ),
                 external_tx_id: BurnExternalTxId::base(&detected_tx_hash),
-                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_id: TxId::random(),
                 planned_burns: vec![],
                 submitted_at: Utc::now(),
             },
@@ -2052,6 +2515,7 @@ mod tests {
                 called_at,
                 alpaca_journal_completed_at,
                 external_tx_id: None,
+                prior_burn_tx: None,
             }
         );
     }
@@ -2225,6 +2689,285 @@ mod tests {
                 found: "Detected".to_string(),
             }
         );
+    }
+
+    fn intended_burn_history(
+        issuer_request_id: &IssuerRedemptionRequestId,
+        sendable_tx: SendableTxWithHash,
+    ) -> Vec<RedemptionEvent> {
+        vec![
+            RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("AAPL"),
+                token: TokenSymbol::new("tAAPL"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(100)),
+                tx_hash: b256!(
+                    "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+                ),
+                block_number: 12345,
+                detected_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new(
+                    "alp-replace-456",
+                ),
+                alpaca_quantity: Quantity::new(Decimal::from(100)),
+                dust_quantity: Quantity::new(Decimal::ZERO),
+                called_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id: issuer_request_id.clone(),
+                alpaca_journal_completed_at: Utc::now(),
+            },
+            RedemptionEvent::BurnIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                sendable_tx,
+                planned_burns: vec![BurnRecord {
+                    receipt_id: uint!(42_U256),
+                    shares_burned: uint!(100_000000000000000000_U256),
+                }],
+            },
+        ]
+    }
+
+    fn replace_dead_burn_command(
+        issuer_request_id: &IssuerRedemptionRequestId,
+        owner: Address,
+    ) -> RedemptionCommand {
+        RedemptionCommand::ReplaceDeadBurn {
+            issuer_request_id: issuer_request_id.clone(),
+            owner,
+        }
+    }
+
+    #[tokio::test]
+    async fn replace_dead_burn_refuses_a_still_mineable_hash() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let old_tx = SendableTxWithHash {
+            hash: b256!(
+                "0x1111111111111111111111111111111111111111111111111111111111111111"
+            ),
+            nonce: 7,
+            ..SendableTxWithHash::default()
+        };
+        let services: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::StillMineable),
+        );
+
+        let error = TestHarness::<Redemption>::with(services)
+            .given(intended_burn_history(&issuer_request_id, old_tx))
+            .when(replace_dead_burn_command(
+                &issuer_request_id,
+                address!("0x1111111111111111111111111111111111111111"),
+            ))
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::BurnReplacementNotSafe { .. }
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn replace_dead_burn_persists_a_fresh_hash() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let destination =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            7,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            8,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let replacement_hash = replacement_tx.hash;
+        let owner = old_tx.signer_for_test();
+        let services: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(replacement_tx),
+        );
+
+        let events = TestHarness::<Redemption>::with(services)
+            .given(intended_burn_history(&issuer_request_id, old_tx))
+            .when(replace_dead_burn_command(&issuer_request_id, owner))
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnIntended { sendable_tx, .. }]
+                if sendable_tx.hash == replacement_hash
+                    && sendable_tx.nonce == 8
+        ));
+    }
+
+    #[tokio::test]
+    async fn replace_dead_burn_refuses_a_non_fresh_nonce() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let destination =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            7,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let non_fresh_tx = SendableTxWithHash::valid_for_test(
+            7,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = old_tx.signer_for_test();
+        let services: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(non_fresh_tx),
+        );
+
+        let error = TestHarness::<Redemption>::with(services)
+            .given(intended_burn_history(&issuer_request_id, old_tx))
+            .when(replace_dead_burn_command(&issuer_request_id, owner))
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::BurnReplacementNotFresh { .. }
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn replace_dead_burn_refuses_changed_calldata() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let destination =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            7,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let changed_call = SendableTxWithHash::valid_for_test(
+            8,
+            destination,
+            Bytes::from_static(&[0xbe, 0xef]),
+        );
+        let owner = old_tx.signer_for_test();
+        let services: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(changed_call),
+        );
+
+        let error = TestHarness::<Redemption>::with(services)
+            .given(intended_burn_history(&issuer_request_id, old_tx))
+            .when(replace_dead_burn_command(&issuer_request_id, owner))
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::BurnReplacementValidationFailed { .. }
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn dead_submitted_burn_replays_to_the_fresh_intent() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let destination =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            7,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            8,
+            destination,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = old_tx.signer_for_test();
+        let mut history =
+            intended_burn_history(&issuer_request_id, old_tx.clone());
+        history.push(RedemptionEvent::BurnTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: BurnExternalTxId::base(&B256::random()),
+            tx_id: old_tx.hash.into(),
+            planned_burns: vec![BurnRecord {
+                receipt_id: uint!(42_U256),
+                shares_burned: uint!(100_000000000000000000_U256),
+            }],
+            submitted_at: Utc::now(),
+        });
+        let services: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(replacement_tx.clone()),
+        );
+
+        let events = TestHarness::<Redemption>::with(services)
+            .given(history.clone())
+            .when(replace_dead_burn_command(&issuer_request_id, owner))
+            .await
+            .events();
+        let replacement_event = events
+            .first()
+            .expect("replacement should append one event")
+            .clone();
+        history.push(replacement_event);
+        let aggregate = replay::<Redemption>(history)
+            .expect("replacement history should replay")
+            .expect("redemption should exist");
+
+        assert!(matches!(
+            aggregate,
+            Redemption::BurnIntended { sendable_tx, .. }
+                if sendable_tx == replacement_tx
+        ));
+    }
+
+    #[test]
+    fn recovery_annotation_events_do_not_change_burn_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let sendable_tx = SendableTxWithHash {
+            hash: B256::random(),
+            nonce: 7,
+            ..SendableTxWithHash::default()
+        };
+        let mut events =
+            intended_burn_history(&issuer_request_id, sendable_tx.clone());
+        events.push(RedemptionEvent::BurnRecoveryAttempted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: sendable_tx.hash,
+            nonce: sendable_tx.nonce,
+            action: BurnRecoveryAction::Rebroadcast,
+            attempted_at: Utc::now(),
+        });
+        events.push(RedemptionEvent::BurnRecoveryExhausted {
+            issuer_request_id,
+            tx_hash: sendable_tx.hash,
+            nonce: sendable_tx.nonce,
+            attempts: 5,
+            exhausted_at: Utc::now(),
+        });
+
+        let aggregate = replay::<Redemption>(events)
+            .expect("history should replay")
+            .expect("aggregate should exist");
+
+        assert!(matches!(aggregate, Redemption::BurnIntended { .. }));
     }
 
     #[test]
@@ -2424,7 +3167,7 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "BurnIntended".to_string(),
+                expected: "BurnIntended or BurnSubmitted".to_string(),
                 found: "Detected".to_string(),
             }
         );
@@ -2559,7 +3302,7 @@ mod tests {
             external_tx_id: BurnExternalTxId::base(&b256!(
                 "0x4444444444444444444444444444444444444444444444444444444444444444"
             )),
-            tx_id: TxId::Legacy("fb-799".to_string()),
+            tx_id: TxId::random(),
             planned_burns: vec![],
             submitted_at: Utc::now(),
         });
@@ -2772,6 +3515,35 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_close_redemption_from_exhausted_burn_intended_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let sendable_tx = SendableTxWithHash::default();
+        let mut history =
+            intended_burn_history(&issuer_request_id, sendable_tx.clone());
+        history.push(RedemptionEvent::BurnRecoveryExhausted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: sendable_tx.hash,
+            nonce: sendable_tx.nonce,
+            attempts: 5,
+            exhausted_at: Utc::now(),
+        });
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "operator reconciled exhausted burn".to_string(),
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::RedemptionClosed { .. }]
+        ));
+    }
+
+    #[tokio::test]
     async fn test_close_redemption_from_detected_fails() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
 
@@ -2803,88 +3575,90 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "Failed, Burning, or BurnSubmitted".to_string(),
+                expected: "Failed, Burning, BurnIntended, or BurnSubmitted"
+                    .to_string(),
                 found: "Detected".to_string(),
             }
         );
     }
 
     #[tokio::test]
-    async fn test_force_complete_burn_from_burning_state() {
+    async fn test_force_complete_burn_without_persisted_hash_fails() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let burn_tx_hash = b256!(
-            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-        );
-        let block_number = 45_989_009;
-        let reason = "burn confirmed on-chain, unrecorded".to_string();
-
-        let events = TestHarness::<Redemption>::with(mock_services())
+        let error = TestHarness::<Redemption>::with(mock_services())
             .given(burning_given_events(&issuer_request_id))
             .when(RedemptionCommand::ForceCompleteBurn {
-                issuer_request_id: issuer_request_id.clone(),
-                burn_tx_hash,
-                block_number,
-                reason: reason.clone(),
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 45_989_009,
+                reason: "another redemption's verified burn".to_string(),
             })
             .await
-            .events();
+            .then_expect_error();
 
-        assert_eq!(events.len(), 1);
-
-        let RedemptionEvent::BurnForceCompleted {
-            issuer_request_id: event_id,
-            burn_tx_hash: event_tx_hash,
-            block_number: event_block,
-            reason: event_reason,
-            ..
-        } = &events[0]
-        else {
-            panic!("Expected BurnForceCompleted event, got {:?}", &events[0]);
-        };
-
-        assert_eq!(event_id, &issuer_request_id);
-        assert_eq!(event_tx_hash, &burn_tx_hash);
-        assert_eq!(event_block, &block_number);
-        assert_eq!(event_reason, &reason);
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::PersistedBurnHashUnavailable
+            )
+        ));
     }
 
     #[tokio::test]
-    async fn test_force_complete_burn_from_burn_submitted_state() {
+    async fn test_force_complete_legacy_submitted_burn_without_hash_fails() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
-        let burn_tx_hash = b256!(
-            "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
-        );
-        let block_number = 45_989_009;
-        let reason = "submitted burn confirmed on-chain".to_string();
-
-        let events = TestHarness::<Redemption>::with(mock_services())
+        let error = TestHarness::<Redemption>::with(mock_services())
             .given(burn_submitted_given_events(&issuer_request_id))
             .when(RedemptionCommand::ForceCompleteBurn {
-                issuer_request_id: issuer_request_id.clone(),
-                burn_tx_hash,
-                block_number,
-                reason: reason.clone(),
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 45_989_009,
+                reason: "another redemption's verified burn".to_string(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::PersistedBurnHashUnavailable
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_burn_from_exhausted_burn_intended_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let sendable_tx = SendableTxWithHash::valid_for_test(
+            7,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let mut history =
+            intended_burn_history(&issuer_request_id, sendable_tx.clone());
+        history.push(RedemptionEvent::BurnRecoveryExhausted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: sendable_tx.hash,
+            nonce: sendable_tx.nonce,
+            attempts: 5,
+            exhausted_at: Utc::now(),
+        });
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: sendable_tx.hash,
+                block_number: 45_989_009,
+                reason: "verified exhausted burn".to_string(),
             })
             .await
             .events();
 
-        assert_eq!(events.len(), 1);
-
-        let RedemptionEvent::BurnForceCompleted {
-            issuer_request_id: event_id,
-            burn_tx_hash: event_tx_hash,
-            block_number: event_block,
-            reason: event_reason,
-            ..
-        } = &events[0]
-        else {
-            panic!("Expected BurnForceCompleted event, got {:?}", &events[0]);
-        };
-
-        assert_eq!(event_id, &issuer_request_id);
-        assert_eq!(event_tx_hash, &burn_tx_hash);
-        assert_eq!(event_block, &block_number);
-        assert_eq!(event_reason, &reason);
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted { .. }]
+        ));
     }
 
     #[test]
@@ -3064,7 +3838,12 @@ mod tests {
 
         assert_eq!(
             redemption,
-            Redemption::Failed { issuer_request_id, reason: error, failed_at }
+            Redemption::Failed {
+                issuer_request_id,
+                reason: error,
+                failed_at,
+                prior_burn_tx: None,
+            }
         );
     }
 
@@ -3760,6 +4539,88 @@ mod tests {
         assert_eq!(*alpaca_journal_completed_at, journal_completed_at);
     }
 
+    #[test]
+    fn prior_burn_transaction_survives_failure_resume_and_snapshot_roundtrip() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let mut history =
+            intended_burn_history(&issuer_request_id, persisted_tx.clone());
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "replacement preparation failed".to_string(),
+            failed_at: Utc::now(),
+            tx_id: None,
+            planned_burns: vec![],
+        });
+        let failed = replay::<Redemption>(history.clone())
+            .expect("failed history should replay")
+            .expect("redemption should exist");
+        assert!(matches!(
+            &failed,
+            Redemption::Failed {
+                prior_burn_tx: Some(prior_burn_tx),
+                ..
+            } if prior_burn_tx == &persisted_tx
+        ));
+
+        history.push(RedemptionEvent::BurnResumed {
+            issuer_request_id,
+            underlying: UnderlyingSymbol::new("AAPL"),
+            token: TokenSymbol::new("tAAPL"),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            quantity: Quantity::new(Decimal::from(100)),
+            tx_hash: b256!(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            ),
+            block_number: 12345,
+            detected_at: Utc::now(),
+            tokenization_request_id: TokenizationRequestId::new(
+                "alp-replace-456",
+            ),
+            alpaca_quantity: Quantity::new(Decimal::from(100)),
+            dust_quantity: Quantity::new(Decimal::ZERO),
+            called_at: Utc::now(),
+            alpaca_journal_completed_at: Utc::now(),
+            external_tx_id: None,
+            resumed_at: Utc::now(),
+        });
+        let burning = replay::<Redemption>(history)
+            .expect("resumed history should replay")
+            .expect("redemption should exist");
+        let snapshot = serde_json::to_string(&burning)
+            .expect("burning snapshot should serialize");
+        let roundtripped: Redemption = serde_json::from_str(&snapshot)
+            .expect("burning snapshot should deserialize");
+        assert!(matches!(
+            &roundtripped,
+            Redemption::Burning {
+                prior_burn_tx: Some(prior_burn_tx),
+                ..
+            } if prior_burn_tx == &persisted_tx
+        ));
+
+        for (aggregate, variant) in [(failed, "Failed"), (burning, "Burning")] {
+            let mut old_snapshot = serde_json::to_value(aggregate)
+                .expect("snapshot should serialize");
+            old_snapshot
+                .pointer_mut(&format!("/{variant}"))
+                .and_then(serde_json::Value::as_object_mut)
+                .expect("snapshot variant should exist")
+                .remove("prior_burn_tx");
+            let restored: Redemption = serde_json::from_value(old_snapshot)
+                .expect("old snapshot should deserialize");
+            assert!(matches!(
+                restored,
+                Redemption::Failed { prior_burn_tx: None, .. }
+                    | Redemption::Burning { prior_burn_tx: None, .. }
+            ));
+        }
+    }
+
     proptest! {
         #[test]
         fn test_serde_roundtrip_proptest(id in arb_issuer_redemption_request_id()) {
@@ -3775,6 +4636,160 @@ mod tests {
             prop_assert!(display.starts_with("0x"));
             prop_assert_eq!(display.len(), 66);
         }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn redemption_v3_burn_submitted_snapshot_replays_the_persisted_transaction()
+     {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!().run(&pool).await.expect("migrations should run");
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let mut history =
+            intended_burn_history(&issuer_request_id, persisted_tx.clone());
+        history.push(RedemptionEvent::BurnTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: BurnExternalTxId::base(&B256::random()),
+            tx_id: persisted_tx.hash.into(),
+            planned_burns: vec![BurnRecord {
+                receipt_id: uint!(42_U256),
+                shares_burned: uint!(100_000000000000000000_U256),
+            }],
+            submitted_at: Utc::now(),
+        });
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Redemption", "version": 3 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .expect("v3 schema registry event should seed");
+
+        for (index, event) in history.iter().enumerate() {
+            let sequence = i64::try_from(index + 1)
+                .expect("test event sequence should fit i64");
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, ?, ?, '{}')
+                ",
+            )
+            .bind(issuer_request_id.to_string())
+            .bind(sequence)
+            .bind(event.event_type())
+            .bind(event.event_version())
+            .bind(
+                serde_json::to_string(event)
+                    .expect("redemption event should serialize"),
+            )
+            .execute(&pool)
+            .await
+            .expect("redemption history should seed");
+        }
+
+        let last_sequence = i64::try_from(history.len())
+            .expect("test event count should fit i64");
+        let aggregate = replay::<Redemption>(history)
+            .expect("history should replay")
+            .expect("history should originate a redemption");
+        let mut stale_snapshot = serde_json::json!({ "Live": aggregate });
+        stale_snapshot
+            .pointer_mut("/Live/BurnSubmitted")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("snapshot should contain BurnSubmitted")
+            .remove("sendable_tx");
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                ?,
+                3,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .bind(last_sequence)
+        .bind(stale_snapshot.to_string())
+        .execute(&pool)
+        .await
+        .expect("v3 snapshot should seed");
+
+        prepare_event_sourced_startup::<Redemption>(&pool)
+            .await
+            .expect("schema reconciliation should succeed");
+        let store = StoreBuilder::<Redemption>::new(pool.clone())
+            .build(mock_services())
+            .await
+            .expect("redemption store should rebuild");
+        let replayed = store
+            .load(&issuer_request_id)
+            .await
+            .expect("redemption should load")
+            .expect("redemption should exist");
+
+        assert!(matches!(
+            replayed,
+            Redemption::BurnSubmitted { sendable_tx, .. }
+                if sendable_tx == persisted_tx
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Cleared stale snapshots", "Redemption"]
+        ));
     }
 
     /// Regression: pre-event-sorcery snapshot payloads must be cleared before

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -391,7 +391,11 @@ impl RedemptionView {
             // View stays in Burning — BurnTxSubmitted and BurnIntended is an internal
             // detail that doesn't change the query-facing state.
             RedemptionEvent::BurnIntended { .. }
-            | RedemptionEvent::BurnTxSubmitted { .. } => self,
+            | RedemptionEvent::BurnTxSubmitted { .. }
+            | RedemptionEvent::BurnRecoveryAttempted { .. }
+            | RedemptionEvent::BurnPreparationRecoveryAttempted { .. }
+            | RedemptionEvent::BurnRecoveryExhausted { .. }
+            | RedemptionEvent::BurnPreparationRecoveryExhausted { .. } => self,
             RedemptionEvent::RedemptionClosed {
                 issuer_request_id,
                 reason,

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -12,11 +12,13 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
+#[cfg(test)]
+use tokio::sync::Notify;
 
 use super::{
-    BurnVerification, MintResult, MultiBurnParams, MultiBurnResult,
-    MultiBurnResultEntry, PreparedMintTx, ReceiptInformation, SubmittedTx,
-    VaultError, VaultService, WalletNonceGuard,
+    BurnTxStatus, BurnVerification, MintResult, MultiBurnParams,
+    MultiBurnResult, MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
+    SubmittedTx, VaultError, VaultService, WalletNonceGuard,
 };
 use crate::redemption::BurnExternalTxId;
 use crate::vault::{SendableTxWithHash, TxId};
@@ -49,6 +51,19 @@ enum MockBehavior {
     /// transaction landed on-chain.
     #[cfg(test)]
     ConfirmPending,
+    /// Wallet lock acquisition waits for an explicit test release.
+    #[cfg(test)]
+    WalletLockBlocked {
+        attempted: Arc<Notify>,
+        release: Arc<Notify>,
+    },
+    /// Burn confirmation waits for an explicit test release, then reports an
+    /// uncertain pending result.
+    #[cfg(test)]
+    ConfirmPendingBlocked {
+        started: Arc<Notify>,
+        release: Arc<Notify>,
+    },
     /// `submit_burn` fails with a definitive on-chain revert
     /// (`VaultError::Reverted`), as the synchronous local backend does when a
     /// burn mines but reverts — exercises the submit-failure release path.
@@ -85,6 +100,13 @@ enum MockCheckTxOutcome {
     /// The prior tx cannot be verified from its identifier or receipt.
     #[default]
     InvalidReceipt,
+}
+
+#[cfg(test)]
+#[derive(Clone, Copy)]
+enum MockBurnTxClassification {
+    Status(BurnTxStatus),
+    RpcError,
 }
 
 #[cfg(test)]
@@ -131,6 +153,16 @@ pub(crate) struct MockVaultService {
     prepared_tx: Arc<Mutex<Option<SendableTxWithHash>>>,
     #[cfg(test)]
     checked_tx_outcome: Arc<Mutex<MockCheckTxOutcome>>,
+    #[cfg(test)]
+    burn_tx_status: Arc<Mutex<MockBurnTxClassification>>,
+    #[cfg(test)]
+    submitted_burn_txs: Arc<Mutex<Vec<SendableTxWithHash>>>,
+    #[cfg(test)]
+    burn_classification_call_count: Arc<AtomicUsize>,
+    #[cfg(test)]
+    burn_preparation_call_count: Arc<AtomicUsize>,
+    #[cfg(test)]
+    replacement_preparation_call_count: Arc<AtomicUsize>,
 }
 
 impl MockVaultService {
@@ -160,6 +192,18 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            #[cfg(test)]
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            #[cfg(test)]
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(test)]
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -182,6 +226,13 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -204,6 +255,13 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -226,6 +284,13 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -234,6 +299,64 @@ impl MockVaultService {
         let mut service = Self::new_success();
         service.behavior = MockBehavior::ConfirmPending;
         service
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_wallet_lock_blocked() -> Self {
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::WalletLockBlocked {
+            attempted: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        };
+        service
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_confirm_pending_blocked() -> Self {
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::ConfirmPendingBlocked {
+            started: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        };
+        service
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_wallet_lock_attempt(&self) {
+        let MockBehavior::WalletLockBlocked { attempted, .. } = &self.behavior
+        else {
+            panic!("mock does not block wallet lock acquisition");
+        };
+        attempted.notified().await;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn release_wallet_lock(&self) {
+        let MockBehavior::WalletLockBlocked { release, .. } = &self.behavior
+        else {
+            panic!("mock does not block wallet lock acquisition");
+        };
+        release.notify_one();
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn wait_for_burn_confirmation(&self) {
+        let MockBehavior::ConfirmPendingBlocked { started, .. } =
+            &self.behavior
+        else {
+            panic!("mock does not block burn confirmation");
+        };
+        started.notified().await;
+    }
+
+    #[cfg(test)]
+    pub(crate) fn release_burn_confirmation(&self) {
+        let MockBehavior::ConfirmPendingBlocked { release, .. } =
+            &self.behavior
+        else {
+            panic!("mock does not block burn confirmation");
+        };
+        release.notify_one();
     }
 
     #[cfg(test)]
@@ -255,6 +378,13 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -277,6 +407,13 @@ impl MockVaultService {
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
             )),
+            burn_tx_status: Arc::new(Mutex::new(
+                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
+            )),
+            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
+            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -320,13 +457,39 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
+    pub(crate) fn submitted_burn_txs(&self) -> Vec<SendableTxWithHash> {
+        self.submitted_burn_txs.lock().unwrap().clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn burn_classification_call_count(&self) -> usize {
+        self.burn_classification_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn burn_preparation_call_count(&self) -> usize {
+        self.burn_preparation_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn replacement_preparation_call_count(&self) -> usize {
+        self.replacement_preparation_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
     pub(crate) fn reset(&self) {
         self.wallet_lock_call_count.store(0, Ordering::Relaxed);
         self.call_count.store(0, Ordering::Relaxed);
         self.multi_burn_call_count.store(0, Ordering::Relaxed);
         *self.last_call.lock().unwrap() = None;
+        *self.last_multi_burn_params.lock().unwrap() = None;
         *self.pending_mint_result.lock().unwrap() = None;
         *self.pending_burn_result.lock().unwrap() = None;
+        *self.prepared_tx.lock().unwrap() = None;
+        self.submitted_burn_txs.lock().unwrap().clear();
+        self.burn_classification_call_count.store(0, Ordering::Relaxed);
+        self.burn_preparation_call_count.store(0, Ordering::Relaxed);
+        self.replacement_preparation_call_count.store(0, Ordering::Relaxed);
     }
 
     #[cfg(test)]
@@ -403,6 +566,31 @@ impl MockVaultService {
         *self.checked_tx_outcome.lock().unwrap() =
             MockCheckTxOutcome::Receipt(Box::new(receipt));
         self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_burn_tx_status(self, status: BurnTxStatus) -> Self {
+        *self.burn_tx_status.lock().unwrap() =
+            MockBurnTxClassification::Status(status);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_burn_tx_classification_failure(self) -> Self {
+        *self.burn_tx_status.lock().unwrap() =
+            MockBurnTxClassification::RpcError;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_burn_tx_status(&self, status: BurnTxStatus) {
+        *self.burn_tx_status.lock().unwrap() =
+            MockBurnTxClassification::Status(status);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_prepared_tx(&self, sendable_tx: SendableTxWithHash) {
+        *self.prepared_tx.lock().unwrap() = Some(sendable_tx);
     }
 }
 
@@ -572,6 +760,8 @@ impl VaultService for MockVaultService {
             #[cfg(test)]
             MockBehavior::ConfirmRevert
             | MockBehavior::ConfirmPending
+            | MockBehavior::WalletLockBlocked { .. }
+            | MockBehavior::ConfirmPendingBlocked { .. }
             | MockBehavior::SubmitRevert
             | MockBehavior::PrepareTxFails
             | MockBehavior::InvalidPreparedMint => {
@@ -615,6 +805,7 @@ impl VaultService for MockVaultService {
         #[cfg(test)]
         {
             *self.last_multi_burn_params.lock().unwrap() = Some(params.clone());
+            self.submitted_burn_txs.lock().unwrap().push(prepared_tx.clone());
         }
 
         // Pre-compute the MultiBurnResult for confirm_burn to return.
@@ -687,12 +878,22 @@ impl VaultService for MockVaultService {
                     message: "receipt polling timed out".to_string(),
                 })
             }
+            #[cfg(test)]
+            MockBehavior::ConfirmPendingBlocked { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
             // SubmitRevert fails at submit; if confirm is somehow reached,
             // return the cached result like the other submit-* behaviors.
             // PrepareTxFails never reaches confirm (fails before submit);
             // if somehow called, return the cached result.
             #[cfg(test)]
-            MockBehavior::SubmitRevert
+            MockBehavior::WalletLockBlocked { .. }
+            | MockBehavior::SubmitRevert
             | MockBehavior::PrepareTxFails
             | MockBehavior::InvalidPreparedMint => {
                 let result = self
@@ -741,6 +942,7 @@ impl VaultService for MockVaultService {
     ) -> Result<SendableTxWithHash, VaultError> {
         #[cfg(test)]
         {
+            self.burn_preparation_call_count.fetch_add(1, Ordering::Relaxed);
             if matches!(self.behavior, MockBehavior::PrepareTxFails) {
                 return Err(VaultError::InvalidReceipt);
             }
@@ -749,6 +951,44 @@ impl VaultService for MockVaultService {
             let prepared = self.prepared_tx.lock().unwrap().clone();
             return Ok(prepared.unwrap_or_default());
         }
+        #[cfg(not(test))]
+        Ok(SendableTxWithHash::default())
+    }
+
+    async fn classify_burn_tx(
+        &self,
+        _owner: Address,
+        _sendable_tx: &SendableTxWithHash,
+    ) -> Result<BurnTxStatus, VaultError> {
+        #[cfg(test)]
+        self.burn_classification_call_count.fetch_add(1, Ordering::Relaxed);
+        #[cfg(test)]
+        let classification = *self.burn_tx_status.lock().unwrap();
+        #[cfg(test)]
+        return match classification {
+            MockBurnTxClassification::Status(status) => Ok(status),
+            MockBurnTxClassification::RpcError => {
+                Err(VaultError::InvalidReceipt)
+            }
+        };
+        #[cfg(not(test))]
+        Ok(BurnTxStatus::StillMineable)
+    }
+
+    async fn prepare_replacement_burn_tx(
+        &self,
+        _owner: Address,
+        _sendable_tx: &SendableTxWithHash,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        #[cfg(test)]
+        self.replacement_preparation_call_count.fetch_add(1, Ordering::Relaxed);
+        #[cfg(test)]
+        return self
+            .prepared_tx
+            .lock()
+            .unwrap()
+            .clone()
+            .ok_or(VaultError::InvalidReceipt);
         #[cfg(not(test))]
         Ok(SendableTxWithHash::default())
     }
@@ -792,7 +1032,16 @@ impl VaultService for MockVaultService {
 
     async fn lock_wallet(&self) -> WalletNonceGuard {
         #[cfg(test)]
-        self.wallet_lock_call_count.fetch_add(1, Ordering::Relaxed);
+        {
+            self.wallet_lock_call_count.fetch_add(1, Ordering::Relaxed);
+            if let MockBehavior::WalletLockBlocked { attempted, release } =
+                &self.behavior
+            {
+                attempted.notify_one();
+                release.notified().await;
+            }
+        }
+
         Some(self.wallet_nonce_lock.clone().lock_owned().await)
     }
 }
@@ -1071,20 +1320,33 @@ mod tests {
 
     #[tokio::test]
     async fn test_reset_clears_multi_burn_state() {
-        let mock = MockVaultService::new_success();
+        let params = test_multi_burn_params();
+        let sendable_tx = test_sendable_tx();
+        let mock = MockVaultService::new_success()
+            .with_prepared_tx(sendable_tx.clone());
 
-        mock.submit_burn(test_multi_burn_params(), test_sendable_tx())
-            .await
-            .unwrap();
-        mock.submit_burn(test_multi_burn_params(), test_sendable_tx())
+        mock.submit_burn(params.clone(), sendable_tx.clone()).await.unwrap();
+        mock.submit_burn(params.clone(), sendable_tx.clone()).await.unwrap();
+        mock.classify_burn_tx(params.owner, &sendable_tx).await.unwrap();
+        mock.prepare_burn_tx(&params).await.unwrap();
+        mock.prepare_replacement_burn_tx(params.owner, &sendable_tx)
             .await
             .unwrap();
 
         assert_eq!(mock.get_multi_burn_call_count(), 2);
+        assert_eq!(mock.submitted_burn_txs().len(), 2);
+        assert_eq!(mock.burn_classification_call_count(), 1);
+        assert_eq!(mock.burn_preparation_call_count(), 1);
+        assert_eq!(mock.replacement_preparation_call_count(), 1);
 
         mock.reset();
 
         assert_eq!(mock.get_multi_burn_call_count(), 0);
+        assert!(mock.get_last_multi_burn_params().is_none());
+        assert!(mock.submitted_burn_txs().is_empty());
+        assert_eq!(mock.burn_classification_call_count(), 0);
+        assert_eq!(mock.burn_preparation_call_count(), 0);
+        assert_eq!(mock.replacement_preparation_call_count(), 0);
     }
 
     #[tokio::test]

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -1,3 +1,4 @@
+use alloy::consensus::transaction::SignerRecoverable;
 #[cfg(test)]
 use alloy::consensus::{SignableTransaction, TxLegacy};
 use alloy::consensus::{Transaction, TxEnvelope};
@@ -10,6 +11,10 @@ use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
 use alloy::primitives::{Signature, TxKind};
 use alloy::providers::SendableTxErr;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+#[cfg(test)]
+use alloy::signers::SignerSync;
+#[cfg(test)]
+use alloy::signers::local::PrivateKeySigner;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -127,11 +132,39 @@ pub(crate) trait VaultService: Send + Sync {
         tx_hash: B256,
     ) -> Result<BurnVerification, VaultError>;
 
-    /// Prepares asigned raw tx that is sendable via eth_sendRawTransaction
+    /// Prepares a signed raw transaction for `eth_sendRawTransaction`.
     async fn prepare_burn_tx(
         &self,
         _params: &MultiBurnParams,
     ) -> Result<SendableTxWithHash, VaultError>;
+
+    /// Classifies whether a persisted signed burn transaction can still land.
+    ///
+    /// Implementations must check the exact hash receipt before comparing the
+    /// owner's finalized nonce. Any provider uncertainty returns an error so
+    /// callers fail closed and keep the persisted transaction live.
+    async fn classify_burn_tx(
+        &self,
+        _owner: Address,
+        _sendable_tx: &SendableTxWithHash,
+    ) -> Result<BurnTxStatus, VaultError> {
+        Ok(BurnTxStatus::StillMineable)
+    }
+
+    /// Re-signs the persisted burn's exact call at a fresh nonce.
+    ///
+    /// Callers may invoke this only after [`VaultService::classify_burn_tx`]
+    /// proves the persisted hash dead. Implementations must preserve the
+    /// destination, value, and calldata rather than reconstructing the burn
+    /// from a lossy projection, and must assign the owner's pending account
+    /// nonce rather than relying on a local nonce cache.
+    async fn prepare_replacement_burn_tx(
+        &self,
+        _owner: Address,
+        _sendable_tx: &SendableTxWithHash,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
 
     /// Fetches the on-chain receipt for `tx_hash`, returning an error if the
     /// transaction reverted.
@@ -147,6 +180,117 @@ pub(crate) trait VaultService: Send + Sync {
 }
 
 pub(crate) type WalletNonceGuard = Option<tokio::sync::OwnedMutexGuard<()>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BurnTxStatus {
+    Mined,
+    Reverted,
+    StillMineable,
+    ProvablyDead,
+}
+
+impl SendableTxWithHash {
+    pub(crate) fn validate(&self) -> Result<TxEnvelope, VaultError> {
+        let envelope = TxEnvelope::decode_2718_exact(&self.tx)?;
+        let decoded_hash = *envelope.tx_hash();
+        if decoded_hash != self.hash {
+            return Err(VaultError::PreparedBurnHashMismatch {
+                expected: self.hash,
+                decoded: decoded_hash,
+            });
+        }
+        let decoded_nonce = envelope.nonce();
+        if decoded_nonce != self.nonce {
+            return Err(VaultError::PreparedBurnNonceMismatch {
+                expected: self.nonce,
+                decoded: decoded_nonce,
+            });
+        }
+        Ok(envelope)
+    }
+
+    pub(crate) fn validate_for_owner(
+        &self,
+        owner: Address,
+    ) -> Result<TxEnvelope, VaultError> {
+        let envelope = self.validate()?;
+        let signer = envelope.recover_signer()?;
+        if signer != owner {
+            return Err(VaultError::PreparedBurnSignerMismatch {
+                expected: owner,
+                decoded: signer,
+            });
+        }
+        Ok(envelope)
+    }
+
+    pub(crate) fn validate_replacement_for_owner(
+        &self,
+        previous: &Self,
+        owner: Address,
+    ) -> Result<(), VaultError> {
+        let previous_envelope = previous.validate_for_owner(owner)?;
+        let replacement_envelope = self.validate_for_owner(owner)?;
+        if replacement_envelope.to() != previous_envelope.to() {
+            return Err(VaultError::BurnReplacementDestinationMismatch {
+                previous: previous_envelope.to(),
+                replacement: replacement_envelope.to(),
+            });
+        }
+        if replacement_envelope.value() != previous_envelope.value() {
+            return Err(VaultError::BurnReplacementValueMismatch {
+                previous: previous_envelope.value(),
+                replacement: replacement_envelope.value(),
+            });
+        }
+        if replacement_envelope.input() != previous_envelope.input() {
+            return Err(VaultError::BurnReplacementInputMismatch {
+                previous: previous_envelope.input().clone(),
+                replacement: replacement_envelope.input().clone(),
+            });
+        }
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn valid_for_test(
+        nonce: u64,
+        destination: Address,
+        input: Bytes,
+    ) -> Self {
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce,
+            gas_price: 1,
+            gas_limit: 100_000,
+            to: TxKind::Call(destination),
+            value: U256::ZERO,
+            input,
+        };
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(1))
+            .expect("test private key should be valid");
+        let signature = signer
+            .sign_hash_sync(&transaction.signature_hash())
+            .expect("test transaction should sign");
+        let envelope = TxEnvelope::from(transaction.into_signed(signature));
+
+        Self {
+            tx: envelope.encoded_2718(),
+            hash: *envelope.tx_hash(),
+            nonce: envelope.nonce(),
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn signer_for_test(&self) -> Address {
+        self.validate()
+            .expect("test burn transaction should decode")
+            .recover_signer()
+            .expect("test burn transaction signature should recover")
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub(crate) struct PreparedMintTx {
@@ -482,6 +626,33 @@ pub(crate) enum VaultError {
         "Persisted mint transaction nonce {expected} does not match decoded nonce {decoded}"
     )]
     PreparedMintNonceMismatch { expected: u64, decoded: u64 },
+    #[error(
+        "Persisted burn transaction hash {expected:?} does not match decoded hash {decoded:?}"
+    )]
+    PreparedBurnHashMismatch { expected: B256, decoded: B256 },
+    #[error(
+        "Persisted burn transaction nonce {expected} does not match decoded nonce {decoded}"
+    )]
+    PreparedBurnNonceMismatch { expected: u64, decoded: u64 },
+    #[error(
+        "Persisted burn transaction signer {decoded:?} does not match wallet {expected:?}"
+    )]
+    PreparedBurnSignerMismatch { expected: Address, decoded: Address },
+    #[error(
+        "Burn replacement destination {replacement:?} differs from persisted destination {previous:?}"
+    )]
+    BurnReplacementDestinationMismatch {
+        previous: Option<Address>,
+        replacement: Option<Address>,
+    },
+    #[error(
+        "Burn replacement value {replacement} differs from persisted value {previous}"
+    )]
+    BurnReplacementValueMismatch { previous: U256, replacement: U256 },
+    #[error("Burn replacement calldata differs from persisted calldata")]
+    BurnReplacementInputMismatch { previous: Bytes, replacement: Bytes },
+    #[error(transparent)]
+    SignerRecovery(#[from] alloy::consensus::crypto::RecoveryError),
     #[error(transparent)]
     Eip2718(#[from] alloy::eips::eip2718::Eip2718Error),
     /// Contract call error

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -9,7 +9,7 @@ use alloy::providers::fillers::{
 use alloy::providers::{
     Identity, PendingTransactionBuilder, Provider, RootProvider,
 };
-use alloy::rpc::types::TransactionReceipt;
+use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
@@ -19,10 +19,10 @@ use tracing::debug;
 
 use super::rain_meta::OaSchemaCache;
 use super::{
-    BurnVerification, MintResult, MultiBurnResult, MultiBurnResultEntry,
-    PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId,
-    VaultError, VaultService, WalletNonceGuard, classify_checked_receipt,
-    verify_burn_in_receipt,
+    BurnTxStatus, BurnVerification, MintResult, MultiBurnResult,
+    MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
+    SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
+    WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
 };
 use crate::bindings::OffchainAssetReceiptVault;
 use crate::redemption::BurnExternalTxId;
@@ -249,21 +249,32 @@ impl VaultService for RealBlockchainService {
         params: super::MultiBurnParams,
         sendable_tx: SendableTxWithHash,
     ) -> Result<SubmittedTx, VaultError> {
-        if let Err(error) =
-            self.provider.send_raw_transaction(&sendable_tx.tx).await
-        {
-            if self
-                .provider
-                .get_transaction_by_hash(sendable_tx.hash)
-                .await?
-                .is_none()
-            {
-                return Err(error.into());
-            }
+        sendable_tx.validate_for_owner(params.owner)?;
 
-            debug!(target: "vault", tx_hash = %sendable_tx.hash,
-                "Burn broadcast errored but the node holds the persisted transaction"
-            );
+        match self.provider.send_raw_transaction(&sendable_tx.tx).await {
+            Ok(pending_tx) => {
+                let returned = *pending_tx.tx_hash();
+                if returned != sendable_tx.hash {
+                    return Err(VaultError::BroadcastHashMismatch {
+                        expected: sendable_tx.hash,
+                        returned,
+                    });
+                }
+            }
+            Err(error) => {
+                if self
+                    .provider
+                    .get_transaction_by_hash(sendable_tx.hash)
+                    .await?
+                    .is_none()
+                {
+                    return Err(error.into());
+                }
+
+                debug!(target: "vault", tx_hash = %sendable_tx.hash,
+                    "Burn broadcast errored but the node holds the persisted transaction"
+                );
+            }
         }
 
         Ok(SubmittedTx {
@@ -436,6 +447,115 @@ impl VaultService for RealBlockchainService {
         })
     }
 
+    async fn classify_burn_tx(
+        &self,
+        owner: Address,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<BurnTxStatus, VaultError> {
+        sendable_tx.validate_for_owner(owner)?;
+        let status = if let Some(receipt) =
+            self.provider.get_transaction_receipt(sendable_tx.hash).await?
+        {
+            if receipt.transaction_hash != sendable_tx.hash
+                || receipt.block_number.is_none()
+            {
+                return Err(VaultError::InvalidReceipt);
+            }
+
+            if receipt.status() {
+                BurnTxStatus::Mined
+            } else {
+                BurnTxStatus::Reverted
+            }
+        } else {
+            let latest_nonce =
+                self.provider.get_transaction_count(owner).latest().await?;
+            let finalized_nonce =
+                self.provider.get_transaction_count(owner).finalized().await?;
+            let status = if finalized_nonce > sendable_tx.nonce {
+                match self
+                    .provider
+                    .get_transaction_receipt(sendable_tx.hash)
+                    .await?
+                {
+                    Some(receipt) => {
+                        if receipt.transaction_hash != sendable_tx.hash
+                            || receipt.block_number.is_none()
+                        {
+                            return Err(VaultError::InvalidReceipt);
+                        }
+                        if receipt.status() {
+                            BurnTxStatus::Mined
+                        } else {
+                            BurnTxStatus::Reverted
+                        }
+                    }
+                    None => BurnTxStatus::ProvablyDead,
+                }
+            } else {
+                BurnTxStatus::StillMineable
+            };
+            debug!(target: "vault",
+                owner = %owner,
+                tx_hash = %sendable_tx.hash,
+                nonce = sendable_tx.nonce,
+                latest_nonce,
+                finalized_nonce,
+                status = ?status,
+                "Classified persisted burn transaction"
+            );
+            return Ok(status);
+        };
+        debug!(target: "vault",
+            owner = %owner,
+            tx_hash = %sendable_tx.hash,
+            nonce = sendable_tx.nonce,
+            status = ?status,
+            "Classified persisted burn transaction"
+        );
+        Ok(status)
+    }
+
+    async fn prepare_replacement_burn_tx(
+        &self,
+        owner: Address,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        let envelope = sendable_tx.validate_for_owner(owner)?;
+        let mut transaction = TransactionRequest::from_transaction(envelope);
+        transaction.from = Some(owner);
+        transaction.nonce =
+            Some(self.provider.get_transaction_count(owner).pending().await?);
+        transaction.gas = None;
+        transaction.gas_price = None;
+        transaction.max_fee_per_gas = None;
+        transaction.max_priority_fee_per_gas = None;
+        transaction.max_fee_per_blob_gas = None;
+
+        let replacement = self
+            .provider
+            .fill(transaction)
+            .await?
+            .try_into_envelope()
+            .map_err(Box::new)?;
+        let replacement = SendableTxWithHash {
+            tx: replacement.encoded_2718(),
+            hash: *replacement.tx_hash(),
+            nonce: replacement.nonce(),
+            signed_at: Utc::now(),
+            dust_shares: sendable_tx.dust_shares,
+        };
+        debug!(target: "vault",
+            owner = %owner,
+            previous_tx_hash = %sendable_tx.hash,
+            previous_nonce = sendable_tx.nonce,
+            replacement_tx_hash = %replacement.hash,
+            replacement_nonce = replacement.nonce,
+            "Prepared fresh-nonce burn replacement"
+        );
+        Ok(replacement)
+    }
+
     async fn check_tx(
         &self,
         tx_id: &TxId,
@@ -464,30 +584,35 @@ mod tests {
         Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Transaction,
         TxEnvelope,
     };
-    use alloy::eips::Decodable2718;
+    use alloy::eips::{Decodable2718, Encodable2718};
     use alloy::network::EthereumWallet;
     use alloy::primitives::{
         Address, B256, Bloom, Bytes, IntoLogData, U256, address, b256,
         fixed_bytes,
     };
-    use alloy::providers::ProviderBuilder;
     use alloy::providers::fillers::{BlobGasFiller, ChainIdFiller};
     use alloy::providers::mock::Asserter;
-    use alloy::rpc::types::{Block, FeeHistory, TransactionReceipt};
+    use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::rpc::types::{
+        Block, FeeHistory, TransactionReceipt, TransactionRequest,
+    };
     use alloy::signers::local::PrivateKeySigner;
     use chrono::Utc;
     use rust_decimal::Decimal;
     use std::sync::Arc;
+    use tracing::Level;
+    use tracing_test::traced_test;
 
-    use super::RealBlockchainService;
+    use super::{RealBlockchainService, RealBlockchainServiceProvider};
     use crate::bindings::OffchainAssetReceiptVault;
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
+    use crate::test_utils::{LocalEvm, logs_contain_at};
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
-        MultiBurnEntry, MultiBurnParams, ReceiptInformation,
+        BurnTxStatus, MultiBurnEntry, MultiBurnParams, ReceiptInformation,
         SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
@@ -517,6 +642,26 @@ mod tests {
 
     fn test_vault_address() -> Address {
         address!("0000000000000000000000000000000000000002")
+    }
+
+    fn test_multi_burn_params(owner: Address) -> MultiBurnParams {
+        MultiBurnParams {
+            vault: test_vault_address(),
+            burns: vec![MultiBurnEntry {
+                receipt_id: U256::from(1),
+                burn_shares: U256::from(100),
+                receipt_info: None,
+                receipt_info_bytes: None,
+            }],
+            dust_shares: U256::ZERO,
+            owner,
+            user: address!("0x3333333333333333333333333333333333333333"),
+            issuer_request_id: test_issuer_redemption_id(),
+            detected_tx_hash: b256!(
+                "0xabababababababababababababababababababababababababababababababab"
+            ),
+            external_tx_id: None,
+        }
     }
 
     fn test_fee_history() -> FeeHistory {
@@ -557,7 +702,13 @@ mod tests {
     }
 
     fn create_service_with_asserter(asserter: Asserter) -> impl VaultService {
-        let signer = PrivateKeySigner::random();
+        create_service_with_signer(asserter, PrivateKeySigner::random())
+    }
+
+    fn create_service_with_signer(
+        asserter: Asserter,
+        signer: PrivateKeySigner,
+    ) -> impl VaultService {
         let provider = ProviderBuilder::new()
             .disable_recommended_fillers()
             .with_gas_estimation()
@@ -570,6 +721,136 @@ mod tests {
             provider,
             Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
         )
+    }
+
+    async fn sign_test_transaction(
+        provider: &RealBlockchainServiceProvider,
+        transaction: TransactionRequest,
+    ) -> SendableTxWithHash {
+        let envelope = provider
+            .fill(transaction)
+            .await
+            .expect("test transaction should fill")
+            .try_into_envelope()
+            .expect("test transaction should be signed");
+        SendableTxWithHash {
+            tx: envelope.encoded_2718(),
+            hash: *envelope.tx_hash(),
+            nonce: envelope.nonce(),
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn anvil_classifies_persisted_transactions_for_recovery() {
+        let evm = LocalEvm::new().await.expect("Anvil should start");
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key)
+            .expect("Anvil key should parse");
+        let owner = signer.address();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .filler(BlobGasFiller)
+            .with_simple_nonce_management()
+            .filler(ChainIdFiller::default())
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .expect("provider should connect");
+        let service = RealBlockchainService::new(
+            provider.clone(),
+            Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
+        );
+        let recipient = address!("0x3333333333333333333333333333333333333333");
+
+        let mineable = sign_test_transaction(
+            &provider,
+            TransactionRequest::default()
+                .from(owner)
+                .to(recipient)
+                .value(U256::from(1u8)),
+        )
+        .await;
+        assert_eq!(
+            service.classify_burn_tx(owner, &mineable).await.unwrap(),
+            BurnTxStatus::StillMineable
+        );
+
+        provider
+            .send_raw_transaction(&mineable.tx)
+            .await
+            .expect("persisted transaction should broadcast")
+            .get_receipt()
+            .await
+            .expect("persisted transaction should mine");
+        assert_eq!(
+            service.classify_burn_tx(owner, &mineable).await.unwrap(),
+            BurnTxStatus::Mined
+        );
+
+        let dead = sign_test_transaction(
+            &provider,
+            TransactionRequest::default()
+                .from(owner)
+                .to(recipient)
+                .value(U256::from(2u8)),
+        )
+        .await;
+        for nonce_offset in 0..3 {
+            provider
+                .send_transaction(
+                    TransactionRequest::default()
+                        .from(owner)
+                        .to(recipient)
+                        .nonce(dead.nonce + nonce_offset)
+                        .value(U256::from(3u64 + nonce_offset)),
+                )
+                .await
+                .expect("competing transaction should broadcast")
+                .get_receipt()
+                .await
+                .expect("competing transaction should mine");
+        }
+        assert_eq!(
+            service.classify_burn_tx(owner, &dead).await.unwrap(),
+            BurnTxStatus::StillMineable,
+            "Anvil's unfinalized nonce advance must not prove death"
+        );
+
+        let invalid_redeem =
+            OffchainAssetReceiptVault::new(evm.vault_address, &provider)
+                .redeem(U256::from(1u8), owner, owner, U256::MAX, Bytes::new())
+                .calldata()
+                .clone();
+        let reverted = sign_test_transaction(
+            &provider,
+            TransactionRequest::default()
+                .from(owner)
+                .to(evm.vault_address)
+                .input(invalid_redeem.into())
+                .gas_limit(100_000),
+        )
+        .await;
+        let receipt = provider
+            .send_raw_transaction(&reverted.tx)
+            .await
+            .expect("reverting transaction should broadcast")
+            .get_receipt()
+            .await
+            .expect("reverting transaction should mine");
+        assert!(!receipt.status(), "test transaction must revert");
+        assert_eq!(
+            service.classify_burn_tx(owner, &reverted).await.unwrap(),
+            BurnTxStatus::Reverted
+        );
+        for status in ["StillMineable", "Mined", "Reverted"] {
+            assert!(logs_contain_at!(
+                Level::DEBUG,
+                &["Classified persisted burn transaction", status]
+            ));
+        }
     }
 
     #[tokio::test]
@@ -869,6 +1150,194 @@ mod tests {
         }
     }
 
+    fn persisted_burn_tx(nonce: u64) -> SendableTxWithHash {
+        SendableTxWithHash::valid_for_test(
+            nonce,
+            test_vault_address(),
+            Bytes::from_static(&[0xde, 0xad]),
+        )
+    }
+
+    #[tokio::test]
+    async fn classify_burn_tx_reports_mined_and_reverted_receipts() {
+        for (succeeded, expected) in
+            [(true, BurnTxStatus::Mined), (false, BurnTxStatus::Reverted)]
+        {
+            let persisted = persisted_burn_tx(7);
+            let owner = persisted.signer_for_test();
+            let mut receipt =
+                create_empty_receipt(test_vault_address(), persisted.hash);
+            receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                Receipt {
+                    status: Eip658Value::Eip658(succeeded),
+                    cumulative_gas_used: 0x6100,
+                    logs: vec![],
+                },
+                Bloom::default(),
+            ));
+            let asserter = Asserter::new();
+            asserter.push_success(&receipt);
+            let service = create_service_with_asserter(asserter);
+
+            let status = service
+                .classify_burn_tx(owner, &persisted)
+                .await
+                .expect("receipt should classify");
+
+            assert_eq!(status, expected);
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn classify_burn_tx_requires_finalized_nonce_to_prove_death() {
+        let persisted = persisted_burn_tx(7);
+        let owner = persisted.signer_for_test();
+
+        for (latest_nonce, finalized_nonce, expected) in [
+            (7, 7, BurnTxStatus::StillMineable),
+            (8, 7, BurnTxStatus::StillMineable),
+            (8, 8, BurnTxStatus::ProvablyDead),
+        ] {
+            let asserter = Asserter::new();
+            asserter.push_success(&Option::<TransactionReceipt>::None);
+            asserter.push_success(&latest_nonce);
+            asserter.push_success(&finalized_nonce);
+            if finalized_nonce > persisted.nonce {
+                asserter.push_success(&Option::<TransactionReceipt>::None);
+            }
+            let service = create_service_with_asserter(asserter);
+
+            let status = service
+                .classify_burn_tx(owner, &persisted)
+                .await
+                .expect("missing receipt should classify by finalized nonce");
+
+            assert_eq!(status, expected);
+        }
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "Classified persisted burn transaction",
+                "latest_nonce=8",
+                "finalized_nonce=7",
+                "StillMineable"
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn classify_burn_tx_rechecks_receipt_after_nonce_advances() {
+        let persisted = persisted_burn_tx(7);
+        let owner = persisted.signer_for_test();
+        let receipt =
+            create_empty_receipt(test_vault_address(), persisted.hash);
+        let asserter = Asserter::new();
+        asserter.push_success(&Option::<TransactionReceipt>::None);
+        asserter.push_success(&8u64);
+        asserter.push_success(&8u64);
+        asserter.push_success(&Some(receipt));
+        let service = create_service_with_asserter(asserter);
+
+        let status = service
+            .classify_burn_tx(owner, &persisted)
+            .await
+            .expect("the second receipt read should win the nonce race");
+
+        assert_eq!(status, BurnTxStatus::Mined);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Classified persisted burn transaction", "Mined"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn replacement_uses_pending_nonce_to_avoid_live_transaction_collision()
+     {
+        let persisted = persisted_burn_tx(7);
+        let owner = persisted.signer_for_test();
+        let pending_nonce = 11u64;
+        let asserter = Asserter::new();
+        asserter.push_success(&pending_nonce);
+        asserter.push_success(&100_000u64);
+        asserter.push_success(&test_fee_history());
+        asserter
+            .push_success(&Block::<alloy::rpc::types::Transaction>::default());
+        asserter.push_success(&1_000_000_000u64);
+        asserter.push_success(&100_000u64);
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(1))
+            .expect("test private key should be valid");
+        let service = create_service_with_signer(asserter, signer);
+
+        let replacement = service
+            .prepare_replacement_burn_tx(owner, &persisted)
+            .await
+            .expect("replacement should use the pending wallet nonce");
+
+        assert_eq!(replacement.nonce, pending_nonce);
+        let previous_envelope =
+            persisted.validate().expect("persisted tx should decode");
+        let replacement_envelope =
+            replacement.validate().expect("replacement should decode");
+        assert_eq!(replacement_envelope.to(), previous_envelope.to());
+        assert_eq!(replacement_envelope.value(), previous_envelope.value());
+        assert_eq!(replacement_envelope.input(), previous_envelope.input());
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "Prepared fresh-nonce burn replacement",
+                "previous_nonce=7",
+                "replacement_nonce=11"
+            ]
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_burn_tx_rejects_unmined_receipt_shape() {
+        let persisted = persisted_burn_tx(7);
+        let owner = persisted.signer_for_test();
+        let mut receipt =
+            create_empty_receipt(test_vault_address(), persisted.hash);
+        receipt.block_number = None;
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.classify_burn_tx(owner, &persisted).await;
+
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
+    }
+
+    #[tokio::test]
+    async fn classify_burn_tx_rejects_corrupt_persisted_identity_before_rpc() {
+        let mut persisted = persisted_burn_tx(7);
+        persisted.hash = B256::ZERO;
+        let service = create_service_with_asserter(Asserter::new());
+
+        let result =
+            service.classify_burn_tx(test_receiver(), &persisted).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::PreparedBurnHashMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_burn_tx_rejects_a_different_signer_before_rpc() {
+        let persisted = persisted_burn_tx(7);
+        let service = create_service_with_asserter(Asserter::new());
+
+        let result = service.classify_burn_tx(Address::ZERO, &persisted).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::PreparedBurnSignerMismatch { .. })
+        ));
+    }
+
     #[tokio::test]
     async fn check_tx_rejects_reverted_receipt_without_block_number() {
         let vault_address = test_vault_address();
@@ -1053,12 +1522,15 @@ mod tests {
     #[tokio::test]
     async fn test_submit_and_confirm_burn_two_burns() {
         let vault_address = test_vault_address();
-        let owner = test_receiver();
         let user = address!("0x3333333333333333333333333333333333333333");
 
-        let tx_hash = fixed_bytes!(
-            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault_address,
+            Bytes::from_static(&[0xde, 0xad]),
         );
+        let tx_hash = prepared_tx.hash;
+        let owner = prepared_tx.signer_for_test();
 
         let burns = vec![
             (U256::from(1), U256::from(100)),
@@ -1081,13 +1553,6 @@ mod tests {
         let detected_tx_hash = b256!(
             "0xabababababababababababababababababababababababababababababababab"
         );
-        let prepared_tx = SendableTxWithHash {
-            tx: vec![],
-            hash: tx_hash,
-            nonce: 0,
-            signed_at: Utc::now(),
-            dust_shares: U256::ZERO,
-        };
         let submitted = service
             .submit_burn(
                 MultiBurnParams {
@@ -1131,12 +1596,15 @@ mod tests {
     #[tokio::test]
     async fn test_submit_burn_propagates_external_tx_id_override() {
         let vault_address = test_vault_address();
-        let owner = test_receiver();
         let user = address!("0x3333333333333333333333333333333333333333");
 
-        let tx_hash = fixed_bytes!(
-            "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault_address,
+            Bytes::from_static(&[0xde, 0xad]),
         );
+        let tx_hash = prepared_tx.hash;
+        let owner = prepared_tx.signer_for_test();
 
         let burns = vec![(U256::from(1), U256::from(100))];
 
@@ -1158,13 +1626,6 @@ mod tests {
         );
         let override_id = "burn-0xabab-retry-2".to_string();
 
-        let prepared_tx = SendableTxWithHash {
-            tx: vec![],
-            hash: tx_hash,
-            nonce: 0,
-            signed_at: Utc::now(),
-            dust_shares: U256::ZERO,
-        };
         let submitted = service
             .submit_burn(
                 MultiBurnParams {
@@ -1198,14 +1659,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn submit_burn_rejects_a_node_hash_for_different_bytes() {
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            test_vault_address(),
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let returned = B256::random();
+        let asserter = Asserter::new();
+        asserter.push_success(&returned);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .submit_burn(
+                test_multi_burn_params(prepared_tx.signer_for_test()),
+                prepared_tx.clone(),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::BroadcastHashMismatch { expected, returned: actual })
+                if expected == prepared_tx.hash && actual == returned
+        ));
+    }
+
+    #[tokio::test]
     async fn test_submit_burn_returns_error_on_missing_events() {
         let vault_address = test_vault_address();
-        let owner = test_receiver();
         let user = address!("0x6666666666666666666666666666666666666666");
 
-        let tx_hash = fixed_bytes!(
-            "0x1111222233334444555566667777888899990000aaaabbbbccccddddeeeeffff"
+        let prepared_tx = SendableTxWithHash::valid_for_test(
+            0,
+            vault_address,
+            Bytes::from_static(&[0xde, 0xad]),
         );
+        let tx_hash = prepared_tx.hash;
+        let owner = prepared_tx.signer_for_test();
 
         let receipt = create_empty_receipt(vault_address, tx_hash);
 
@@ -1214,13 +1704,6 @@ mod tests {
 
         let service = create_service_with_asserter(asserter);
 
-        let prepared_tx = SendableTxWithHash {
-            tx: vec![],
-            hash: tx_hash,
-            nonce: 0,
-            signed_at: Utc::now(),
-            dust_shares: U256::ZERO,
-        };
         let submit_result = service
             .submit_burn(MultiBurnParams {
                 vault: vault_address,


### PR DESCRIPTION
## Motivation

The crash-safe burn path persists exact signed bytes before broadcast, but unresolved transactions still needed manual intervention after a restart. With Turnkey in place we can recover them generically without creating two live hashes for one redemption.

Closes [RAI-1383](https://linear.app/makeitrain/issue/RAI-1383/add-generic-burn-transaction-recovery-after-turnkey-migration).

## Solution

- Classify the persisted burn as mined, reverted, still mineable, or provably dead. Recovery re-broadcasts the exact bytes while they can still land. It only declares the old hash dead after `finalized_nonce(wallet) > persisted_nonce` and a second receipt read still returns none, then signs a replacement at the pending account nonce.
- Persist transaction recovery and pre-signing preparation retries in one five-attempt redemption-wide budget. Repeated signing failures exhaust durably even when no transaction hash or nonce was produced.
- RPC uncertainty fails closed, keeps the receipt reservation, emits one actionable operator warning at exhaustion, and prevents the admin recovery endpoint from re-arming the burn.
- Run burn reconciliation at startup and every five minutes, preserve the exact signed transaction across replay, and require admin force-complete to prove that same persisted hash.
- Specify the state machine and operator recovery behavior in `SPEC.md` and the ops guide.

## Checks

By submitting this for review, I am confirming I have done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Verified with `nix develop -c cargo test --workspace` and strict workspace Clippy across all targets and features.