### PR TITLE
feat: guard unresolved burn admin recovery

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -410,16 +410,24 @@ on-chain transfer through calling Alpaca to burning tokens.
   transaction lands, recovery reuses the same retry id. Emits `BurnResumed`
   event. The admin recovery path immediately invokes burn recovery in-process so
   the on-chain burn does not wait for a service restart.
-- `CloseRedemption { issuer_request_id, reason }` - Admin-close a redemption
-  that cannot be automatically recovered, recording an operator `reason`. Valid
-  from `Failed`, `Burning`, `BurnIntended`, or `BurnSubmitted`. This is the
+- `CloseRedemption { issuer_request_id, reason,
+  acknowledged_unresolved_burn_tx_hash }` - Admin-close a redemption that
+  cannot be automatically recovered, recording an operator `reason`. Valid
+  from `Failed`, `Burning`, `BurnIntended`, or `BurnSubmitted`. A redemption
+  with a persisted signed transaction is rejected by default because that
+  transaction may still land. Closing it requires
+  `acknowledged_unresolved_burn_tx_hash` to equal the persisted hash exactly;
+  the signed identity is retained across a transition to `Failed`, and the
+  acknowledgement is recorded in the terminal event. An acknowledgement is
+  rejected when no persisted signed burn exists. This is the
   honest terminal path for a redemption whose burn cannot or should not be re-submitted and is
   **not** verifiable on-chain (e.g. a `Failed -> Burning` recovery regression
   where no burn ever landed, or an ambiguous case pending off-chain
   reconciliation). A held receipt reservation is **left in place** (the
   conservative policy for `Closed`), since an ambiguous burn may still have
   landed. Emits `RedemptionClosed`.
-- `ForceCompleteBurn { issuer_request_id, burn_tx_hash, block_number, reason }` -
+- `ForceCompleteBurn { issuer_request_id, burn_tx_hash, block_number, reason,
+  acknowledged_unresolved_burn_tx_hash }` -
   Admin-terminalize a redemption stuck in
   `BurnIntended`/`BurnSubmitted` whose persisted exact burn transaction
   **already landed on-chain** but was never recorded (e.g. the bot crashed
@@ -431,9 +439,20 @@ on-chain transfer through calling Alpaca to burning tokens.
   completion. Emits `BurnForceCompleted`, transitioning to `Completed`.
   The persisted bytes must decode with matching hash and nonce and recover the
   configured bot wallet as signer; the supplied hash must then equal that exact
-  transaction hash. Legacy or pre-intent states without a trustworthy
-  persisted transaction are **not** force-completed; ops use `CloseRedemption`
-  after off-chain reconciliation instead.
+  transaction hash unless the operator explicitly acknowledges the persisted
+  hash with `acknowledged_unresolved_burn_tx_hash`. A different proving hash is
+  rejected by default while the persisted transaction may still land. The
+  acknowledgement must equal the persisted hash exactly and is recorded in the
+  terminal event. The alternate transaction's per-receipt withdrawals,
+  recipient wallet, and dust share transfer must also match the persisted burn
+  semantics exactly, including the aggregate burned-share total. Its signer
+  nonce must equal the persisted transaction's nonce, proving it is a mined
+  replacement rather than an unrelated burn and ensuring the acknowledged
+  transaction can no longer land. This prevents
+  another redemption's same-vault burn from being used as proof. Legacy or pre-intent
+  states without a trustworthy persisted
+  transaction are **not** force-completed; ops use `CloseRedemption` after
+  off-chain reconciliation instead.
 
 **Events:**
 
@@ -477,12 +496,18 @@ on-chain transfer through calling Alpaca to burning tokens.
   `planned_burns` for recovery of previously submitted transactions
 - `ExistingBurnRecovered` - Existing on-chain burn discovered during recovery
 - `RedemptionClosed` - Admin-closed redemption (terminal). Carries the operator
-  `reason` and `closed_at`. Closed redemptions do not appear in stuck queries.
+  `reason`, `closed_at`, and optional
+  `acknowledged_unresolved_burn_tx_hash`. Closed redemptions do not appear in
+  stuck queries. Receipt reservations remain held, including after an
+  acknowledged close, because the unresolved transaction may still land.
 - `BurnForceCompleted` - Admin-recorded terminal success for a stuck
   `BurnIntended`/`BurnSubmitted` redemption whose persisted exact burn was
   verified on-chain. Carries the proving `burn_tx_hash`, `block_number`,
-  operator `reason`, and `completed_at`. Transitions to `Completed` (terminal
-  success).
+  operator `reason`, optional `acknowledged_unresolved_burn_tx_hash`, and
+  `completed_at`. Transitions to `Completed` (terminal success). Its receipt
+  reservation is settled after the terminal event, including when the operator
+  acknowledged the persisted transaction superseded by the proving
+  same-nonce replacement.
 - `Reprocessed` - Redemption reset to `Detected` state for reprocessing. Carries
   the original `RedemptionMetadata`, the previous state name, and a timestamp.
   Used for audit trail — shows when and from what state a manual reprocess was
@@ -2354,7 +2379,13 @@ permanently rejected the journal, or tokens were consumed by other operations).
 
 **Endpoint:** `POST /admin/close/redemption/<issuer_request_id>`
 
-**Request body:** `{ "reason": "string" }`
+**Request body:**
+`{ "reason": "string", "acknowledged_unresolved_burn_tx_hash": "0x..." }`.
+The acknowledgement is optional unless the redemption has a persisted signed
+burn transaction. In that case omission or a hash mismatch returns `422`; the
+operator must echo the exact persisted hash shown by `/admin/stuck` after
+off-chain reconciliation. Supplying an acknowledgement when no persisted
+signed burn exists also returns `422`.
 
 **Commands/Events:**
 
@@ -2364,7 +2395,31 @@ permanently rejected the journal, or tokens were consumed by other operations).
 
 - `200`: Redemption closed
 - `409`: Already completed or closed
-- `422`: Not in `Failed` state
+- `422`: Invalid state, or a persisted signed burn was not acknowledged exactly
+
+Close responses and structured logs include the acknowledged persisted hash
+when an override is used. Closing never releases a held receipt reservation.
+
+### Force-complete Redemption Burn
+
+**Endpoint:**
+`POST /admin/force-complete/redemption/<issuer_request_id>`
+
+**Request body:**
+`{ "burn_tx_hash": "0x...", "reason": "string",
+"acknowledged_unresolved_burn_tx_hash": "0x..." }`.
+
+The proving `burn_tx_hash` must normally equal the redemption's persisted signed
+transaction hash. If a different transaction proves the burn, the request is
+rejected unless `acknowledged_unresolved_burn_tx_hash` exactly echoes the
+persisted hash being superseded. The terminal event, response, and structured
+logs record both identities, and the alternate proof's per-receipt withdrawals,
+receiver, dust transfer, and signer nonce must equal the persisted burn
+semantics, so the mined proof is a replacement and the persisted transaction
+can no longer land. The held
+receipt reservation is settled after the
+terminal event; operators must reconcile the acknowledged transaction before
+using this override.
 
 ### List Stuck Aggregates
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -51,6 +51,7 @@ pub(crate) trait RedemptionBurnRecovery: Send + Sync {
         issuer_request_id: &IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<BurnVerification, BurnManagerError>;
 }
 
@@ -68,8 +69,15 @@ impl RedemptionBurnRecovery for BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<BurnVerification, BurnManagerError> {
-        self.force_complete_burn(issuer_request_id, burn_tx_hash, reason).await
+        self.force_complete_burn(
+            issuer_request_id,
+            burn_tx_hash,
+            reason,
+            acknowledged_unresolved_burn_tx_hash,
+        )
+        .await
     }
 }
 
@@ -112,8 +120,8 @@ pub(crate) struct StuckAggregate {
     tx_hash: Option<B256>,
     /// Transaction ID associated with this aggregate's current
     /// stuck step. For mints, sourced from the most recent
-    /// `MintTxSubmitted` event. For redemptions, populated only on
-    /// `BurnFailed` (the view carries it for that variant).
+    /// `MintTxSubmitted` event. For redemptions, populated from the persisted
+    /// burn intent or a later submission/failure event.
     #[serde(skip_serializing_if = "Option::is_none")]
     tx_id: Option<String>,
 }
