### PR TITLE
Add st0x-deploy ABIs via soldeer-based Nix builder

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -614,6 +614,44 @@ authorization has not yet arrived is `mint_mode: Orchestrator` with no
 `mint_authorization` — it is not, and must never be read as, a vault-direct
 mint.
 
+**Orchestrator mode** introduces no new commands: `Deposit`, `SubmitMint`,
+`ConfirmMint`, and `Recover` are reused unchanged, with the handler branching on
+`VaultMode` internally to submit `orchestrator.mint()` calldata instead of the
+vault multicall and to emit the orchestrator-mode events above. An
+orchestrator-mode mint creates no bot-held receipt for the receipt monitor to
+discover (the orchestrator custodies it — see "Orchestrator Migration" ->
+"Dual-Mode Operation and Cutover"), so `RecoverFromReceipt` does not apply;
+`Recover`'s existing-mint check instead queries the orchestrator's `Minted` log
+by `(wallet, nonce)`, emitting `OrchestratorMintRecovered` only when the log's
+`token`/`amount` also exactly match this mint's own request facts (see "Nonce"
+below for the full-match rule and its manual-failure fallback). See
+"Orchestrator Migration" for the mint flow, failure states
+(`BadRecipientSignature`, `RecipientCallbackRejected`, `VaultAmountMismatch`,
+`VaultLogicMismatch`/`ReceiptLogicMismatch`), and the full event reuse/new
+rationale.
+
+Mirroring the mode-scoping rule given for Redemption below, a mint's mode does
+not follow later `VaultMode` flips of its asset: `Recover`, `SubmitMint`, and
+`ConfirmMint` determine which mode to use for a given mint from that mint's own
+event history — the `mint_mode` field persisted on its `Initiated` event,
+resolved from configuration at initiate time — never re-resolved from the
+asset's currently-configured `VaultMode`. This ensures a mint `Initiated` while
+its asset was in `vault_direct` mode is still recovered as a vault-direct mint
+even after that asset's configured `vault_mode` is later flipped to
+orchestrator, exactly as Redemption's persisted `burn_mode` (captured on
+`RedemptionDetected`) prevents the analogous mismatch on the Redemption side.
+
+The mode anchor is deliberately **not** the presence of `mint_authorization`.
+`Initiated` is written synchronously on Alpaca's `POST /inkind/issuance`, before
+the liquidity bot delivers the authorization on the internal mint-authorization
+call, and events are immutable — an already-persisted `Initiated` can never grow
+an authorization field. Mode (known from config at initiate time) and
+authorization (arriving later, on `MintAuthorizationReceived`) are therefore
+orthogonal facts on two separate events. An orchestrator-mode mint whose
+authorization has not yet arrived is `mint_mode: Orchestrator` with no
+`mint_authorization` — it is not, and must never be read as, a vault-direct
+mint.
+
 ### Redemption Aggregate
 
 The `Redemption` aggregate manages the redemption lifecycle, from detecting an

--- a/flake.lock
+++ b/flake.lock
@@ -502,7 +502,8 @@
         "nixos-anywhere": "nixos-anywhere",
         "nixpkgs": "nixpkgs",
         "ragenix": "ragenix",
-        "rainix": "rainix"
+        "rainix": "rainix",
+        "st0x-deploy": "st0x-deploy"
       }
     },
     "rust-overlay": {
@@ -578,6 +579,25 @@
       "original": {
         "type": "file",
         "url": "https://github.com/argotorg/solc-bin/raw/83cb756/macosx-amd64/list.json"
+      }
+    },
+    "st0x-deploy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784133383,
+        "narHash": "sha256-zsRMSYyBCAAFpi69TZ7HKsDeVO3aNYjJpwe1c79qLKA=",
+        "ref": "refs/heads/main",
+        "rev": "c526422e4c493b9e8be30ddfd7f7ec536efe2fb0",
+        "revCount": 775,
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/S01-Issuer/st0x.deploy"
+      },
+      "original": {
+        "rev": "c526422e4c493b9e8be30ddfd7f7ec536efe2fb0",
+        "submodules": true,
+        "type": "git",
+        "url": "https://github.com/S01-Issuer/st0x.deploy"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,13 @@
       flake = false;
       submodules = true;
     };
