### PR TITLE
Add `VaultMode` config with orchestrator support and smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2295,7 +2295,7 @@ dependencies = [
  "atomic 0.6.1",
  "pear",
  "serde",
- "toml",
+ "toml 0.8.23",
  "uncased",
  "version_check",
 ]
@@ -5303,6 +5303,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5994,6 +6003,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "toml 1.1.3+spec-1.1.0",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
@@ -6434,9 +6444,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53c96ecdfa941c8fc4fcaed14f99ada8ebed502eef533015095a07e3301d4c3c"
+dependencies = [
+ "indexmap 2.14.0",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -6465,7 +6490,7 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned",
+ "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
@@ -6497,6 +6522,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
 
 [[package]]
 name = "tonic"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ fireblocks-sdk = { git = "https://github.com/0xgleb/fireblocks-sdk-rs.git", bran
 jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 sha2 = "0.11.0"
 rand = "0.8"
+toml = "1.1.3"
 
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,0 +1,26 @@
+# Template for the optional TOML configuration file, passed via
+# `--config <path>` (or the CONFIG environment variable).
+#
+# The flag is optional: with no config file (or one containing no orchestrator
+# entries) every asset is vault-direct, which is the dark-deploy default.
+#
+# Parsing is strict — unknown keys and invalid vault_mode strings are startup
+# errors, and any asset resolving to orchestrator mode while
+# [orchestrator].address is missing or malformed is a startup error.
+
+[orchestrator]
+# ST0xOrchestrator contract address. Required when any asset resolves to
+# orchestrator mode; rejected as a startup error if that is the case and it
+# is missing, malformed, or the zero address.
+address = "0x1234567890abcdef1234567890abcdef12345678"
+
+# Mode for assets without a per-asset override below:
+# "vault_direct" (the default when omitted) | "orchestrator".
+# The full-rollout end state sets this to "orchestrator" and drops the
+# per-asset overrides, so newly onboarded assets default to the orchestrator.
+default_vault_mode = "vault_direct"
+
+# Per-asset override, keyed by underlying symbol. During the pilot exactly one
+# asset carries this; every other asset stays on the default.
+[assets.RKLB]
+vault_mode = "orchestrator"

--- a/config.prod.toml
+++ b/config.prod.toml
@@ -1,0 +1,10 @@
+# Production TOML configuration, baked into the st0x-issuance systemd unit as
+# `CONFIG=<nix store path>` (see nix/upgradeable-services.nix).
+#
+# Deliberately dark: no [orchestrator] section and no [assets.<SYM>] overrides
+# means every asset runs vault-direct. See config.example.toml for the full
+# schema and the per-asset orchestrator rollout knobs.
+#
+# Parsing is strict — unknown keys and invalid vault_mode strings are startup
+# errors, and any asset resolving to orchestrator mode while
+# [orchestrator].address is missing or malformed is a startup error.

--- a/config.staging.toml
+++ b/config.staging.toml
@@ -1,0 +1,10 @@
+# Staging TOML configuration, baked into the st0x-issuance systemd unit as
+# `CONFIG=<nix store path>` (see nix/upgradeable-services.nix).
+#
+# Deliberately dark: no [orchestrator] section and no [assets.<SYM>] overrides
+# means every asset runs vault-direct. See config.example.toml for the full
+# schema and the per-asset orchestrator rollout knobs.
+#
+# Parsing is strict — unknown keys and invalid vault_mode strings are startup
+# errors, and any asset resolving to orchestrator mode while
+# [orchestrator].address is missing or malformed is a startup error.

--- a/nix/upgradeable-services.nix
+++ b/nix/upgradeable-services.nix
@@ -45,6 +45,18 @@ let
             throw "Unsupported environment '${environment}'"
         }"
         "LOG_LEVEL=debug"
+        # Per-environment orchestrator/vault-mode TOML config; the committed
+        # files are dark (no orchestrator entries = every asset vault-direct).
+        # Interpolating the path copies the file into the nix store, so the
+        # unit always sees the config that shipped with the deployed rev.
+        "CONFIG=${
+          if environment == "prod" then
+            ../config.prod.toml
+          else if environment == "staging" then
+            ../config.staging.toml
+          else
+            throw "Unsupported environment '${environment}'"
+        }"
       ]
     else
       [ ];

--- a/src/account/api.rs
+++ b/src/account/api.rs
@@ -346,6 +346,7 @@ mod tests {
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         }
     }
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -3120,6 +3120,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         };
 
         let pool = setup_pool().await;
@@ -3420,6 +3421,7 @@ mod tests {
             alpaca: AlpacaConfig::test_default(),
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         };
 
         rocket::build()