@@ -790,6 +798,8 @@ const fn map_redemption_error(
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct CloseRedemptionRequest {
     reason: String,
+    #[schema(value_type = Option<String>)]
+    acknowledged_unresolved_burn_tx_hash: Option<B256>,
 }
 
 /// Admin endpoint to close a redemption that cannot be automatically recovered.
@@ -832,18 +842,22 @@ pub(crate) async fn close_redemption(
     body: Json<CloseRedemptionRequest>,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let aggregate_id = issuer_request_id.to_string();
+    let CloseRedemptionRequest { reason, acknowledged_unresolved_burn_tx_hash } =
+        body.into_inner();
 
     store
         .send(
             &issuer_request_id,
             RedemptionCommand::CloseRedemption {
                 issuer_request_id: issuer_request_id.clone(),
-                reason: body.into_inner().reason,
+                reason,
+                acknowledged_unresolved_burn_tx_hash,
             },
         )
         .await
         .map_err(|err| {
             error!(target: "admin", aggregate_id = %aggregate_id,
+                acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
                 error = %err,
                 "Failed to close redemption"
             );
@@ -855,14 +869,24 @@ pub(crate) async fn close_redemption(
 
     info!(target: "admin", aggregate_id = %aggregate_id,
         previous_state = %previous_state,
+        acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
         "Redemption closed"
+    );
+
+    let message = acknowledged_unresolved_burn_tx_hash.map_or_else(
+        || "Redemption closed by admin".to_string(),
+        |acknowledged_hash| {
+            format!(
+                "Redemption closed by admin after acknowledging unresolved burn {acknowledged_hash:#x}"
+            )
+        },
     );
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Redemption,
         aggregate_id,
         previous_state,
-        message: "Redemption closed by admin".to_string(),
+        message,
     }))
 }
 
@@ -874,6 +898,8 @@ pub(crate) struct ForceCompleteRedemptionRequest {
     burn_tx_hash: B256,
     /// Operator-supplied audit reason recorded with the terminal event.
     reason: String,
+    #[schema(value_type = Option<String>)]
+    acknowledged_unresolved_burn_tx_hash: Option<B256>,
 }
 
 /// Admin endpoint to terminalize a redemption stuck in `Burning`/`BurnSubmitted`
@@ -918,14 +944,24 @@ pub(crate) async fn force_complete_redemption(
     body: Json<ForceCompleteRedemptionRequest>,
 ) -> Result<Json<ReprocessResponse>, Status> {
     let aggregate_id = issuer_request_id.to_string();
-    let ForceCompleteRedemptionRequest { burn_tx_hash, reason } =
-        body.into_inner();
+    let ForceCompleteRedemptionRequest {
+        burn_tx_hash,
+        reason,
+        acknowledged_unresolved_burn_tx_hash,
+    } = body.into_inner();
 
     let verification = burn_recovery
-        .force_complete_burn(&issuer_request_id, burn_tx_hash, reason)
+        .force_complete_burn(
+            &issuer_request_id,
+            burn_tx_hash,
+            reason,
+            acknowledged_unresolved_burn_tx_hash,
+        )
         .await
         .map_err(|err| {
             error!(target: "admin", aggregate_id = %aggregate_id,
+                burn_tx_hash = ?burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
                 error = %err,
                 "Failed to force-complete redemption"
             );
@@ -937,6 +973,7 @@ pub(crate) async fn force_complete_redemption(
 
     info!(target: "admin", aggregate_id = %aggregate_id,
         burn_tx_hash = ?burn_tx_hash,
+        acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
         block_number = verification.block_number,
         previous_state = %previous_state,
         "Redemption force-completed"
@@ -946,9 +983,17 @@ pub(crate) async fn force_complete_redemption(
         aggregate_type: AggregateKind::Redemption,
         aggregate_id,
         previous_state,
-        message: format!(
-            "Force-completed: burn verified on-chain at block {} ({} shares)",
-            verification.block_number, verification.shares_burned
+        message: acknowledged_unresolved_burn_tx_hash.map_or_else(
+            || {
+                format!(
+                    "Force-completed: burn verified on-chain at block {} ({} shares)",
+                    verification.block_number, verification.shares_burned
+                )
+            },
+            |acknowledged_hash| format!(
+                "Force-completed: burn {burn_tx_hash:#x} verified on-chain at block {} ({} shares) after acknowledging unresolved burn {acknowledged_hash:#x}",
+                verification.block_number, verification.shares_burned
+            ),
         ),
     }))
 }
@@ -1029,6 +1074,8 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
             | VaultError::Reverted { .. },
         )
         | BurnManagerError::InvalidAggregateState { .. }
+        | BurnManagerError::Redemption(_)
+        | BurnManagerError::AlternateBurnSemanticsMismatch { .. }
         | BurnManagerError::Cqrs(AggregateError::UserError(_)) => {
             Status::UnprocessableEntity
         }
@@ -1576,6 +1623,11 @@ fn redemption_history_summary_from_events(
             | RedemptionEvent::BurningFailed { tx_id: Some(tx_id), .. } => {
                 summary.tx_id = Some(tx_id);
             }
+            RedemptionEvent::BurnIntended { sendable_tx, .. }
+                if !sendable_tx.tx.is_empty() =>
+            {
+                summary.tx_id = Some(TxId::Hash(sendable_tx.hash));
+            }
             _ => {}
         }
     }
@@ -1805,7 +1857,7 @@ mod tests {
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
     use chrono::Utc;
-    use event_sorcery::{Store, test_store};
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use rocket::http::Status;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -1813,6 +1865,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tracing::Level;
     use tracing_test::traced_test;
+    use url::Url;
 
     use super::{
         AggregateKind, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS, StuckAggregate,
@@ -1825,11 +1878,14 @@ mod tests {
     use crate::alpaca::{
         AlpacaError, AlpacaService, MintCallbackRequest, RedeemRequest,
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
+        service::AlpacaConfig,
     };
+    use crate::auth::{FailedAuthRateLimiter, test_auth_config};
+    use crate::config::{Config, Environment, LogLevel};
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
-        ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
-        Shares,
+        CqrsReceiptService, ReceiptId, ReceiptInventory,
+        ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::{
@@ -1837,11 +1893,15 @@ mod tests {
         RedemptionCommand, RedemptionEvent, RedemptionMetadata, RedemptionView,
     };
     use crate::test_utils::logs_contain_at;
-    use crate::tokenized_asset::{TokenSymbol, UnderlyingSymbol};
+    use crate::tokenized_asset::{
+        Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
+    };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        MultiBurnEntry, SendableTxWithHash, TxId, VaultService,
+        MultiBurnEntry, SendableTxWithHash, TxId, VaultService, VerifiedBurn,
     };
+    use crate::wallet::SignerConfig;
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
@@ -1973,6 +2033,9 @@ mod tests {
             _issuer_request_id: &IssuerRedemptionRequestId,
             _burn_tx_hash: alloy::primitives::B256,
             _reason: String,
+            _acknowledged_unresolved_burn_tx_hash: Option<
+                alloy::primitives::B256,
+            >,
         ) -> Result<super::BurnVerification, super::BurnManagerError> {
             unimplemented!("not used by redemption recovery route tests")
         }
@@ -1998,12 +2061,18 @@ mod tests {
             _issuer_request_id: &IssuerRedemptionRequestId,
             burn_tx_hash: alloy::primitives::B256,
             _reason: String,
+            _acknowledged_unresolved_burn_tx_hash: Option<
+                alloy::primitives::B256,
+            >,
         ) -> Result<super::BurnVerification, super::BurnManagerError> {
             self.force_calls.fetch_add(1, Ordering::Relaxed);
             match self.force_result {
                 MockForceResult::Verified => Ok(super::BurnVerification {
                     block_number: 45_989_009,
+                    nonce: 0,
                     shares_burned: alloy::primitives::U256::from(17u64),
+                    burns: vec![],
+                    share_transfers: vec![],
                 }),
                 MockForceResult::NotABurn => {
                     Err(super::BurnManagerError::Vault(
@@ -3813,18 +3882,47 @@ mod tests {
         metadata
     }
 
-    fn force_complete_rocket(
-        pool: sqlx::Pool<sqlx::Sqlite>,
-        burn_recovery: Arc<dyn super::RedemptionBurnRecovery>,
-    ) -> rocket::Rocket<rocket::Build> {
-        use crate::alpaca::service::AlpacaConfig;
-        use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-        use crate::config::{Config, Environment, LogLevel};
-        use crate::wallet::SignerConfig;
-        use alloy::primitives::B256;
-        use url::Url;
+    async fn setup_burn_intended(
+        store: &Store<Redemption>,
+        persisted_tx: &SendableTxWithHash,
+        vault: Address,
+    ) -> RedemptionMetadata {
+        setup_burn_intended_with_dust(store, persisted_tx, vault, U256::ZERO)
+            .await
+    }
 
-        let config = Config {
+    async fn setup_burn_intended_with_dust(
+        store: &Store<Redemption>,
+        persisted_tx: &SendableTxWithHash,
+        vault: Address,
+        dust_shares: U256,
+    ) -> RedemptionMetadata {
+        let metadata = setup_burning(store).await;
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: U256::from(42),
+                        burn_shares: U256::from(17),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares,
+                    owner: persisted_tx.signer_for_test(),
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("IntendBurn failed");
+
+        metadata
+    }
+
+    fn admin_test_config() -> Config {
+        Config {
             database_url: "sqlite::memory:".to_string(),
             database_max_connections: 5,
             rpc_url: Url::parse("wss://localhost:8545").unwrap(),
@@ -3838,14 +3936,247 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
-        };
+        }
+    }
 
+    fn close_redemption_rocket(
+        store: Arc<Store<Redemption>>,
+        pool: sqlx::Pool<sqlx::Sqlite>,
+    ) -> rocket::Rocket<rocket::Build> {
         rocket::build()
-            .manage(config)
+            .manage(admin_test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(store)
+            .manage(pool)
+            .mount("/", rocket::routes![super::close_redemption])
+    }
+
+    async fn dispatch_close_redemption(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        body: &str,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+        let response = client
+            .post(format!("/admin/close/redemption/{issuer_request_id}"))
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(body)
+            .dispatch()
+            .await;
+
+        let status = response.status();
+        let body = response.into_string().await.unwrap();
+        (status, body)
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn close_endpoint_rejects_unacknowledged_persisted_burn() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_service: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let store = setup_store_with_vault(&pool, vault_service);
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+
+        let rocket = close_redemption_rocket(store.clone(), pool);
+        let (status, _) = dispatch_close_redemption(
+            rocket,
+            &metadata.issuer_request_id,
+            r#"{"reason":"operator reconciled externally"}"#,
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::BurnIntended { .. })
+        ));
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[
+                "Failed to close redemption",
+                "requires explicit operator acknowledgement",
+                &persisted_hash,
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn close_endpoint_records_and_reports_burn_acknowledgement() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_service: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let store = setup_store_with_vault(&pool, vault_service);
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        receipt_store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(U256::from(42)),
+                    balance: Shares::new(U256::from(17)),
+                    block_number: 1,
+                    tx_hash: B256::random(),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .expect("receipt discovery should succeed");
+        let receipt_service = CqrsReceiptService::new(receipt_store);
+        receipt_service
+            .reserve_burn(
+                vault,
+                metadata.issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(42),
+                    shares_burned: U256::from(17),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
+
+        let rocket = close_redemption_rocket(store.clone(), pool);
+        let body = format!(
+            r#"{{"reason":"operator reconciled externally","acknowledged_unresolved_burn_tx_hash":"{:#x}"}}"#,
+            persisted_tx.hash
+        );
+        let (status, response_body) = dispatch_close_redemption(
+            rocket,
+            &metadata.issuer_request_id,
+            &body,
+        )
+        .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(
+            response_body.contains(&format!("{:#x}", persisted_tx.hash)),
+            "body: {response_body}"
+        );
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::Closed { .. })
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![metadata.issuer_request_id.clone()],
+            "acknowledged close must retain the unresolved reservation"
+        );
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[
+                "Redemption closed",
+                "acknowledged_unresolved_burn_tx_hash",
+                &persisted_hash,
+            ]
+        ));
+    }
+
+    fn force_complete_rocket(
+        pool: sqlx::Pool<sqlx::Sqlite>,
+        burn_recovery: Arc<dyn super::RedemptionBurnRecovery>,
+    ) -> rocket::Rocket<rocket::Build> {
+        rocket::build()
+            .manage(admin_test_config())
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(pool)
             .manage(burn_recovery)
             .mount("/", rocket::routes![super::force_complete_redemption])
+    }
+
+    async fn real_burn_recovery(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        store: Arc<Store<Redemption>>,
+        vault_service: Arc<dyn VaultService>,
+        vault: Address,
+        owner: Address,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> (Arc<dyn super::RedemptionBurnRecovery>, Arc<CqrsReceiptService>) {
+        let (asset_store, _asset_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .expect("tokenized asset store should build");
+        let underlying = UnderlyingSymbol::new("AAPL");
+        asset_store
+            .send(
+                &underlying,
+                TokenizedAssetCommand::Add {
+                    underlying: underlying.clone(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::Base,
+                    vault,
+                },
+            )
+            .await
+            .expect("tokenized asset should seed");
+
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        receipt_store
+            .send(
+                &vault,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(U256::from(42)),
+                    balance: Shares::new(U256::from(17)),
+                    block_number: 1,
+                    tx_hash: B256::random(),
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .expect("receipt should seed");
+        let receipt_service = Arc::new(CqrsReceiptService::new(receipt_store));
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: U256::from(42),
+                    shares_burned: U256::from(17),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
+        let burn_recovery: Arc<dyn super::RedemptionBurnRecovery> =
+            Arc::new(super::BurnManager::new(
+                vault_service,
+                pool.clone(),
+                store,
+                receipt_service.clone(),
+                owner,
+            ));
+
+        (burn_recovery, receipt_service)
     }
 
     async fn dispatch_force_complete(
@@ -3875,6 +4206,91 @@ mod tests {
         (status, body)
     }
 
+    fn stuck_rocket(
+        pool: sqlx::Pool<sqlx::Sqlite>,
+        vault_service: Arc<dyn VaultService>,
+    ) -> rocket::Rocket<rocket::Build> {
+        rocket::build()
+            .manage(admin_test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .manage(vault_service)
+            .mount("/", rocket::routes![super::list_stuck])
+    }
+
+    #[tokio::test]
+    async fn stuck_endpoint_exposes_persisted_burn_intent_hash() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_service = Arc::new(
+            MockVaultService::new_success()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let alpaca = test_alpaca_data();
+        let old_timestamp = Utc::now() - chrono::Duration::hours(2);
+        let view = RedemptionView::Burning {
+            issuer_request_id: metadata.issuer_request_id.clone(),
+            tokenization_request_id: alpaca.tokenization_request_id,
+            underlying: metadata.underlying,
+            token: metadata.token,
+            wallet: metadata.wallet,
+            quantity: metadata.quantity,
+            alpaca_quantity: alpaca.alpaca_quantity,
+            dust_quantity: alpaca.dust_quantity,
+            tx_hash: metadata.detected_tx_hash,
+            block_number: metadata.block_number,
+            detected_at: metadata.detected_at,
+            called_at: old_timestamp,
+            alpaca_journal_completed_at: old_timestamp,
+            burning_entered_at: old_timestamp,
+        };
+        let payload = serde_json::to_string(&view).unwrap();
+        sqlx::query(
+            "
+            INSERT INTO redemption_view (
+                view_id,
+                version,
+                payload
+            )
+            VALUES (?, 4, ?)
+            ",
+        )
+        .bind(metadata.issuer_request_id.to_string())
+        .bind(payload)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let client = rocket::local::asynchronous::Client::tracked(
+            stuck_rocket(pool, vault_service),
+        )
+        .await
+        .unwrap();
+        let response = client
+            .get("/admin/stuck")
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+
+        assert_eq!(response.status(), Status::Ok);
+        let body = response.into_string().await.unwrap();
+        assert!(
+            body.contains(&format!("{:#x}", persisted_tx.hash)),
+            "body: {body}"
+        );
+    }
+
     #[traced_test]
     #[tokio::test]
     async fn test_endpoint_force_complete_records_verified_burn() {
@@ -3885,54 +4301,25 @@ mod tests {
             vault,
             Bytes::from_static(&[0xde, 0xad]),
         );
-        let vault_service: Arc<dyn VaultService> = Arc::new(
+        let vault_mock = Arc::new(
             MockVaultService::new_success()
+                .with_verified_burn(45_989_009, U256::from(17))
                 .with_prepared_tx(persisted_tx.clone()),
         );
-        let store = setup_store_with_vault(&pool, vault_service);
-        let metadata = setup_burning(&store).await;
-        store
-            .send(
-                &metadata.issuer_request_id,
-                RedemptionCommand::IntendBurn {
-                    issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: U256::from(42),
-                        burn_shares: U256::from(17),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: persisted_tx.signer_for_test(),
-                    external_tx_id: None,
-                },
-            )
-            .await
-            .expect("IntendBurn failed");
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
 
-        // In production `force_complete_burn` appends `BurnForceCompleted` before
-        // the endpoint reads the prior state; the mock can't, so append it here
-        // to reproduce the real on-disk shape (terminal event = `BurnForceCompleted`,
-        // so `redemption_state_before_last_event` resolves to `Burning`).
-        store
-            .send(
-                &metadata.issuer_request_id,
-                RedemptionCommand::ForceCompleteBurn {
-                    issuer_request_id: metadata.issuer_request_id.clone(),
-                    burn_tx_hash: persisted_tx.hash,
-                    block_number: 45_989_009,
-                    reason: "burn confirmed on-chain".to_string(),
-                },
-            )
-            .await
-            .expect("ForceCompleteBurn failed");
-
-        let burn_recovery = Arc::new(MockBurnRecovery::default());
-        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
-            burn_recovery.clone();
-
-        let rocket = force_complete_rocket(pool, burn_recovery_state);
+        let rocket = force_complete_rocket(pool, burn_recovery);
         let body = format!(
             r#"{{"burn_tx_hash":"{:#x}","reason":"burn confirmed on-chain"}}"#,
             persisted_tx.hash
@@ -3947,8 +4334,400 @@ mod tests {
         assert!(body.contains("Force-completed"), "body: {body}");
         assert!(body.contains("45989009"), "body: {body}");
         assert!(body.contains("BurnIntended"), "body: {body}");
-        assert_eq!(burn_recovery.force_calls(), 1);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::Completed { .. })
+        ));
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(vault_mock.verify_burn_call_count(), 1);
         assert!(logs_contain_at!(Level::INFO, &["Redemption force-completed"]));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_endpoint_passes_and_reports_burn_acknowledgement() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let proving_burn_tx_hash = B256::random();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: persisted_tx.signer_for_test(),
+                        receiver: test_metadata().wallet,
+                        receipt_id: U256::from(42),
+                        shares_burned: U256::from(17),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
+        let rocket = force_complete_rocket(pool, burn_recovery);
+        let body = format!(
+            r#"{{"burn_tx_hash":"{proving_burn_tx_hash:#x}","reason":"alternate burn reconciled","acknowledged_unresolved_burn_tx_hash":"{:#x}"}}"#,
+            persisted_tx.hash
+        );
+
+        let (status, response_body) =
+            dispatch_force_complete(rocket, &metadata.issuer_request_id, &body)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(
+            response_body.contains(&format!("{proving_burn_tx_hash:#x}")),
+            "body: {response_body}"
+        );
+        assert!(
+            response_body.contains(&format!("{:#x}", persisted_tx.hash)),
+            "body: {response_body}"
+        );
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::Completed { burn_tx_hash, .. })
+                if burn_tx_hash == proving_burn_tx_hash
+        ));
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert_eq!(vault_mock.verify_burn_call_count(), 1);
+        let proving_hash = format!("{proving_burn_tx_hash:?}");
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[
+                "Redemption force-completed",
+                "acknowledged_unresolved_burn_tx_hash",
+                &proving_hash,
+                &persisted_hash,
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_endpoint_rejects_alternate_burn_missing_dust() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let dust_shares = U256::from(3);
+        let mut persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        persisted_tx.dust_shares = dust_shares;
+        let proving_burn_tx_hash = B256::random();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: persisted_tx.signer_for_test(),
+                        receiver: test_metadata().wallet,
+                        receipt_id: U256::from(42),
+                        shares_burned: U256::from(17),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended_with_dust(
+            &store,
+            &persisted_tx,
+            vault,
+            dust_shares,
+        )
+        .await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
+        let body = format!(
+            r#"{{"burn_tx_hash":"{proving_burn_tx_hash:#x}","reason":"alternate burn omitted dust","acknowledged_unresolved_burn_tx_hash":"{:#x}"}}"#,
+            persisted_tx.hash
+        );
+
+        let (status, _) = dispatch_force_complete(
+            force_complete_rocket(pool, burn_recovery),
+            &metadata.issuer_request_id,
+            &body,
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(vault_mock.verify_burn_call_count(), 1);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::BurnIntended { .. })
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![metadata.issuer_request_id]
+        );
+        let proving_hash = format!("{proving_burn_tx_hash:?}");
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[
+                "Failed to force-complete redemption",
+                "Alternate proving transaction does not match",
+                "expected nonce 7",
+                "dust 3",
+                &proving_hash,
+                &persisted_hash,
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_endpoint_rejects_mismatched_aggregate_burn_total() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let proving_burn_tx_hash = B256::random();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns_and_total(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    U256::from(18),
+                    vec![VerifiedBurn {
+                        sender: persisted_tx.signer_for_test(),
+                        receiver: test_metadata().wallet,
+                        receipt_id: U256::from(42),
+                        shares_burned: U256::from(17),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
+        let body = format!(
+            r#"{{"burn_tx_hash":"{proving_burn_tx_hash:#x}","reason":"alternate burn has mismatched total","acknowledged_unresolved_burn_tx_hash":"{:#x}"}}"#,
+            persisted_tx.hash
+        );
+
+        let (status, _) = dispatch_force_complete(
+            force_complete_rocket(pool, burn_recovery),
+            &metadata.issuer_request_id,
+            &body,
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(vault_mock.verify_burn_call_count(), 1);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::BurnIntended { .. })
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![metadata.issuer_request_id]
+        );
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[
+                "Failed to force-complete redemption",
+                "expected nonce 7",
+                "total shares 17",
+                "verified nonce 7",
+                "total shares 18",
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_endpoint_rejects_wrong_burn_acknowledgement() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: persisted_tx.signer_for_test(),
+                        receiver: test_metadata().wallet,
+                        receipt_id: U256::from(42),
+                        shares_burned: U256::from(17),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
+        let proving_hash = B256::random();
+        let wrong_acknowledgement = B256::random();
+        let body = format!(
+            r#"{{"burn_tx_hash":"{proving_hash:#x}","reason":"wrong acknowledgement","acknowledged_unresolved_burn_tx_hash":"{wrong_acknowledgement:#x}"}}"#
+        );
+
+        let (status, _) = dispatch_force_complete(
+            force_complete_rocket(pool, burn_recovery),
+            &metadata.issuer_request_id,
+            &body,
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(vault_mock.verify_burn_call_count(), 0);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::BurnIntended { .. })
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![metadata.issuer_request_id]
+        );
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        let wrong_hash = format!("{wrong_acknowledgement:?}");
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[
+                "Failed to force-complete redemption",
+                &persisted_hash,
+                &wrong_hash,
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_endpoint_rejects_redundant_burn_acknowledgement() {
+        let pool = setup_pool().await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: persisted_tx.signer_for_test(),
+                        receiver: test_metadata().wallet,
+                        receipt_id: U256::from(42),
+                        shares_burned: U256::from(17),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let vault_service: Arc<dyn VaultService> = vault_mock.clone();
+        let store = setup_store_with_vault(&pool, vault_service.clone());
+        let metadata = setup_burn_intended(&store, &persisted_tx, vault).await;
+        let (burn_recovery, receipt_service) = real_burn_recovery(
+            &pool,
+            store.clone(),
+            vault_service,
+            vault,
+            persisted_tx.signer_for_test(),
+            &metadata.issuer_request_id,
+        )
+        .await;
+        let body = format!(
+            r#"{{"burn_tx_hash":"{0:#x}","reason":"persisted burn verified","acknowledged_unresolved_burn_tx_hash":"{0:#x}"}}"#,
+            persisted_tx.hash
+        );
+
+        let (status, _) = dispatch_force_complete(
+            force_complete_rocket(pool, burn_recovery),
+            &metadata.issuer_request_id,
+            &body,
+        )
+        .await;
+
+        assert_eq!(status, Status::UnprocessableEntity);
+        assert_eq!(vault_mock.verify_burn_call_count(), 0);
+        assert!(matches!(
+            store.load(&metadata.issuer_request_id).await.unwrap(),
+            Some(Redemption::BurnIntended { .. })
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![metadata.issuer_request_id]
+        );
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[
+                "Failed to force-complete redemption",
+                "redundant because the proving burn is the persisted signed burn",
+                &persisted_hash,
+            ]
+        ));
     }
 
     #[traced_test]
@@ -4005,6 +4784,15 @@ mod tests {
                     current_state: "Completed".to_string()
                 }
             ),
+            Status::UnprocessableEntity
+        );
+        assert_eq!(
+            map_burn_manager_error(&super::BurnManagerError::Redemption(
+                crate::redemption::RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                    expected: tx,
+                    provided: B256::random(),
+                },
+            )),
             Status::UnprocessableEntity
         );
         // A hash that resolves to no receipt (or one that doesn't prove a burn)
@@ -4623,5 +5411,24 @@ mod tests {
         );
         // tokenization_request_id is preserved (it doesn't reset).
         assert_eq!(summary.tokenization_request_id, Some(tok_id));
+    }
+
+    #[test]
+    fn redemption_history_summary_exposes_persisted_burn_intent_hash() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let sendable_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let summary = super::redemption_history_summary_from_events([
+            RedemptionEvent::BurnIntended {
+                issuer_request_id: IssuerRedemptionRequestId::random(),
+                sendable_tx: sendable_tx.clone(),
+                planned_burns: vec![],
+            },
+        ]);
+
+        assert_eq!(summary.tx_id, Some(TxId::Hash(sendable_tx.hash)));
     }
 }

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -29,7 +29,7 @@ use crate::tokenized_asset::view::{
 };
 use crate::vault::{
     BurnTxStatus, BurnVerification, MultiBurnEntry, SendableTxWithHash, TxId,
-    VaultError, VaultService,
+    VaultError, VaultService, VerifiedBurn, VerifiedShareTransfer,
 };
 
 const WALLET_INTENT_WAIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -249,6 +249,7 @@ impl BurnManager {
         issuer_request_id: &IssuerRedemptionRequestId,
         burn_tx_hash: B256,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<BurnVerification, BurnManagerError> {
         let redemption =
             self.store.load(issuer_request_id).await?.ok_or_else(|| {
@@ -259,21 +260,16 @@ impl BurnManager {
 
         let persisted_burn_tx = redemption.persisted_burn_tx()?;
         persisted_burn_tx.validate_for_owner(self.bot_wallet)?;
-        let persisted_burn_hash = persisted_burn_tx.hash;
-        if persisted_burn_hash != burn_tx_hash {
-            return Err(BurnManagerError::Redemption(
-                RedemptionError::BurnHashMismatch {
-                    expected: persisted_burn_hash,
-                    provided: burn_tx_hash,
-                },
-            ));
-        }
+        let acknowledged_unresolved_burn_tx_hash = redemption
+            .validate_force_complete_burn_hash(
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash,
+            )?;
 
-        let underlying = match &redemption {
-            Redemption::Burning { metadata, .. }
-            | Redemption::BurnIntended { metadata, .. }
-            | Redemption::BurnSubmitted { metadata, .. } => {
-                metadata.underlying.clone()
+        let (underlying, recipient, planned_burns) = match &redemption {
+            Redemption::BurnIntended { metadata, planned_burns, .. }
+            | Redemption::BurnSubmitted { metadata, planned_burns, .. } => {
+                (metadata.underlying.clone(), metadata.wallet, planned_burns)
             }
             other => {
                 return Err(BurnManagerError::InvalidAggregateState {
@@ -292,9 +288,39 @@ impl BurnManager {
             .vault_service
             .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
             .await?;
+        if burn_tx_hash != persisted_burn_tx.hash
+            && !burn_verification_matches_plan(
+                &verification,
+                planned_burns,
+                self.bot_wallet,
+                recipient,
+                persisted_burn_tx.dust_shares,
+                persisted_burn_tx.nonce,
+            )
+        {
+            let expected_shares_burned = planned_burns
+                .iter()
+                .try_fold(U256::ZERO, |total, burn| {
+                    total.checked_add(burn.shares_burned)
+                })
+                .ok_or(BurnManagerError::SharesOverflow)?;
+            return Err(BurnManagerError::AlternateBurnSemanticsMismatch {
+                expected_burns: planned_burns.clone(),
+                expected_shares_burned,
+                expected_recipient: recipient,
+                expected_dust_shares: persisted_burn_tx.dust_shares,
+                expected_nonce: persisted_burn_tx.nonce,
+                verified_burns: verification.burns.clone(),
+                verified_shares_burned: verification.shares_burned,
+                verified_nonce: verification.nonce,
+                verified_share_transfers: verification.share_transfers.clone(),
+            });
+        }
 
         info!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_tx_hash = ?burn_tx_hash,
+            persisted_burn_tx_hash = ?persisted_burn_tx.hash,
+            acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
             block_number = verification.block_number,
             shares_burned = %verification.shares_burned,
             "Force-completing stuck Burning redemption: burn verified on-chain"
@@ -308,6 +334,7 @@ impl BurnManager {
                     burn_tx_hash,
                     block_number: verification.block_number,
                     reason,
+                    acknowledged_unresolved_burn_tx_hash,
                 },
             )
             .await?;
@@ -2370,6 +2397,20 @@ pub(crate) enum BurnManagerError {
     AssetNotFound { underlying: UnderlyingSymbol },
     #[error("Arithmetic overflow when computing total shares needed")]
     SharesOverflow,
+    #[error(
+        "Alternate proving transaction does not match the persisted burn semantics: expected nonce {expected_nonce}, total shares {expected_shares_burned}, burns {expected_burns:?}, recipient {expected_recipient}, dust {expected_dust_shares}; verified nonce {verified_nonce}, total shares {verified_shares_burned}, burns {verified_burns:?}, transfers {verified_share_transfers:?}"
+    )]
+    AlternateBurnSemanticsMismatch {
+        expected_burns: Vec<BurnRecord>,
+        expected_shares_burned: U256,
+        expected_recipient: Address,
+        expected_dust_shares: U256,
+        expected_nonce: u64,
+        verified_burns: Vec<VerifiedBurn>,
+        verified_shares_burned: U256,
+        verified_nonce: u64,
+        verified_share_transfers: Vec<VerifiedShareTransfer>,
+    },
     #[error("Receipt reservation error: {0}")]
     ReceiptRegistration(#[from] ReceiptRegistrationError),
     #[error(
@@ -2378,6 +2419,51 @@ pub(crate) enum BurnManagerError {
     WalletIntentWaitTimeout { issuer_request_id: IssuerRedemptionRequestId },
     #[error("Burn recovery attempt counter overflowed for {issuer_request_id}")]
     RecoveryAttemptOverflow { issuer_request_id: IssuerRedemptionRequestId },
+}
+
+fn burn_verification_matches_plan(
+    verification: &BurnVerification,
+    planned_burns: &[BurnRecord],
+    owner: Address,
+    recipient: Address,
+    dust_shares: U256,
+    expected_nonce: u64,
+) -> bool {
+    let Some(expected_shares_burned) =
+        planned_burns.iter().try_fold(U256::ZERO, |total, burn| {
+            total.checked_add(burn.shares_burned)
+        })
+    else {
+        return false;
+    };
+    let mut expected = planned_burns
+        .iter()
+        .map(|burn| (burn.receipt_id, burn.shares_burned))
+        .collect::<Vec<_>>();
+    let mut verified = verification
+        .burns
+        .iter()
+        .filter(|burn| burn.sender == owner && burn.receiver == recipient)
+        .map(|burn| (burn.receipt_id, burn.shares_burned))
+        .collect::<Vec<_>>();
+    expected.sort_unstable();
+    verified.sort_unstable();
+    let expected_share_transfers = if dust_shares.is_zero() {
+        vec![]
+    } else {
+        vec![(recipient, dust_shares)]
+    };
+    let verified_share_transfers = verification
+        .share_transfers
+        .iter()
+        .map(|transfer| (transfer.recipient, transfer.shares))
+        .collect::<Vec<_>>();
+
+    verification.nonce == expected_nonce
+        && verification.shares_burned == expected_shares_burned
+        && expected == verified
+        && verification.burns.len() == verified.len()
+        && expected_share_transfers == verified_share_transfers
 }
 
 #[cfg(test)]
@@ -2394,7 +2480,7 @@ mod tests {
     use super::{
         BurnManager, BurnManagerError, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
         RecoveryOutcome, Redemption, RedemptionCommand,
-        should_release_reserved_burn,
+        burn_verification_matches_plan, should_release_reserved_burn,
     };
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Network, Quantity, TokenizationRequestId};
@@ -2414,8 +2500,9 @@ mod tests {
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        BurnTxStatus, MultiBurnEntry, ReceiptInformation, SendableTxWithHash,
-        TxId, VaultError, VaultService,
+        BurnTxStatus, BurnVerification, MultiBurnEntry, ReceiptInformation,
+        SendableTxWithHash, TxId, VaultError, VaultService, VerifiedBurn,
+        VerifiedShareTransfer,
     };
 
     const TEST_WALLET: Address =
@@ -2460,6 +2547,75 @@ mod tests {
             "ambiguous parse errors must not release the reservation"
         );
         assert!(!should_release_reserved_burn(&VaultError::InvalidReceipt));
+    }
+
+    #[test]
+    fn alternate_burn_semantics_require_recipient_and_dust_transfer() {
+        let owner = TEST_WALLET;
+        let recipient = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let planned_burns = vec![BurnRecord {
+            receipt_id: uint!(42_U256),
+            shares_burned: uint!(17_U256),
+        }];
+        let verification = BurnVerification {
+            block_number: 45_989_009,
+            nonce: 7,
+            shares_burned: uint!(17_U256),
+            burns: vec![VerifiedBurn {
+                sender: owner,
+                receiver: recipient,
+                receipt_id: uint!(42_U256),
+                shares_burned: uint!(17_U256),
+            }],
+            share_transfers: vec![],
+        };
+
+        assert!(!burn_verification_matches_plan(
+            &verification,
+            &planned_burns,
+            owner,
+            recipient,
+            uint!(3_U256),
+            7,
+        ));
+
+        let verification = BurnVerification {
+            share_transfers: vec![VerifiedShareTransfer {
+                recipient,
+                shares: uint!(3_U256),
+            }],
+            ..verification
+        };
+        assert!(burn_verification_matches_plan(
+            &verification,
+            &planned_burns,
+            owner,
+            recipient,
+            uint!(3_U256),
+            7,
+        ));
+        let mismatched_total = BurnVerification {
+            shares_burned: uint!(18_U256),
+            ..verification.clone()
+        };
+        assert!(!burn_verification_matches_plan(
+            &mismatched_total,
+            &planned_burns,
+            owner,
+            recipient,
+            uint!(3_U256),
+            7,
+        ));
+        let replayed_at_another_nonce =
+            BurnVerification { nonce: 8, ..verification };
+        assert!(!burn_verification_matches_plan(
+            &replayed_at_another_nonce,
+            &planned_burns,
+            owner,
+            recipient,
+            uint!(3_U256),
+            7,
+        ));
     }
 
     struct TestHarness {
@@ -2648,6 +2804,7 @@ mod tests {
         issuer_request_id: &IssuerRedemptionRequestId,
         vault: Address,
         owner: Address,
+        dust_shares: U256,
     ) {
         store
             .send(
@@ -2661,7 +2818,7 @@ mod tests {
                         receipt_info: None,
                         receipt_info_bytes: None,
                     }],
-                    dust_shares: U256::ZERO,
+                    dust_shares,
                     owner,
                     external_tx_id: None,
                 },
@@ -2858,7 +3015,7 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
-    async fn test_force_complete_burn_records_verified_burn() {
+    async fn force_complete_acknowledged_alternate_burn_settles_reservation() {
         let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let persisted_tx = SendableTxWithHash::valid_for_test(
             7,
@@ -2868,7 +3025,19 @@ mod tests {
         let owner = persisted_tx.signer_for_test();
         let vault_mock = Arc::new(
             MockVaultService::new_success()
-                .with_verified_burn(45_989_009, uint!(17_U256))
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: owner,
+                        receiver: address!(
+                            "0x1234567890abcdef1234567890abcdef12345678"
+                        ),
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_U256),
+                    }],
+                    vec![],
+                )
                 .with_prepared_tx(persisted_tx.clone()),
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
@@ -2915,15 +3084,23 @@ mod tests {
             vec![issuer_request_id.clone()],
             "reservation should be held before force-complete"
         );
-        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
 
-        let burn_tx_hash = persisted_tx.hash;
+        let burn_tx_hash = B256::random();
 
         let verification = manager
             .force_complete_burn(
                 &issuer_request_id,
                 burn_tx_hash,
                 "burn confirmed on-chain".to_string(),
+                Some(persisted_tx.hash),
             )
             .await
             .expect("force-complete should succeed");
@@ -2951,10 +3128,215 @@ mod tests {
             "force-complete must leave no dangling reservation"
         );
 
+        let proving_hash = format!("{burn_tx_hash:?}");
+        let persisted_hash = format!("{:?}", persisted_tx.hash);
         assert!(logs_contain_at!(
             tracing::Level::INFO,
-            &["Force-completing stuck Burning redemption", "verified on-chain"]
+            &[
+                "Force-completing stuck Burning redemption",
+                "verified on-chain",
+                "acknowledged_unresolved_burn_tx_hash",
+                &proving_hash,
+                &persisted_hash,
+            ]
         ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_rejects_alternate_burn_for_another_recipient() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    vec![VerifiedBurn {
+                        sender: owner,
+                        receiver: address!(
+                            "0x9999999999999999999999999999999999999999"
+                        ),
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_U256),
+                    }],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        harness.discover_receipt(vault, uint!(42_U256), uint!(17_U256)).await;
+        receipt_service
+            .reserve_burn(
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(42_U256),
+                    shares_burned: uint!(17_U256),
+                }],
+            )
+            .await
+            .expect("reservation should seed");
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                B256::random(),
+                "another redemption's burn".to_string(),
+                Some(persisted_tx.hash),
+            )
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::AlternateBurnSemanticsMismatch { .. })
+        ));
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+        assert!(
+            receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id)
+        );
+    }
+
+    #[tokio::test]
+    async fn force_complete_forwards_persisted_dust_and_nonce_to_verification()
+    {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let recipient = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let dust_shares = uint!(3_U256);
+
+        for (scenario, verified_nonce, verified_share_transfers) in [
+            ("missing dust transfer", 7, vec![]),
+            (
+                "different nonce",
+                8,
+                vec![VerifiedShareTransfer { recipient, shares: dust_shares }],
+            ),
+        ] {
+            let mut persisted_tx = SendableTxWithHash::valid_for_test(
+                7,
+                vault,
+                Bytes::from_static(&[0xde, 0xad]),
+            );
+            persisted_tx.dust_shares = dust_shares;
+            let owner = persisted_tx.signer_for_test();
+            let vault_mock = Arc::new(
+                MockVaultService::new_success()
+                    .with_verified_burns(
+                        45_989_009,
+                        verified_nonce,
+                        vec![VerifiedBurn {
+                            sender: owner,
+                            receiver: recipient,
+                            receipt_id: uint!(42_U256),
+                            shares_burned: uint!(17_U256),
+                        }],
+                        verified_share_transfers,
+                    )
+                    .with_prepared_tx(persisted_tx.clone()),
+            );
+            let harness =
+                TestHarness::with_vault_mock(vault_mock.clone()).await;
+            let TestHarness { store, receipt_service, pool, .. } = &harness;
+            harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+            let manager = BurnManager::new(
+                vault_mock.clone(),
+                pool.clone(),
+                store.clone(),
+                receipt_service.clone(),
+                owner,
+            );
+            let issuer_request_id = IssuerRedemptionRequestId::random();
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+            harness
+                .discover_receipt(vault, uint!(42_U256), uint!(17_U256))
+                .await;
+            receipt_service
+                .reserve_burn(
+                    vault,
+                    issuer_request_id.clone(),
+                    vec![BurnRecord {
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_U256),
+                    }],
+                )
+                .await
+                .expect("reservation should seed");
+            persist_test_burn_intent(
+                store,
+                &issuer_request_id,
+                vault,
+                owner,
+                dust_shares,
+            )
+            .await;
+
+            let result = manager
+                .force_complete_burn(
+                    &issuer_request_id,
+                    B256::random(),
+                    scenario.to_string(),
+                    Some(persisted_tx.hash),
+                )
+                .await;
+
+            assert!(
+                matches!(
+                    &result,
+                    Err(BurnManagerError::AlternateBurnSemanticsMismatch {
+                        expected_dust_shares,
+                        expected_nonce,
+                        ..
+                    }) if *expected_dust_shares == dust_shares
+                        && *expected_nonce == persisted_tx.nonce
+                ),
+                "scenario {scenario} unexpectedly succeeded: {result:?}"
+            );
+            assert!(
+                matches!(
+                    load_aggregate(store, &issuer_request_id).await,
+                    Redemption::BurnIntended { .. }
+                ),
+                "scenario {scenario} changed the redemption"
+            );
+            assert_eq!(
+                receipt_service.reserved_redemptions(vault).await.unwrap(),
+                vec![issuer_request_id],
+                "scenario {scenario} released the reservation"
+            );
+            assert_eq!(vault_mock.verify_burn_call_count(), 1);
+        }
     }
 
     #[tokio::test]
@@ -2990,13 +3372,21 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
 
         let result = manager
             .force_complete_burn(
                 &issuer_request_id,
                 persisted_tx.hash,
                 "operator hash is not a burn".to_string(),
+                None,
             )
             .await;
 
@@ -3047,13 +3437,21 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
 
         let result = manager
             .force_complete_burn(
                 &issuer_request_id,
                 persisted_tx.hash,
                 "operator hash reverted".to_string(),
+                None,
             )
             .await;
 
@@ -3093,6 +3491,7 @@ mod tests {
                 &issuer_request_id,
                 B256::random(),
                 "another redemption's verified burn".to_string(),
+                None,
             )
             .await;
 
@@ -3135,6 +3534,7 @@ mod tests {
                     "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
                 ),
                 "wrong state".to_string(),
+                None,
             )
             .await;
 
@@ -4873,8 +5273,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
-            .await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            TEST_WALLET,
+            U256::ZERO,
+        )
+        .await;
 
         let stale = load_aggregate(store, &issuer_request_id).await;
         let Redemption::BurnIntended {
@@ -4977,8 +5383,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
-            .await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            TEST_WALLET,
+            U256::ZERO,
+        )
+        .await;
         let manager = BurnManager::new(
             vault_mock.clone(),
             pool.clone(),
@@ -5033,8 +5445,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
-            .await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            TEST_WALLET,
+            U256::ZERO,
+        )
+        .await;
         record_test_recovery_attempts(
             store,
             &issuer_request_id,
@@ -5117,7 +5535,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
         record_test_recovery_attempts(
             store,
             &issuer_request_id,
@@ -5207,7 +5632,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, owner).await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            owner,
+            U256::ZERO,
+        )
+        .await;
         record_test_recovery_attempts(
             store,
             &issuer_request_id,
@@ -5286,8 +5718,14 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         create_test_redemption_in_burning_state(store, &issuer_request_id)
             .await;
-        persist_test_burn_intent(store, &issuer_request_id, vault, TEST_WALLET)
-            .await;
+        persist_test_burn_intent(
+            store,
+            &issuer_request_id,
+            vault,
+            TEST_WALLET,
+            U256::ZERO,
+        )
+        .await;
         record_test_recovery_attempts(
             store,
             &issuer_request_id,
@@ -5944,7 +6382,7 @@ mod tests {
         let TestHarness { store, receipt_service, pool, .. } = &harness;
         harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
         let manager = BurnManager::new(
-            vault_mock,
+            vault_mock.clone(),
             pool.clone(),
             store.clone(),
             receipt_service.clone(),
@@ -5991,14 +6429,17 @@ mod tests {
                 &issuer_request_id,
                 other_redemption_hash,
                 "wrong redemption".to_string(),
+                None,
             )
             .await;
 
         assert!(matches!(
             result,
             Err(BurnManagerError::Redemption(
-                RedemptionError::BurnHashMismatch { expected, provided }
-            )) if expected == persisted_tx.hash && provided == other_redemption_hash
+                RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                    burn_tx_hash,
+                }
+            )) if burn_tx_hash == persisted_tx.hash
         ));
         assert!(matches!(
             load_aggregate(store, &issuer_request_id).await,
@@ -6011,6 +6452,27 @@ mod tests {
                 .unwrap()
                 .contains(&issuer_request_id)
         );
+
+        let wrong_acknowledgement = B256::random();
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                other_redemption_hash,
+                "wrong acknowledgement".to_string(),
+                Some(wrong_acknowledgement),
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(BurnManagerError::Redemption(
+                RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                    expected,
+                    provided,
+                }
+            )) if expected == persisted_tx.hash
+                && provided == wrong_acknowledgement
+        ));
+        assert_eq!(vault_mock.verify_burn_call_count(), 0);
     }
 
     #[tokio::test]
@@ -6062,6 +6524,7 @@ mod tests {
                 &issuer_request_id,
                 persisted_tx.hash,
                 "untrusted persisted identity".to_string(),
+                None,
             )
             .await;
 

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -93,6 +93,10 @@ pub(crate) enum RedemptionCommand {
     CloseRedemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
+        /// Exact persisted signed burn hash the operator has reconciled and is
+        /// explicitly acknowledging may still land.
+        #[serde(default)]
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     },
     /// Admin-terminalizes a redemption stuck in
     /// `Burning`/`BurnIntended`/`BurnSubmitted` whose burn already landed
@@ -104,6 +108,10 @@ pub(crate) enum RedemptionCommand {
         burn_tx_hash: B256,
         block_number: u64,
         reason: String,
+        /// Exact persisted signed burn hash the operator has reconciled when
+        /// `burn_tx_hash` proves a different transaction.
+        #[serde(default)]
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     },
     /// Resumes a post-Alpaca failed redemption directly to Burning state.
     /// Only valid from `Failed` state when Alpaca was already called and

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -195,6 +195,8 @@ pub(crate) enum RedemptionEvent {
     RedemptionClosed {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
+        #[serde(default)]
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
         closed_at: DateTime<Utc>,
     },
     /// Admin-recorded terminal success for a redemption stuck in
@@ -208,6 +210,8 @@ pub(crate) enum RedemptionEvent {
         burn_tx_hash: B256,
         block_number: u64,
         reason: String,
+        #[serde(default)]
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
         completed_at: DateTime<Utc>,
     },
     /// Post-Alpaca failed redemption resumed directly to Burning state.
@@ -330,7 +334,9 @@ impl DomainEvent for RedemptionEvent {
             Self::TokensBurned(_)
             | Self::BurningFailed { .. }
             | Self::BurnTxSubmitted { .. }
-            | Self::ExistingBurnRecovered { .. } => "2.0".to_string(),
+            | Self::ExistingBurnRecovered { .. }
+            | Self::RedemptionClosed { .. }
+            | Self::BurnForceCompleted { .. } => "2.0".to_string(),
             _ => "1.0".to_string(),
         }
     }
@@ -340,6 +346,7 @@ impl DomainEvent for RedemptionEvent {
 mod tests {
     use alloy::primitives::{U256, b256, uint};
     use chrono::Utc;
+    use serde_json::{from_value, to_value};
 
     use super::*;
 
@@ -392,11 +399,57 @@ mod tests {
             ),
             block_number: 1000,
             reason: "admin recovery".to_string(),
+            acknowledged_unresolved_burn_tx_hash: None,
             completed_at: Utc::now(),
         };
 
         assert_eq!(event.event_type(), "RedemptionEvent::BurnForceCompleted");
-        assert_eq!(event.event_version(), "1.0");
+        assert_eq!(event.event_version(), "2.0");
+    }
+
+    #[test]
+    fn terminal_admin_events_replay_without_acknowledgement_field() {
+        let events = [
+            RedemptionEvent::RedemptionClosed {
+                issuer_request_id: test_redemption_id(),
+                reason: "legacy close".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+                closed_at: Utc::now(),
+            },
+            RedemptionEvent::BurnForceCompleted {
+                issuer_request_id: test_redemption_id(),
+                burn_tx_hash: B256::random(),
+                block_number: 1000,
+                reason: "legacy force-complete".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+                completed_at: Utc::now(),
+            },
+        ];
+
+        for event in events {
+            let mut value = to_value(&event).unwrap();
+            let payload = value
+                .as_object_mut()
+                .unwrap()
+                .values_mut()
+                .next()
+                .unwrap()
+                .as_object_mut()
+                .unwrap();
+            payload.remove("acknowledged_unresolved_burn_tx_hash");
+
+            let replayed: RedemptionEvent = from_value(value).unwrap();
+            assert!(matches!(
+                replayed,
+                RedemptionEvent::RedemptionClosed {
+                    acknowledged_unresolved_burn_tx_hash: None,
+                    ..
+                } | RedemptionEvent::BurnForceCompleted {
+                    acknowledged_unresolved_burn_tx_hash: None,
+                    ..
+                }
+            ));
+        }
     }
 
     #[test]

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -263,10 +263,11 @@ pub(crate) enum Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
         failed_at: DateTime<Utc>,
-        /// Exact prior transaction used to validate durable recovery
-        /// exhaustion after replacement preparation fails.
+        /// A signed burn persisted before the failure and still capable of
+        /// landing on-chain. Retained both for durable recovery exhaustion and
+        /// so terminal admin actions cannot bypass the acknowledgement guard.
         #[serde(default)]
-        prior_burn_tx: Option<SendableTxWithHash>,
+        unresolved_burn_tx: Option<SendableTxWithHash>,
     },
     Closed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -361,11 +362,12 @@ impl Redemption {
     }
 
     /// Returns the quantity sent to Alpaca (truncated to 9 decimals).
-    /// Only available in AlpacaCalled, Burning, and BurnSubmitted states.
+    /// Available in every state from AlpacaCalled through burn submission.
     pub(crate) const fn alpaca_quantity(&self) -> Option<&Quantity> {
         match self {
             Self::AlpacaCalled { alpaca_quantity, .. }
             | Self::Burning { alpaca_quantity, .. }
+            | Self::BurnIntended { alpaca_quantity, .. }
             | Self::BurnSubmitted { alpaca_quantity, .. } => {
                 Some(alpaca_quantity)
             }
@@ -720,6 +722,7 @@ impl Redemption {
         &self,
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
         if !matches!(
             self,
@@ -740,9 +743,31 @@ impl Redemption {
             });
         }
 
+        let persisted_burn_tx = self
+            .persisted_unresolved_burn_tx()
+            .filter(|sendable_tx| !sendable_tx.tx.is_empty());
+        let acknowledged_unresolved_burn_tx_hash =
+            match (persisted_burn_tx, acknowledged_unresolved_burn_tx_hash) {
+                (Some(sendable_tx), acknowledgement) => {
+                    Some(Self::require_unresolved_burn_acknowledgement(
+                        sendable_tx.hash,
+                        acknowledgement,
+                    )?)
+                }
+                (None, Some(provided)) => {
+                    return Err(
+                    RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
+                        provided,
+                    },
+                );
+                }
+                (None, None) => None,
+            };
+
         Ok(vec![RedemptionEvent::RedemptionClosed {
             issuer_request_id,
             reason,
+            acknowledged_unresolved_burn_tx_hash,
             closed_at: Utc::now(),
         }])
     }
@@ -759,6 +784,7 @@ impl Redemption {
         burn_tx_hash: B256,
         block_number: u64,
         reason: String,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
         if !matches!(
             self,
@@ -777,21 +803,41 @@ impl Redemption {
                 },
             });
         }
-        let persisted_burn_hash = self.persisted_burn_hash()?;
-        if persisted_burn_hash != burn_tx_hash {
-            return Err(RedemptionError::BurnHashMismatch {
-                expected: persisted_burn_hash,
-                provided: burn_tx_hash,
-            });
-        }
+        let acknowledged_unresolved_burn_tx_hash = self
+            .validate_force_complete_burn_hash(
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash,
+            )?;
 
         Ok(vec![RedemptionEvent::BurnForceCompleted {
             issuer_request_id,
             burn_tx_hash,
             block_number,
             reason,
+            acknowledged_unresolved_burn_tx_hash,
             completed_at: Utc::now(),
         }])
+    }
+
+    fn require_unresolved_burn_acknowledgement(
+        persisted_burn_hash: B256,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
+    ) -> Result<B256, RedemptionError> {
+        let acknowledged_hash = acknowledged_unresolved_burn_tx_hash.ok_or(
+            RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                burn_tx_hash: persisted_burn_hash,
+            },
+        )?;
+        if acknowledged_hash != persisted_burn_hash {
+            return Err(
+                RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                    expected: persisted_burn_hash,
+                    provided: acknowledged_hash,
+                },
+            );
+        }
+
+        Ok(acknowledged_hash)
     }
 
     fn handle_confirm_alpaca_complete(
@@ -932,14 +978,52 @@ impl Redemption {
         }
     }
 
+    const fn persisted_unresolved_burn_tx(
+        &self,
+    ) -> Option<&SendableTxWithHash> {
+        match self {
+            Self::BurnIntended { sendable_tx, .. }
+            | Self::BurnSubmitted { sendable_tx, .. } => Some(sendable_tx),
+            Self::Burning { prior_burn_tx, .. } => prior_burn_tx.as_ref(),
+            Self::Failed { unresolved_burn_tx, .. } => {
+                unresolved_burn_tx.as_ref()
+            }
+            _ => None,
+        }
+    }
+
     fn persisted_burn_hash(&self) -> Result<B256, RedemptionError> {
         Ok(self.persisted_burn_tx()?.hash)
+    }
+
+    pub(crate) fn validate_force_complete_burn_hash(
+        &self,
+        proving_burn_tx_hash: B256,
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
+    ) -> Result<Option<B256>, RedemptionError> {
+        let persisted_burn_hash = self.persisted_burn_hash()?;
+        if persisted_burn_hash == proving_burn_tx_hash {
+            if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
+                return Err(
+                    RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                        provided,
+                    },
+                );
+            }
+
+            return Ok(None);
+        }
+
+        Ok(Some(Self::require_unresolved_burn_acknowledgement(
+            persisted_burn_hash,
+            acknowledged_unresolved_burn_tx_hash,
+        )?))
     }
 
     fn persisted_burn_tx(
         &self,
     ) -> Result<&SendableTxWithHash, RedemptionError> {
-        self.current_sendable_tx()
+        self.persisted_unresolved_burn_tx()
             .filter(|sendable_tx| !sendable_tx.tx.is_empty())
             .ok_or(RedemptionError::PersistedBurnHashUnavailable)
     }
@@ -1042,8 +1126,10 @@ impl Redemption {
         nonce: u64,
     ) -> Result<(), RedemptionError> {
         let sendable_tx = self.current_sendable_tx().or(match self {
-            Self::Burning { prior_burn_tx, .. }
-            | Self::Failed { prior_burn_tx, .. } => prior_burn_tx.as_ref(),
+            Self::Burning { prior_burn_tx, .. } => prior_burn_tx.as_ref(),
+            Self::Failed { unresolved_burn_tx, .. } => {
+                unresolved_burn_tx.as_ref()
+            }
             _ => None,
         });
         let sendable_tx =
@@ -1181,9 +1267,21 @@ pub(crate) enum RedemptionError {
     #[error("Burn confirmation remains pending for {tx_id}: {message}")]
     BurnConfirmationPending { tx_id: TxId, message: String },
     #[error(
-        "Burn hash mismatch: expected persisted hash {expected:?}, provided {provided:?}"
+        "Unresolved persisted burn {burn_tx_hash:?} requires explicit operator acknowledgement"
     )]
-    BurnHashMismatch { expected: B256, provided: B256 },
+    UnresolvedBurnRequiresAcknowledgement { burn_tx_hash: B256 },
+    #[error(
+        "Unresolved burn acknowledgement mismatch: expected {expected:?}, provided {provided:?}"
+    )]
+    UnresolvedBurnAcknowledgementMismatch { expected: B256, provided: B256 },
+    #[error(
+        "Unresolved burn acknowledgement {provided:?} was provided, but this redemption has no persisted signed burn"
+    )]
+    UnexpectedUnresolvedBurnAcknowledgement { provided: B256 },
+    #[error(
+        "Unresolved burn acknowledgement {provided:?} is redundant because the proving burn is the persisted signed burn"
+    )]
+    RedundantUnresolvedBurnAcknowledgement { provided: B256 },
     #[error(
         "Force-completion requires a non-empty exact transaction persisted for this redemption"
     )]
