### PR TITLE
fix: retry receipt inventory conflicts

### DIFF
--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -14,6 +14,7 @@ use tracing::{info, trace};
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
     ReceiptInventoryError, ReceiptSource, Shares, determine_source,
+    send_receipt_inventory_command,
 };
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::mint::IssuerMintRequestId;
@@ -456,33 +457,33 @@ where
             Some(discovery.receipt_information.clone())
         };
 
-        self.store
-            .send(
-                &self.vault,
-                ReceiptInventoryCommand::DiscoverReceipt {
-                    receipt_id: discovery.receipt_id,
-                    balance: Shares::from(current_balance),
-                    block_number: discovery.block_number,
-                    tx_hash: discovery.tx_hash,
-                    source: source.clone(),
-                    receipt_info: receipt_info.map(Box::new),
-                    receipt_info_bytes,
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &self.vault,
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: discovery.receipt_id,
+                balance: Shares::from(current_balance),
+                block_number: discovery.block_number,
+                tx_hash: discovery.tx_hash,
+                source: source.clone(),
+                receipt_info: receipt_info.map(Box::new),
+                receipt_info_bytes,
+            },
+        )
+        .await?;
 
         // For already-known receipts, DiscoverReceipt is a no-op. Reconcile
         // ensures the aggregate reflects the current on-chain balance (e.g.,
         // after an inbound transfer increases the balance).