@@ -4336,6 +4338,7 @@ mod tests {
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         };
 
         rocket::build()

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -356,6 +356,7 @@ mod tests {
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,9 @@
+use alloy::primitives::Address;
 use alloy::providers::Provider;
 use clap::{Args, Parser};
+use st0x_issuance_dto::{UnderlyingSymbol, UnderlyingSymbolError};
+use std::collections::HashMap;
+use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{Level, warn};
 use url::Url;
@@ -12,6 +16,31 @@ use crate::chain::{
 use crate::telemetry::{HyperDxApiKey, HyperDxConfig};
 use crate::tokenized_asset::Network;
 use crate::wallet::{SignerConfig, SignerConfigError, SignerEnv};
+
+/// How a specific tokenized asset's mint/burn is executed on-chain.
+///
+/// `VaultDirect` calls the `OffchainAssetReceiptVault` directly (existing
+/// behaviour). `Orchestrator` routes through the `ST0xOrchestrator` contract
+/// at the given address, which handles the EIP-712 mint-auth and the
+/// receipt-walk for burns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum VaultMode {
+    #[default]
+    VaultDirect,
+    Orchestrator {
+        address: Address,
+    },
+}
+
+/// Resolved per-asset vault-mode configuration loaded from the optional TOML
+/// config file. Defaults to all-`VaultDirect` when no file is provided.
+#[derive(Debug, Clone, Default)]
+pub struct VaultModeConfig {
+    /// Per-asset overrides keyed by the underlying symbol string (e.g. "AAPL").
+    per_asset: HashMap<String, VaultMode>,
+    /// Fallback used for any asset not listed in `per_asset`.
+    default: VaultMode,
+}
 
 /// Default chain ID (Base mainnet)
 pub const DEFAULT_CHAIN_ID: u64 = 8453;
@@ -47,6 +76,7 @@ pub struct Config {
     /// env vars preserve the Base-only path; complete `CHAIN_<NETWORK>_*`
     /// groups override Base or append additional networks.
     pub chains: Vec<ChainConfig>,
+    pub vault_mode_config: VaultModeConfig,
 }
 
 impl Config {
@@ -70,6 +100,20 @@ impl Config {
         build_chain_registry(self.chains.clone(), &self.signer)
             .await
             .map_err(|error| ConfigError::ChainRegistry(Box::new(error)))
+    }
+
+    /// Returns the `VaultMode` for the given underlying asset symbol.
+    ///
+    /// Uses the per-asset override from the TOML config if present, otherwise
+    /// falls back to the configured default (which itself defaults to
+    /// `VaultDirect` when no TOML file is provided).
+    #[must_use]
+    pub fn vault_mode_for(&self, underlying: &UnderlyingSymbol) -> VaultMode {
+        self.vault_mode_config
+            .per_asset
+            .get(underlying.as_str())
+            .copied()
+            .unwrap_or(self.vault_mode_config.default)
     }
 }
 
@@ -260,6 +304,15 @@ struct Env {
         help = "Receipt-backfill start block for the HyperEVM group"
     )]
     chain_hyperevm_backfill_start_block: Option<u64>,