@@ -1244,7 +1342,7 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 4;
+    const SCHEMA_VERSION: u64 = 5;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {
@@ -1470,17 +1568,24 @@ impl EventSourced for Redemption {
             RedemptionCommand::CloseRedemption {
                 issuer_request_id,
                 reason,
-            } => self.handle_close_redemption(issuer_request_id, reason),
+                acknowledged_unresolved_burn_tx_hash,
+            } => self.handle_close_redemption(
+                issuer_request_id,
+                reason,
+                acknowledged_unresolved_burn_tx_hash,
+            ),
             RedemptionCommand::ForceCompleteBurn {
                 issuer_request_id,
                 burn_tx_hash,
                 block_number,
                 reason,
+                acknowledged_unresolved_burn_tx_hash,
             } => self.handle_force_complete_burn(
                 issuer_request_id,
                 burn_tx_hash,
                 block_number,
                 reason,
+                acknowledged_unresolved_burn_tx_hash,
             ),
             RedemptionCommand::Reprocess { issuer_request_id, metadata } => {
                 self.handle_reprocess(issuer_request_id, metadata)
@@ -1668,12 +1773,10 @@ impl Redemption {
     }
 
     fn apply_failure_event(&mut self, event: RedemptionEvent) {
-        let prior_burn_tx =
-            self.current_sendable_tx().cloned().or_else(|| match self {
-                Self::Burning { prior_burn_tx, .. }
-                | Self::Failed { prior_burn_tx, .. } => prior_burn_tx.clone(),
-                _ => None,
-            });
+        let unresolved_burn_tx = self
+            .persisted_unresolved_burn_tx()
+            .filter(|sendable_tx| !sendable_tx.tx.is_empty())
+            .cloned();
         let (issuer_request_id, reason, failed_at) = match event {
             RedemptionEvent::AlpacaCallFailed {
                 issuer_request_id,
@@ -1698,7 +1801,7 @@ impl Redemption {
             issuer_request_id,
             reason,
             failed_at,
-            prior_burn_tx,
+            unresolved_burn_tx,
         };
     }
 
@@ -1754,7 +1857,9 @@ impl Redemption {
 
     fn apply_burn_resumed_event(&mut self, event: RedemptionEvent) {
         let prior_burn_tx = match self {
-            Self::Failed { prior_burn_tx, .. } => prior_burn_tx.clone(),
+            Self::Failed { unresolved_burn_tx, .. } => {
+                unresolved_burn_tx.clone()
+            }
             _ => None,
         };
         let RedemptionEvent::BurnResumed {
@@ -1829,6 +1934,7 @@ impl Redemption {
                 issuer_request_id,
                 reason,
                 closed_at,
+                ..
             } => {
                 *self = Self::Closed { issuer_request_id, reason, closed_at };
             }
@@ -1938,7 +2044,7 @@ mod tests {
         Address, B256, Bytes, TxHash, U256, address, b256, uint,
     };
     use chrono::Utc;
-    use cqrs_es::DomainEvent;
+    use cqrs_es::{AggregateError, DomainEvent};
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
@@ -3328,6 +3434,22 @@ mod tests {
         events
     }
 
+    #[test]
+    fn burn_intended_preserves_alpaca_quantity_for_admin_context() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let redemption = replay::<Redemption>(burn_intended_given_events(
+            &issuer_request_id,
+            B256::random(),
+        ))
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(
+            redemption.alpaca_quantity(),
+            Some(&Quantity::new(Decimal::from(17)))
+        );
+    }
+
     #[tokio::test]
     async fn test_confirm_burn_from_burn_intended_with_matching_hash() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -3421,6 +3543,7 @@ mod tests {
                 burn_tx_hash,
                 block_number: 45_989_009,
                 reason: "persisted burn confirmed on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3441,6 +3564,7 @@ mod tests {
             .when(RedemptionCommand::CloseRedemption {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: reason.clone(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3458,6 +3582,31 @@ mod tests {
 
         assert_eq!(event_id, &issuer_request_id);
         assert_eq!(event_reason, &reason);
+    }
+
+    #[tokio::test]
+    async fn close_redemption_rejects_acknowledgement_without_persisted_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let acknowledged_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "no signed burn exists".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
+                    provided,
+                }
+            ) if provided == acknowledged_hash
+        ));
     }
 
     #[tokio::test]
@@ -3477,6 +3626,7 @@ mod tests {
             .when(RedemptionCommand::CloseRedemption {
                 issuer_request_id,
                 reason: "unrecoverable".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3495,6 +3645,7 @@ mod tests {
             .when(RedemptionCommand::CloseRedemption {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: reason.clone(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3512,6 +3663,154 @@ mod tests {
 
         assert_eq!(event_id, &issuer_request_id);
         assert_eq!(event_reason, &reason);
+    }
+
+    #[tokio::test]
+    async fn close_redemption_rejects_unacknowledged_persisted_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, burn_tx_hash))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                burn_tx_hash,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn close_redemption_rejects_wrong_burn_acknowledgement() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = B256::random();
+        let acknowledged_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, burn_tx_hash))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                expected: burn_tx_hash,
+                provided: acknowledged_hash,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn close_redemption_records_matching_burn_acknowledgement() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = B256::random();
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(&issuer_request_id, burn_tx_hash))
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(burn_tx_hash),
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::RedemptionClosed {
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+                ..
+            }] if *acknowledged_hash == burn_tx_hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_failed_redemption_requires_persisted_burn_acknowledgement() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let burn_tx_hash = B256::random();
+        let mut history =
+            burn_intended_given_events(&issuer_request_id, burn_tx_hash);
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "confirmation was ambiguous".to_string(),
+            failed_at: Utc::now(),
+            tx_id: Some(TxId::Hash(burn_tx_hash)),
+            planned_burns: vec![],
+        });
+
+        let missing = TestHarness::<Redemption>::with(mock_services())
+            .given(history.clone())
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(matches!(
+            missing,
+            LifecycleError::Apply(
+                RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                    burn_tx_hash: unresolved_hash,
+                }
+            ) if unresolved_hash == burn_tx_hash
+        ));
+
+        let wrong_hash = B256::random();
+        let mismatch = TestHarness::<Redemption>::with(mock_services())
+            .given(history.clone())
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(wrong_hash),
+            })
+            .await
+            .then_expect_error();
+        assert!(matches!(
+            mismatch,
+            LifecycleError::Apply(
+                RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                    expected,
+                    provided,
+                }
+            ) if expected == burn_tx_hash && provided == wrong_hash
+        ));
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::CloseRedemption {
+                issuer_request_id,
+                reason: "operator reconciled externally".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(burn_tx_hash),
+            })
+            .await
+            .events();
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::RedemptionClosed {
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+                ..
+            }] if *acknowledged_hash == burn_tx_hash
+        ));
     }
 
     #[tokio::test]