+    st0x-deploy = {
+      type = "git";
+      url = "https://github.com/S01-Issuer/st0x.deploy";
+      rev = "c526422e4c493b9e8be30ddfd7f7ec536efe2fb0";
+      flake = false;
+      submodules = true;
+    };
   };
 
   outputs =
@@ -53,6 +60,7 @@
       ethgild,
       disko,
       nixos-anywhere,
+      st0x-deploy,
       ...
     }:
     let
@@ -237,13 +245,14 @@
             solc = rainix.pkgs.${system}.solc_0_8_25;
           })
           mkAbi
+          mkSoldeerAbi
           ;
 
         inherit
           (import ./nix/abis.nix {
-            inherit pkgs mkAbi;
+            inherit pkgs mkAbi mkSoldeerAbi;
             sources = {
-              inherit ethgild;
+              inherit ethgild st0x-deploy;
             };
           })
           abis
@@ -275,7 +284,9 @@
             prepSolArtifacts = pkgs.writeShellApplication {
               name = "prep-sol-artifacts";
               text = ''
-                ln -sfn ${abis.ethgild}/out abis
+                mkdir -p abis
+                ln -sfn ${abis.ethgild}/out abis/ethgild
+                ln -sfn ${abis.st0x-deploy}/out abis/st0x.deploy
               '';
             };
 
@@ -369,7 +380,9 @@
             inherit (rainix.devShells.${system}.default) nativeBuildInputs;
             shellHook = ''
               ${rainix.devShells.${system}.default.shellHook or ""}
-              ln -sfn ${abis.ethgild}/out abis
+              mkdir -p abis
+              ln -sfn ${abis.ethgild}/out abis/ethgild
+              ln -sfn ${abis.st0x-deploy}/out abis/st0x.deploy
             '';
 
             buildInputs =

--- a/nix/abis.nix
+++ b/nix/abis.nix
@@ -1,6 +1,7 @@
 {
   pkgs,
   mkAbi,
+  mkSoldeerAbi,
   sources,
 }:
 
@@ -17,6 +18,10 @@ let
     ethgild = import ./ethgild.nix {
       inherit mkAbi;
       src = sources.ethgild;
+    };
+    st0x-deploy = import ./st0x-deploy.nix {
+      inherit mkSoldeerAbi;
+      src = sources.st0x-deploy;
     };
   };
 

--- a/nix/mk-abi.nix
+++ b/nix/mk-abi.nix
@@ -47,4 +47,66 @@ in
       FOUNDRY_SOLC = "${solc}/bin/solc-0.8.25";
       FOUNDRY_OFFLINE = "true";
     };
+
+  # Two-phase builder for projects that use soldeer for dependency management.
+  # Phase 1 (soldeerDeps): FOD with network access — runs `forge soldeer install`
+  #   and caches the resulting dependencies/ directory. Hash only changes when
+  #   soldeer.lock changes, not when contracts change.
+  # Phase 2 (main build): sandboxed — injects the vendored deps then runs
+  #   `forge build` offline.
+  #
+  # To get soldeerDepsHash: set it to "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  # run `nix develop`, and replace with the hash printed in the error message.
+  mkSoldeerAbi =
+    {
+      pname,
+      src,
+      soldeerDepsHash,
+      installPhase ? defaultInstall,
+    }:
+    let
+      soldeerDeps = pkgs.stdenvNoCC.mkDerivation {
+        name = "${pname}-soldeer-deps";
+        inherit src;
+        outputHashAlgo = "sha256";
+        outputHash = soldeerDepsHash;
+        outputHashMode = "recursive";
+        nativeBuildInputs = [
+          foundry
+          pkgs.git
+          pkgs.cacert
+        ];
+        buildPhase = ''
+          export HOME="$TMPDIR"
+          export GIT_SSL_CAINFO="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          export SSL_CERT_FILE="${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+          forge soldeer install
+        '';
+        installPhase = ''
+          cp -r dependencies $out
+        '';
+      };
+    in
+    pkgs.stdenvNoCC.mkDerivation {
+      inherit
+        pname
+        src
+        installPhase
+        ;
+      version = "0.0.0";
+      nativeBuildInputs = [
+        foundry
+        solc
+      ];
+      FOUNDRY_SOLC = "${solc}/bin/solc-0.8.25";
+      FOUNDRY_OFFLINE = "true";
+      buildPhase = ''
+        runHook preBuild
+        export HOME="$TMPDIR"
+        cp -r ${soldeerDeps}/. dependencies
+        chmod -R u+w dependencies
+        forge build
+        runHook postBuild
+      '';
+    };
 }