+
+    #[arg(
+        long,
+        env = "CONFIG",
+        help = "Path to TOML configuration file for orchestrator/vault-mode settings. \
+                Omitting this arg (or providing a file with no [orchestrator] section) \
+                keeps every asset in vault-direct mode (safe default)."
+    )]
+    config: Option<PathBuf>,
 }
 
 impl Env {
@@ -272,6 +325,16 @@ impl Env {
         let backfill_start_block = base.backfill_start_block;
         let signer = self.signer.into_config()?;
         let hyperdx = self.hyperdx.into_config(log_level_tracing);
+        let vault_mode_config = if let Some(config_path) = self.config {
+            let content =
+                std::fs::read_to_string(&config_path).map_err(|error| {
+                    ConfigError::ConfigFileRead { path: config_path, error }
+                })?;
+            let toml_file: TomlFile = toml::from_str(&content)?;
+            resolve_vault_modes(&toml_file)?
+        } else {
+            VaultModeConfig::default()
+        };
 
         Ok(Config {
             database_url: self.database_url,
@@ -288,6 +351,7 @@ impl Env {
             alpaca: self.alpaca,
             subgraph_url,
             chains,
+            vault_mode_config,
         })
     }
 
@@ -576,6 +640,139 @@ pub enum ConfigError {
     },
     #[error("chain registry initialization failed: {0}")]
     ChainRegistry(#[source] Box<ChainRegistryError>),
+    #[error("Failed to read config file '{path}': {error}")]
+    ConfigFileRead {
+        path: PathBuf,
+        #[source]
+        error: std::io::Error,
+    },
+    #[error("Failed to parse toml config file: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error(
+        "[orchestrator].address is required when any asset resolves to \
+         orchestrator mode"
+    )]
+    MissingOrchestratorAddress,
+    #[error("Invalid [orchestrator].address '{0}': not a valid EVM address")]
+    InvalidOrchestratorAddress(String),
+    #[error("Invalid [assets] key '{symbol}': {error}")]
+    InvalidAssetSymbol {
+        symbol: String,
+        #[source]
+        error: UnderlyingSymbolError,
+    },
+    #[error(
+        "multiple [assets] keys normalize to '{symbol}'; keep exactly one \
+         entry per asset"
+    )]
+    DuplicateAssetSymbol { symbol: String },
+}
+
+// Sourced from the file given to `--config`.  All structs carry
+// `deny_unknown_fields` so a typo in the config is a startup error rather than
+// a silent no-op.
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct TomlFile {
+    orchestrator: Option<OrchestratorSection>,
+    #[serde(default)]
+    assets: HashMap<String, AssetSection>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct OrchestratorSection {
+    address: Option<String>,
+    default_vault_mode: Option<VaultModeStr>,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AssetSection {
+    vault_mode: VaultModeStr,
+}
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum VaultModeStr {
+    VaultDirect,
+    Orchestrator,
+}
+
+/// Converts the raw TOML file into a validated `VaultModeConfig`.
+///
+/// Validation rules:
+/// - `default_vault_mode = "orchestrator"` requires `[orchestrator].address`.
+/// - Any `[assets.<X>].vault_mode = "orchestrator"` requires
+///   `[orchestrator].address`.
+/// - An unknown `vault_mode` string fails via serde (see `VaultModeStr`).
+/// - `[assets.<X>]` keys are validated as underlying symbols and normalized
+///   to upper case (matching how assets are keyed everywhere else), so
+///   `[assets.rklb]` configures RKLB instead of silently configuring
+///   nothing; `deny_unknown_fields` cannot catch map keys, so this is where
+///   a typo'd key becomes a startup error instead of a silent no-op. Two
+///   keys normalizing to the same symbol are rejected rather than one
+///   silently winning.
+fn resolve_vault_modes(
+    toml: &TomlFile,
+) -> Result<VaultModeConfig, ConfigError> {
+    let orchestrator_address =
+        match toml.orchestrator.as_ref().and_then(|o| o.address.as_ref()) {
+            Some(addr_str) => {
+                let address = addr_str.parse::<Address>().map_err(|_| {
+                    ConfigError::InvalidOrchestratorAddress(addr_str.clone())
+                })?;
+                if address.is_zero() {
+                    return Err(ConfigError::InvalidOrchestratorAddress(
+                        addr_str.clone(),
+                    ));
+                }
+                Some(address)
+            }
+            None => None,
+        };
+
+    let resolve_mode =
+        |mode_str: &VaultModeStr| -> Result<VaultMode, ConfigError> {
+            match mode_str {
+                VaultModeStr::VaultDirect => Ok(VaultMode::VaultDirect),
+                VaultModeStr::Orchestrator => {
+                    let address = orchestrator_address
+                        .ok_or(ConfigError::MissingOrchestratorAddress)?;
+                    Ok(VaultMode::Orchestrator { address })
+                }
+            }
+        };
+
+    let default = match toml
+        .orchestrator
+        .as_ref()
+        .and_then(|o| o.default_vault_mode.as_ref())
+    {
+        None => VaultMode::VaultDirect,
+        Some(mode_str) => resolve_mode(mode_str)?,
+    };
+
+    let mut per_asset = HashMap::new();
+    for (symbol, asset_section) in &toml.assets {
+        let normalized = UnderlyingSymbol::new(symbol.to_ascii_uppercase())
+            .map_err(|error| ConfigError::InvalidAssetSymbol {
+                symbol: symbol.clone(),
+                error,
+            })?
+            .as_str()
+            .to_string();
+
+        let mode = resolve_mode(&asset_section.vault_mode)?;
+        if per_asset.insert(normalized.clone(), mode).is_some() {
+            return Err(ConfigError::DuplicateAssetSymbol {
+                symbol: normalized,
+            });
+        }
+    }
+
+    Ok(VaultModeConfig { per_asset, default })
 }
 
 /// RPC URL uses a scheme that cannot be mapped to HTTP.
@@ -1171,5 +1368,323 @@ mod tests {
         let expected = address!("7E5F4552091A69125d5DfCb7b8C2659029395Bdf");
 
         assert_eq!(config.signer.address().unwrap(), expected);
+    }
+
+    const ORCH_ADDR: &str = "0x1234567890abcdef1234567890abcdef12345678";
+
+    fn orch_address() -> Address {
+        ORCH_ADDR.parse().unwrap()
+    }
+
+    #[test]
+    fn no_config_file_every_asset_vault_direct() {
+        let cfg = VaultModeConfig::default();
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+        assert!(cfg.per_asset.is_empty());
+    }
+
+    // Pins the committed per-environment deploy configs (baked into the
+    // systemd unit as CONFIG=<store path>, see nix/upgradeable-services.nix)
+    // to the strict parser: they must always parse, and while the rollout is
+    // dark they must resolve every asset to vault-direct.
+    #[test]
+    fn deploy_config_files_parse_and_stay_dark() {
+        for (name, content) in [
+            ("config.prod.toml", include_str!("../config.prod.toml")),
+            ("config.staging.toml", include_str!("../config.staging.toml")),
+        ] {
+            let toml_file: TomlFile = toml::from_str(content)
+                .unwrap_or_else(|error| panic!("{name} must parse: {error}"));
+
+            let cfg = resolve_vault_modes(&toml_file)
+                .unwrap_or_else(|error| panic!("{name} must resolve: {error}"));
+
+            assert_eq!(cfg.default, VaultMode::VaultDirect, "{name} not dark");
+            assert!(cfg.per_asset.is_empty(), "{name} has asset overrides");
+        }
+    }
+
+    // Pins config.example.toml to the strict parser so the committed example
+    // can never drift into something the bot would reject at startup.
+    #[test]
+    fn example_config_file_parses_and_resolves() {
+        let toml_file: TomlFile =
+            toml::from_str(include_str!("../config.example.toml")).unwrap();
+
+        let cfg = resolve_vault_modes(&toml_file).unwrap();
+
+        assert_eq!(
+            cfg.per_asset.get("RKLB").copied(),
+            Some(VaultMode::Orchestrator { address: orch_address() })
+        );
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+    }
+
+    #[test]
+    fn per_asset_override_to_orchestrator() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: None,
+            }),
+            assets: HashMap::from([(
+                "AAPL".to_string(),
+                AssetSection { vault_mode: VaultModeStr::Orchestrator },
+            )]),
+        };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(
+            cfg.per_asset.get("AAPL").copied(),
+            Some(VaultMode::Orchestrator { address: orch_address() })
+        );
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+    }
+
+    #[test]
+    fn per_asset_override_to_vault_direct_ignores_default() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: Some(VaultModeStr::Orchestrator),
+            }),
+            assets: HashMap::from([(
+                "TSLA".to_string(),
+                AssetSection { vault_mode: VaultModeStr::VaultDirect },
+            )]),
+        };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(
+            cfg.per_asset.get("TSLA").copied(),
+            Some(VaultMode::VaultDirect)
+        );
+        assert_eq!(
+            cfg.default,
+            VaultMode::Orchestrator { address: orch_address() }
+        );
+    }
+
+    #[test]
+    fn no_per_asset_override_uses_default_vault_mode() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: Some(VaultModeStr::Orchestrator),
+            }),
+            assets: HashMap::new(),
+        };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(
+            cfg.default,
+            VaultMode::Orchestrator { address: orch_address() }
+        );
+    }
+
+    #[test]
+    fn no_orchestrator_section_defaults_to_vault_direct() {
+        let toml = TomlFile { orchestrator: None, assets: HashMap::new() };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+        assert!(cfg.per_asset.is_empty());
+    }
+
+    #[test]
+    fn orchestrator_asset_without_address_is_startup_error() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: None,
+                default_vault_mode: None,
+            }),
+            assets: HashMap::from([(
+                "AAPL".to_string(),
+                AssetSection { vault_mode: VaultModeStr::Orchestrator },
+            )]),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::MissingOrchestratorAddress)
+        ));
+    }
+
+    #[test]
+    fn default_orchestrator_without_address_is_startup_error() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: None,
+                default_vault_mode: Some(VaultModeStr::Orchestrator),
+            }),
+            assets: HashMap::new(),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::MissingOrchestratorAddress)
+        ));
+    }
+
+    #[test]
+    fn invalid_orchestrator_address_is_startup_error() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some("not-an-address".to_string()),
+                default_vault_mode: None,
+            }),
+            assets: HashMap::new(),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::InvalidOrchestratorAddress(_))
+        ));
+    }
+
+    #[test]
+    fn zero_orchestrator_address_is_startup_error() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(Address::ZERO.to_string()),
+                default_vault_mode: None,
+            }),
+            assets: HashMap::from([(
+                "AAPL".to_string(),
+                AssetSection { vault_mode: VaultModeStr::Orchestrator },
+            )]),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::InvalidOrchestratorAddress(message))
+                if message == Address::ZERO.to_string()
+        ));
+    }
+
+    // A lowercase key must configure the same asset the uppercase symbol
+    // names — before normalization, `[assets.rklb]` parsed and resolved
+    // cleanly but never matched the stored uppercase symbol, silently
+    // leaving the asset vault-direct.
+    #[test]
+    fn lowercase_asset_key_normalizes_to_the_stored_symbol() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: None,
+            }),
+            assets: HashMap::from([(
+                "rklb".to_string(),
+                AssetSection { vault_mode: VaultModeStr::Orchestrator },
+            )]),
+        };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(
+            cfg.per_asset.get("RKLB").copied(),
+            Some(VaultMode::Orchestrator { address: orch_address() })
+        );
+        assert!(!cfg.per_asset.contains_key("rklb"));
+    }
+
+    #[test]
+    fn blank_asset_key_is_startup_error() {
+        let toml = TomlFile {
+            orchestrator: None,
+            assets: HashMap::from([(
+                "  ".to_string(),
+                AssetSection { vault_mode: VaultModeStr::VaultDirect },
+            )]),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::InvalidAssetSymbol { symbol, .. })
+                if symbol == "  "
+        ));
+    }
+
+    #[test]
+    fn asset_keys_colliding_after_normalization_are_a_startup_error() {
+        let toml = TomlFile {
+            orchestrator: None,
+            assets: HashMap::from([
+                (
+                    "rklb".to_string(),
+                    AssetSection { vault_mode: VaultModeStr::VaultDirect },
+                ),
+                (
+                    "RKLB".to_string(),
+                    AssetSection { vault_mode: VaultModeStr::VaultDirect },
+                ),
+            ]),
+        };
+
+        assert!(matches!(
+            resolve_vault_modes(&toml),
+            Err(ConfigError::DuplicateAssetSymbol { symbol })
+                if symbol == "RKLB"
+        ));
+    }
+
+    #[test]
+    fn unknown_vault_mode_string_in_toml_is_parse_error() {
+        let bad_toml = r#"
+            [orchestrator]
+            address = "0x1234567890abcdef1234567890abcdef12345678"
+
+            [assets.AAPL]
+            vault_mode = "not_a_valid_mode"
+        "#;
+
+        let result = toml::from_str::<TomlFile>(bad_toml);
+        assert!(result.is_err(), "expected parse error for unknown vault_mode");
+    }
+
+    #[test]
+    fn unknown_toml_key_is_parse_error() {
+        let bad_toml = r#"
+            [orchestrator]
+            address = "0x1234567890abcdef1234567890abcdef12345678"
+            unexpected_key = "oops"
+        "#;
+
+        let result = toml::from_str::<TomlFile>(bad_toml);
+        assert!(result.is_err(), "expected parse error for unknown key");
+    }
+
+    #[test]
+    fn vault_mode_for_uses_per_asset_override_then_default() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: Some(VaultModeStr::Orchestrator),
+            }),
+            assets: HashMap::from([(
+                "TSLA".to_string(),
+                AssetSection { vault_mode: VaultModeStr::VaultDirect },
+            )]),
+        };
+        let args = minimal_args();
+        let env = Env::try_parse_from(args).unwrap();
+        let mut config = env.into_config().unwrap();
+        config.vault_mode_config = resolve_vault_modes(&toml).unwrap();
+
+        // Explicit VaultDirect override wins over the orchestrator default
+        assert_eq!(
+            config.vault_mode_for(&UnderlyingSymbol::new("TSLA").unwrap()),
+            VaultMode::VaultDirect
+        );
+
+        // Asset not in per_asset falls back to default (orchestrator)
+        assert_eq!(
+            config.vault_mode_for(&UnderlyingSymbol::new("AAPL").unwrap()),
+            VaultMode::Orchestrator { address: orch_address() }
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,9 @@ pub mod bindings;
 pub use alpaca::AlpacaConfig;
 pub use auth::{AuthConfig, InternalIpWhitelist, IpWhitelist, IssuerApiKey};
 pub use chain::ChainConfig;
-pub use config::{Config, Environment, LogLevel, setup_tracing};
+pub use config::{
+    Config, Environment, LogLevel, VaultMode, VaultModeConfig, setup_tracing,
+};
 pub use st0x_issuance_dto::Network;
 pub use telemetry::TelemetryGuard;
 pub use test_utils::{

--- a/src/mint/api/test_utils.rs
+++ b/src/mint/api/test_utils.rs
@@ -48,6 +48,7 @@ pub(crate) fn test_config() -> Config {
         subgraph_url: Url::parse("http://localhost:0/subgraph")
             .expect("valid test URL"),
         chains: Vec::new(),
+        vault_mode_config: crate::config::VaultModeConfig::default(),
     }
 }
 

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -5,9 +5,14 @@ pub const ROLE_CERTIFY: &str = "CERTIFY";
 use alloy::hex;
 use alloy::network::EthereumWallet;
 use alloy::node_bindings::{Anvil, AnvilInstance};
-use alloy::primitives::{Address, B256, Bytes, U256, address, keccak256};
+use alloy::primitives::{
+    Address, B256, Bytes, U256, address, bytes, keccak256,
+};
 use alloy::providers::{PendingTransactionError, Provider, ProviderBuilder};
+use alloy::rpc::types::TransactionRequest;
 use alloy::signers::local::PrivateKeySigner;
+use alloy::sol;
+use alloy::sol_types::SolCall;
 use alloy::sol_types::SolValue;
 use alloy::transports::{RpcError, TransportErrorKind};
 use apalis_sqlite::SqlitePool as ApalisSqlitePool;
@@ -30,7 +35,7 @@ use crate::alpaca::service::AlpacaConfig;
 use crate::auth::{FailedAuthRateLimiter, test_auth_config};
 use crate::bindings::{
     CloneFactory, OffchainAssetReceiptVault,
-    OffchainAssetReceiptVaultAuthorizerV1, Receipt,
+    OffchainAssetReceiptVaultAuthorizerV1, Receipt, ST0xOrchestrator,
 };
 use crate::config::{Config, Environment, LogLevel};
 use crate::mint::Mint;
@@ -67,6 +72,58 @@ fn find_anvil() -> Option<PathBuf> {
             .find(|candidate| candidate.is_file())
     })
 }
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    UpgradeableBeacon,
+    env!("ST0X_UPGRADEABLE_BEACON_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    BeaconProxy,
+    env!("ST0X_BEACON_PROXY_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    StoxReceipt,
+    env!("ST0X_STOX_RECEIPT_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    StoxReceiptVault,
+    env!("ST0X_STOX_RECEIPT_VAULT_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[allow(clippy::too_many_arguments)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    StoxOffchainAssetReceiptVaultBeaconSetDeployer,
+    env!("ST0X_STOX_OARV_BEACON_SET_DEPLOYER_ABI")
+);
+
+/// The Zoltu deterministic CREATE2 factory (salt 0), as pinned by
+/// rain-deploy's `LibRainDeploy.sol` (`ZOLTU_FACTORY`,
+/// `ZOLTU_FACTORY_BYTECODE`). st0x.deploy deploys its production contracts
+/// through this factory, so their addresses depend only on creation code —
+/// etching the factory on Anvil and replaying the deploys reproduces the
+/// exact production addresses baked into `ST0xOrchestrator`'s bytecode.
+const ZOLTU_FACTORY: Address =
+    address!("0x7A0D94F55792C434d74a40883C6ed8545E406D12");
+
+const ZOLTU_FACTORY_BYTECODE: Bytes =
+    bytes!("0x60003681823780368234f58015156014578182fd5b80825250506014600cf3");
 
 /// Returns test Alpaca legacy auth credentials for mock Alpaca API requests.
 ///
@@ -110,6 +167,7 @@ fn test_config() -> Result<Config, anyhow::Error> {
         alpaca: AlpacaConfig::test_default(),
         subgraph_url: Url::parse("http://localhost:0/subgraph")?,
         chains: Vec::new(),
+        vault_mode_config: crate::config::VaultModeConfig::default(),
     })
 }
 
@@ -285,6 +343,16 @@ impl LocalEvm {
     /// - Any contract deployment step fails
     pub async fn new() -> Result<Self, LocalEvmError> {
         Self::with_chain_id(ANVIL_CHAIN_ID).await
+    }
+
+    async fn connect(&self) -> Result<impl Provider, LocalEvmError> {
+        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
+        let wallet = EthereumWallet::from(signer);
+
+        Ok(ProviderBuilder::new()
+            .wallet(wallet)
+            .connect(&self.endpoint)
+            .await?)
     }
 
     /// Creates a new [`LocalEvm`] on an Anvil instance with the given chain ID.
@@ -550,13 +618,7 @@ impl LocalEvm {
         &self,
         until: U256,
     ) -> Result<(), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let vault =
             OffchainAssetReceiptVault::new(self.vault_address, &provider);
@@ -575,13 +637,7 @@ impl LocalEvm {
         role_name: &str,
         to: Address,
     ) -> Result<(), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let authorizer = OffchainAssetReceiptVaultAuthorizerV1::new(
             self.authorizer_address,
@@ -627,13 +683,7 @@ impl LocalEvm {
         to: Address,
         receipt_information: Bytes,
     ) -> Result<(U256, U256, Bytes), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let vault =
             OffchainAssetReceiptVault::new(self.vault_address, &provider);
@@ -679,13 +729,7 @@ impl LocalEvm {
     pub async fn deploy_additional_vault(
         &self,
     ) -> Result<(Address, Address), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         Self::deploy_vault(&provider, self.wallet_address).await
     }
@@ -704,13 +748,7 @@ impl LocalEvm {
         amount: U256,
         to: Address,
     ) -> Result<(U256, U256), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let vault = OffchainAssetReceiptVault::new(vault_address, &provider);
         let share_ratio = U256::from(10).pow(U256::from(18));
@@ -753,13 +791,7 @@ impl LocalEvm {
         shares: U256,
         receiver: Address,
     ) -> Result<(), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let vault =
             OffchainAssetReceiptVault::new(self.vault_address, &provider);
@@ -791,13 +823,7 @@ impl LocalEvm {
         role_name: &str,
         to: Address,
     ) -> Result<(), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let authorizer = OffchainAssetReceiptVaultAuthorizerV1::new(
             authorizer_address,
@@ -805,6 +831,154 @@ impl LocalEvm {
         );
         let role = keccak256(role_name);
         authorizer.grantRole(role, to).send().await?.get_receipt().await?;
+
+        Ok(())
+    }
+
+    /// Deploys `ST0xOrchestrator` behind a beacon proxy, wires it to the
+    /// default vault, and grants `MINT_ROLE` + `BURN_ROLE` to the deployer
+    /// wallet so tests can call `mint` / `burn` directly.
+    ///
+    /// Setup steps:
+    /// 1. Reproduce the pinned production vault beacon set at its canonical
+    ///    addresses so the orchestrator's vault-logic version lock passes
+    ///    (see `deploy_pinned_vault_beacon_set`).
+    /// 2. Deploy `ST0xOrchestrator` as the implementation contract. The
+    ///    constructor calls `_disableInitializers()` on the impl's own storage
+    ///    — this is the standard OZ upgradeable pattern and does NOT prevent
+    ///    `initialize()` from succeeding on a proxy.
+    /// 3. Deploy `UpgradeableBeacon(impl, wallet)` to hold the implementation.
+    /// 4. Deploy `BeaconProxy(beacon, initialize_calldata)` — the constructor
+    ///    delegatecalls `initialize(wallet)` via the beacon, setting up roles.
+    /// 5. Grant `MINT_ROLE` + `BURN_ROLE` on the proxy to the deployer wallet.
+    /// 6. Grant `DEPOSIT` + `WITHDRAW` on the vault's authorizer to the proxy.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any deployment or role-granting transaction fails.
+    pub async fn deploy_orchestrator(&self) -> Result<Address, LocalEvmError> {
+        let provider = self.connect().await?;
+
+        Self::deploy_pinned_vault_beacon_set(&provider).await?;
+
+        // Deploy the implementation. Constructor calls _disableInitializers()
+        // on the impl's own storage — that's intentional OZ pattern.
+        let impl_instance = ST0xOrchestrator::deploy(&provider).await?;
+        let impl_address = *impl_instance.address();
+
+        // Deploy a beacon pointing to the implementation.
+        let beacon = UpgradeableBeacon::deploy(
+            &provider,
+            impl_address,
+            self.wallet_address,
+        )
+        .await?;
+        let beacon_address = *beacon.address();
+
+        // Encode initialize(owner) as BeaconProxy init calldata. The proxy
+        // constructor delegatecalls this on the implementation via the beacon,
+        // initialising the proxy's own storage (fresh — separate from impl).
+        let init_data = Bytes::from(
+            ST0xOrchestrator::initializeCall { owner: self.wallet_address }
+                .abi_encode(),
+        );
+
+        let proxy =
+            BeaconProxy::deploy(&provider, beacon_address, init_data).await?;
+        let orchestrator_address = *proxy.address();
+
+        // Grant MINT_ROLE + BURN_ROLE on the proxy to the deployer wallet.
+        // This must happen before the grant_role_on_authorizer calls below:
+        // `provider`'s recommended fillers cache nonces locally
+        // (alloy-provider fillers/nonce.rs: `NonceFiller<M: NonceManager =
+        // CachedNonceManager>`), while each helper builds a fresh provider —
+        // interleaving their transactions leaves this provider's cached
+        // nonce stale and its next send fails with "nonce too low".
+        let orchestrator =
+            ST0xOrchestrator::new(orchestrator_address, &provider);
+        let mint_role = orchestrator.MINT_ROLE().call().await?;
+        let burn_role = orchestrator.BURN_ROLE().call().await?;
+
+        orchestrator
+            .grantRole(mint_role, self.wallet_address)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        orchestrator
+            .grantRole(burn_role, self.wallet_address)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        // Grant DEPOSIT + WITHDRAW on the vault's authorizer to the orchestrator,
+        // using the same `provider` to avoid the nonce-caching hazard described above.
+        let authorizer = OffchainAssetReceiptVaultAuthorizerV1::new(
+            self.authorizer_address,
+            &provider,
+        );
+        authorizer
+            .grantRole(keccak256(ROLE_DEPOSIT), orchestrator_address)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        authorizer
+            .grantRole(keccak256(ROLE_WITHDRAW), orchestrator_address)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        Ok(orchestrator_address)
+    }
+
+    // ST0xOrchestrator refuses to initialize (and mint/burn) unless the
+    // production vault beacon set exists at the address baked into its
+    // bytecode and its beacons point at the pinned implementations:
+    // ST0xOrchestrator.initialize -> _checkVaultLogic (ST0xOrchestrator.sol)
+    // reads IST0xVaultBeaconSet(LibProdDeployCurrent
+    // .STOX_OFFCHAIN_ASSET_RECEIPT_VAULT_BEACON_SET_DEPLOYER) and compares
+    // beacon implementations against LibProdDeployCurrent.STOX_RECEIPT_VAULT
+    // and .STOX_RECEIPT. Those addresses are CREATE2 outputs of the Zoltu
+    // factory (salt 0), so replaying the same deploys on Anvil reproduces
+    // them exactly — this mirrors upstream's test setup
+    // (st0x.deploy test/lib/LibTestDeploy.sol
+    // `deployOffchainAssetReceiptVaultBeaconSet`). Order matters: the
+    // beacon-set deployer's constructor points its beacons at the receipt
+    // and vault implementations, which must already have code.
+    async fn deploy_pinned_vault_beacon_set(
+        provider: &impl Provider,
+    ) -> Result<(), LocalEvmError> {
+        provider
+            .raw_request::<_, ()>(
+                "anvil_setCode".into(),
+                (ZOLTU_FACTORY, ZOLTU_FACTORY_BYTECODE),
+            )
+            .await?;
+
+        for creation_code in [
+            &StoxReceipt::BYTECODE,
+            &StoxReceiptVault::BYTECODE,
+            &StoxOffchainAssetReceiptVaultBeaconSetDeployer::BYTECODE,
+        ] {
+            let deploy_via_factory = TransactionRequest::default()
+                .to(ZOLTU_FACTORY)
+                .input(creation_code.clone().into());
+
+            let receipt = provider
+                .send_transaction(deploy_via_factory)
+                .await?
+                .get_receipt()
+                .await?;
+
+            if !receipt.status() {
+                return Err(LocalEvmError::EventNotFound);
+            }
+        }
 
         Ok(())
     }
@@ -819,13 +993,7 @@ impl LocalEvm {
         vault_address: Address,
         until: U256,
     ) -> Result<(), LocalEvmError> {
-        let signer = PrivateKeySigner::from_bytes(&self.private_key)?;
-        let wallet = EthereumWallet::from(signer);
-
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(&self.endpoint)
-            .await?;
+        let provider = self.connect().await?;
 
         let vault = OffchainAssetReceiptVault::new(vault_address, &provider);
         vault

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -342,6 +342,7 @@ mod tests {
             subgraph_url: Url::parse("http://localhost:0/subgraph")
                 .expect("valid test URL"),
             chains: Vec::new(),
+            vault_mode_config: crate::config::VaultModeConfig::default(),
         }
     }
 

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -33,7 +33,7 @@ use st0x_issuance::test_utils::{
 };
 use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
-    IpWhitelist, LogLevel, Network, SignerConfig,
+    IpWhitelist, LogLevel, Network, SignerConfig, VaultModeConfig,
 };
 
 pub type TestProviderBuilder = ProviderBuilder<
@@ -583,6 +583,7 @@ pub fn create_config_with_db(
                 subgraph_url,
                 backfill_start_block: 0,
             }],
+            vault_mode_config: VaultModeConfig::default(),
         },
         mock_subgraph,
     ))