@@ -3533,6 +3832,7 @@ mod tests {
             .when(RedemptionCommand::CloseRedemption {
                 issuer_request_id,
                 reason: "operator reconciled exhausted burn".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3565,6 +3865,7 @@ mod tests {
             .when(RedemptionCommand::CloseRedemption {
                 issuer_request_id,
                 reason: "too early".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .then_expect_error();
@@ -3592,6 +3893,7 @@ mod tests {
                 burn_tx_hash: B256::random(),
                 block_number: 45_989_009,
                 reason: "another redemption's verified burn".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .then_expect_error();
@@ -3614,6 +3916,7 @@ mod tests {
                 burn_tx_hash: B256::random(),
                 block_number: 45_989_009,
                 reason: "another redemption's verified burn".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .then_expect_error();
@@ -3651,6 +3954,7 @@ mod tests {
                 burn_tx_hash: sendable_tx.hash,
                 block_number: 45_989_009,
                 reason: "verified exhausted burn".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .events();
@@ -3658,6 +3962,133 @@ mod tests {
         assert!(matches!(
             events.as_slice(),
             [RedemptionEvent::BurnForceCompleted { .. }]
+        ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_rejects_different_unacknowledged_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+        let proving_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(
+                &issuer_request_id,
+                persisted_hash,
+            ))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: proving_hash,
+                block_number: 45_989_009,
+                reason: "different burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                burn_tx_hash: persisted_hash,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn force_complete_records_acknowledged_different_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+        let proving_hash = B256::random();
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(
+                &issuer_request_id,
+                persisted_hash,
+            ))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: proving_hash,
+                block_number: 45_989_009,
+                reason: "different burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(persisted_hash),
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted {
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+                ..
+            }] if *burn_tx_hash == proving_hash
+                && *acknowledged_hash == persisted_hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_rejects_acknowledgement_for_persisted_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(
+                &issuer_request_id,
+                persisted_hash,
+            ))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: persisted_hash,
+                block_number: 45_989_009,
+                reason: "persisted burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(persisted_hash),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                    provided,
+                }
+            ) if provided == persisted_hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_rejects_wrong_burn_acknowledgement() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+        let proving_hash = B256::random();
+        let acknowledged_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_intended_given_events(
+                &issuer_request_id,
+                persisted_hash,
+            ))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: proving_hash,
+                block_number: 45_989_009,
+                reason: "different burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(acknowledged_hash),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            error,
+            LifecycleError::Apply(
+                RedemptionError::UnresolvedBurnAcknowledgementMismatch {
+                    expected,
+                    provided,
+                }
+            ) if expected == persisted_hash && provided == acknowledged_hash
         ));
     }
 
@@ -3674,6 +4105,7 @@ mod tests {
             burn_tx_hash,
             block_number: 45_989_009,
             reason: "verified".to_string(),
+            acknowledged_unresolved_burn_tx_hash: None,
             completed_at: Utc::now(),
         });
 
@@ -3700,6 +4132,7 @@ mod tests {
                 ),
                 block_number: 45_989_009,
                 reason: "nope".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
             })
             .await
             .then_expect_error();