--- a/nix/st0x-deploy.nix
+++ b/nix/st0x-deploy.nix
@@ -1,0 +1,27 @@
+{ mkSoldeerAbi, src }:
+
+let
+  abi = mkSoldeerAbi {
+    pname = "st0x-deploy-abis";
+    inherit src;
+    soldeerDepsHash = "sha256-CoY0rhBAA4Y1PdXzvBKyjfPRUV8+sl9Ydaz0iZrtTSU=";
+    installPhase = ''
+      runHook preInstall
+      mkdir -p $out
+      cp -r out $out/out
+      runHook postInstall
+    '';
+  };
+in
+{
+  inherit abi;
+  abiEnv = {
+    IST0X_ORCHESTRATOR_V1_ABI = "${abi}/out/IST0xOrchestratorV1.sol/IST0xOrchestratorV1.json";
+    ST0X_ORCHESTRATOR_ABI = "${abi}/out/ST0xOrchestrator.sol/ST0xOrchestrator.json";
+    ST0X_UPGRADEABLE_BEACON_ABI = "${abi}/out/UpgradeableBeacon.sol/UpgradeableBeacon.json";
+    ST0X_BEACON_PROXY_ABI = "${abi}/out/BeaconProxy.sol/BeaconProxy.json";
+    ST0X_STOX_RECEIPT_ABI = "${abi}/out/StoxReceipt.sol/StoxReceipt.json";
+    ST0X_STOX_RECEIPT_VAULT_ABI = "${abi}/out/StoxReceiptVault.sol/StoxReceiptVault.json";
+    ST0X_STOX_OARV_BEACON_SET_DEPLOYER_ABI = "${abi}/out/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol/StoxOffchainAssetReceiptVaultBeaconSetDeployer.json";
+  };
+}

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -27,3 +27,18 @@ sol!(
     OffchainAssetReceiptVaultAuthorizerV1,
     env!("ST0X_OFFCHAIN_ASSET_RECEIPT_VAULT_AUTHORIZER_V1_ABI")
 );
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IST0xOrchestratorV1,
+    env!("IST0X_ORCHESTRATOR_V1_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    ST0xOrchestrator,
+    env!("ST0X_ORCHESTRATOR_ABI")
+);


### PR DESCRIPTION
## Motivation

The project needs ABI definitions from the `st0x-deploy` repository to interact with ST0x contracts (orchestrator, beacon, proxy, receipt vault, etc.). Previously, only `ethgild` ABIs were available, and there was no mechanism to handle Soldeer-based dependency management in the Nix build system.

## Solution

A two-phase `mkSoldeerAbi` builder was introduced to support Forge projects that use Soldeer for dependency management. The first phase is a fixed-output derivation with network access that runs `forge soldeer install` and caches the resulting `dependencies/` directory. The second phase is a sandboxed build that injects the vendored dependencies and runs `forge build` offline. This separation ensures the dependency hash only changes when `soldeer.lock` changes, not when contracts change.

The `st0x-deploy` repository is added as a flake input and wired through `abis.nix` using a new `nix/st0x-deploy.nix` module. The `abis` symlink structure is updated so that each source's compiled output lives under its own named subdirectory (`abis/ethgild` and `abis/st0x.deploy`) rather than a single flat `abis` symlink. ABI environment variables for the ST0x orchestrator, beacon, proxy, receipt, receipt vault, and beacon set deployer contracts are exposed via `abiEnv`.

Closes [RAI-1408](https://linear.app/makeitrain/issue/RAI-1408/update-nix-setup-to-build-st0xdeploy-abis)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for St0x deployment artifacts and contract interfaces.
  * Added ABI generation and integration for orchestrator, beacon, proxy, receipt, and vault contracts.
  * Included new bindings for interacting with St0x orchestrator contracts.
* **Build Improvements**
  * Added offline-compatible dependency preparation for reproducible contract builds.
  * Development environments now expose the new St0x deployment artifacts alongside existing ABI files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->