--- a/tests/orchestrator_smoke.rs
+++ b/tests/orchestrator_smoke.rs
@@ -1,0 +1,102 @@
+#![allow(clippy::unwrap_used)]
+
+//! Smoke test for `ST0xOrchestrator` integration: deploy → mint → burn.
+//!
+//! Verifies that the test harness's `deploy_orchestrator()` correctly wires the
+//! orchestrator to the vault and that a signed EIP-712 mint auth round-trips
+//! through a full mint-then-burn cycle on Anvil.
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{B256, Bytes, U256};
+use alloy::signers::SignerSync;
+use alloy::signers::local::PrivateKeySigner;
+use st0x_issuance::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
+use st0x_issuance::test_utils::LocalEvm;
+
+use crate::harness::create_provider;
+
+/// Full mint-then-burn cycle through the orchestrator.
+///
+/// 1. Deploy vault + orchestrator (grants MINT_ROLE / BURN_ROLE to deployer).
+/// 2. Build a `MintAuthV1` digest, sign it with the deployer's key.
+/// 3. Mint shares to the deployer via `orchestrator.mint()`.
+/// 4. Approve the orchestrator allowance, then burn via `orchestrator.burn()`.
+/// 5. Assert ERC-20 share balance returns to zero.
+#[tokio::test]
+async fn orchestrator_mint_burn_roundtrip()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+
+    // Certify the vault so deposits and withdrawals are enabled.
+    evm.grant_certify_role(evm.wallet_address).await?;
+    let far_future = U256::from(u64::MAX);
+    evm.certify_vault(far_future).await?;
+
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    let signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    let wallet = EthereumWallet::from(signer.clone());
+
+    let provider =
+        create_provider().wallet(wallet).connect(&evm.endpoint).await?;
+
+    let orchestrator =
+        IST0xOrchestratorV1::new(orchestrator_address, &provider);
+    let vault = OffchainAssetReceiptVault::new(evm.vault_address, &provider);
+
+    let amount = U256::from(1_000_000u64);
+    let nonce = B256::ZERO;
+
+    // Obtain the EIP-712 digest the orchestrator expects us to sign.
+    let digest = orchestrator
+        .mintAuthDigest(evm.vault_address, evm.wallet_address, amount, nonce)
+        .call()
+        .await?;
+
+    // Sign the digest off-chain — alloy's `sign_hash_sync` signs the raw bytes.
+    let signature = signer.sign_hash_sync(&digest)?;
+
+    let auth = IST0xOrchestratorV1::MintAuthV1 {
+        nonce,
+        signature: Bytes::from(signature.as_bytes().to_vec()),
+    };
+
+    orchestrator
+        .mint(evm.vault_address, evm.wallet_address, amount, auth, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let balance_after_mint = vault.balanceOf(evm.wallet_address).call().await?;
+    assert!(
+        balance_after_mint > U256::ZERO,
+        "expected positive share balance after mint, got {balance_after_mint}"
+    );
+
+    // Approve the orchestrator to pull shares, then burn.
+    vault
+        .approve(orchestrator_address, balance_after_mint)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    orchestrator
+        .burn(evm.vault_address, balance_after_mint, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let balance_after_burn = vault.balanceOf(evm.wallet_address).call().await?;
+    assert_eq!(
+        balance_after_burn,
+        U256::ZERO,
+        "expected zero share balance after burn, got {balance_after_burn}"
+    );
+
+    Ok(())
+}

--- a/tests/receipt_inventory.rs
+++ b/tests/receipt_inventory.rs
@@ -18,8 +18,8 @@ use st0x_issuance::bindings::Receipt::ReceiptInstance;
 use st0x_issuance::test_utils::{LocalEvm, ROLE_CERTIFY, ROLE_DEPOSIT};
 use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
-    IpWhitelist, LogLevel, Network, SignerConfig, initialize_rocket,
-    receipt_inventory_aggregate_id,
+    IpWhitelist, LogLevel, Network, SignerConfig, VaultModeConfig,
+    initialize_rocket, receipt_inventory_aggregate_id,
 };
 
 use crate::harness::create_provider;