@@ -3842,7 +4275,7 @@ mod tests {
                 issuer_request_id,
                 reason: error,
                 failed_at,
-                prior_burn_tx: None,
+                unresolved_burn_tx: None,
             }
         );
     }
@@ -4562,7 +4995,7 @@ mod tests {
         assert!(matches!(
             &failed,
             Redemption::Failed {
-                prior_burn_tx: Some(prior_burn_tx),
+                unresolved_burn_tx: Some(prior_burn_tx),
                 ..
             } if prior_burn_tx == &persisted_tx
         ));
@@ -4603,22 +5036,35 @@ mod tests {
             } if prior_burn_tx == &persisted_tx
         ));
 
-        for (aggregate, variant) in [(failed, "Failed"), (burning, "Burning")] {
-            let mut old_snapshot = serde_json::to_value(aggregate)
-                .expect("snapshot should serialize");
-            old_snapshot
-                .pointer_mut(&format!("/{variant}"))
-                .and_then(serde_json::Value::as_object_mut)
-                .expect("snapshot variant should exist")
-                .remove("prior_burn_tx");
-            let restored: Redemption = serde_json::from_value(old_snapshot)
-                .expect("old snapshot should deserialize");
-            assert!(matches!(
-                restored,
-                Redemption::Failed { prior_burn_tx: None, .. }
-                    | Redemption::Burning { prior_burn_tx: None, .. }
-            ));
-        }
+        let mut old_failed_snapshot =
+            serde_json::to_value(failed).expect("snapshot should serialize");
+        old_failed_snapshot
+            .pointer_mut("/Failed")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("failed snapshot should exist")
+            .remove("unresolved_burn_tx");
+        let restored_failed: Redemption =
+            serde_json::from_value(old_failed_snapshot)
+                .expect("old failed snapshot should deserialize");
+        assert!(matches!(
+            restored_failed,
+            Redemption::Failed { unresolved_burn_tx: None, .. }
+        ));
+
+        let mut old_burning_snapshot =
+            serde_json::to_value(burning).expect("snapshot should serialize");
+        old_burning_snapshot
+            .pointer_mut("/Burning")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("burning snapshot should exist")
+            .remove("prior_burn_tx");
+        let restored_burning: Redemption =
+            serde_json::from_value(old_burning_snapshot)
+                .expect("old burning snapshot should deserialize");
+        assert!(matches!(
+            restored_burning,
+            Redemption::Burning { prior_burn_tx: None, .. }
+        ));
     }
 
     proptest! {
@@ -4785,6 +5231,151 @@ mod tests {
             replayed,
             Redemption::BurnSubmitted { sendable_tx, .. }
                 if sendable_tx == persisted_tx
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Cleared stale snapshots", "Redemption"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn redemption_v4_failed_snapshot_cannot_drop_unresolved_burn_guard() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!().run(&pool).await.unwrap();
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let mut history =
+            intended_burn_history(&issuer_request_id, persisted_tx.clone());
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "ambiguous confirmation".to_string(),
+            failed_at: Utc::now(),
+            tx_id: Some(TxId::Hash(persisted_tx.hash)),
+            planned_burns: vec![],
+        });
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'SchemaRegistry',
+                'schema',
+                1,
+                'SchemaRegistryEvent::VersionUpdated',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(
+            serde_json::json!({
+                "VersionUpdated": { "name": "Redemption", "version": 4 }
+            })
+            .to_string(),
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        for (index, event) in history.iter().enumerate() {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, ?, ?, '{}')
+                ",
+            )
+            .bind(issuer_request_id.to_string())
+            .bind(i64::try_from(index + 1).unwrap())
+            .bind(event.event_type())
+            .bind(event.event_version())
+            .bind(serde_json::to_string(event).unwrap())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+        let aggregate = replay::<Redemption>(history.clone()).unwrap().unwrap();
+        let mut stale_snapshot = serde_json::json!({ "Live": aggregate });
+        stale_snapshot
+            .pointer_mut("/Live/Failed")
+            .and_then(serde_json::Value::as_object_mut)
+            .unwrap()
+            .remove("unresolved_burn_tx");
+        sqlx::query(
+            "
+            INSERT INTO snapshots (
+                aggregate_type,
+                aggregate_id,
+                last_sequence,
+                snapshot_version,
+                payload,
+                timestamp
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                ?,
+                4,
+                ?,
+                strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+            )
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .bind(i64::try_from(history.len()).unwrap())
+        .bind(stale_snapshot.to_string())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        prepare_event_sourced_startup::<Redemption>(&pool).await.unwrap();
+        let store = StoreBuilder::<Redemption>::new(pool)
+            .build(mock_services())
+            .await
+            .unwrap();
+        let error = store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::CloseRedemption {
+                    issuer_request_id: issuer_request_id.clone(),
+                    reason: "operator close".to_string(),
+                    acknowledged_unresolved_burn_tx_hash: None,
+                },
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            AggregateError::UserError(LifecycleError::Apply(
+                RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                    burn_tx_hash,
+                }
+            )) if burn_tx_hash == persisted_tx.hash
         ));
         assert!(logs_contain_at!(
             tracing::Level::INFO,

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -400,6 +400,7 @@ impl RedemptionView {
                 issuer_request_id,
                 reason,
                 closed_at,
+                ..
             } => Self::Closed {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: reason.clone(),
@@ -959,6 +960,7 @@ mod tests {
                 RedemptionEvent::RedemptionClosed {
                     issuer_request_id: id.clone(),
                     reason: reason.to_string(),
+                    acknowledged_unresolved_burn_tx_hash: None,
                     closed_at: Utc::now(),
                 },
             )
@@ -2285,6 +2287,7 @@ mod tests {
                 RedemptionEvent::RedemptionClosed {
                     issuer_request_id: issuer_request_id.clone(),
                     reason: reason.clone(),
+                    acknowledged_unresolved_burn_tx_hash: None,
                     closed_at,
                 },
             )
@@ -2326,6 +2329,7 @@ mod tests {
                     burn_tx_hash,
                     block_number,
                     reason: "admin recovery".to_string(),
+                    acknowledged_unresolved_burn_tx_hash: None,
                     completed_at,
                 },
             )

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -20,6 +20,8 @@ use super::{
     MultiBurnResult, MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
     SubmittedTx, VaultError, VaultService, WalletNonceGuard,
 };
+#[cfg(test)]
+use super::{VerifiedBurn, VerifiedShareTransfer};
 use crate::redemption::BurnExternalTxId;
 use crate::vault::{SendableTxWithHash, TxId};
 
@@ -82,7 +84,13 @@ enum MockBehavior {
 #[derive(Clone)]
 enum MockVerifyBurn {
     /// The tx proves a burn: return this block number and shares burned.
-    Verified { block_number: u64, shares_burned: U256 },
+    Verified {
+        block_number: u64,
+        nonce: u64,
+        shares_burned: U256,
+        burns: Vec<VerifiedBurn>,
+        share_transfers: Vec<VerifiedShareTransfer>,
+    },
     /// The tx succeeded but contains no matching burn.
     NotABurn,
     /// The tx reverted on-chain.
@@ -114,7 +122,10 @@ impl Default for MockVerifyBurn {
     fn default() -> Self {
         Self::Verified {
             block_number: 45_989_009,
+            nonce: 0,
             shares_burned: U256::from(1u8),
+            burns: vec![],
+            share_transfers: vec![],
         }
     }
 }
@@ -148,6 +159,8 @@ pub(crate) struct MockVaultService {
     /// verification, exercising the force-complete happy path.
     #[cfg(test)]
     verify_burn: Arc<Mutex<MockVerifyBurn>>,
+    #[cfg(test)]
+    verify_burn_call_count: Arc<AtomicUsize>,
     /// Signed tx returned by `prepare_tx` when local signing is configured.
     #[cfg(test)]
     prepared_tx: Arc<Mutex<Option<SendableTxWithHash>>>,
@@ -187,6 +200,8 @@ impl MockVaultService {
             #[cfg(test)]
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
             #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
             prepared_tx: Arc::new(Mutex::new(None)),
             #[cfg(test)]
             checked_tx_outcome: Arc::new(Mutex::new(
@@ -222,6 +237,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
             prepared_tx: Arc::new(Mutex::new(None)),
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
@@ -251,6 +268,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
             prepared_tx: Arc::new(Mutex::new(None)),
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
@@ -280,6 +299,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
             prepared_tx: Arc::new(Mutex::new(None)),
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
@@ -374,6 +395,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
             prepared_tx: Arc::new(Mutex::new(None)),
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
@@ -403,6 +426,8 @@ impl MockVaultService {
             share_balance: Arc::new(Mutex::new(U256::MAX)),
             last_multi_burn_params: Arc::new(Mutex::new(None)),
             verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
+            #[cfg(test)]
+            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
             prepared_tx: Arc::new(Mutex::new(None)),
             checked_tx_outcome: Arc::new(Mutex::new(
                 MockCheckTxOutcome::default(),
@@ -477,6 +502,11 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
+    pub(crate) fn verify_burn_call_count(&self) -> usize {
+        self.verify_burn_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
     pub(crate) fn reset(&self) {
         self.wallet_lock_call_count.store(0, Ordering::Relaxed);
         self.call_count.store(0, Ordering::Relaxed);
@@ -506,8 +536,53 @@ impl MockVaultService {
         block_number: u64,
         shares_burned: U256,
     ) -> Self {
-        *self.verify_burn.lock().unwrap() =
-            MockVerifyBurn::Verified { block_number, shares_burned };
+        *self.verify_burn.lock().unwrap() = MockVerifyBurn::Verified {
+            block_number,
+            nonce: 0,
+            shares_burned,
+            burns: vec![],
+            share_transfers: vec![],
+        };
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_verified_burns(
+        self,
+        block_number: u64,
+        nonce: u64,
+        burns: Vec<VerifiedBurn>,
+        share_transfers: Vec<VerifiedShareTransfer>,
+    ) -> Self {
+        let shares_burned = burns
+            .iter()
+            .fold(U256::ZERO, |total, burn| total + burn.shares_burned);
+        *self.verify_burn.lock().unwrap() = MockVerifyBurn::Verified {
+            block_number,
+            nonce,
+            shares_burned,
+            burns,
+            share_transfers,
+        };
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_verified_burns_and_total(
+        self,
+        block_number: u64,
+        nonce: u64,
+        shares_burned: U256,
+        burns: Vec<VerifiedBurn>,
+        share_transfers: Vec<VerifiedShareTransfer>,
+    ) -> Self {
+        *self.verify_burn.lock().unwrap() = MockVerifyBurn::Verified {
+            block_number,
+            nonce,
+            shares_burned,
+            burns,
+            share_transfers,
+        };
         self
     }
 
@@ -918,11 +993,22 @@ impl VaultService for MockVaultService {
         {
             use MockVerifyBurn::{NotABurn, Reverted, Verified};
 
+            self.verify_burn_call_count.fetch_add(1, Ordering::Relaxed);
             let outcome = self.verify_burn.lock().unwrap().clone();
             match outcome {
-                Verified { block_number, shares_burned } => {
-                    Ok(BurnVerification { block_number, shares_burned })
-                }
+                Verified {
+                    block_number,
+                    nonce,
+                    shares_burned,
+                    burns,
+                    share_transfers,
+                } => Ok(BurnVerification {
+                    block_number,
+                    nonce,
+                    shares_burned,
+                    burns,
+                    share_transfers,
+                }),
                 NotABurn => Err(VaultError::NotABurn { tx_hash }),
                 Reverted => Err(VaultError::Reverted { tx_hash }),
             }
@@ -931,7 +1017,10 @@ impl VaultService for MockVaultService {
         {
             Ok(BurnVerification {
                 block_number: 0,
+                nonce: 0,
                 shares_burned: U256::from(1u8),
+                burns: vec![],
+                share_transfers: vec![],
             })
         }
     }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -122,9 +122,11 @@ pub(crate) trait VaultService: Send + Sync {
     ///
     /// Fetches the receipt for `tx_hash` and confirms it proves a burn of
     /// `vault` shares by `owner` — a successful transaction emitting at least
-    /// one `Transfer(owner -> 0x0)` from the vault share token. Used by the
-    /// admin force-complete path to terminalize a redemption stuck in `Burning`
-    /// whose burn already landed on-chain but was never recorded.
+    /// one `Transfer(owner -> 0x0)` from the vault share token — and returns
+    /// the signer nonce, owner's per-receipt `Withdraw` entries, and share
+    /// transfers. Used by the admin
+    /// force-complete path to bind an alternate proving transaction to the
+    /// persisted burn plan before terminalizing the redemption.
     async fn verify_burn_tx(
         &self,
         vault: Address,
@@ -364,10 +366,34 @@ pub(crate) struct SendableTxWithHash {
 pub(crate) struct BurnVerification {
     /// Block number the burn transaction was included in.
     pub(crate) block_number: u64,
+    /// Signer nonce of the mined transaction. An alternate proof must replace
+    /// the persisted transaction at this exact nonce.
+    pub(crate) nonce: u64,
     /// Total shares burned by the owner in this transaction (sum of all
-    /// matching `Transfer(owner -> 0x0)` events). Reported for audit logging;
-    /// the operator is responsible for confirming the amount off-chain.
+    /// matching `Transfer(owner -> 0x0)` events). Alternate-burn recovery
+    /// requires this to equal the persisted burn plan's aggregate total.
     pub(crate) shares_burned: U256,
+    /// Per-receipt withdrawals emitted for this owner. Admin recovery uses
+    /// these to bind an alternate proving transaction to the redemption's
+    /// persisted burn plan.
+    pub(crate) burns: Vec<VerifiedBurn>,
+    /// Non-burn share transfers sent by the owner in the same transaction.
+    /// A redemption's dust return must match these exactly.
+    pub(crate) share_transfers: Vec<VerifiedShareTransfer>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerifiedBurn {
+    pub(crate) sender: Address,
+    pub(crate) receiver: Address,
+    pub(crate) receipt_id: U256,
+    pub(crate) shares_burned: U256,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct VerifiedShareTransfer {
+    pub(crate) recipient: Address,
+    pub(crate) shares: U256,
 }
 
 /// Verifies that `receipt` proves `owner` burned shares of the `vault` share
@@ -383,6 +409,7 @@ pub(crate) fn verify_burn_in_receipt(
     vault: Address,
     owner: Address,
     tx_hash: B256,
+    nonce: u64,
 ) -> Result<BurnVerification, VaultError> {
     if !receipt.status() {
         return Err(VaultError::Reverted { tx_hash });
@@ -390,24 +417,43 @@ pub(crate) fn verify_burn_in_receipt(
 
     let mut shares_burned = U256::ZERO;
     let mut found_burn = false;
+    let mut burns = Vec::new();
+    let mut share_transfers = Vec::new();
 
     for log in receipt.inner.logs() {
         if log.address() != vault {
             continue;
         }
 
-        let Ok(decoded) =
+        if let Ok(decoded) =
             log.log_decode::<OffchainAssetReceiptVault::Transfer>()
-        else {
-            continue;
-        };
+        {
+            let transfer = decoded.data();
+            if transfer.from == owner && transfer.to == Address::ZERO {
+                found_burn = true;
+                shares_burned = shares_burned
+                    .checked_add(transfer.value)
+                    .ok_or(VaultError::InvalidReceipt)?;
+            } else if transfer.from == owner {
+                share_transfers.push(VerifiedShareTransfer {
+                    recipient: transfer.to,
+                    shares: transfer.value,
+                });
+            }
+        }
 
-        let transfer = decoded.data();
-        if transfer.from == owner && transfer.to == Address::ZERO {
-            found_burn = true;
-            shares_burned = shares_burned
-                .checked_add(transfer.value)
-                .ok_or(VaultError::InvalidReceipt)?;
+        if let Ok(decoded) =
+            log.log_decode::<OffchainAssetReceiptVault::Withdraw>()
+        {
+            let withdrawal = decoded.data();
+            if withdrawal.owner == owner {
+                burns.push(VerifiedBurn {
+                    sender: withdrawal.sender,
+                    receiver: withdrawal.receiver,
+                    receipt_id: withdrawal.id,
+                    shares_burned: withdrawal.shares,
+                });
+            }
         }
     }
 
@@ -418,7 +464,13 @@ pub(crate) fn verify_burn_in_receipt(
     let block_number =
         receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
 
-    Ok(BurnVerification { block_number, shares_burned })
+    Ok(BurnVerification {
+        block_number,
+        nonce,
+        shares_burned,
+        burns,
+        share_transfers,
+    })
 }
 
 /// Result of a successful on-chain minting operation.
@@ -488,7 +540,7 @@ pub(crate) struct MultiBurnParams {
 }
 
 /// Result of a single burn within a multi-receipt burn operation.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub(crate) struct MultiBurnResultEntry {
     /// ERC-1155 receipt ID that was burned from
     pub(crate) receipt_id: U256,
@@ -819,7 +871,10 @@ impl<'de> Deserialize<'de> for TxId {
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{address, b256};
+    use alloy::consensus::{
+        Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
+    };
+    use alloy::primitives::{Bloom, Bytes, IntoLogData, address, b256};
     use chrono::Utc;
     use rust_decimal_macros::dec;
 
@@ -959,11 +1014,6 @@ mod tests {
         block_number: u64,
         transfers: Vec<(Address, Address, Address, U256)>,
     ) -> TransactionReceipt {
-        use alloy::consensus::{
-            Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
-        };
-        use alloy::primitives::{Bloom, IntoLogData};
-
         let logs: Vec<alloy::rpc::types::Log> = transfers
             .into_iter()
             .enumerate()
@@ -987,6 +1037,14 @@ mod tests {
             })
             .collect();
 
+        receipt_with_logs(success, block_number, logs)
+    }
+
+    fn receipt_with_logs(
+        success: bool,
+        block_number: u64,
+        logs: Vec<alloy::rpc::types::Log>,
+    ) -> TransactionReceipt {
         let consensus_receipt: Receipt<alloy::rpc::types::Log> = Receipt {
             status: Eip658Value::Eip658(success),
             cumulative_gas_used: 0x8000,
@@ -1021,11 +1079,78 @@ mod tests {
         );
 
         let verification =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
                 .unwrap();
 
         assert_eq!(verification.block_number, 45_989_009);
         assert_eq!(verification.shares_burned, U256::from(17u64));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_reports_owner_withdrawals_by_receipt() {
+        let transfer = OffchainAssetReceiptVault::Transfer {
+            from: BOT_WALLET,
+            to: Address::ZERO,
+            value: U256::from(17u64),
+        };
+        let withdrawal = OffchainAssetReceiptVault::Withdraw {
+            sender: BOT_WALLET,
+            receiver: address!("0x3333333333333333333333333333333333333333"),
+            owner: BOT_WALLET,
+            assets: U256::from(17u64),
+            shares: U256::from(17u64),
+            id: U256::from(42u64),
+            receiptInformation: Bytes::new(),
+        };
+        let dust_transfer = OffchainAssetReceiptVault::Transfer {
+            from: BOT_WALLET,
+            to: address!("0x3333333333333333333333333333333333333333"),
+            value: U256::from(3u64),
+        };
+        let logs = [
+            transfer.into_log_data(),
+            withdrawal.into_log_data(),
+            dust_transfer.into_log_data(),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, data)| alloy::rpc::types::Log {
+            inner: alloy::primitives::Log { address: VAULT, data },
+            block_hash: None,
+            block_number: Some(45_989_009),
+            block_timestamp: None,
+            transaction_hash: Some(BURN_TX),
+            transaction_index: Some(0),
+            log_index: Some(index as u64),
+            removed: false,
+        })
+        .collect();
+        let receipt = receipt_with_logs(true, 45_989_009, logs);
+
+        let verification =
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
+                .unwrap();
+
+        assert_eq!(
+            verification.burns,
+            vec![VerifiedBurn {
+                sender: BOT_WALLET,
+                receiver: address!(
+                    "0x3333333333333333333333333333333333333333"
+                ),
+                receipt_id: U256::from(42u64),
+                shares_burned: U256::from(17u64),
+            }]
+        );
+        assert_eq!(
+            verification.share_transfers,
+            vec![VerifiedShareTransfer {
+                recipient: address!(
+                    "0x3333333333333333333333333333333333333333"
+                ),
+                shares: U256::from(3u64),
+            }]
+        );
     }
 
     #[test]
@@ -1051,7 +1176,7 @@ mod tests {
         );
 
         let verification =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
                 .unwrap();
 
         assert_eq!(verification.shares_burned, U256::from(15u64));
@@ -1065,8 +1190,9 @@ mod tests {
             vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
         );
 
-        let err = verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
-            .unwrap_err();
+        let err =
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
+                .unwrap_err();
 
         assert!(matches!(err, VaultError::Reverted { .. }));
     }
@@ -1081,8 +1207,9 @@ mod tests {
             vec![(VAULT, BOT_WALLET, user, U256::from(17u64))],
         );
 
-        let err = verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX)
-            .unwrap_err();
+        let err =
+            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
+                .unwrap_err();
 
         assert!(matches!(err, VaultError::NotABurn { .. }));
     }

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -1,6 +1,7 @@
 use alloy::consensus::Transaction;
+use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Encodable2718;
-use alloy::network::EthereumWallet;
+use alloy::network::{EthereumWallet, TransactionResponse};
 use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill,
@@ -356,13 +357,37 @@ impl VaultService for RealBlockchainService {
         owner: Address,
         tx_hash: B256,
     ) -> Result<BurnVerification, VaultError> {
+        let transaction = self
+            .provider
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or(VaultError::InvalidReceipt)?;
+        if transaction.tx_hash() != tx_hash {
+            return Err(VaultError::InvalidReceipt);
+        }
+        let recovered_signer = transaction.inner.inner().recover_signer()?;
+        if recovered_signer != owner {
+            return Err(VaultError::NotABurn { tx_hash });
+        }
+        if transaction.inner.signer() != recovered_signer {
+            return Err(VaultError::InvalidReceipt);
+        }
         let receipt = self
             .provider
             .get_transaction_receipt(tx_hash)
             .await?
             .ok_or(VaultError::InvalidReceipt)?;
+        if receipt.transaction_hash != tx_hash {
+            return Err(VaultError::InvalidReceipt);
+        }
 
-        verify_burn_in_receipt(&receipt, vault, owner, tx_hash)
+        verify_burn_in_receipt(
+            &receipt,
+            vault,
+            owner,
+            tx_hash,
+            transaction.nonce(),
+        )
     }
 
     /// Prepares a signed tx that can be sent on-chain via eth_sendRawTransaction
@@ -580,6 +605,7 @@ impl VaultService for RealBlockchainService {
 
 #[cfg(test)]
 mod tests {
+    use alloy::consensus::transaction::Recovered;
     use alloy::consensus::{
         Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom, Transaction,
         TxEnvelope,
@@ -594,7 +620,8 @@ mod tests {
     use alloy::providers::mock::Asserter;
     use alloy::providers::{Provider, ProviderBuilder};
     use alloy::rpc::types::{
-        Block, FeeHistory, TransactionReceipt, TransactionRequest,
+        Block, FeeHistory, Transaction as RpcTransaction, TransactionReceipt,
+        TransactionRequest,
     };
     use alloy::signers::local::PrivateKeySigner;
     use chrono::Utc;
@@ -1150,6 +1177,131 @@ mod tests {
         }
     }
 
+    fn rpc_transaction(
+        persisted: &SendableTxWithHash,
+        reported_signer: Address,
+    ) -> RpcTransaction {
+        let mut encoded = persisted.tx.as_ref();
+        let envelope = TxEnvelope::decode_2718(&mut encoded)
+            .expect("test transaction should decode");
+
+        RpcTransaction {
+            inner: Recovered::new_unchecked(envelope, reported_signer),
+            block_hash: Some(fixed_bytes!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            )),
+            block_number: Some(0x7d0),
+            transaction_index: Some(0),
+            effective_gas_price: Some(0x3b9a_ca00),
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_burn_tx_returns_verified_nonce_from_matching_rpc_transaction()
+     {
+        let vault_address = test_vault_address();
+        let persisted = SendableTxWithHash::valid_for_test(
+            17,
+            vault_address,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted.signer_for_test();
+        let receiver = test_receiver();
+        let transaction = rpc_transaction(&persisted, owner);
+        let receipt = create_multi_withdraw_receipt(
+            vault_address,
+            persisted.hash,
+            owner,
+            receiver,
+            vec![(U256::from(7), U256::from(50))],
+        );
+        let asserter = Asserter::new();
+        asserter.push_success(&transaction);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let verification = service
+            .verify_burn_tx(vault_address, owner, persisted.hash)
+            .await
+            .expect("matching transaction and receipt should verify");
+
+        assert_eq!(verification.nonce, persisted.nonce);
+        assert_eq!(verification.block_number, 0x9c4);
+        assert_eq!(verification.shares_burned, U256::from(50));
+        assert_eq!(verification.burns.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn verify_burn_tx_rejects_rpc_transaction_for_another_hash() {
+        let persisted = persisted_burn_tx(17);
+        let owner = persisted.signer_for_test();
+        let transaction = rpc_transaction(&persisted, owner);
+        let requested_tx_hash = B256::random();
+        let asserter = Asserter::new();
+        asserter.push_success(&transaction);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .verify_burn_tx(test_vault_address(), owner, requested_tx_hash)
+            .await;
+
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
+    }
+
+    #[tokio::test]
+    async fn verify_burn_tx_rejects_rpc_transaction_with_inconsistent_from() {
+        let persisted = persisted_burn_tx(17);
+        let owner = persisted.signer_for_test();
+        let transaction = rpc_transaction(&persisted, Address::random());
+        let asserter = Asserter::new();
+        asserter.push_success(&transaction);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .await;
+
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
+    }
+
+    #[tokio::test]
+    async fn verify_burn_tx_rejects_another_signature_when_rpc_reports_owner() {
+        let persisted = persisted_burn_tx(17);
+        let owner = Address::random();
+        let transaction = rpc_transaction(&persisted, owner);
+        let asserter = Asserter::new();
+        asserter.push_success(&transaction);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::NotABurn { tx_hash }) if tx_hash == persisted.hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn verify_burn_tx_rejects_rpc_receipt_for_another_hash() {
+        let persisted = persisted_burn_tx(17);
+        let owner = persisted.signer_for_test();
+        let transaction = rpc_transaction(&persisted, owner);
+        let receipt =
+            create_empty_receipt(test_vault_address(), B256::random());
+        let asserter = Asserter::new();
+        asserter.push_success(&transaction);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .await;
+
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
+    }
+
     fn persisted_burn_tx(nonce: u64) -> SendableTxWithHash {
         SendableTxWithHash::valid_for_test(
             nonce,
@@ -1460,10 +1612,30 @@ mod tests {
         user: Address,
         burns: Vec<(U256, U256)>,
     ) -> TransactionReceipt {
-        let logs: Vec<alloy::rpc::types::Log> = burns
-            .into_iter()
-            .enumerate()
-            .map(|(i, (receipt_id, shares))| {
+        let shares_burned =
+            burns.iter().fold(U256::ZERO, |total, (_, shares)| total + shares);
+        let transfer_event = OffchainAssetReceiptVault::Transfer {
+            from: owner,
+            to: Address::ZERO,
+            value: shares_burned,
+        };
+        let mut logs = vec![alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: vault_address,
+                data: transfer_event.into_log_data(),
+            },
+            block_hash: Some(b256!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            )),
+            block_number: Some(0x9c4),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }];
+        logs.extend(burns.into_iter().enumerate().map(
+            |(index, (receipt_id, shares))| {
                 let withdraw_event = OffchainAssetReceiptVault::Withdraw {
                     sender: owner,
                     receiver: user,
@@ -1486,11 +1658,11 @@ mod tests {
                     block_timestamp: None,
                     transaction_hash: Some(tx_hash),
                     transaction_index: Some(0),
-                    log_index: Some(i as u64),
+                    log_index: Some(index as u64 + 1),
                     removed: false,
                 }
-            })
-            .collect();
+            },
+        ));
 
         let consensus_receipt: Receipt<alloy::rpc::types::Log> = Receipt {
             status: Eip658Value::Eip658(true),


### PR DESCRIPTION
## Motivation

A persisted signed burn can still land after an admin action. Closing the redemption or force-completing it with an unrelated proof could leave an on-chain burn outside the audit trail and corrupt receipt reservation handling.

Closes [RAI-1381](https://linear.app/makeitrain/issue/RAI-1381/add-explicit-admin-handling-for-unresolved-burn-transactions).

## Solution

- Require an exact typed acknowledgement before close or alternate force-complete can terminalize a redemption with a persisted signed burn. Retain that transaction through `Failed`, record the acknowledgement in versioned terminal events, and preserve legacy replay through schema version 5.
- Expose the persisted burn hash through `/admin/stuck`, responses, and structured logs so ops can verify what they are acknowledging. Acknowledged close keeps the reservation held.
- Accept an alternate force-complete proof only when its signed envelope, RPC identities, nonce, per-receipt withdrawals, receiver, and dust transfer prove a same-nonce replacement of the persisted transaction. Successful force-complete settles the reservation.
- Cover aggregate, manager, endpoint, snapshot replay, receipt parsing, and mocked RPC behavior, including signer, hash, nonce, recipient, and dust mismatches.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

Verified with `nix develop -c cargo test --workspace`, formatting, strict workspace Clippy across all targets and features, and a clean five-pass review loop.