-        self.store
-            .send(
-                &self.vault,
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id: discovery.receipt_id,
-                    on_chain_balance: Shares::from(current_balance),
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &self.vault,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id: discovery.receipt_id,
+                on_chain_balance: Shares::from(current_balance),
+            },
+        )
+        .await?;
 
         trace!(target: "receipt", receipt_id = %discovery.receipt_id,
             balance = %current_balance,
@@ -511,15 +512,15 @@ where
             .call()
             .await?;
 
-        self.store
-            .send(
-                &self.vault,
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id,
-                    on_chain_balance: Shares::from(on_chain_balance),
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &self.vault,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id,
+                on_chain_balance: Shares::from(on_chain_balance),
+            },
+        )
+        .await?;
 
         trace!(target: "receipt", receipt_id = %receipt_id,
             on_chain_balance = %on_chain_balance,

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -12,9 +12,10 @@ use event_sorcery::{EventSourced, LifecycleError, Nil, SendError, Store};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use thiserror::Error;
-use tracing::warn;
+use tracing::{debug, warn};
 
 use crate::mint::IssuerMintRequestId;
 use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
@@ -29,6 +30,8 @@ pub(crate) use burn_tracking::{
 pub(crate) use cmd::ReceiptInventoryCommand;
 pub(crate) use event::{ReceiptInventoryEvent, ReceiptSource};
 use reconcile::ReconcileError;
+
+const RECEIPT_INVENTORY_MAX_ATTEMPTS: usize = 3;
 
 /// Receipt data recovered from the inventory for mint recovery.
 #[derive(Debug, Clone)]
@@ -332,6 +335,68 @@ pub(crate) async fn load_inventory(
     Ok(store.load(vault).await?.unwrap_or_default())
 }
 
+const fn receipt_inventory_operation(
+    command: &ReceiptInventoryCommand,
+) -> &'static str {
+    match command {
+        ReceiptInventoryCommand::DiscoverReceipt { .. } => "discover",
+        ReceiptInventoryCommand::ReconcileBalance { .. } => "reconcile_balance",
+        ReceiptInventoryCommand::ReserveBurn { .. } => "reserve_burn",
+        ReceiptInventoryCommand::ReleaseBurn { .. } => "release_burn",
+        ReceiptInventoryCommand::SettleBurn { .. } => "settle_burn",
+    }
+}
+
+async fn retry_receipt_inventory_conflicts<Send, SendFuture>(
+    vault: Address,
+    operation: &'static str,
+    mut send: Send,
+) -> Result<(), SendError<ReceiptInventory>>
+where
+    Send: FnMut() -> SendFuture,
+    SendFuture: Future<Output = Result<(), SendError<ReceiptInventory>>>,
+{
+    let mut attempt = 1;
+    let exhausted_attempt = loop {
+        match send().await {
+            Ok(()) => return Ok(()),
+            Err(AggregateError::AggregateConflict)
+                if attempt < RECEIPT_INVENTORY_MAX_ATTEMPTS =>
+            {
+                debug!(target: "receipt", %vault,
+                    attempt,
+                    max_attempts = RECEIPT_INVENTORY_MAX_ATTEMPTS,
+                    operation,
+                    "Receipt inventory optimistic-concurrency conflict; retrying"
+                );
+                attempt += 1;
+            }
+            Err(AggregateError::AggregateConflict) => break attempt,
+            Err(error) => return Err(error),
+        }
+    };
+
+    warn!(target: "receipt", %vault,
+        attempt = exhausted_attempt,
+        max_attempts = RECEIPT_INVENTORY_MAX_ATTEMPTS,
+        operation,
+        "Receipt inventory conflict retry budget exhausted"
+    );
+    Err(AggregateError::AggregateConflict)
+}
+
+pub(crate) async fn send_receipt_inventory_command(
+    store: &Store<ReceiptInventory>,
+    vault: &Address,
+    command: ReceiptInventoryCommand,
+) -> Result<(), SendError<ReceiptInventory>> {
+    let operation = receipt_inventory_operation(&command);
+    retry_receipt_inventory_conflicts(*vault, operation, || {
+        store.send(vault, command.clone())
+    })
+    .await
+}
+
 /// Translates an `event_sorcery` send/load error back into the
 /// `AggregateError<ReceiptInventoryError>` the service contract exposes.
 ///
@@ -402,20 +467,20 @@ impl ReceiptService for CqrsReceiptService {
     ) -> Result<(), ReceiptRegistrationError> {
         let issuer_request_id = params.receipt_info.issuer_request_id.clone();
 
-        self.store
-            .send(
-                &params.vault,
-                ReceiptInventoryCommand::DiscoverReceipt {
-                    receipt_id: params.receipt_id,
-                    balance: params.shares,
-                    block_number: params.block_number,
-                    tx_hash: params.tx_hash,
-                    source: ReceiptSource::Itn { issuer_request_id },
-                    receipt_info: Some(Box::new(params.receipt_info)),
-                    receipt_info_bytes: Some(params.receipt_info_bytes),
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &params.vault,
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: params.receipt_id,
+                balance: params.shares,
+                block_number: params.block_number,
+                tx_hash: params.tx_hash,
+                source: ReceiptSource::Itn { issuer_request_id },
+                receipt_info: Some(Box::new(params.receipt_info)),
+                receipt_info_bytes: Some(params.receipt_info_bytes),
+            },
+        )
+        .await?;
 
         Ok(())
     }
@@ -440,15 +505,15 @@ impl ReceiptService for CqrsReceiptService {
         redemption_issuer_request_id: IssuerRedemptionRequestId,
         burns: Vec<BurnRecord>,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.store
-            .send(
-                &vault,
-                ReceiptInventoryCommand::ReserveBurn {
-                    redemption_issuer_request_id,
-                    burns,
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &vault,
+            ReceiptInventoryCommand::ReserveBurn {
+                redemption_issuer_request_id,
+                burns,
+            },
+        )
+        .await?;
 
         Ok(())
     }
@@ -458,14 +523,14 @@ impl ReceiptService for CqrsReceiptService {
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.store
-            .send(
-                &vault,
-                ReceiptInventoryCommand::ReleaseBurn {
-                    redemption_issuer_request_id,
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &vault,
+            ReceiptInventoryCommand::ReleaseBurn {
+                redemption_issuer_request_id,
+            },
+        )
+        .await?;
 
         Ok(())
     }
@@ -475,14 +540,14 @@ impl ReceiptService for CqrsReceiptService {
         vault: Address,
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     ) -> Result<(), ReceiptRegistrationError> {
-        self.store
-            .send(
-                &vault,
-                ReceiptInventoryCommand::SettleBurn {
-                    redemption_issuer_request_id,
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &vault,
+            ReceiptInventoryCommand::SettleBurn {
+                redemption_issuer_request_id,
+            },
+        )
+        .await?;
 
         Ok(())
     }
@@ -1136,6 +1201,8 @@ mod tests {
     use event_sorcery::{StoreBuilder, test_store};
     use sqlx::sqlite::SqlitePoolOptions;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::sync::Barrier;
     use tracing::Level;
     use tracing_test::traced_test;
 
@@ -1650,6 +1717,193 @@ mod tests {
             "the From<SendError> conversion BurnManager relies on must \
              preserve AggregateConflict"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_receipt_inventory_conflicts_retry_until_success() {
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        retry_receipt_inventory_conflicts(vault, "discover", || {
+            let attempts = attempts.clone();
+            async move {
+                let attempt = attempts.fetch_add(1, Ordering::SeqCst) + 1;
+                if attempt < RECEIPT_INVENTORY_MAX_ATTEMPTS {
+                    Err(SendError::<ReceiptInventory>::AggregateConflict)
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await
+        .expect("the final attempt should succeed");
+
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            RECEIPT_INVENTORY_MAX_ATTEMPTS
+        );
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "vault=0x",
+                "attempt=1",
+                "operation=\"discover\"",
+                "optimistic-concurrency conflict; retrying",
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn concurrent_same_vault_writes_reload_and_preserve_both_receipts() {
+        let store = setup_store().await;
+        let vault = address!("0xdddddddddddddddddddddddddddddddddddddddd");
+        let tx_hash = b256!(
+            "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+        );
+        let pair_count = 8u64;
+
+        for pair_index in 0..pair_count {
+            let barrier = Arc::new(Barrier::new(3));
+            let first_store = store.clone();
+            let first_barrier = barrier.clone();
+            let first_receipt_id = make_receipt_id(pair_index * 2);
+            let first = tokio::spawn(async move {
+                first_barrier.wait().await;
+                send_receipt_inventory_command(
+                    &first_store,
+                    &vault,
+                    discover_receipt_cmd(
+                        first_receipt_id,
+                        make_shares(100),
+                        pair_index,
+                        tx_hash,
+                    ),
+                )
+                .await
+            });
+
+            let second_store = store.clone();
+            let second_barrier = barrier.clone();
+            let second_receipt_id = make_receipt_id(pair_index * 2 + 1);
+            let second = tokio::spawn(async move {
+                second_barrier.wait().await;
+                send_receipt_inventory_command(
+                    &second_store,
+                    &vault,
+                    discover_receipt_cmd(
+                        second_receipt_id,
+                        make_shares(200),
+                        pair_index,
+                        tx_hash,
+                    ),
+                )
+                .await
+            });
+
+            barrier.wait().await;
+            first
+                .await
+                .expect("first task should join")
+                .expect("first receipt should persist");
+            second
+                .await
+                .expect("second task should join")
+                .expect("second receipt should persist after retry");
+        }
+
+        let inventory = load_inventory(&store, &vault)
+            .await
+            .expect("inventory should load");
+        let expected_receipt_count = usize::try_from(pair_count * 2)
+            .expect("test receipt count should fit usize");
+        assert_eq!(inventory.receipts.len(), expected_receipt_count);
+        assert!(
+            inventory
+                .receipts
+                .values()
+                .any(|receipt| { receipt.balance == make_shares(100) })
+        );
+        assert!(
+            inventory
+                .receipts
+                .values()
+                .any(|receipt| { receipt.balance == make_shares(200) })
+        );
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "vault=0x",
+                "attempt=1",
+                "operation=\"discover\"",
+                "optimistic-concurrency conflict; retrying",
+            ]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_receipt_inventory_conflict_exhaustion_is_propagated() {
+        let vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let attempts = Arc::new(AtomicUsize::new(0));
+
+        let result = retry_receipt_inventory_conflicts(
+            vault,
+            "reconcile_balance",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async { Err(SendError::<ReceiptInventory>::AggregateConflict) }
+            },
+        )
+        .await;
+
+        assert!(matches!(result, Err(AggregateError::AggregateConflict)));
+        assert_eq!(
+            attempts.load(Ordering::SeqCst),
+            RECEIPT_INVENTORY_MAX_ATTEMPTS
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                "vault=0x",
+                "attempt=3",
+                "operation=\"reconcile_balance\"",
+                "retry budget exhausted",
+            ]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_receipt_inventory_domain_error_is_not_retried() {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let receipt_id = make_receipt_id(42);
+
+        let result = retry_receipt_inventory_conflicts(
+            address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            "reserve_burn",
+            || {
+                attempts.fetch_add(1, Ordering::SeqCst);
+                async {
+                    Err(SendError::<ReceiptInventory>::UserError(
+                        LifecycleError::Apply(
+                            ReceiptInventoryError::UnknownReceipt {
+                                receipt_id,
+                            },
+                        ),
+                    ))
+                }
+            },
+        )
+        .await;
+
+        assert!(matches!(
+            result,
+            Err(AggregateError::UserError(LifecycleError::Apply(
+                ReceiptInventoryError::UnknownReceipt { .. }
+            )))
+        ));
+        assert_eq!(attempts.load(Ordering::SeqCst), 1);
     }
 
     #[tokio::test]

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -9,6 +9,7 @@ use tracing::{debug, info, trace};
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
     ReceiptInventoryError, Shares, load_inventory,
+    send_receipt_inventory_command,
 };
 use crate::bindings::Receipt;
 
@@ -108,6 +109,9 @@ where
                 Ok(false) => {
                     checked += 1;
                 }
+                Err(error @ ReconcileError::Aggregate(_)) => {
+                    return Err(error);
+                }
                 Err(err) => {
                     debug!(target: "receipt", vault = %self.vault,
                         error = %err,
@@ -158,15 +162,15 @@ where
             "Balance mismatch detected"
         );
 
-        self.store
-            .send(
-                &self.vault,
-                ReceiptInventoryCommand::ReconcileBalance {
-                    receipt_id,
-                    on_chain_balance: on_chain_shares,
-                },
-            )
-            .await?;
+        send_receipt_inventory_command(
+            &self.store,
+            &self.vault,
+            ReceiptInventoryCommand::ReconcileBalance {
+                receipt_id,
+                on_chain_balance: on_chain_shares,
+            },
+        )
+        .await?;
 
         Ok(true)
     }

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -339,7 +339,7 @@ impl BurnManager {
             )
             .await?;
 
-        self.settle_reserved_burn(vault, issuer_request_id).await;
+        self.settle_reserved_burn(vault, issuer_request_id).await?;
 
         Ok(verification)
     }
@@ -421,7 +421,7 @@ impl BurnManager {
                 debug!(target: "redemption", issuer_request_id = %issuer_request_id,
                     "Settling reservation for completed redemption"
                 );
-                self.settle_reserved_burn(vault, issuer_request_id).await;
+                self.settle_reserved_burn(vault, issuer_request_id).await?;
             }
             // All other states are LEFT in place. A definitive failure already
             // released its reservation in the live/recovery paths (gated on
@@ -712,7 +712,7 @@ impl BurnManager {
                     )
                     .await?;
 
-                self.settle_reserved_burn(vault, issuer_request_id).await;
+                self.settle_reserved_burn(vault, issuer_request_id).await?;
 
                 Ok(())
             }
@@ -720,7 +720,8 @@ impl BurnManager {
                 if should_release_reserved_burn(&err) {
                     // Confirmed on-chain revert: the tx consumed no receipts,
                     // so it is safe to release the reservation and terminalize.
-                    self.release_reserved_burn(vault, issuer_request_id).await;
+                    self.release_reserved_burn(vault, issuer_request_id)
+                        .await?;
 
                     let reason = format!(
                         "Burn transaction confirmation failed for tx {tx_id}: {err}"
@@ -801,7 +802,7 @@ impl BurnManager {
                     "Burn confirmed successfully during recovery"
                 );
 
-                self.settle_reserved_burn(vault, issuer_request_id).await;
+                self.settle_reserved_burn(vault, issuer_request_id).await?;
 
                 Ok(RecoveryOutcome::ExistingBurnRecorded)
             }
@@ -825,16 +826,15 @@ impl BurnManager {
                 }
 
                 if release_reservation {
+                    // Release before reserving a replacement attempt or
+                    // terminalizing the redemption. A failed release cannot
+                    // consume the finite recovery budget, and a crash after
+                    // the idempotent release leaves the aggregate recoverable.
+                    self.release_reserved_burn(vault, issuer_request_id)
+                        .await?;
                     let exact_recovery = self
                         .reserve_replacement_after_revert(issuer_request_id)
                         .await?;
-                    // Release before terminalizing the redemption. A crash
-                    // after this idempotent release leaves the aggregate in
-                    // its recoverable state, so the same transaction is
-                    // checked again. Recording failure first could strand a
-                    // reservation because burning-state recovery would no
-                    // longer revisit the aggregate.
-                    self.release_reserved_burn(vault, issuer_request_id).await;
                     self.store
                         .send(
                             issuer_request_id,
@@ -1895,9 +1895,10 @@ impl BurnManager {
         execution: &BurnExecutionPlan,
     ) -> Result<(), BurnManagerError> {
         let result = self
-            .reserve_with_conflict_retry(
+            .receipt_service
+            .reserve_burn(
                 execution.vault,
-                issuer_request_id,
+                issuer_request_id.clone(),
                 execution.planned_burns.clone(),
             )
             .await;
@@ -1959,7 +1960,7 @@ impl BurnManager {
                     "Preparing signed burn tx failed"
                 );
                 self.release_reserved_burn(execution.vault, issuer_request_id)
-                    .await;
+                    .await?;
                 self.store
                     .send(
                         issuer_request_id,
@@ -2031,7 +2032,7 @@ impl BurnManager {
                         execution.vault,
                         issuer_request_id,
                     )
-                    .await;
+                    .await?;
                 }
 
                 if !release_reservation {
@@ -2111,7 +2112,7 @@ impl BurnManager {
                     "Burn confirmed successfully"
                 );
                 self.settle_reserved_burn(execution.vault, issuer_request_id)
-                    .await;
+                    .await?;
                 Ok(())
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
@@ -2122,14 +2123,14 @@ impl BurnManager {
                     "Burn confirmation failed"
                 );
                 if release_reservation {
-                    let exact_recovery = self
-                        .reserve_replacement_after_revert(issuer_request_id)
-                        .await?;
                     self.release_before_terminal_failure(
                         execution.vault,
                         issuer_request_id,
                     )
-                    .await;
+                    .await?;
+                    let exact_recovery = self
+                        .reserve_replacement_after_revert(issuer_request_id)
+                        .await?;
                     self.store
                         .send(
                             issuer_request_id,
@@ -2165,12 +2166,12 @@ impl BurnManager {
         &self,
         vault: Address,
         issuer_request_id: &IssuerRedemptionRequestId,
-    ) {
+    ) -> Result<(), BurnManagerError> {
         // A crash after this idempotent release leaves the redemption in its
         // recoverable state, so the same transaction is checked again.
         // Recording failure first could strand the reservation because
         // burning-state recovery would no longer revisit the aggregate.
-        self.release_reserved_burn(vault, issuer_request_id).await;
+        self.release_reserved_burn(vault, issuer_request_id).await
     }
 
     /// Reserves the recovery action that may sign a fresh transaction after a
@@ -2198,91 +2199,29 @@ impl BurnManager {
         .map(Some)
     }
 
-    /// Reserves planned burns, retrying a bounded number of times on an
-    /// optimistic-concurrency conflict.
-    ///
-    /// Concurrent redemptions for the same vault contend on the single
-    /// `ReceiptInventory` aggregate; a lost commit race is transient and should
-    /// be retried (each `execute` reloads), not treated as a terminal burn
-    /// failure the way a genuine `InsufficientReceiptBalance` is.
-    async fn reserve_with_conflict_retry(
-        &self,
-        vault: Address,
-        issuer_request_id: &IssuerRedemptionRequestId,
-        planned_burns: Vec<super::BurnRecord>,
-    ) -> Result<(), ReceiptRegistrationError> {
-        const MAX_ATTEMPTS: usize = 3;
-
-        let mut attempt = 1;
-        loop {
-            match self
-                .receipt_service
-                .reserve_burn(
-                    vault,
-                    issuer_request_id.clone(),
-                    planned_burns.clone(),
-                )
-                .await
-            {
-                Ok(()) => return Ok(()),
-                Err(ReceiptRegistrationError::Aggregate(
-                    AggregateError::AggregateConflict,
-                )) if attempt < MAX_ATTEMPTS => {
-                    warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                        attempt,
-                        "Reserve hit an optimistic-concurrency conflict; retrying"
-                    );
-                    attempt += 1;
-                }
-                Err(err) => return Err(err),
-            }
-        }
-    }
-
     /// Releases a redemption's burn reservation, restoring available inventory.
-    ///
-    /// Best-effort: a failure is logged but not propagated. A stuck reservation
-    /// is the failure mode the startup reservation recovery scan
-    /// (`recover_stuck_reservations`) exists to clean up.
     async fn release_reserved_burn(
         &self,
         vault: Address,
         issuer_request_id: &IssuerRedemptionRequestId,
-    ) {
-        if let Err(err) = self
-            .receipt_service
+    ) -> Result<(), BurnManagerError> {
+        self.receipt_service
             .release_burn(vault, issuer_request_id.clone())
-            .await
-        {
-            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Failed to release burn receipt reservation"
-            );
-        }
+            .await?;
+        Ok(())
     }
 
     /// Settles a redemption's burn reservation after on-chain confirmation,
     /// reducing the mirror balance by the reserved amount.
-    ///
-    /// Best-effort: a failure is logged but not propagated. A reservation left
-    /// unsettled here is recovered by the startup reservation recovery scan
-    /// (`recover_stuck_reservations`); reconciliation cannot heal it because a
-    /// landed-but-unsettled burn sits inside the reconcile no-op band.
     async fn settle_reserved_burn(
         &self,
         vault: Address,
         issuer_request_id: &IssuerRedemptionRequestId,
-    ) {
-        if let Err(err) = self
-            .receipt_service
+    ) -> Result<(), BurnManagerError> {
+        self.receipt_service
             .settle_burn(vault, issuer_request_id.clone())
-            .await
-        {
-            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                error = %err,
-                "Failed to settle burn receipt reservation"
-            );
-        }
+            .await?;
+        Ok(())
     }
 }
 
@@ -2470,6 +2409,7 @@ fn burn_verification_matches_plan(
 mod tests {
     use alloy::primitives::{Address, B256, Bytes, U256, address, b256, uint};
     use chrono::Utc;
+    use cqrs_es::AggregateError;
     use event_sorcery::{Store, StoreBuilder, test_store};
     use rust_decimal::Decimal;
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
@@ -2485,8 +2425,10 @@ mod tests {
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Network, Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
-        BurnTrackingError, CqrsReceiptService, ReceiptId, ReceiptInventory,
-        ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
+        BurnPlan, BurnTrackingError, CqrsReceiptService, MintedReceiptParams,
+        ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
+        ReceiptInventoryError, ReceiptLookupError, ReceiptRegistrationError,
+        ReceiptService, ReceiptSource, RecoveredReceipt, Shares,
     };
     use crate::redemption::BurnExternalTxId;
     use crate::redemption::view::{RedemptionViewReactor, find_burn_failed};
@@ -2624,6 +2566,162 @@ mod tests {
         receipt_inventory_store: Arc<Store<ReceiptInventory>>,
         pool: sqlx::Pool<sqlx::Sqlite>,
         asset_store: Arc<Store<TokenizedAsset>>,
+    }
+
+    struct ReleaseFailingReceiptService {
+        inner: Arc<dyn ReceiptService>,
+    }
+
+    #[async_trait::async_trait]
+    impl ReceiptService for ReleaseFailingReceiptService {
+        async fn register_minted_receipt(
+            &self,
+            params: MintedReceiptParams,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner.register_minted_receipt(params).await
+        }
+
+        async fn for_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: &IssuerRedemptionRequestId,
+            shares_to_burn: Shares,
+            dust: Shares,
+        ) -> Result<BurnPlan, BurnTrackingError> {
+            self.inner
+                .for_burn(
+                    vault,
+                    redemption_issuer_request_id,
+                    shares_to_burn,
+                    dust,
+                )
+                .await
+        }
+
+        async fn reserve_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: IssuerRedemptionRequestId,
+            burns: Vec<BurnRecord>,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner
+                .reserve_burn(vault, redemption_issuer_request_id, burns)
+                .await
+        }
+
+        async fn release_burn(
+            &self,
+            _vault: Address,
+            _redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Err(ReceiptRegistrationError::Aggregate(AggregateError::UserError(
+                ReceiptInventoryError::UnknownReceipt {
+                    receipt_id: ReceiptId::from(U256::ZERO),
+                },
+            )))
+        }
+
+        async fn settle_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner.settle_burn(vault, redemption_issuer_request_id).await
+        }
+
+        async fn reserved_redemptions(
+            &self,
+            vault: Address,
+        ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
+        {
+            self.inner.reserved_redemptions(vault).await
+        }
+
+        async fn find_by_issuer_request_id(
+            &self,
+            vault: &Address,
+            issuer_request_id: &IssuerMintRequestId,
+        ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
+            self.inner.find_by_issuer_request_id(vault, issuer_request_id).await
+        }
+    }
+
+    struct SettleFailingReceiptService {
+        inner: Arc<dyn ReceiptService>,
+    }
+
+    #[async_trait::async_trait]
+    impl ReceiptService for SettleFailingReceiptService {
+        async fn register_minted_receipt(
+            &self,
+            params: MintedReceiptParams,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner.register_minted_receipt(params).await
+        }
+
+        async fn for_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: &IssuerRedemptionRequestId,
+            shares_to_burn: Shares,
+            dust: Shares,
+        ) -> Result<BurnPlan, BurnTrackingError> {
+            self.inner
+                .for_burn(
+                    vault,
+                    redemption_issuer_request_id,
+                    shares_to_burn,
+                    dust,
+                )
+                .await
+        }
+
+        async fn reserve_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: IssuerRedemptionRequestId,
+            burns: Vec<BurnRecord>,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner
+                .reserve_burn(vault, redemption_issuer_request_id, burns)
+                .await
+        }
+
+        async fn release_burn(
+            &self,
+            vault: Address,
+            redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            self.inner.release_burn(vault, redemption_issuer_request_id).await
+        }
+
+        async fn settle_burn(
+            &self,
+            _vault: Address,
+            _redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Err(ReceiptRegistrationError::Aggregate(AggregateError::UserError(
+                ReceiptInventoryError::UnknownReceipt {
+                    receipt_id: ReceiptId::from(U256::ZERO),
+                },
+            )))
+        }
+
+        async fn reserved_redemptions(
+            &self,
+            vault: Address,
+        ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
+        {
+            self.inner.reserved_redemptions(vault).await
+        }
+
+        async fn find_by_issuer_request_id(
+            &self,
+            vault: &Address,
+            issuer_request_id: &IssuerMintRequestId,
+        ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
+            self.inner.find_by_issuer_request_id(vault, issuer_request_id).await
+        }
     }
 
     impl TestHarness {
@@ -4069,6 +4167,73 @@ mod tests {
                 .is_empty(),
             "a definitive on-chain revert must release the reservation"
         );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_revert_release_failure_preserves_recovery_budget() {
+        let vault_mock = Arc::new(MockVaultService::new_confirm_revert());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let failing_receipt_service: Arc<dyn ReceiptService> =
+            Arc::new(ReleaseFailingReceiptService {
+                inner: receipt_service.clone(),
+            });
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+        let manager = BurnManager::new(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            failing_receipt_service,
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        harness
+            .discover_receipt(
+                vault,
+                uint!(7_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(result, Err(BurnManagerError::ReceiptRegistration(_))),
+            "release failure must surface before reserving recovery: {result:?}"
+        );
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnSubmitted { .. }
+        ));
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![issuer_request_id.clone()]
+        );
+        let recovery_attempts: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::BurnRecoveryAttempted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        assert_eq!(recovery_attempts, 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Burn confirmation failed", &issuer_request_id.to_string()]
+        ));
     }
 
     #[tokio::test]
@@ -7149,6 +7314,65 @@ mod tests {
         );
     }
 
+    #[traced_test]
+    #[tokio::test]
+    async fn prepare_tx_failure_remains_recoverable_when_release_fails() {
+        let vault_mock = Arc::new(MockVaultService::new_prepare_tx_failure());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let failing_receipt_service: Arc<dyn ReceiptService> =
+            Arc::new(ReleaseFailingReceiptService {
+                inner: receipt_service.clone(),
+            });
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        let manager = BurnManager::new(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            failing_receipt_service,
+            TEST_WALLET,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(99_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        let result = manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await;
+
+        assert!(
+            matches!(result, Err(BurnManagerError::ReceiptRegistration(_))),
+            "release failure must surface instead of terminalizing: {result:?}"
+        );
+        assert_eq!(vault_mock.get_multi_burn_call_count(), 0);
+        assert_eq!(
+            receipt_service.reserved_redemptions(vault).await.unwrap(),
+            vec![issuer_request_id.clone()],
+            "failed release must leave the reservation visible for retry"
+        );
+
+        let updated = load_aggregate(store, &issuer_request_id).await;
+        assert!(
+            matches!(updated, Redemption::Burning { .. }),
+            "release failure must leave the aggregate recoverable, got {updated:?}"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Preparing signed burn tx failed"]
+        ));
+    }
+
     /// Tests that recovery from `BurnSubmitted` state (crash between submit
     /// and confirm) successfully confirms the existing transaction without
     /// submitting a new one.
@@ -7370,6 +7594,105 @@ mod tests {
                 .is_empty(),
             "GC must settle the reservation of a completed redemption"
         );
+    }
+
+    /// A settlement failure during reservation recovery must surface (logged)
+    /// and leave the completed redemption's reservation in place, so the next
+    /// recovery pass retries it rather than silently dropping the mirror
+    /// reduction.
+    #[traced_test]
+    #[tokio::test]
+    async fn test_recover_stuck_reservations_settle_failure_stays_recoverable()
+    {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        harness.add_asset(&UnderlyingSymbol::new("AAPL"), vault).await;
+
+        // Drive the redemption to `Completed` through the real receipt service
+        // so the burn settles cleanly; recovery below runs against a
+        // settle-failing wrapper.
+        let blockchain_service: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let manager = BurnManager::new(
+            blockchain_service,
+            harness.pool.clone(),
+            harness.store.clone(),
+            harness.receipt_service.clone(),
+            TEST_WALLET,
+        );
+
+        harness
+            .discover_receipt(
+                vault,
+                uint!(1_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(2_U256),
+                uint!(50_000000000000000000_U256),
+            )
+            .await;
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let aggregate = create_test_redemption_in_burning_state(
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await
+            .unwrap();
+        assert!(matches!(
+            load_aggregate(&harness.store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+
+        seed_stuck_reservation(
+            &harness,
+            vault,
+            &issuer_request_id,
+            uint!(2_U256),
+            uint!(50_000000000000000000_U256),
+        )
+        .await;
+
+        let settle_failing: Arc<dyn ReceiptService> =
+            Arc::new(SettleFailingReceiptService {
+                inner: harness.receipt_service.clone(),
+            });
+        let recovery_blockchain: Arc<dyn crate::vault::VaultService> =
+            vault_mock.clone();
+        let failing_manager = BurnManager::new(
+            recovery_blockchain,
+            harness.pool.clone(),
+            harness.store.clone(),
+            settle_failing,
+            TEST_WALLET,
+        );
+
+        failing_manager.recover_stuck_reservations(&[vault]).await;
+
+        assert!(
+            harness
+                .receipt_service
+                .reserved_redemptions(vault)
+                .await
+                .unwrap()
+                .contains(&issuer_request_id),
+            "a failed settlement must leave the reservation recoverable for the next pass"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &[
+                "Failed to resolve stuck reservation",
+                &issuer_request_id.to_string()
+            ]
+        ));
     }
 
     /// A reservation surviving on a `Failed` redemption is from an *ambiguous*


### PR DESCRIPTION
## Motivation

Receipt backfill, reconciliation, and burn reservation updates all write to one `ReceiptInventory` aggregate per vault. Valid concurrent writes could lose the optimistic commit race and abort startup or leave a redemption in the wrong recovery state.

Closes [RAI-1382](https://linear.app/makeitrain/issue/RAI-1382/retry-receipt-inventory-commands-on-optimistic-concurrency-conflicts).

## Solution

- Retry receipt inventory commands up to three attempts only on optimistic-concurrency conflicts. Every attempt goes through `Store::send`, so it reloads the latest aggregate state; domain and infrastructure errors still propagate immediately.
- Apply the policy to the proven concurrent writers: receipt discovery and reconciliation, minted-receipt registration, and burn reserve, release, and settle operations. Retries log at DEBUG; exhausted budgets log once at WARN with the vault and attempt count.
- Propagate release failures before terminalizing a redemption, keeping the aggregate recoverable and its reservation visible. Exhausted reconciliation and settlement conflicts now surface to their callers too.
- Cover the real same-vault race with barrier-synchronized store writes, plus retry success, exhaustion, domain-error, observability, and failed-release recovery tests.

## Checks

- [x] `nix develop -c cargo test --workspace`
- [x] strict workspace Clippy across all targets and features
- [x] formatting and `git diff --check`
- [x] clean two-pass correctness, Rust/type, and test review loop


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved receipt inventory updates during concurrent operations, reducing conflicts and preserving successful changes.
  - Reconciliation now stops promptly when a critical inventory conflict occurs instead of continuing with potentially incomplete results.
  - Burn recovery now reports reservation release or settlement failures and keeps affected redemptions recoverable rather than incorrectly marking them as failed.
  - Added limited retry handling for transient inventory update conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->