@@ -327,6 +327,7 @@ async fn test_multi_vault_backfill_discovers_receipts_from_all_assets()
             subgraph_url,
             backfill_start_block: 0,
         }],
+        vault_mode_config: VaultModeConfig::default(),
     };
 
     // Start rocket - backfill should run and discover the TSLA receipt

--- a/tests/unwhitelist.rs
+++ b/tests/unwhitelist.rs
@@ -14,7 +14,8 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaul
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
-    IpWhitelist, LogLevel, Network, SignerConfig, initialize_rocket,
+    IpWhitelist, LogLevel, Network, SignerConfig, VaultModeConfig,
+    initialize_rocket,
 };
 
 use crate::harness::create_provider;
@@ -83,6 +84,7 @@ async fn test_unwhitelist_wallet_blocks_mint_and_redemption()
             subgraph_url,
             backfill_start_block: 0,
         }],
+        vault_mode_config: VaultModeConfig::default(),
     };
 
     let rocket = initialize_rocket(config).await?;


### PR DESCRIPTION
## Motivation

The issuance service needs to support routing mint/burn operations through the `ST0xOrchestrator` contract (which handles EIP-712 mint-auth and receipt-walk for burns) as an alternative to calling `OffchainAssetReceiptVault` directly. During the pilot phase, only specific assets will use the orchestrator path while others remain on the existing vault-direct path. A safe, zero-config default (all assets vault-direct) is required so the dark-deploy state is unchanged without an explicit config file.

