### PR TITLE
Persist `burn_mode` anchor and `BurnFailureClassification` on redemption events

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -237,6 +237,7 @@ async fn load_reprocess_context(
                 tx_hash,
                 block_number,
                 detected_at,
+                burn_mode,
             } => {
                 if metadata.is_none() {
                     metadata = Some(RedemptionMetadata {
@@ -249,6 +250,7 @@ async fn load_reprocess_context(
                         detected_tx_hash: *tx_hash,
                         block_number: *block_number,
                         detected_at: *detected_at,
+                        burn_mode: *burn_mode,
                     });
                 }
             }
@@ -2081,6 +2083,7 @@ mod tests {
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
     };
     use crate::auth::FailedAuthRateLimiter;
+    use crate::config::VaultMode;
     use crate::mint::test_utils::{TestHarness, test_config};
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::ReceiptVaultKey;
@@ -2088,11 +2091,11 @@ mod tests {
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
         Shares,
     };
-    use crate::redemption::BurnExternalTxId;
+    use crate::redemption::{BurnExternalTxId, RedemptionServices};
     use crate::redemption::{
-        BurnRecord, BurnRecoveryAction, IssuerRedemptionRequestId, Redemption,
-        RedemptionCommand, RedemptionEvent, RedemptionMetadata,
-        RedemptionServices, RedemptionView,
+        BurnFailureClassification, BurnRecord, BurnRecoveryAction,
+        IssuerRedemptionRequestId, Redemption, RedemptionCommand,
+        RedemptionEvent, RedemptionMetadata, RedemptionView,
     };
     use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
     use crate::tokenized_asset::schedule::FreezeScheduler;
@@ -2369,6 +2372,7 @@ mod tests {
 
     fn test_metadata() -> RedemptionMetadata {
         RedemptionMetadata {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: IssuerRedemptionRequestId::random(),
             underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
@@ -2471,6 +2475,8 @@ mod tests {
         let tx_id = TxId::random();
         let failed_at = Utc::now();
         let view = RedemptionView::BurnFailed {
+            burn_mode: VaultMode::VaultDirect,
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: metadata.issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             underlying: metadata.underlying.clone(),
@@ -2563,6 +2569,7 @@ mod tests {
             .send(
                 &metadata.issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -2629,6 +2636,7 @@ mod tests {
                     quantity: metadata.quantity.clone(),
                     tx_hash: metadata.detected_tx_hash,
                     block_number: metadata.block_number,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -2715,6 +2723,7 @@ mod tests {
                     error: "burn terminally failed".to_string(),
                     tx_id: Some(tx_id.clone()),
                     planned_burns: vec![],
+                    classification: BurnFailureClassification::Unclassified,
                 },
             )
             .await
@@ -3150,6 +3159,7 @@ mod tests {
             .send(
                 &metadata.issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -3188,6 +3198,7 @@ mod tests {
             .send(
                 &metadata.issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -3285,6 +3296,7 @@ mod tests {
             .send(
                 &metadata.issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     error: "burn terminally failed".to_string(),
                     tx_id: Some(tx_id),
@@ -4141,6 +4153,7 @@ mod tests {
                     quantity: metadata.quantity.clone(),
                     tx_hash: metadata.detected_tx_hash,
                     block_number: metadata.block_number,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -4271,6 +4284,7 @@ mod tests {
             .send(
                 &metadata.issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -4589,6 +4603,7 @@ mod tests {
         // selects detected_entered_at — this is the post-reprocess clock.
         let detected_entered_at = detected_at + chrono::Duration::days(7);
         let detected = Detected {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer.clone(),
             underlying: underlying.clone(),
             token: token.clone(),
@@ -4607,6 +4622,7 @@ mod tests {
 
         // AlpacaCalled → InProgress with called_at.
         let alpaca_called = AlpacaCalled {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer.clone(),
             tokenization_request_id: tok_id.clone(),
             underlying: underlying.clone(),
@@ -4631,6 +4647,7 @@ mod tests {
         // redemptions). Use a distinct journal-completion time to make the
         // distinction observable.
         let burning = Burning {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer.clone(),
             tokenization_request_id: tok_id.clone(),
             underlying: underlying.clone(),
@@ -4667,6 +4684,8 @@ mod tests {
         // variant that motivated this PR (the original red-79631d72 /
         // red-742f9f3a incident).
         let burn_failed = BurnFailed {
+            burn_mode: VaultMode::VaultDirect,
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: issuer.clone(),
             tokenization_request_id: tok_id,
             underlying,
@@ -4721,6 +4740,7 @@ mod tests {
         // detected_entered_at (the post-reprocess clock) over detected_at.
         let detected_entered_at = detected_at + chrono::Duration::days(3);
         let detected_view = RedemptionView::Detected {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: metadata.issuer_request_id.clone(),
             underlying: metadata.underlying.clone(),
             token: metadata.token.clone(),
@@ -4752,6 +4772,7 @@ mod tests {
         let called_at = Utc::now();
         let tok_id = TokenizationRequestId::new("tok-progress");
         let alpaca_called_view = RedemptionView::AlpacaCalled {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: metadata.issuer_request_id.clone(),
             tokenization_request_id: tok_id.clone(),
             underlying: metadata.underlying.clone(),
@@ -4783,6 +4804,7 @@ mod tests {
         let journal_completed_at = Utc::now() - chrono::Duration::days(7);
         let burning_entered_at = Utc::now();
         let burning_view = RedemptionView::Burning {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: metadata.issuer_request_id.clone(),
             tokenization_request_id: tok_id.clone(),
             underlying: metadata.underlying.clone(),
@@ -4817,6 +4839,7 @@ mod tests {
         // text on a post-submission row. BurnTxSubmitted leaves
         // the view in Burning, so this branch is the only signal.
         let burning_view_with_history = RedemptionView::Burning {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: metadata.issuer_request_id.clone(),
             tokenization_request_id: tok_id,
             underlying: metadata.underlying.clone(),
@@ -5061,6 +5084,7 @@ mod tests {
         // back into Burning with NO new submission yet.
         let events = vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -5092,6 +5116,7 @@ mod tests {
                 submitted_at: now,
             },
             RedemptionEvent::BurningFailed {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id: issuer.clone(),
                 error: "tx failed".to_string(),
                 failed_at: now,
@@ -5106,6 +5131,7 @@ mod tests {
             // Operator resumes the burn — no new BurnTxSubmitted
             // has happened yet.
             RedemptionEvent::BurnResumed {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer,
                 underlying,
                 token,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,20 @@ use crate::wallet::{SignerConfig, SignerConfigError, SignerEnv};
 /// behaviour). `Orchestrator` routes through the `ST0xOrchestrator` contract
 /// at the given address, which handles the EIP-712 mint-auth and the
 /// receipt-walk for burns.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+///
+/// The serde representation (`"VaultDirect"` /
+/// `{"Orchestrator":{"address":"0x…"}}`) is embedded in persisted redemption
+/// events and is therefore a permanent event schema — it must never change.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Default,
+    serde::Serialize,
+    serde::Deserialize,
+)]
 pub enum VaultMode {
     #[default]
     VaultDirect,
@@ -40,6 +53,26 @@ pub struct VaultModeConfig {
     per_asset: HashMap<String, VaultMode>,
     /// Fallback used for any asset not listed in `per_asset`.
     default: VaultMode,
+}
+
+impl VaultModeConfig {
+    #[must_use]
+    pub const fn new(
+        per_asset: HashMap<String, VaultMode>,
+        default: VaultMode,
+    ) -> Self {
+        Self { per_asset, default }
+    }
+
+    /// Returns the `VaultMode` for the given underlying asset symbol.
+    ///
+    /// Uses the per-asset override from the TOML config if present, otherwise
+    /// falls back to the configured default (which itself defaults to
+    /// `VaultDirect` when no TOML file is provided).
+    #[must_use]
+    pub fn mode_for(&self, underlying: &UnderlyingSymbol) -> VaultMode {
+        self.per_asset.get(underlying.as_str()).copied().unwrap_or(self.default)
+    }
 }
 
 /// Default chain ID (Base mainnet)
@@ -103,17 +136,9 @@ impl Config {
     }
 
     /// Returns the `VaultMode` for the given underlying asset symbol.
-    ///
-    /// Uses the per-asset override from the TOML config if present, otherwise
-    /// falls back to the configured default (which itself defaults to
-    /// `VaultDirect` when no TOML file is provided).
     #[must_use]
     pub fn vault_mode_for(&self, underlying: &UnderlyingSymbol) -> VaultMode {
-        self.vault_mode_config
-            .per_asset
-            .get(underlying.as_str())
-            .copied()
-            .unwrap_or(self.vault_mode_config.default)
+        self.vault_mode_config.mode_for(underlying)
     }
 }
 
@@ -1544,6 +1569,55 @@ mod tests {
             resolve_vault_modes(&toml),
             Err(ConfigError::InvalidOrchestratorAddress(_))
         ));
+    }
+
+    #[test]
+    fn vault_mode_serde_wire_format_is_stable() {
+        assert_eq!(
+            serde_json::to_value(VaultMode::VaultDirect).unwrap(),
+            serde_json::json!("VaultDirect")
+        );
+        assert_eq!(
+            serde_json::to_value(VaultMode::Orchestrator {
+                address: orch_address()
+            })
+            .unwrap(),
+            serde_json::json!({"Orchestrator": {"address": ORCH_ADDR}})
+        );
+    }
+
+    #[test]
+    fn vault_mode_serde_round_trips() {
+        for mode in [
+            VaultMode::VaultDirect,
+            VaultMode::Orchestrator { address: orch_address() },
+        ] {
+            let json = serde_json::to_value(mode).unwrap();
+            assert_eq!(
+                serde_json::from_value::<VaultMode>(json).unwrap(),
+                mode
+            );
+        }
+    }
+
+    #[test]
+    fn mode_for_prefers_per_asset_override_and_falls_back_to_default() {
+        let cfg = VaultModeConfig::new(
+            HashMap::from([(
+                "AAPL".to_string(),
+                VaultMode::Orchestrator { address: orch_address() },
+            )]),
+            VaultMode::VaultDirect,
+        );
+
+        assert_eq!(
+            cfg.mode_for(&UnderlyingSymbol::new("AAPL").unwrap()),
+            VaultMode::Orchestrator { address: orch_address() }
+        );
+        assert_eq!(
+            cfg.mode_for(&UnderlyingSymbol::new("TSLA").unwrap()),
+            VaultMode::VaultDirect
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -454,6 +454,7 @@ pub async fn initialize_rocket(
                 redeem_call_manager: managers.redeem_call.clone(),
                 journal_manager: managers.journal.clone(),
                 burn_manager: managers.burn.clone(),
+                vault_mode_config: config.vault_mode_config.clone(),
             });
 
             let mut poller_shutdown = shutdown_rx.clone();

--- a/src/receipt_inventory/burn_tracking.rs
+++ b/src/receipt_inventory/burn_tracking.rs
@@ -362,10 +362,11 @@ mod tests {
     use sqlx::sqlite::SqlitePoolOptions;
 
     use super::*;
+    use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::redemption::{
-        BurnRecord, IssuerRedemptionRequestId, Redemption, RedemptionEvent,
-        TokensBurnedData,
+        BurnFailureClassification, BurnRecord, IssuerRedemptionRequestId,
+        Redemption, RedemptionEvent, TokensBurnedData,
     };
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::TxId;
@@ -515,6 +516,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let events = vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
@@ -535,6 +537,7 @@ mod tests {
                 called_at: Utc::now(),
             },
             RedemptionEvent::BurningFailed {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id: issuer_request_id.clone(),
                 error: "test error".to_string(),
                 failed_at: Utc::now(),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -22,7 +22,8 @@ use crate::receipt_inventory::{
     Shares,
 };
 use crate::redemption::{
-    BurnRecord, RedemptionMetadata, has_unresolved_signer_intent,
+    BurnFailureClassification, BurnRecord, RedemptionMetadata,
+    has_unresolved_signer_intent,
 };
 use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
@@ -148,6 +149,7 @@ impl BurnManager {
                     error,
                     tx_id,
                     planned_burns,
+                    classification: BurnFailureClassification::Unclassified,
                 },
             )
             .await?;
@@ -494,6 +496,7 @@ impl BurnManager {
             alpaca_journal_completed_at,
             tokenization_request_id,
             tx_id,
+            burn_mode,
             ..
         } = view
         else {
@@ -588,6 +591,7 @@ impl BurnManager {
             detected_tx_hash: *tx_hash,
             block_number: *block_number,
             detected_at: *detected_at,
+            burn_mode: *burn_mode,
         };
 
         self.store
@@ -855,6 +859,8 @@ impl BurnManager {
                         .send(
                             issuer_request_id,
                             RedemptionCommand::RecordBurnFailure {
+                                classification:
+                                    BurnFailureClassification::Unclassified,
                                 issuer_request_id: issuer_request_id.clone(),
                                 error: err.clone(),
                                 tx_id: exact_recovery
@@ -1300,6 +1306,7 @@ impl BurnManager {
                 .send(
                     issuer_request_id,
                     RedemptionCommand::RecordBurnFailure {
+                        classification: BurnFailureClassification::Unclassified,
                         issuer_request_id: issuer_request_id.clone(),
                         error: error_msg,
                         tx_id: None,
@@ -1606,6 +1613,7 @@ impl BurnManager {
             .send(
                 issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: error_msg.clone(),
                     tx_id: None,
@@ -1732,6 +1740,7 @@ impl BurnManager {
             .send(
                 issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: error.to_string(),
                     tx_id: None,
@@ -1789,6 +1798,8 @@ impl BurnManager {
                     .send(
                         issuer_request_id,
                         RedemptionCommand::RecordBurnFailure {
+                            classification:
+                                BurnFailureClassification::Unclassified,
                             issuer_request_id: issuer_request_id.clone(),
                             error: message.clone(),
                             tx_id: None,
@@ -1912,6 +1923,8 @@ impl BurnManager {
                     .send(
                         issuer_request_id,
                         RedemptionCommand::RecordBurnFailure {
+                            classification:
+                                BurnFailureClassification::Unclassified,
                             issuer_request_id: issuer_request_id.clone(),
                             error: message.clone(),
                             tx_id: tx_id.clone(),
@@ -2002,6 +2015,8 @@ impl BurnManager {
                         .send(
                             issuer_request_id,
                             RedemptionCommand::RecordBurnFailure {
+                                classification:
+                                    BurnFailureClassification::Unclassified,
                                 issuer_request_id: issuer_request_id.clone(),
                                 error: message.clone(),
                                 tx_id: exact_recovery
@@ -2248,6 +2263,7 @@ pub(crate) const fn is_pending_burn_confirmation(error: &VaultError) -> bool {
     )
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum BurnManagerError {
     #[error("Vault error: {0}")]
@@ -2309,6 +2325,7 @@ mod tests {
         should_release_reserved_burn,
     };
     use crate::burn_excess::BurnExcessEvent;
+    use crate::config::VaultMode;
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
@@ -2322,8 +2339,8 @@ mod tests {
     use crate::redemption::RedemptionServices;
     use crate::redemption::view::{RedemptionViewReactor, find_burn_failed};
     use crate::redemption::{
-        BurnRecord, BurnRecoveryAction, IssuerRedemptionRequestId,
-        RedemptionError,
+        BurnFailureClassification, BurnRecord, BurnRecoveryAction,
+        IssuerRedemptionRequestId, RedemptionError,
     };
     use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
     use crate::tokenized_asset::{
@@ -2649,6 +2666,7 @@ mod tests {
             .send(
                 issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -3145,6 +3163,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "burn failed".to_string(),
                     tx_id: None,
@@ -3696,6 +3715,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -3820,6 +3840,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token,
@@ -4096,6 +4117,7 @@ mod tests {
                     quantity: quantity.clone(),
                     tx_hash,
                     block_number: 12345,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -4260,6 +4282,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -4328,6 +4351,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Initial burn failed".to_string(),
                     tx_id: None,
@@ -4404,6 +4428,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "RPC timeout".to_string(),
                     tx_id: None,
@@ -4471,6 +4496,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "ERC1155: burn amount exceeds balance".to_string(),
                     tx_id: None,
@@ -4562,6 +4588,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "polling timeout".to_string(),
                     tx_id: Some(TxId::random()),
@@ -4660,6 +4687,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "polling timeout".to_string(),
                     tx_id: Some(tx_id.clone()),
@@ -4763,6 +4791,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: "rpc timeout".to_string(),
                     tx_id: Some(tx_id.clone()),

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -3,7 +3,9 @@ use serde::{Deserialize, Serialize};
 
 use super::{BurnExternalTxId, IssuerRedemptionRequestId};
 use crate::Quantity;
+use crate::config::VaultMode;
 use crate::mint::TokenizationRequestId;
+use crate::redemption::event::BurnFailureClassification;
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{MultiBurnEntry, TxId};
 
@@ -18,6 +20,12 @@ pub(crate) enum RedemptionCommand {
         quantity: Quantity,
         tx_hash: B256,
         block_number: u64,
+        /// The asset's `VaultMode` resolved from config at detection time.
+        /// Persisted on `Detected` to anchor mode derivation for the whole
+        /// redemption lifecycle. Deliberately no `#[serde(default)]`:
+        /// commands are not persisted, so a default here would only mask a
+        /// caller that forgot to resolve the mode.
+        burn_mode: VaultMode,
     },
     RecordAlpacaCall {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -68,6 +76,9 @@ pub(crate) enum RedemptionCommand {
         tx_id: Option<TxId>,
         /// Planned burns at the time of failure.
         planned_burns: Vec<super::BurnRecord>,
+        /// Typed failure classification persisted on `BurningFailed`.
+        /// Deliberately no `#[serde(default)]` — see `Detect::burn_mode`.
+        classification: BurnFailureClassification,
     },
     /// Resets a failed redemption back to Detected state for reprocessing.
     /// Only valid from `Failed` state — post-Alpaca states have dedicated

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -6,9 +6,34 @@ use serde::{Deserialize, Serialize};
 use super::{
     BurnExternalTxId, IssuerRedemptionRequestId, default_redemption_network,
 };
+use crate::config::VaultMode;
 use crate::mint::{Quantity, TokenizationRequestId};
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{SendableTxWithHash, TxId};
+
+/// Typed classification of an on-chain or pre-submit burn failure.
+///
+/// Retry-exclusion, log-level selection, and admin grouping key off this
+/// typed field, never off parsing the free-text `error` string. Historical
+/// `BurningFailed` events predate the field and replay as `Unclassified`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum BurnFailureClassification {
+    #[default]
+    Unclassified,
+    /// The orchestrator's per-token receipt walk cannot cover the requested
+    /// burn amount. Token-global anomaly; never auto-retried — recovery is a
+    /// manual `EMERGENCY_ROLE` action followed by admin `ResumeBurn`.
+    InsufficientReceipts { shortfall: U256 },
+    /// The bot-side pre-submit `allowance(bot, orchestrator) >= amount` check
+    /// failed. Never auto-retried — ops must grant the approval first.
+    AllowanceInsufficient,
+    /// The orchestrator reverted because the production vault beacon was
+    /// upgraded ahead of its expectations. Environmental halt, not a burn
+    /// defect; never advances retry counters.
+    VaultLogicMismatch,
+    /// Same halt condition as `VaultLogicMismatch`, for the receipt beacon.
+    ReceiptLogicMismatch,
+}
 
 /// A single burn operation within a multi-receipt burn.
 ///
@@ -115,6 +140,12 @@ pub(crate) enum RedemptionEvent {
         tx_hash: B256,
         block_number: u64,
         detected_at: DateTime<Utc>,
+        /// The asset's resolved `VaultMode` at detection time. Anchors every
+        /// later burn step's mode derivation — never re-resolved from live
+        /// config. Historical events predate orchestrator mode and replay as
+        /// `VaultDirect`.
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     AlpacaCalled {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -154,6 +185,10 @@ pub(crate) enum RedemptionEvent {
         /// Absent for pre-enrichment events.
         #[serde(default)]
         planned_burns: Vec<BurnRecord>,
+        /// Typed failure classification. Absent for pre-orchestrator events,
+        /// which replay as `Unclassified`.
+        #[serde(default)]
+        classification: BurnFailureClassification,
     },
     /// Redemption reset to Detected state for reprocessing.
     /// Carries the original metadata so apply() can reconstruct Detected.
@@ -170,6 +205,10 @@ pub(crate) enum RedemptionEvent {
         detected_at: DateTime<Utc>,
         previous_state: String,
         reprocessed_at: DateTime<Utc>,
+        /// Preserves the redemption's mode anchor across a reset to
+        /// `Detected`. Absent on pre-orchestrator events (`VaultDirect`).
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     /// Burn transaction submitted to the signing backend.
     /// Persists the backend transaction ID so polling can resume after a restart.
@@ -247,6 +286,10 @@ pub(crate) enum RedemptionEvent {
         #[serde(default)]
         external_tx_id: Option<BurnExternalTxId>,
         resumed_at: DateTime<Utc>,
+        /// Preserves the redemption's mode anchor across a resume to
+        /// `Burning`. Absent on pre-orchestrator events (`VaultDirect`).
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     BurnIntended {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -487,6 +530,7 @@ mod tests {
     #[test]
     fn test_burning_failed_event_type() {
         let event = RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: test_redemption_id(),
             error: "Blockchain error: timeout".to_string(),
             failed_at: Utc::now(),
@@ -528,6 +572,7 @@ mod tests {
     #[test]
     fn test_burning_failed_serialization() {
         let event = RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: test_redemption_id(),
             error: "Network timeout".to_string(),
             failed_at: Utc::now(),
@@ -558,13 +603,19 @@ mod tests {
 
         let event: RedemptionEvent = serde_json::from_str(json).unwrap();
 
-        let RedemptionEvent::BurningFailed { tx_id, planned_burns, .. } = event
+        let RedemptionEvent::BurningFailed {
+            tx_id,
+            planned_burns,
+            classification,
+            ..
+        } = event
         else {
             panic!("Expected BurningFailed variant");
         };
 
         assert_eq!(tx_id, None);
         assert!(planned_burns.is_empty());
+        assert_eq!(classification, BurnFailureClassification::Unclassified);
     }
 
     /// Old BurningFailed events stored the transaction id under `fireblocks_tx_id`.
@@ -714,6 +765,90 @@ mod tests {
         assert_eq!(network, Network::Base);
     }
 
+    /// Historical `Detected` events predate orchestrator mode; an absent
+    /// `burn_mode` must replay as `VaultDirect`.
+    #[test]
+    fn detected_without_burn_mode_replays_as_vault_direct() {
+        let json = r#"{
+            "Detected": {
+                "issuer_request_id": "red-abcdef12",
+                "underlying": "AAPL",
+                "token": "tAAPL",
+                "wallet": "0x1234567890abcdef1234567890abcdef12345678",
+                "quantity": "1",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "block_number": 1,
+                "detected_at": "2025-01-01T00:00:00Z"
+            }
+        }"#;
+
+        let event: RedemptionEvent = serde_json::from_str(json).unwrap();
+
+        let RedemptionEvent::Detected { burn_mode, .. } = event else {
+            panic!("Expected Detected variant");
+        };
+
+        assert_eq!(burn_mode, VaultMode::VaultDirect);
+    }
+
+    /// Historical `Reprocessed` events predate orchestrator mode; an absent
+    /// `burn_mode` must replay as `VaultDirect`.
+    #[test]
+    fn reprocessed_without_burn_mode_replays_as_vault_direct() {
+        let json = r#"{
+            "Reprocessed": {
+                "issuer_request_id": "red-abcdef12",
+                "underlying": "AAPL",
+                "token": "tAAPL",
+                "wallet": "0x1234567890abcdef1234567890abcdef12345678",
+                "quantity": "1",
+                "tx_hash": "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd",
+                "block_number": 1,
+                "detected_at": "2025-01-01T00:00:00Z",
+                "previous_state": "Failed",
+                "reprocessed_at": "2025-01-02T00:00:00Z"
+            }
+        }"#;
+
+        let event: RedemptionEvent = serde_json::from_str(json).unwrap();
+
+        let RedemptionEvent::Reprocessed { burn_mode, .. } = event else {
+            panic!("Expected Reprocessed variant");
+        };
+
+        assert_eq!(burn_mode, VaultMode::VaultDirect);
+    }
+
+    /// Pins the persisted orchestrator wire format: the mode anchor including
+    /// the orchestrator address must round-trip through the event store.
+    #[test]
+    fn detected_with_orchestrator_burn_mode_round_trips() {
+        let event = RedemptionEvent::Detected {
+            issuer_request_id: test_redemption_id(),
+            underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+            token: TokenSymbol::new("tRKLB"),
+            wallet: alloy::primitives::address!(
+                "0x1234567890abcdef1234567890abcdef12345678"
+            ),
+            quantity: Quantity::default(),
+            tx_hash: B256::random(),
+            block_number: 7,
+            detected_at: Utc::now(),
+            burn_mode: VaultMode::Orchestrator {
+                address: alloy::primitives::address!(
+                    "0x00000000000000000000000000000000000000aa"
+                ),
+            },
+            network: Network::Base,
+        };
+
+        let serialized = serde_json::to_string(&event).unwrap();
+        let deserialized: RedemptionEvent =
+            serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(event, deserialized);
+    }
+
     /// Tests that old BurnResumed events without external_tx_id default to None.
     #[test]
     fn test_backwards_compat_burn_resumed_without_external_tx_id() {
@@ -738,13 +873,18 @@ mod tests {
 
         let event: RedemptionEvent = serde_json::from_str(json).unwrap();
 
-        let RedemptionEvent::BurnResumed { external_tx_id, network, .. } =
-            event
+        let RedemptionEvent::BurnResumed {
+            external_tx_id,
+            network,
+            burn_mode,
+            ..
+        } = event
         else {
             panic!("Expected BurnResumed variant");
         };
 
         assert_eq!(external_tx_id, None);
         assert_eq!(network, Network::Base);
+        assert_eq!(burn_mode, VaultMode::VaultDirect);
     }
 }

--- a/src/redemption/force_complete.rs
+++ b/src/redemption/force_complete.rs
@@ -425,10 +425,10 @@ mod tests {
     use super::*;
     use crate::bindings::OffchainAssetReceiptVault;
     use crate::receipt_inventory::{ReceiptSource, ReceiptVaultKey};
-    use crate::redemption::TxId;
+    use crate::redemption::{BurnFailureClassification, TxId};
     use crate::test_utils::{ANVIL_CHAIN_ID, LocalEvm};
     use crate::tokenized_asset::TokenSymbol;
-    use crate::{Network, Quantity};
+    use crate::{Network, Quantity, VaultMode};
 
     async fn pool_with_migrations() -> Pool<Sqlite> {
         let pool = SqlitePoolOptions::new()
@@ -486,6 +486,7 @@ mod tests {
             ),
             block_number: 30_000_000,
             detected_at: Utc::now(),
+            burn_mode: VaultMode::VaultDirect,
         }
     }
 
@@ -499,6 +500,7 @@ mod tests {
             failed_at: Utc::now(),
             tx_id: Some(TxId::Legacy("fb-1417".to_string())),
             planned_burns,
+            classification: BurnFailureClassification::Unclassified,
         }
     }
 

--- a/src/redemption/journal_manager.rs
+++ b/src/redemption/journal_manager.rs
@@ -605,6 +605,7 @@ mod tests {
     use crate::alpaca::{
         AlpacaError, AlpacaService, RedeemRequestStatus, TokenizationRequest,
     };
+    use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::redemption::IssuerRedemptionRequestId;
     use crate::redemption::view::RedemptionViewReactor;
@@ -662,6 +663,7 @@ mod tests {
             .send(
                 issuer_request_id,
                 RedemptionCommand::Detect {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
@@ -1874,6 +1876,7 @@ mod tests {
 
         let quantity = Quantity::new(dec!(100));
         let view = RedemptionView::AlpacaCalled {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             underlying: UnderlyingSymbol::new("AAPL").unwrap(),

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::Quantity;
+use crate::config::VaultMode;
 use crate::mint::TokenizationRequestId;
 use crate::redemption::burn_manager::{
     extract_tx_hash, is_pending_burn_confirmation, should_release_reserved_burn,
@@ -231,7 +232,9 @@ impl RedemptionServices {
 }
 
 pub(crate) use cmd::RedemptionCommand;
-pub(crate) use event::{BurnRecord, RedemptionEvent, TokensBurnedData};
+pub(crate) use event::{
+    BurnFailureClassification, BurnRecord, RedemptionEvent, TokensBurnedData,
+};
 pub(crate) use view::{
     RedemptionView, RedemptionViewError, find_alpaca_called, find_detected,
     find_stuck,
@@ -249,6 +252,11 @@ pub(crate) struct RedemptionMetadata {
     pub(crate) detected_tx_hash: B256,
     pub(crate) block_number: u64,
     pub(crate) detected_at: DateTime<Utc>,
+    /// Mode anchor captured on `Detected`. Every mode-dependent burn step
+    /// derives from this persisted value, never from live config. Snapshots
+    /// and states persisted before orchestrator mode default to `VaultDirect`.
+    #[serde(default)]
+    pub(crate) burn_mode: VaultMode,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -642,6 +650,7 @@ impl Redemption {
         error: String,
         tx_id: Option<TxId>,
         planned_burns: Vec<BurnRecord>,
+        classification: BurnFailureClassification,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
         if !matches!(
             self,
@@ -661,6 +670,7 @@ impl Redemption {
             failed_at: Utc::now(),
             tx_id,
             planned_burns,
+            classification,
         }])
     }
 
@@ -697,6 +707,7 @@ impl Redemption {
             detected_at: metadata.detected_at,
             previous_state: self.state_name().to_string(),
             reprocessed_at: Utc::now(),
+            burn_mode: metadata.burn_mode,
         }])
     }
 
@@ -738,6 +749,7 @@ impl Redemption {
             alpaca_journal_completed_at: input.alpaca_journal_completed_at,
             external_tx_id: input.external_tx_id,
             resumed_at: Utc::now(),
+            burn_mode: input.metadata.burn_mode,
         }])
     }
 
@@ -1473,6 +1485,7 @@ impl EventSourced for Redemption {
                 tx_hash,
                 block_number,
                 detected_at,
+                burn_mode,
             } => Some(Self::Detected {
                 metadata: RedemptionMetadata {
                     issuer_request_id: issuer_request_id.clone(),
@@ -1484,6 +1497,7 @@ impl EventSourced for Redemption {
                     detected_tx_hash: *tx_hash,
                     block_number: *block_number,
                     detected_at: *detected_at,
+                    burn_mode: *burn_mode,
                 },
             }),
             _ => None,
@@ -1513,6 +1527,7 @@ impl EventSourced for Redemption {
                 quantity,
                 tx_hash,
                 block_number,
+                burn_mode,
             } => Ok(vec![RedemptionEvent::Detected {
                 issuer_request_id,
                 underlying,
@@ -1523,6 +1538,7 @@ impl EventSourced for Redemption {
                 tx_hash,
                 block_number,
                 detected_at: Utc::now(),
+                burn_mode,
             }]),
             RedemptionCommand::RecordAlpacaCall { .. }
             | RedemptionCommand::RecordAlpacaFailure { .. } => {
@@ -1674,11 +1690,13 @@ impl EventSourced for Redemption {
                 error,
                 tx_id,
                 planned_burns,
+                classification,
             } => self.handle_record_burn_failure(
                 issuer_request_id,
                 error,
                 tx_id,
                 planned_burns,
+                classification,
             ),
             RedemptionCommand::RecordExistingBurn {
                 issuer_request_id,
@@ -1871,6 +1889,7 @@ impl Redemption {
             tx_hash,
             block_number,
             detected_at,
+            burn_mode,
         }
         | RedemptionEvent::Reprocessed {
             issuer_request_id,
@@ -1882,6 +1901,7 @@ impl Redemption {
             tx_hash,
             block_number,
             detected_at,
+            burn_mode,
             ..
         }) = event
         else {
@@ -1899,6 +1919,7 @@ impl Redemption {
                 detected_tx_hash: tx_hash,
                 block_number,
                 detected_at,
+                burn_mode,
             },
         };
     }
@@ -2009,6 +2030,7 @@ impl Redemption {
             called_at,
             alpaca_journal_completed_at,
             external_tx_id,
+            burn_mode,
             ..
         } = event
         else {
@@ -2026,6 +2048,7 @@ impl Redemption {
                 detected_tx_hash: tx_hash,
                 block_number,
                 detected_at,
+                burn_mode,
             },
             tokenization_request_id,
             alpaca_quantity,
@@ -2205,8 +2228,10 @@ mod tests {
         RedemptionServices, TokensBurnedData, has_unresolved_signer_intent,
         next_burn_retry_external_tx_id_from_history,
     };
+    use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::prepare_event_sourced_startup;
+    use crate::redemption::BurnFailureClassification;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
@@ -2636,6 +2661,7 @@ mod tests {
                 submitted_at: Utc::now(),
             },
             RedemptionEvent::BurnResumed {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: IssuerRedemptionRequestId::new(
                     detected_tx_hash,
                 ),
@@ -2681,6 +2707,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given_no_previous_events()
             .when(RedemptionCommand::Detect {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -2704,6 +2731,7 @@ mod tests {
             tx_hash: event_tx_hash,
             block_number: event_block_number,
             detected_at,
+            burn_mode: event_burn_mode,
             ..
         } = &events[0]
         else {
@@ -2718,6 +2746,7 @@ mod tests {
         assert_eq!(event_tx_hash, &tx_hash);
         assert_eq!(event_block_number, &block_number);
         assert!(detected_at.timestamp() > 0);
+        assert_eq!(event_burn_mode, &VaultMode::VaultDirect);
     }
 
     #[tokio::test]
@@ -2734,6 +2763,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -2745,6 +2775,7 @@ mod tests {
                 detected_at: Utc::now(),
             }])
             .when(RedemptionCommand::Detect {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying,
                 token,
@@ -2783,6 +2814,7 @@ mod tests {
 
         let redemption =
             replay::<Redemption>(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -2800,6 +2832,7 @@ mod tests {
             redemption,
             Redemption::Detected {
                 metadata: RedemptionMetadata {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id,
                     underlying,
                     token,
@@ -2814,6 +2847,218 @@ mod tests {
         );
     }
 
+    fn orchestrator_mode() -> VaultMode {
+        VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        }
+    }
+
+    #[tokio::test]
+    async fn detect_with_orchestrator_mode_anchors_it_on_the_event() {
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given_no_previous_events()
+            .when(RedemptionCommand::Detect {
+                issuer_request_id: IssuerRedemptionRequestId::random(),
+                underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                token: TokenSymbol::new("tRKLB"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(10)),
+                tx_hash: B256::random(),
+                block_number: 1,
+                burn_mode: orchestrator_mode(),
+                network: Network::Base,
+            })
+            .await
+            .events();
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [RedemptionEvent::Detected { burn_mode, .. }]
+                    if *burn_mode == orchestrator_mode()
+            ),
+            "Detected must carry the orchestrator anchor, got {events:?}"
+        );
+    }
+
+    /// The mode anchor must survive replay through the whole pre-burn
+    /// lifecycle: an orchestrator-detected redemption stays orchestrator in
+    /// `Burning` state regardless of what the asset's config says later.
+    #[test]
+    fn burn_mode_anchor_survives_replay_to_burning() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        let redemption = replay::<Redemption>(vec![
+            RedemptionEvent::Detected {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                token: TokenSymbol::new("tRKLB"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(10)),
+                tx_hash: B256::random(),
+                block_number: 1,
+                detected_at: Utc::now(),
+                burn_mode: orchestrator_mode(),
+                network: Network::Base,
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("tok-1"),
+                alpaca_quantity: Quantity::new(Decimal::from(10)),
+                dust_quantity: Quantity::new(Decimal::ZERO),
+                called_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id,
+                alpaca_journal_completed_at: Utc::now(),
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        let Redemption::Burning { metadata, .. } = redemption else {
+            panic!("Expected Burning state, got {redemption:?}");
+        };
+        assert_eq!(metadata.burn_mode, orchestrator_mode());
+    }
+
+    /// `Reprocessed` and `BurnResumed` flatten metadata into the event; both
+    /// must preserve the orchestrator anchor so a recovered redemption never
+    /// silently falls back to vault-direct.
+    #[test]
+    fn burn_mode_anchor_survives_reprocess_and_resume_replay() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let detected_tx_hash = B256::random();
+        let detected = RedemptionEvent::Detected {
+            issuer_request_id: issuer_request_id.clone(),
+            underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+            token: TokenSymbol::new("tRKLB"),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            quantity: Quantity::new(Decimal::from(10)),
+            tx_hash: detected_tx_hash,
+            block_number: 1,
+            detected_at: Utc::now(),
+            burn_mode: orchestrator_mode(),
+            network: Network::Base,
+        };
+        let failed = RedemptionEvent::RedemptionFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "alpaca timeout".to_string(),
+            failed_at: Utc::now(),
+        };
+
+        let reprocessed = replay::<Redemption>(vec![
+            detected.clone(),
+            failed.clone(),
+            RedemptionEvent::Reprocessed {
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                token: TokenSymbol::new("tRKLB"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(10)),
+                tx_hash: detected_tx_hash,
+                block_number: 1,
+                detected_at: Utc::now(),
+                previous_state: "Failed".to_string(),
+                reprocessed_at: Utc::now(),
+                burn_mode: orchestrator_mode(),
+                network: Network::Base,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+        let Redemption::Detected { metadata } = reprocessed else {
+            panic!("Expected Detected state, got {reprocessed:?}");
+        };
+        assert_eq!(metadata.burn_mode, orchestrator_mode());
+
+        let resumed = replay::<Redemption>(vec![
+            detected,
+            failed,
+            RedemptionEvent::BurnResumed {
+                issuer_request_id,
+                underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                token: TokenSymbol::new("tRKLB"),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                quantity: Quantity::new(Decimal::from(10)),
+                tx_hash: detected_tx_hash,
+                block_number: 1,
+                detected_at: Utc::now(),
+                tokenization_request_id: TokenizationRequestId::new("tok-1"),
+                alpaca_quantity: Quantity::new(Decimal::from(10)),
+                dust_quantity: Quantity::new(Decimal::ZERO),
+                called_at: Utc::now(),
+                alpaca_journal_completed_at: Utc::now(),
+                external_tx_id: None,
+                resumed_at: Utc::now(),
+                burn_mode: orchestrator_mode(),
+                network: Network::Base,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+        let Redemption::Burning { metadata, .. } = resumed else {
+            panic!("Expected Burning state, got {resumed:?}");
+        };
+        assert_eq!(metadata.burn_mode, orchestrator_mode());
+    }
+
+    /// `Reprocess` and `ResumeBurn` handlers copy the caller-supplied
+    /// metadata's anchor onto the emitted event, so the persisted history
+    /// keeps the orchestrator mode across admin recovery.
+    #[tokio::test]
+    async fn reprocess_command_preserves_orchestrator_burn_mode() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let detected_tx_hash = B256::random();
+        let metadata = RedemptionMetadata {
+            issuer_request_id: issuer_request_id.clone(),
+            underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+            token: TokenSymbol::new("tRKLB"),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            quantity: Quantity::new(Decimal::from(10)),
+            detected_tx_hash,
+            block_number: 1,
+            detected_at: Utc::now(),
+            burn_mode: orchestrator_mode(),
+            network: Network::Base,
+        };
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(vec![
+                RedemptionEvent::Detected {
+                    issuer_request_id: issuer_request_id.clone(),
+                    underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                    token: TokenSymbol::new("tRKLB"),
+                    wallet: address!(
+                        "0x1234567890abcdef1234567890abcdef12345678"
+                    ),
+                    quantity: Quantity::new(Decimal::from(10)),
+                    tx_hash: detected_tx_hash,
+                    block_number: 1,
+                    detected_at: Utc::now(),
+                    burn_mode: orchestrator_mode(),
+                    network: Network::Base,
+                },
+                RedemptionEvent::RedemptionFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    reason: "alpaca timeout".to_string(),
+                    failed_at: Utc::now(),
+                },
+            ])
+            .when(RedemptionCommand::Reprocess { issuer_request_id, metadata })
+            .await
+            .events();
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [RedemptionEvent::Reprocessed { burn_mode, .. }]
+                    if *burn_mode == orchestrator_mode()
+            ),
+            "Reprocessed must carry the orchestrator anchor, got {events:?}"
+        );
+    }
+
     #[tokio::test]
     async fn test_record_alpaca_call_from_detected_state() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -2821,6 +3066,7 @@ mod tests {
 
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
@@ -2896,6 +3142,7 @@ mod tests {
 
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("TSLA").unwrap(),
                 token: TokenSymbol::new("tTSLA"),
@@ -2967,6 +3214,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
@@ -3058,6 +3306,7 @@ mod tests {
 
         let redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -3087,6 +3336,7 @@ mod tests {
             redemption,
             Redemption::Burning {
                 metadata: RedemptionMetadata {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id,
                     underlying,
                     token,
@@ -3117,6 +3367,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
@@ -3173,6 +3424,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                     token: TokenSymbol::new("tAAPL"),
@@ -3240,6 +3492,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("NVDA").unwrap(),
                 token: TokenSymbol::new("tNVDA"),
@@ -3288,6 +3541,7 @@ mod tests {
     ) -> Vec<RedemptionEvent> {
         vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("AAPL").unwrap(),
                 token: TokenSymbol::new("tAAPL"),
@@ -3597,6 +3851,7 @@ mod tests {
 
         let redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
                 token: token.clone(),
@@ -3631,6 +3886,7 @@ mod tests {
             redemption,
             Redemption::BurnIntended {
                 metadata: RedemptionMetadata {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id,
                     underlying,
                     token,
@@ -3666,6 +3922,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("TSLA").unwrap(),
                     token: TokenSymbol::new("tTSLA"),
@@ -3737,6 +3994,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("NVDA").unwrap(),
                 token: TokenSymbol::new("tNVDA"),
@@ -3885,6 +4143,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: UnderlyingSymbol::new("GOOG").unwrap(),
                     token: TokenSymbol::new("tGOOG"),
@@ -3912,6 +4171,7 @@ mod tests {
                 },
             ])
             .when(RedemptionCommand::RecordBurnFailure {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id: issuer_request_id.clone(),
                 error: error.clone(),
                 tx_id: None,
@@ -3944,6 +4204,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given_no_previous_events()
             .when(RedemptionCommand::RecordBurnFailure {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id,
                 error: "Some error".to_string(),
                 tx_id: None,
@@ -3971,6 +4232,7 @@ mod tests {
     ) -> Vec<RedemptionEvent> {
         vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("ARKK").unwrap(),
                 token: TokenSymbol::new("tARKK"),
@@ -4115,6 +4377,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(burn_intended_given_events(&issuer_request_id, tx_hash))
             .when(RedemptionCommand::RecordBurnFailure {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id,
                 error: "receipt reverted".to_string(),
                 tx_id: Some(TxId::Hash(tx_hash)),
@@ -4214,6 +4477,7 @@ mod tests {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let mut given = burning_given_events(&issuer_request_id);
         given.push(RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: issuer_request_id.clone(),
             error: "burn reverted".to_string(),
             failed_at: Utc::now(),
@@ -4350,6 +4614,7 @@ mod tests {
         let mut history =
             burn_intended_given_events(&issuer_request_id, burn_tx_hash);
         history.push(RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: issuer_request_id.clone(),
             error: "confirmation was ambiguous".to_string(),
             failed_at: Utc::now(),
@@ -4449,6 +4714,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: UnderlyingSymbol::new("ARKK").unwrap(),
                 token: TokenSymbol::new("tARKK"),
@@ -4551,6 +4817,7 @@ mod tests {
                 receipt_id: uint!(3_U256),
                 shares_burned: uint!(40_000000000000000_U256),
             }],
+            classification: BurnFailureClassification::Unclassified,
         });
         history.push(RedemptionEvent::RedemptionFailed {
             issuer_request_id: issuer_request_id.clone(),
@@ -4602,6 +4869,7 @@ mod tests {
                 receipt_id: uint!(3_U256),
                 shares_burned: uint!(40_000000000000000_U256),
             }],
+            classification: BurnFailureClassification::Unclassified,
         });
         history.push(RedemptionEvent::RedemptionFailed {
             issuer_request_id: issuer_request_id.clone(),
@@ -4657,6 +4925,7 @@ mod tests {
                 receipt_id: uint!(3_U256),
                 shares_burned: uint!(40_000000000000000_U256),
             }],
+            classification: BurnFailureClassification::Unclassified,
         });
         history.push(RedemptionEvent::RedemptionFailed {
             issuer_request_id: issuer_request_id.clone(),
@@ -4709,6 +4978,7 @@ mod tests {
             failed_at: Utc::now(),
             tx_id: None,
             planned_burns: vec![],
+            classification: BurnFailureClassification::Unclassified,
         });
 
         let error = TestHarness::<Redemption>::with(mock_services())
@@ -4753,6 +5023,7 @@ mod tests {
             failed_at: Utc::now(),
             tx_id: None,
             planned_burns: vec![],
+            classification: BurnFailureClassification::Unclassified,
         });
         history.push(RedemptionEvent::RedemptionClosed {
             issuer_request_id: issuer_request_id.clone(),
@@ -4802,6 +5073,7 @@ mod tests {
             failed_at: Utc::now(),
             tx_id: None,
             planned_burns: vec![],
+            classification: BurnFailureClassification::Unclassified,
         });
         history.push(RedemptionEvent::RedemptionClosed {
             issuer_request_id: issuer_request_id.clone(),
@@ -5081,6 +5353,7 @@ mod tests {
 
         let redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying,
                 token,
@@ -5146,6 +5419,7 @@ mod tests {
 
         let redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying,
                 token,
@@ -5168,6 +5442,7 @@ mod tests {
                 alpaca_journal_completed_at,
             },
             RedemptionEvent::BurningFailed {
+                classification: BurnFailureClassification::Unclassified,
                 issuer_request_id: issuer_request_id.clone(),
                 error: error.clone(),
                 failed_at,
@@ -5203,6 +5478,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -5386,6 +5662,7 @@ mod tests {
 
     fn test_metadata() -> RedemptionMetadata {
         RedemptionMetadata {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: IssuerRedemptionRequestId::random(),
             underlying: UnderlyingSymbol::new("RKLB").unwrap(),
             token: TokenSymbol::new("tRKLB"),
@@ -5409,6 +5686,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: expected_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -5456,6 +5734,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: metadata.underlying.clone(),
                 token: metadata.token.clone(),
@@ -5490,6 +5769,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -5538,6 +5818,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -5622,6 +5903,7 @@ mod tests {
 
         let mut redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: metadata.underlying.clone(),
                 token: metadata.token.clone(),
@@ -5644,6 +5926,7 @@ mod tests {
         assert!(matches!(redemption, Redemption::Failed { .. }));
 
         redemption.apply_event(RedemptionEvent::Reprocessed {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             underlying: metadata.underlying.clone(),
             token: metadata.token.clone(),
@@ -5670,6 +5953,7 @@ mod tests {
                     detected_tx_hash: metadata.detected_tx_hash,
                     block_number: metadata.block_number,
                     detected_at: metadata.detected_at,
+                    burn_mode: VaultMode::VaultDirect,
                 }
             }
         );
@@ -5697,6 +5981,7 @@ mod tests {
         let events = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: metadata.issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -5752,6 +6037,7 @@ mod tests {
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: metadata.underlying.clone(),
                     token: metadata.token.clone(),
@@ -5809,6 +6095,7 @@ mod tests {
 
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(vec![RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: metadata.issuer_request_id.clone(),
                 underlying: metadata.underlying.clone(),
                 token: metadata.token.clone(),
@@ -5842,6 +6129,7 @@ mod tests {
 
         let mut redemption = replay::<Redemption>(vec![
             RedemptionEvent::Detected {
+                burn_mode: VaultMode::VaultDirect,
                 issuer_request_id: metadata.issuer_request_id.clone(),
                 underlying: metadata.underlying.clone(),
                 token: metadata.token.clone(),
@@ -5864,6 +6152,7 @@ mod tests {
         assert!(matches!(redemption, Redemption::Failed { .. }));
 
         redemption.apply_event(RedemptionEvent::BurnResumed {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: metadata.issuer_request_id.clone(),
             underlying: metadata.underlying.clone(),
             token: metadata.token.clone(),
@@ -5906,6 +6195,7 @@ mod tests {
         let mut history =
             intended_burn_history(&issuer_request_id, persisted_tx.clone());
         history.push(RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: issuer_request_id.clone(),
             error: "replacement preparation failed".to_string(),
             failed_at: Utc::now(),
@@ -5924,6 +6214,7 @@ mod tests {
         ));
 
         history.push(RedemptionEvent::BurnResumed {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id,
             underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
@@ -6180,6 +6471,7 @@ mod tests {
         let mut history =
             intended_burn_history(&issuer_request_id, persisted_tx.clone());
         history.push(RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
             issuer_request_id: issuer_request_id.clone(),
             error: "ambiguous confirmation".to_string(),
             failed_at: Utc::now(),

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -21,6 +21,7 @@ use super::{
     },
 };
 use crate::bindings;
+use crate::config::VaultModeConfig;
 use crate::poll_checkpoint::{
     self, CheckpointError, TRANSFER_POLL, advance_transfer_poll,
     load_transfer_poll,
@@ -89,6 +90,7 @@ pub(crate) struct TransferPoller<P> {
     redeem_call_manager: Arc<RedeemCallManager>,
     journal_manager: Arc<JournalManager>,
     burn_manager: Arc<BurnManager>,
+    vault_mode_config: VaultModeConfig,
 }
 
 /// Configuration for constructing a [`TransferPoller`].
@@ -102,6 +104,7 @@ pub(crate) struct TransferPollerConfig<P> {
     pub(crate) redeem_call_manager: Arc<RedeemCallManager>,
     pub(crate) journal_manager: Arc<JournalManager>,
     pub(crate) burn_manager: Arc<BurnManager>,
+    pub(crate) vault_mode_config: VaultModeConfig,
 }
 
 impl<P> TransferPoller<P> {
@@ -116,6 +119,7 @@ impl<P> TransferPoller<P> {
             redeem_call_manager: config.redeem_call_manager,
             journal_manager: config.journal_manager,
             burn_manager: config.burn_manager,
+            vault_mode_config: config.vault_mode_config,
         }
     }
 }
@@ -453,6 +457,7 @@ where
             assets,
             &self.store,
             &self.pool,
+            &self.vault_mode_config,
         )
         .await
         {
@@ -617,6 +622,7 @@ mod tests {
 
     use super::{TransferPollError, watch_redemption_flow};
     use crate::alpaca::mock::MockAlpacaService;
+    use crate::config::VaultModeConfig;
     use crate::poll_checkpoint::{
         self, TRANSFER_POLL, advance_transfer_poll, load_transfer_poll,
     };
@@ -723,6 +729,7 @@ mod tests {
             redeem_call_manager,
             journal_manager,
             burn_manager,
+            vault_mode_config: VaultModeConfig::default(),
         });
 
         TestPollerSetup { poller, pool }

--- a/src/redemption/redeem_call_manager.rs
+++ b/src/redemption/redeem_call_manager.rs
@@ -355,6 +355,7 @@ mod tests {
         AlpacaError, AlpacaService, Fees, RedeemRequest, RedeemRequestStatus,
         RedeemResponse, TokenizationRequest, TokenizationRequestType,
     };
+    use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::redemption::view::RedemptionViewReactor;
     use crate::redemption::{
@@ -499,6 +500,7 @@ mod tests {
                             "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
                         ),
                         block_number: 12345,
+                        burn_mode: VaultMode::VaultDirect,
                     },
                 )
                 .await
@@ -569,6 +571,7 @@ mod tests {
                     quantity,
                     tx_hash,
                     block_number,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -702,6 +705,7 @@ mod tests {
                     quantity,
                     tx_hash,
                     block_number: 12345,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -15,6 +15,7 @@ use crate::account::view::{AccountViewError, find_by_wallet};
 use crate::account::{AccountView, AlpacaAccountNumber, ClientId};
 use crate::bindings;
 use crate::burn_excess::exclusion::is_excluded_funding_log;
+use crate::config::VaultModeConfig;
 use crate::tokenized_asset::{
     Network, TokenSymbol, TokenizedAssetView, UnderlyingSymbol,
 };
@@ -101,6 +102,7 @@ pub(crate) async fn detect_transfer(
     assets: &[TokenizedAssetView],
     store: &Store<Redemption>,
     pool: &Pool<Sqlite>,
+    vault_modes: &VaultModeConfig,
 ) -> Result<TransferOutcome, TransferProcessingError> {
     let transfer_event =
         bindings::OffchainAssetReceiptVault::Transfer::decode_log(&log.inner)?;
@@ -155,6 +157,11 @@ pub(crate) async fn detect_transfer(
     let issuer_request_id = IssuerRedemptionRequestId::new(tx_hash);
     let quantity = Quantity::from_u256_with_18_decimals(transfer_event.value)?;
 
+    // Anchor the asset's currently-configured mode on the Detected event:
+    // every later burn step derives from this persisted value, so an asset
+    // cutover mid-redemption never switches an in-flight redemption's path.
+    let burn_mode = vault_modes.mode_for(&underlying);
+
     let command = RedemptionCommand::Detect {
         issuer_request_id: issuer_request_id.clone(),
         underlying,
@@ -164,6 +171,7 @@ pub(crate) async fn detect_transfer(
         quantity,
         tx_hash,
         block_number,
+        burn_mode,
     };
 
     match store.send(&issuer_request_id, command).await {
@@ -179,6 +187,7 @@ pub(crate) async fn detect_transfer(
 
     info!(target: "redemption", %issuer_request_id,
         from = %transfer_event.from,
+        burn_mode = ?burn_mode,
         "Redemption transfer detected"
     );
 
@@ -370,6 +379,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{TransferOutcome, TransferProcessingError, detect_transfer};
+    use crate::config::{VaultMode, VaultModeConfig};
     use crate::redemption::IssuerRedemptionRequestId;
     use crate::redemption::Redemption;
     use crate::redemption::RedemptionServices;
@@ -416,9 +426,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         let outcome = result.expect("Expected success");
         assert!(
@@ -438,6 +455,73 @@ mod tests {
         assert!(logs_contain_at!(
             tracing::Level::INFO,
             &["Redemption transfer detected"]
+        ));
+    }
+
+    /// The asset's configured `VaultMode` is resolved at detection time and
+    /// persisted on the `Detected` event, anchoring the whole redemption to
+    /// that mode regardless of later config changes.
+    #[traced_test]
+    #[tokio::test]
+    async fn detect_transfer_anchors_configured_orchestrator_mode() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let ap_wallet = address!("0x9999999999999999999999999999999999999999");
+        let orchestrator_mode = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+
+        let pool = setup_test_db_with_asset(vault, Some(ap_wallet)).await;
+        let store = setup_test_store(&pool);
+
+        // `setup_test_db_with_asset` seeds AAPL on `vault`.
+        let vault_modes = VaultModeConfig::new(
+            std::collections::HashMap::from([(
+                "AAPL".to_string(),
+                orchestrator_mode,
+            )]),
+            VaultMode::VaultDirect,
+        );
+
+        let value = U256::from_str_radix("100000000000000000000", 10).unwrap();
+        let tx_hash = b256!(
+            "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+        );
+
+        let log = create_transfer_log(
+            vault, ap_wallet, bot_wallet, value, tx_hash, 12345,
+        );
+
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &vault_modes,
+        )
+        .await;
+
+        let TransferOutcome::Detected { issuer_request_id, .. } =
+            result.expect("Expected success")
+        else {
+            panic!("Expected Detected outcome");
+        };
+
+        let redemption = store.load(&issuer_request_id).await.unwrap().unwrap();
+        let Redemption::Detected { metadata } = redemption else {
+            panic!("Expected Detected state");
+        };
+        assert_eq!(
+            metadata.burn_mode, orchestrator_mode,
+            "detection must anchor the configured per-asset mode"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Redemption transfer detected", "Orchestrator"]
         ));
     }
 
@@ -478,9 +562,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         let outcome = result.expect("Expected success");
         assert!(
@@ -599,6 +690,7 @@ mod tests {
             &assets,
             &store,
             &pool,
+            &VaultModeConfig::default(),
         )
         .await
         .unwrap();
@@ -629,6 +721,7 @@ mod tests {
             &assets,
             &store,
             &pool,
+            &VaultModeConfig::default(),
         )
         .await
         .unwrap();
@@ -656,6 +749,7 @@ mod tests {
             &assets,
             &store,
             &pool,
+            &VaultModeConfig::default(),
         )
         .await
         .unwrap();
@@ -680,6 +774,7 @@ mod tests {
             &assets,
             &store,
             &pool,
+            &VaultModeConfig::default(),
         )
         .await
         .unwrap();
@@ -718,9 +813,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(result, Ok(TransferOutcome::SkippedMint)),
@@ -755,9 +857,16 @@ mod tests {
         log.transaction_hash = None;
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(result, Err(TransferProcessingError::MissingTxHash)),
@@ -787,9 +896,16 @@ mod tests {
         log.block_number = None;
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(result, Err(TransferProcessingError::MissingBlockNumber)),
@@ -819,9 +935,16 @@ mod tests {
         log.log_index = None;
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(result, Err(TransferProcessingError::MissingLogIndex)),
@@ -859,9 +982,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(
@@ -920,9 +1050,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(
@@ -964,9 +1101,16 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let result =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let result = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
 
         assert!(
             matches!(result, Ok(TransferOutcome::SkippedNoAccount)),
@@ -999,17 +1143,31 @@ mod tests {
         );
 
         let assets = list_enabled_assets(&pool).await.unwrap();
-        let first =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let first = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
         assert!(
             matches!(first, Ok(TransferOutcome::Detected { .. })),
             "First detection should succeed, got {first:?}"
         );
 
-        let second =
-            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
-                .await;
+        let second = detect_transfer(
+            &log,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+            &VaultModeConfig::default(),
+        )
+        .await;
         assert!(
             matches!(second, Ok(TransferOutcome::AlreadyDetected)),
             "Second detection should return AlreadyDetected, got {second:?}"

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -8,7 +8,9 @@ use thiserror::Error;
 use tracing::{debug, warn};
 
 use super::{IssuerRedemptionRequestId, default_redemption_network};
+use crate::config::VaultMode;
 use crate::mint::{Quantity, TokenizationRequestId};
+use crate::redemption::event::BurnFailureClassification;
 use crate::redemption::{Redemption, RedemptionEvent, TokensBurnedData};
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::TxId;
@@ -34,6 +36,10 @@ pub(crate) enum RedemptionView {
         /// staleness gate reflect the latest entry rather than the
         /// original detection.
         detected_entered_at: DateTime<Utc>,
+        /// Mode anchor captured on `Detected` (see the aggregate's
+        /// `RedemptionMetadata::burn_mode`).
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     AlpacaCalled {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -50,6 +56,8 @@ pub(crate) enum RedemptionView {
         block_number: u64,
         detected_at: DateTime<Utc>,
         called_at: DateTime<Utc>,
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     Burning {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -73,6 +81,8 @@ pub(crate) enum RedemptionView {
         /// triage and the staleness gate reflect the latest entry rather than
         /// the original journal completion.
         burning_entered_at: DateTime<Utc>,
+        #[serde(default)]
+        burn_mode: VaultMode,
     },
     Completed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -110,6 +120,12 @@ pub(crate) enum RedemptionView {
         /// Planned burns at the time of failure.
         #[serde(default)]
         planned_burns: Vec<super::BurnRecord>,
+        #[serde(default)]
+        burn_mode: VaultMode,
+        /// Typed failure classification; keys retry-exclusion and admin
+        /// grouping.
+        #[serde(default)]
+        classification: BurnFailureClassification,
     },
     Closed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -153,6 +169,7 @@ impl RedemptionView {
             tx_hash,
             block_number,
             detected_at,
+            burn_mode,
             ..
         } = self
         else {
@@ -173,6 +190,7 @@ impl RedemptionView {
             block_number,
             detected_at,
             called_at,
+            burn_mode,
         }
     }
 
@@ -194,6 +212,7 @@ impl RedemptionView {
             block_number,
             detected_at,
             called_at,
+            burn_mode,
             ..
         } = self
         else {
@@ -216,6 +235,7 @@ impl RedemptionView {
             called_at,
             alpaca_journal_completed_at,
             burning_entered_at: alpaca_journal_completed_at,
+            burn_mode,
         }
     }
 
@@ -225,6 +245,7 @@ impl RedemptionView {
         failed_at: DateTime<Utc>,
         tx_id: Option<&TxId>,
         planned_burns: &[super::BurnRecord],
+        classification: &BurnFailureClassification,
     ) -> Self {
         let Self::Burning {
             issuer_request_id,
@@ -242,6 +263,7 @@ impl RedemptionView {
             called_at,
             alpaca_journal_completed_at,
             burning_entered_at: _,
+            burn_mode,
         } = self
         else {
             return self;
@@ -266,6 +288,8 @@ impl RedemptionView {
             failed_at,
             tx_id: tx_id.cloned(),
             planned_burns: planned_burns.to_vec(),
+            burn_mode,
+            classification: classification.clone(),
         }
     }
 }
@@ -283,6 +307,7 @@ impl RedemptionView {
                 tx_hash,
                 block_number,
                 detected_at,
+                burn_mode,
             } => Self::Detected {
                 issuer_request_id: issuer_request_id.clone(),
                 underlying: underlying.clone(),
@@ -294,6 +319,7 @@ impl RedemptionView {
                 block_number: *block_number,
                 detected_at: *detected_at,
                 detected_entered_at: *detected_at,
+                burn_mode: *burn_mode,
             },
             RedemptionEvent::Reprocessed {
                 issuer_request_id,
@@ -306,6 +332,7 @@ impl RedemptionView {
                 block_number,
                 detected_at,
                 reprocessed_at,
+                burn_mode,
                 ..
             } => Self::Detected {
                 issuer_request_id: issuer_request_id.clone(),
@@ -318,6 +345,7 @@ impl RedemptionView {
                 block_number: *block_number,
                 detected_at: *detected_at,
                 detected_entered_at: *reprocessed_at,
+                burn_mode: *burn_mode,
             },
             RedemptionEvent::AlpacaCalled {
                 issuer_request_id,
@@ -352,12 +380,14 @@ impl RedemptionView {
                 failed_at,
                 tx_id,
                 planned_burns,
+                classification,
                 ..
             } => self.update_burning_failed(
                 error,
                 *failed_at,
                 tx_id.as_ref(),
                 planned_burns,
+                classification,
             ),
 
             RedemptionEvent::AlpacaJournalCompleted {
@@ -383,6 +413,7 @@ impl RedemptionView {
                 called_at,
                 alpaca_journal_completed_at,
                 resumed_at,
+                burn_mode,
                 ..
             } => Self::Burning {
                 issuer_request_id: issuer_request_id.clone(),
@@ -400,6 +431,7 @@ impl RedemptionView {
                 called_at: *called_at,
                 alpaca_journal_completed_at: *alpaca_journal_completed_at,
                 burning_entered_at: *resumed_at,
+                burn_mode: *burn_mode,
             },
             RedemptionEvent::TokensBurned(TokensBurnedData {
                 issuer_request_id,
@@ -770,10 +802,11 @@ mod tests {
         RedemptionView, RedemptionViewReactor, find_alpaca_called,
         find_burn_failed, find_burning, find_detected, find_stuck,
     };
+    use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::redemption::{
-        BurnRecord, IssuerRedemptionRequestId, Redemption, RedemptionEvent,
-        TokensBurnedData,
+        BurnFailureClassification, BurnRecord, IssuerRedemptionRequestId,
+        Redemption, RedemptionEvent, TokensBurnedData,
     };
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::TxId;
@@ -885,6 +918,7 @@ mod tests {
             self.emit(
                 id,
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: id.clone(),
                     underlying: UnderlyingSymbol::new(underlying).unwrap(),
                     token: TokenSymbol::new(format!("t{underlying}")),
@@ -978,6 +1012,7 @@ mod tests {
             self.emit(
                 id,
                 RedemptionEvent::BurningFailed {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: id.clone(),
                     error: error.to_string(),
                     failed_at: Utc::now(),
@@ -1033,6 +1068,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -1057,7 +1093,8 @@ mod tests {
             block_number: view_block_number,
             detected_at: view_detected_at,
             detected_entered_at: view_detected_entered_at,
-            ..
+            burn_mode: view_burn_mode,
+            network: view_network,
         } = load_view(&pool, &issuer_request_id).await
         else {
             panic!("Expected Detected view");
@@ -1071,6 +1108,8 @@ mod tests {
         assert_eq!(view_tx_hash, tx_hash);
         assert_eq!(view_block_number, block_number);
         assert_eq!(view_detected_at, detected_at);
+        assert_eq!(view_burn_mode, VaultMode::VaultDirect);
+        assert_eq!(view_network, Network::Base);
         // On first Detection, detected_entered_at mirrors detected_at — the
         // view has not yet been reprocessed.
         assert_eq!(view_detected_entered_at, detected_at);
@@ -1099,6 +1138,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -1140,11 +1180,15 @@ mod tests {
             block_number: view_block_number,
             detected_at: view_detected_at,
             called_at: view_called_at,
-            ..
+            burn_mode: view_burn_mode,
+            network: view_network,
         } = load_view(&pool, &issuer_request_id).await
         else {
             panic!("Expected AlpacaCalled view");
         };
+
+        assert_eq!(view_burn_mode, VaultMode::VaultDirect);
+        assert_eq!(view_network, Network::Base);
 
         assert_eq!(view_id, issuer_request_id);
         assert_eq!(view_tok_id, tokenization_request_id);
@@ -1191,6 +1235,7 @@ mod tests {
                     tx_hash,
                     block_number: 54321,
                     detected_at,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -1252,6 +1297,7 @@ mod tests {
                     tx_hash,
                     block_number: 99999,
                     detected_at,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -1325,6 +1371,7 @@ mod tests {
                     tx_hash,
                     block_number: 88888,
                     detected_at,
+                    burn_mode: VaultMode::VaultDirect,
                 },
             )
             .await
@@ -1364,6 +1411,7 @@ mod tests {
                     failed_at,
                     tx_id: None,
                     planned_burns: vec![],
+                    classification: BurnFailureClassification::Unclassified,
                 },
             )
             .await
@@ -1403,6 +1451,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -1457,11 +1506,15 @@ mod tests {
             called_at: view_called_at,
             alpaca_journal_completed_at: view_alpaca_journal_completed_at,
             burning_entered_at: view_burning_entered_at,
-            ..
+            burn_mode: view_burn_mode,
+            network: view_network,
         } = load_view(&pool, &issuer_request_id).await
         else {
             panic!("Expected Burning view");
         };
+
+        assert_eq!(view_burn_mode, VaultMode::VaultDirect);
+        assert_eq!(view_network, Network::Base);
 
         assert_eq!(view_id, issuer_request_id);
         assert_eq!(view_tok_id, tokenization_request_id);
@@ -1508,6 +1561,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -1571,6 +1625,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying,
                     token,
@@ -1929,6 +1984,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -1977,6 +2033,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::BurningFailed {
+                    classification: BurnFailureClassification::Unclassified,
                     issuer_request_id: issuer_request_id.clone(),
                     error: error.clone(),
                     failed_at,
@@ -2091,6 +2148,7 @@ mod tests {
         let quantity = Quantity::new(Decimal::from(100));
 
         let detected_event = RedemptionEvent::Detected {
+            burn_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             underlying: UnderlyingSymbol::new("AAPL").unwrap(),
             token: TokenSymbol::new("tAAPL"),
@@ -2334,6 +2392,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Detected {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -2373,6 +2432,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::Reprocessed {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token,
@@ -2437,6 +2497,7 @@ mod tests {
             .receive::<Redemption>(
                 issuer_request_id.clone(),
                 RedemptionEvent::BurnResumed {
+                    burn_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     underlying: underlying.clone(),
                     token: token.clone(),
@@ -2473,11 +2534,15 @@ mod tests {
             called_at: view_called_at,
             alpaca_journal_completed_at: view_journal_completed_at,
             burning_entered_at: view_burning_entered_at,
-            ..
+            burn_mode: view_burn_mode,
+            network: view_network,
         } = load_view(&pool, &issuer_request_id).await
         else {
             panic!("Expected Burning view after BurnResumed");
         };
+
+        assert_eq!(view_burn_mode, VaultMode::VaultDirect);
+        assert_eq!(view_network, Network::Base);
 
         assert_eq!(view_id, issuer_request_id);
         assert_eq!(view_tok_id, tokenization_request_id);

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -1969,7 +1969,9 @@ mod tests {
 
     use super::*;
     use crate::Quantity;
-    use crate::redemption::{BurnRecord, RedemptionEvent};
+    use crate::redemption::{
+        BurnFailureClassification, BurnRecord, RedemptionEvent,
+    };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
@@ -2596,6 +2598,7 @@ mod tests {
                 ),
                 block_number: 30_000_000,
                 detected_at: Utc::now(),
+                burn_mode: crate::VaultMode::VaultDirect,
             },
             RedemptionEvent::BurningFailed {
                 issuer_request_id: issuer_request_id.clone(),
@@ -2606,6 +2609,7 @@ mod tests {
                     receipt_id: U256::from(3),
                     shares_burned: U256::from(40_000_000_000_000_000_u64),
                 }],
+                classification: BurnFailureClassification::Unclassified,
             },
         ];
         for (index, event) in events.iter().enumerate() {


### PR DESCRIPTION
## Motivation

Redemptions that span an asset's `VaultMode` config cutover (e.g. from `VaultDirect` to `Orchestrator`) were at risk of silently switching burn paths mid-flight, because the mode was re-resolved from live config at each burn step rather than being anchored at detection time. Additionally, burn failures carried only a free-text error string with no typed classification, forcing downstream logic to parse strings for retry-exclusion and admin grouping decisions.

## Solution

`VaultMode` now derives `serde::Serialize` / `serde::Deserialize`, making it embeddable in persisted events. Its wire format (`"VaultDirect"` / `{"Orchestrator":{"address":"0x…"}}`) is treated as a permanent event schema contract.

A `burn_mode` field is added to `RedemptionMetadata` and to the `Detected`, `Reprocessed`, `BurnResumed` events (and their corresponding commands). At transfer detection time, `detect_transfer` resolves the asset's mode from `VaultModeConfig` once and writes it onto the `Detected` event. Every subsequent burn step reads `metadata.burn_mode` from the aggregate rather than querying config, so a config change mid-redemption has no effect on in-flight redemptions. The `TransferPoller` receives a `VaultModeConfig` at construction and passes it through to `detect_transfer`.

A `BurnFailureClassification` enum is introduced on `BurningFailed` events and the `RecordBurnFailure` command. Variants cover `Unclassified` (default for historical events), `InsufficientReceipts`, `AllowanceInsufficient`, `VaultLogicMismatch`, and `ReceiptLogicMismatch`. All current call sites emit `Unclassified`; the enum is the extension point for future typed classification. The classification is propagated through to `RedemptionView::BurnFailed`.

`VaultModeConfig` gains a `mode_for` method and a `new` constructor, and `Config::vault_mode_for` delegates to it. Backward compatibility is preserved throughout: all new event fields carry `#[serde(default)]`, so historical events without them replay as `VaultDirect` / `Unclassified`.  
  
Closes [RAI-1434](https://linear.app/makeitrain/issue/RAI-1434/redemption-burn-mode-anchoring)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vault mode can now be configured per asset, with a default fallback.
  * Each redemption preserves its selected vault mode throughout processing, recovery, replay, and resumption.
  * Burn failures now include clearer classifications, such as insufficient receipts, allowance issues, and logic mismatches.
* **Bug Fixes**
  * Improved redemption recovery and replay behavior when configuration changes during an active redemption.
  * Existing redemption records remain compatible with the updated data format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->