## Solution

Introduces a `VaultMode` enum (`VaultDirect` | `Orchestrator { address }`) and a `VaultModeConfig` struct that holds a per-asset override map and a global default. `Config::vault_mode_for(&UnderlyingSymbol)` resolves the correct mode for any given asset at call time.

Configuration is loaded from an optional TOML file passed via `--config` / `CONFIG`. The file schema (`[orchestrator]`, `[assets.<SYMBOL>]`) uses `deny_unknown_fields` so typos are startup errors rather than silent no-ops. Validation enforces that any asset or default resolving to `Orchestrator` mode requires a valid `[orchestrator].address`; missing or malformed addresses are hard startup errors.

A `config.example.toml` is committed alongside the code to document the schema and is pinned to the strict parser in a test so it can never silently drift out of sync.

The `LocalEvm` test harness gains a `deploy_orchestrator()` helper that reproduces the pinned production vault beacon set at its canonical CREATE2 addresses (via the Zoltu deterministic factory etched onto Anvil), deploys `ST0xOrchestrator` behind a beacon proxy, and grants `MINT_ROLE`/`BURN_ROLE` to the deployer wallet. A new `orchestrator_smoke` integration test exercises a full deploy → EIP-712 sign → mint → approve → burn round-trip on Anvil, asserting the share balance returns to zero.

Closes [RAI-1409](https://linear.app/makeitrain/issue/RAI-1409/impl-toml-config-and-smok-tests)  
Closes [RAI-1217](https://linear.app/makeitrain/issue/RAI-1217/2-orchestrator-bindings-config-and-anvil-test-harness)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable vault execution modes, including per-asset direct or orchestrator-driven routing.
  * Added optional TOML configuration loading with strict validation and environment-based selection.
* **Documentation**
  * Added example, staging, and production configuration templates.
* **Bug Fixes**
  * Invalid configuration, asset symbols, duplicate entries, and orchestrator addresses now fail startup with clear errors.
* **Tests**
  * Added an end-to-end orchestrator mint-and-burn smoke test.
  * Updated test configurations with default vault-mode settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->