### PR TITLE
feat: orchestrator burn vault service implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,7 @@ dependencies = [
  "alloy-core",
  "alloy-eips",
  "alloy-genesis",
+ "alloy-json-rpc",
  "alloy-network",
  "alloy-node-bindings",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ alloy = { version = "1.0.41", features = [
   "node-bindings",
   "rand",
   "k256",
+  "json-rpc",
 ] }
 rust_decimal = { version = "1.39.0", features = ["serde"] }
 tokio = { workspace = true, features = ["time"] }

--- a/SPEC.md
+++ b/SPEC.md
@@ -1695,15 +1695,14 @@ st0x.deploy audit report covering the orchestrator.
   its economic value. `burn_range` is audit-trail provenance only: no burned
   quantity may ever be derived from the range width.
 
-  **RAI-1220 acceptance criterion.** This reading is the one the spec requires,
-  inferred from the field name `nextBurnReceiptIdAfter` and the
-  `nextBurnReceiptId(token)` view — it is **not yet verified against the merged
-  contract**. Before wiring the `Burned` decoder, assert against the merged
-  `IST0xOrchestratorV1.sol` that (a) `nextBurnReceiptIdAfter` is exclusive of
-  the receipts this burn fully drained, and (b) it names the receipt a
-  subsequent burn resumes from. Encode both in a decoder test against a real
-  `Burned` log. If the merged ABI disagrees, correct this section first — do not
-  work around it in the decoder.
+  **RAI-1220 acceptance criterion — verified.** This reading is asserted against
+  a real `Burned` log emitted by the deployed contract on Anvil
+  (`tests/orchestrator_smoke.rs`, `orchestrator_mint_burn_roundtrip`): (a)
+  `nextBurnReceiptIdAfter` is exclusive of the receipts the burn fully drained,
+  and (b) it equals the post-burn `nextBurnReceiptId(token)` — the receipt the
+  subsequent burn resumes from. The same run pins `firstReceiptId` as the
+  **pre-burn pointer value** (0 on a fresh orchestrator, where receipt ids start
+  at 1), consistent with the pointer-movement reading above.
 - Roles: `MINT_ROLE` and `BURN_ROLE` (held by the bot wallet, gating the two
   entry points above), `EMERGENCY_ROLE` (manual recovery: moving receipts
   between wallets, adjusting the burn pointer).

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -1042,7 +1042,9 @@ const fn is_uncertain_broadcast_error(error: &VaultError) -> bool {
         | VaultError::MissingBlockNumber { .. }
         | VaultError::EventNotFound { .. }
         | VaultError::Reverted { .. }
+        | VaultError::OrchestratorReverted { .. }
         | VaultError::NotABurn { .. }
+        | VaultError::BurnedEventMismatch { .. }
         | VaultError::PreparedMintHashMismatch { .. }
         | VaultError::PreparedMintNonceMismatch { .. }
         | VaultError::PreparedMintSignerMismatch { .. }
@@ -1076,7 +1078,12 @@ const fn is_uncertain_confirm_observation(error: &VaultError) -> bool {
         | VaultError::MissingBlockNumber { .. } => true,
         VaultError::EventNotFound { .. }
         | VaultError::Reverted { .. }
+        | VaultError::OrchestratorReverted { .. }
         | VaultError::NotABurn { .. }
+        // Burn-confirm-only variant, unreachable on the mint paths; grouped
+        // with the definitive observations so nothing uncertain-retries an
+        // integrity anomaly.
+        | VaultError::BurnedEventMismatch { .. }
         | VaultError::BroadcastHashMismatch { .. }
         | VaultError::PreparedMintHashMismatch { .. }
         | VaultError::PreparedMintNonceMismatch { .. }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -17,11 +17,13 @@ use tokio::sync::Notify;
 
 use super::{
     BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnParams,
-    MultiBurnResult, MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
-    SubmittedTx, VaultError, VaultService, WalletNonceGuard,
+    MultiBurnResult, MultiBurnResultEntry, OrchestratorBurnParams,
+    OrchestratorBurnReadiness, OrchestratorBurnResult, PreparedMintTx,
+    ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    WalletNonceGuard,
 };
 #[cfg(test)]
-use super::{VerifiedBurn, VerifiedShareTransfer};
+use super::{OrchestratorRevertReason, VerifiedBurn, VerifiedShareTransfer};
 use crate::redemption::BurnExternalTxId;
 use crate::vault::{SendableTxWithHash, TxId};
 
@@ -135,6 +137,31 @@ impl Default for MockVerifyBurn {
     }
 }
 
+/// Shared mock state for the orchestrator burn methods, grouped so every
+/// constructor initializes it with a single field.
+#[derive(Default)]
+struct OrchestratorMockState {
+    /// Cached result from `submit_orchestrator_burn` for retrieval in
+    /// `confirm_orchestrator_burn`.
+    pending_result: Mutex<Option<OrchestratorBurnResult>>,
+    /// Readiness returned by `check_orchestrator_burn_readiness`;
+    /// `None` means `Ready`.
+    #[cfg(test)]
+    readiness: Mutex<Option<OrchestratorBurnReadiness>>,
+    /// When set, `confirm_orchestrator_burn` fails with
+    /// `VaultError::OrchestratorReverted` carrying this reason.
+    #[cfg(test)]
+    confirm_revert: Mutex<Option<OrchestratorRevertReason>>,
+    #[cfg(test)]
+    last_params: Mutex<Option<OrchestratorBurnParams>>,
+    #[cfg(test)]
+    preparation_call_count: AtomicUsize,
+    #[cfg(test)]
+    submit_call_count: AtomicUsize,
+    #[cfg(test)]
+    readiness_call_count: AtomicUsize,
+}
+
 /// Mock blockchain service for testing.
 ///
 /// This mock is NOT behind `#[cfg(test)]` because `setup_test_rocket()` (used by E2E tests
@@ -143,6 +170,7 @@ impl Default for MockVerifyBurn {
 /// without `#[cfg(test)]` enabled. Unit tests (inside the crate) can access `#[cfg(test)]`
 /// code, so they get full mock functionality including failures and timing behavior.
 pub(crate) struct MockVaultService {
+    orchestrator: Arc<OrchestratorMockState>,
     behavior: MockBehavior,
     mint_delay_ms: u64,
     wallet_nonce_lock: Arc<tokio::sync::Mutex<()>>,
@@ -205,6 +233,7 @@ impl MockVaultService {
         Self {
             behavior: MockBehavior::Success,
             mint_delay_ms: 0,
+            orchestrator: Arc::new(OrchestratorMockState::default()),
             wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
             #[cfg(test)]
             wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
@@ -652,6 +681,16 @@ const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
 
 const MOCK_BURN_TX_HASH: alloy::primitives::B256 =
     b256!("0x4545454545454545454545454545454545454545454545454545454545454545");
+
+fn default_orchestrator_burn_result() -> OrchestratorBurnResult {
+    OrchestratorBurnResult {
+        tx_hash: MOCK_BURN_TX_HASH,
+        shares_burned: U256::from(100_000_000_000_000_000_000u128),
+        burn_range: (U256::from(1u8), U256::from(2u8)),
+        gas_used: 50000,
+        block_number: 5000,
+    }
+}
 
 fn default_multi_burn_result(dust_shares: U256) -> MultiBurnResult {
     MultiBurnResult {
@@ -1167,6 +1206,168 @@ impl VaultService for MockVaultService {
         }
 
         Some(self.wallet_nonce_lock.clone().lock_owned().await)
+    }
+
+    async fn check_orchestrator_burn_readiness(
+        &self,
+        _orchestrator: Address,
+        _token: Address,
+        _owner: Address,
+        _amount: U256,
+    ) -> Result<OrchestratorBurnReadiness, VaultError> {
+        #[cfg(test)]
+        {
+            self.orchestrator
+                .readiness_call_count
+                .fetch_add(1, Ordering::Relaxed);
+            let readiness_opt = *self.orchestrator.readiness.lock().unwrap();
+            if let Some(readiness) = readiness_opt {
+                return Ok(readiness);
+            }
+        }
+
+        Ok(OrchestratorBurnReadiness::Ready)
+    }
+
+    async fn prepare_orchestrator_burn_tx(
+        &self,
+        _params: &OrchestratorBurnParams,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        #[cfg(test)]
+        {
+            self.orchestrator
+                .preparation_call_count
+                .fetch_add(1, Ordering::Relaxed);
+            if matches!(self.behavior, MockBehavior::PrepareTxFails) {
+                return Err(VaultError::InvalidReceipt);
+            }
+            // Use configured tx if present, otherwise fall back to default.
+            // Cloned (not taken) so retries can re-use the same configured tx.
+            let prepared = self.prepared_tx.lock().unwrap().clone();
+            return Ok(prepared.unwrap_or_default());
+        }
+        #[cfg(not(test))]
+        Ok(SendableTxWithHash::default())
+    }
+
+    async fn submit_orchestrator_burn(
+        &self,
+        params: &OrchestratorBurnParams,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<SubmittedTx, VaultError> {
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitFailure) {
+            return Err(VaultError::InvalidReceipt);
+        }
+
+        #[cfg(test)]
+        if matches!(self.behavior, MockBehavior::SubmitRevert) {
+            return Err(VaultError::Reverted { tx_hash: MOCK_BURN_TX_HASH });
+        }
+
+        #[cfg(test)]
+        {
+            self.orchestrator.submit_call_count.fetch_add(1, Ordering::Relaxed);
+            *self.orchestrator.last_params.lock().unwrap() =
+                Some(params.clone());
+        }
+
+        // Pre-compute the OrchestratorBurnResult for confirm to return: the
+        // orchestrator burns the full amount from a single-receipt walk.
+        {
+            let mut pending = self
+                .orchestrator
+                .pending_result
+                .lock()
+                .expect("orchestrator pending_result mutex poisoned");
+            // Preserve a pre-seeded pending result configured by a test;
+            // only fill the cache when empty.
+            if pending.is_none() {
+                *pending = Some(OrchestratorBurnResult {
+                    tx_hash: MOCK_BURN_TX_HASH,
+                    shares_burned: params.amount,
+                    burn_range: (U256::from(1u8), U256::from(2u8)),
+                    gas_used: 50000,
+                    block_number: 5000,
+                });
+            }
+        }
+
+        Ok(SubmittedTx {
+            external_tx_id: params
+                .external_tx_id
+                .clone()
+                .unwrap_or_else(|| {
+                    BurnExternalTxId::base(&params.detected_tx_hash)
+                })
+                .into_string(),
+            tx_id: sendable_tx.hash.into(),
+        })
+    }
+
+    async fn confirm_orchestrator_burn(
+        &self,
+        _tx_id: &TxId,
+    ) -> Result<OrchestratorBurnResult, VaultError> {
+        #[cfg(test)]
+        let reason_opt = *self.orchestrator.confirm_revert.lock().unwrap();
+        #[cfg(test)]
+        if let Some(reason) = reason_opt {
+            return Err(VaultError::OrchestratorReverted {
+                tx_hash: MOCK_BURN_TX_HASH,
+                reason,
+            });
+        }
+
+        match &self.behavior {
+            MockBehavior::Success => {
+                let result = self
+                    .orchestrator
+                    .pending_result
+                    .lock()
+                    .expect("orchestrator pending_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(default_orchestrator_burn_result);
+
+                Ok(result)
+            }
+            #[cfg(test)]
+            MockBehavior::Failure => Err(VaultError::InvalidReceipt),
+            #[cfg(test)]
+            MockBehavior::ConfirmRevert => {
+                Err(VaultError::Reverted { tx_hash: MOCK_BURN_TX_HASH })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPending => {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPendingBlocked { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::SubmitFailure
+            | MockBehavior::WalletLockBlocked { .. }
+            | MockBehavior::SubmitRevert
+            | MockBehavior::PrepareTxFails => {
+                let result = self
+                    .orchestrator
+                    .pending_result
+                    .lock()
+                    .expect("orchestrator pending_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(default_orchestrator_burn_result);
+                Ok(result)
+            }
+        }
     }
 }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -28,11 +28,17 @@ use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
 pub(crate) mod mock;
 pub(crate) mod network_services;
+pub(crate) mod orchestrator;
 pub(crate) mod rain_meta;
 pub(crate) mod service;
 
 pub(crate) use network_services::{
     NetworkVault, NetworkVaultServices, UnconfiguredNetworkError,
+};
+
+pub(crate) use orchestrator::{
+    OrchestratorBurnParams, OrchestratorBurnReadiness, OrchestratorBurnResult,
+    OrchestratorRevertReason,
 };
 
 /// Service abstraction for vault operations.
@@ -204,6 +210,59 @@ pub(crate) trait VaultService: Send + Sync {
     /// Serializes the local wallet's nonce assignment through broadcast.
     async fn lock_wallet(&self) -> WalletNonceGuard {
         None
+    }
+
+    /// Runs the pre-submit orchestrator burn gates: the ERC-20 allowance
+    /// check, then `vaultLogicIsExpected()`. See
+    /// [`OrchestratorBurnReadiness`] for the outcome semantics.
+    ///
+    /// The default implementation fails closed for implementations without
+    /// orchestrator support (mirroring
+    /// [`VaultService::prepare_replacement_burn_tx`]).
+    #[allow(dead_code)]
+    async fn check_orchestrator_burn_readiness(
+        &self,
+        _orchestrator: Address,
+        _token: Address,
+        _owner: Address,
+        _amount: U256,
+    ) -> Result<OrchestratorBurnReadiness, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Builds and signs the `ST0xOrchestrator.burn()` transaction without
+    /// broadcasting it. The returned bytes must be persisted (via
+    /// `BurnIntended`) before [`VaultService::submit_orchestrator_burn`].
+    #[allow(dead_code)]
+    async fn prepare_orchestrator_burn_tx(
+        &self,
+        _params: &OrchestratorBurnParams,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Broadcasts the exact signed orchestrator burn persisted before this
+    /// call. Repeated calls must rebroadcast the same bytes rather than sign
+    /// a replacement.
+    #[allow(dead_code)]
+    async fn submit_orchestrator_burn(
+        &self,
+        _params: &OrchestratorBurnParams,
+        _sendable_tx: &SendableTxWithHash,
+    ) -> Result<SubmittedTx, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Confirms a previously submitted orchestrator burn, parsing the
+    /// orchestrator's `Burned` event. A mined-but-reverted burn fails with
+    /// [`VaultError::OrchestratorReverted`] carrying the decoded typed
+    /// reason.
+    #[allow(dead_code)]
+    async fn confirm_orchestrator_burn(
+        &self,
+        _tx_id: &TxId,
+    ) -> Result<OrchestratorBurnResult, VaultError> {
+        Err(VaultError::InvalidReceipt)
     }
 }
 
@@ -756,11 +815,25 @@ pub(crate) enum VaultError {
          transaction {tx_hash:?}"
     )]
     ContradictoryDeathSignals { tx_hash: B256, nonce: u64 },
+    /// An orchestrator transaction was mined but reverted, with the revert
+    /// data decoded into a typed reason. Like [`VaultError::Reverted`], this
+    /// is a definitive on-chain failure.
+    #[error(
+        "Orchestrator transaction reverted on-chain: {tx_hash:?} ({reason:?})"
+    )]
+    OrchestratorReverted { tx_hash: B256, reason: OrchestratorRevertReason },
     /// Transaction was mined and succeeded but does not prove the expected
     /// burn — it contains no `Transfer(owner -> 0x0)` of the vault's shares.
     /// The operator-supplied hash cannot terminalize the redemption.
     #[error("Transaction is not a burn of the expected shares: {tx_hash:?}")]
     NotABurn { tx_hash: B256 },
+    /// The mined burn's `Burned` event names a token or amount different
+    /// from the transaction's own decoded calldata. The hash pins our
+    /// persisted bytes, so a divergence means the orchestrator emitted an
+    /// event our burn never requested — accounting must not terminalize on
+    /// it.
+    #[error("Burned event diverges from the mined burn calldata: {tx_hash:?}")]
+    BurnedEventMismatch { tx_hash: B256 },
     #[error(
         "Node returned transaction hash {returned:?} for persisted transaction {expected:?}"
     )]

--- a/src/vault/orchestrator.rs
+++ b/src/vault/orchestrator.rs
@@ -1,0 +1,84 @@
+use alloy::primitives::{Address, B256, U256};
+use serde::{Deserialize, Serialize};
+
+use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
+
+/// Parameters for a single `ST0xOrchestrator.burn()` call.
+///
+/// Unlike the vault-direct [`super::MultiBurnParams`], there is no per-receipt
+/// plan and no dust entry: the orchestrator walks its own receipts on-chain
+/// and dust is retained in the bot wallet (recorded as `dust_retained` on the
+/// confirming event, never returned on-chain).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OrchestratorBurnParams {
+    /// `ST0xOrchestrator` contract address, taken from the redemption's
+    /// persisted `burn_mode` anchor — never from live config.
+    pub(crate) orchestrator: Address,
+    /// The vault contract, which is also the ERC-20 share token being burned.
+    pub(crate) token: Address,
+    /// Burn amount in 18-decimal share-wei: the redemption's
+    /// `alpaca_quantity` scaled via `Quantity::to_u256_with_18_decimals()`
+    /// — never the raw Alpaca-precision decimal. Dust stays in the bot
+    /// wallet and is excluded from this amount.
+    pub(crate) amount: U256,
+    /// Bot wallet holding the shares the orchestrator pulls via
+    /// `transferFrom`.
+    pub(crate) owner: Address,
+    /// Redemption's issuer request ID.
+    pub(crate) issuer_request_id: IssuerRedemptionRequestId,
+    /// Transfer that triggered this redemption, used for the deterministic
+    /// `externalTxId` fallback.
+    pub(crate) detected_tx_hash: B256,
+    /// Optional deterministic `externalTxId` override for retry submissions.
+    #[serde(default)]
+    pub(crate) external_tx_id: Option<BurnExternalTxId>,
+}
+
+/// Result of a confirmed `ST0xOrchestrator.burn()`, parsed from the
+/// orchestrator's `Burned` event.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OrchestratorBurnResult {
+    pub(crate) tx_hash: B256,
+    /// `Burned.amount` — total shares pulled and burned.
+    pub(crate) shares_burned: U256,
+    /// Consumed receipt pointer range:
+    /// `(Burned.firstReceiptId, Burned.nextBurnReceiptIdAfter)`.
+    pub(crate) burn_range: (U256, U256),
+    pub(crate) gas_used: u64,
+    pub(crate) block_number: u64,
+}
+
+/// Outcome of the pre-submit orchestrator burn gates (SPEC "Failure States").
+///
+/// Evaluated allowance-first, then `vaultLogicIsExpected()`: an allowance
+/// shortfall is an actionable ops failure and must be reported even while the
+/// orchestrator is halted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrchestratorBurnReadiness {
+    Ready,
+    /// `token.allowance(owner, orchestrator) < amount` — the burn must not be
+    /// submitted until ops grants the approval.
+    AllowanceInsufficient {
+        required: U256,
+        current: U256,
+    },
+    /// `vaultLogicIsExpected()` returned `false` — the orchestrator is halted
+    /// pending upgrade; defer without recording any failure.
+    VaultLogicMismatch,
+}
+
+/// Typed revert reason decoded from a mined-but-reverted orchestrator burn.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum OrchestratorRevertReason {
+    /// `InsufficientReceipts(token, shortfall)` — the on-chain receipt walk
+    /// cannot cover the burn amount.
+    InsufficientReceipts {
+        token: Address,
+        shortfall: U256,
+    },
+    VaultLogicMismatch,
+    ReceiptLogicMismatch,
+    /// Revert data was unavailable or did not decode to one of the
+    /// orchestrator's typed errors.
+    Unknown,
+}

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -10,7 +10,9 @@ use alloy::providers::fillers::{
 use alloy::providers::{
     Identity, PendingTransactionBuilder, Provider, RootProvider,
 };
+use alloy::rpc::json_rpc::ErrorPayload;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
+use alloy::sol_types::SolCall;
 use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
@@ -21,11 +23,13 @@ use tracing::debug;
 use super::rain_meta::OaSchemaCache;
 use super::{
     BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnResult,
-    MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
-    SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
-    WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
+    MultiBurnResultEntry, OrchestratorBurnParams, OrchestratorBurnReadiness,
+    OrchestratorBurnResult, OrchestratorRevertReason, PreparedMintTx,
+    ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId, VaultError,
+    VaultService, WalletNonceGuard, classify_checked_receipt,
+    verify_burn_in_receipt,
 };
-use crate::bindings::OffchainAssetReceiptVault;
+use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
 use crate::redemption::BurnExternalTxId;
 
 pub type RealBlockchainServiceProvider = FillProvider<
@@ -80,6 +84,100 @@ impl RealBlockchainService {
             provider,
             oa_schema_cache,
             wallet_nonce_lock: Arc::new(Mutex::new(())),
+        }
+    }
+
+    /// Decodes the typed revert reason of a mined-but-reverted orchestrator
+    /// transaction by replaying it as an `eth_call` pinned at the parent of
+    /// its mined block — the pre-transaction state a transaction in block N
+    /// executes against is post-block-N-1 (ignoring same-block predecessors;
+    /// the receipt itself carries no revert data). Best-effort: any lookup,
+    /// replay, or decode uncertainty yields
+    /// [`OrchestratorRevertReason::Unknown`], which downstream treats as an
+    /// unclassified definitive revert.
+    async fn decode_orchestrator_revert(
+        &self,
+        tx_hash: alloy::primitives::B256,
+        block_number: u64,
+    ) -> OrchestratorRevertReason {
+        use alloy::sol_types::SolInterface;
+
+        let Ok(Some(transaction)) =
+            self.provider.get_transaction_by_hash(tx_hash).await
+        else {
+            return OrchestratorRevertReason::Unknown;
+        };
+        let Some(to) = transaction.to() else {
+            return OrchestratorRevertReason::Unknown;
+        };
+
+        let request = TransactionRequest::default()
+            .from(transaction.inner.signer())
+            .to(to)
+            .input(transaction.input().clone().into())
+            .value(transaction.value());
+
+        let Err(error) =
+            self.provider.call(request).block(block_number.into()).await
+        else {
+            return OrchestratorRevertReason::Unknown;
+        };
+
+        error
+            .as_error_resp()
+            .and_then(ErrorPayload::as_revert_data)
+            .and_then(|data| {
+                IST0xOrchestratorV1::IST0xOrchestratorV1Errors::abi_decode(
+                    &data,
+                )
+                .ok()
+            })
+            .map_or(OrchestratorRevertReason::Unknown, |decoded| {
+                use IST0xOrchestratorV1::IST0xOrchestratorV1Errors::{
+                    InsufficientReceipts, ReceiptLogicMismatch,
+                    VaultLogicMismatch,
+                };
+                match decoded {
+                    InsufficientReceipts(error) => {
+                        OrchestratorRevertReason::InsufficientReceipts {
+                            token: error.token,
+                            shortfall: error.shortfall,
+                        }
+                    }
+                    VaultLogicMismatch(_) => {
+                        OrchestratorRevertReason::VaultLogicMismatch
+                    }
+                    ReceiptLogicMismatch(_) => {
+                        OrchestratorRevertReason::ReceiptLogicMismatch
+                    }
+                    _ => OrchestratorRevertReason::Unknown,
+                }
+            })
+    }
+
+    async fn try_broadcast_tx(
+        &self,
+        tx: &[u8],
+        hash: B256,
+    ) -> Result<Option<()>, VaultError> {
+        match self.provider.send_raw_transaction(tx).await {
+            Ok(pending_tx) => {
+                let returned = *pending_tx.tx_hash();
+                if returned != hash {
+                    return Err(VaultError::BroadcastHashMismatch {
+                        expected: hash,
+                        returned,
+                    });
+                }
+                Ok(Some(()))
+            }
+            Err(error) => {
+                if self.provider.get_transaction_by_hash(hash).await?.is_none()
+                {
+                    return Err(error.into());
+                }
+                Ok(None)
+            }
         }
     }
 }
@@ -146,33 +244,15 @@ impl VaultService for RealBlockchainService {
         prepared_tx: &PreparedMintTx,
     ) -> Result<SubmittedTx, VaultError> {
         prepared_tx.validate()?;
-
-        match self.provider.send_raw_transaction(&prepared_tx.tx).await {
-            Ok(pending_tx) => {
-                let returned = *pending_tx.tx_hash();
-                if returned != prepared_tx.hash {
-                    return Err(VaultError::BroadcastHashMismatch {
-                        expected: prepared_tx.hash,
-                        returned,
-                    });
-                }
-            }
-            Err(error) => {
-                if self
-                    .provider
-                    .get_transaction_by_hash(prepared_tx.hash)
-                    .await?
-                    .is_none()
-                {
-                    return Err(error.into());
-                }
-
-                debug!(target: "vault", tx_hash = %prepared_tx.hash,
-                    "Mint broadcast errored but the node holds the persisted transaction"
-                );
-            }
+        if self
+            .try_broadcast_tx(&prepared_tx.tx, prepared_tx.hash)
+            .await?
+            .is_none()
+        {
+            debug!(target: "vault", tx_hash = %prepared_tx.hash,
+                "Mint broadcast errored but the node holds the persisted transaction"
+            );
         }
-
         Ok(SubmittedTx {
             external_tx_id: prepared_tx.external_tx_id.clone(),
             tx_id: prepared_tx.hash.into(),
@@ -398,36 +478,19 @@ impl VaultService for RealBlockchainService {
         sendable_tx: SendableTxWithHash,
     ) -> Result<SubmittedTx, VaultError> {
         sendable_tx.validate_for_owner(params.owner)?;
-
-        match self.provider.send_raw_transaction(&sendable_tx.tx).await {
-            Ok(pending_tx) => {
-                let returned = *pending_tx.tx_hash();
-                if returned != sendable_tx.hash {
-                    return Err(VaultError::BroadcastHashMismatch {
-                        expected: sendable_tx.hash,
-                        returned,
-                    });
-                }
-            }
-            Err(error) => {
-                if self
-                    .provider
-                    .get_transaction_by_hash(sendable_tx.hash)
-                    .await?
-                    .is_none()
-                {
-                    return Err(error.into());
-                }
-
-                debug!(target: "vault", tx_hash = %sendable_tx.hash,
-                    "Burn broadcast errored but the node holds the persisted transaction"
-                );
-            }
+        if self
+            .try_broadcast_tx(&sendable_tx.tx, sendable_tx.hash)
+            .await?
+            .is_none()
+        {
+            debug!(target: "vault", tx_hash = %sendable_tx.hash,
+                "Burn broadcast errored but the node holds the persisted transaction"
+            );
         }
-
         Ok(SubmittedTx {
             external_tx_id: params
                 .external_tx_id
+                .clone()
                 .unwrap_or_else(|| {
                     BurnExternalTxId::base(&params.detected_tx_hash)
                 })
@@ -747,6 +810,178 @@ impl VaultService for RealBlockchainService {
 
     async fn lock_wallet(&self) -> WalletNonceGuard {
         Some(self.wallet_nonce_lock.clone().lock_owned().await)
+    }
+
+    async fn check_orchestrator_burn_readiness(
+        &self,
+        orchestrator: Address,
+        token: Address,
+        owner: Address,
+        amount: U256,
+    ) -> Result<OrchestratorBurnReadiness, VaultError> {
+        // Allowance first: an approval shortfall is an actionable ops failure
+        // and must be reported even while the orchestrator is halted.
+        let token_contract =
+            OffchainAssetReceiptVault::new(token, &self.provider);
+        let current =
+            token_contract.allowance(owner, orchestrator).call().await?;
+        if current < amount {
+            return Ok(OrchestratorBurnReadiness::AllowanceInsufficient {
+                required: amount,
+                current,
+            });
+        }
+
+        let orchestrator_contract =
+            IST0xOrchestratorV1::new(orchestrator, &self.provider);
+        if !orchestrator_contract.vaultLogicIsExpected().call().await? {
+            return Ok(OrchestratorBurnReadiness::VaultLogicMismatch);
+        }
+
+        Ok(OrchestratorBurnReadiness::Ready)
+    }
+
+    async fn prepare_orchestrator_burn_tx(
+        &self,
+        params: &OrchestratorBurnParams,
+    ) -> Result<SendableTxWithHash, VaultError> {
+        let orchestrator_contract =
+            IST0xOrchestratorV1::new(params.orchestrator, &self.provider);
+
+        let tx = orchestrator_contract
+            .burn(params.token, params.amount, Bytes::new())
+            .into_transaction_request();
+
+        let envelope = self
+            .provider
+            .fill(tx)
+            .await?
+            .try_into_envelope()
+            .map_err(Box::new)?;
+
+        Ok(SendableTxWithHash {
+            nonce: envelope.nonce(),
+            hash: *envelope.tx_hash(),
+            tx: envelope.encoded_2718(),
+            signed_at: Utc::now(),
+            // The orchestrator burn retains dust in the bot wallet; there is
+            // no on-chain dust return to encode.
+            dust_shares: U256::ZERO,
+        })
+    }
+
+    async fn submit_orchestrator_burn(
+        &self,
+        params: &OrchestratorBurnParams,
+        sendable_tx: &SendableTxWithHash,
+    ) -> Result<SubmittedTx, VaultError> {
+        sendable_tx.validate_for_owner(params.owner)?;
+        if self
+            .try_broadcast_tx(&sendable_tx.tx, sendable_tx.hash)
+            .await?
+            .is_none()
+        {
+            debug!(target: "vault", tx_hash = %sendable_tx.hash,
+                "Orchestrator burn broadcast errored but the node holds \
+                    the persisted transaction"
+            );
+        }
+        Ok(SubmittedTx {
+            external_tx_id: params
+                .external_tx_id
+                .clone()
+                .unwrap_or_else(|| {
+                    BurnExternalTxId::base(&params.detected_tx_hash)
+                })
+                .into_string(),
+            tx_id: sendable_tx.hash.into(),
+        })
+    }
+
+    async fn confirm_orchestrator_burn(
+        &self,
+        tx_id: &TxId,
+    ) -> Result<OrchestratorBurnResult, VaultError> {
+        debug!(target: "vault", tx_hash = %tx_id,
+            "Getting orchestrator burn tx data from chain"
+        );
+
+        let tx_hash = tx_id.to_hash().ok_or(VaultError::InvalidReceipt)?;
+
+        let receipt = PendingTransactionBuilder::new(
+            self.provider.root().clone(),
+            tx_hash,
+        )
+        .with_timeout(Some(Duration::from_secs(120)))
+        .get_receipt()
+        .await
+        .map_err(|error| VaultError::ConfirmationPending {
+            tx_id: TxId::Hash(tx_hash),
+            message: error.to_string(),
+        })?;
+
+        let block_number =
+            receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
+
+        // A mined-but-reverted orchestrator burn is a definitive failure;
+        // decode its typed reason so the aggregate records the right
+        // classification.
+        if !receipt.status() {
+            let reason = self
+                .decode_orchestrator_revert(
+                    tx_hash,
+                    block_number.saturating_sub(1),
+                )
+                .await;
+            return Err(VaultError::OrchestratorReverted { tx_hash, reason });
+        }
+
+        // Bind the decoded event to OUR burn before terminalizing
+        // accounting: it must be emitted by the orchestrator this persisted
+        // transaction targeted (`receipt.to`), for the transaction's own
+        // sender as `caller` — a same-signature event emitted by any other
+        // contract in the call tree must never be mistaken for it.
+        let orchestrator = receipt.to.ok_or(VaultError::InvalidReceipt)?;
+        let burned = receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                if log.address() != orchestrator {
+                    return None;
+                }
+                let decoded =
+                    log.log_decode::<IST0xOrchestratorV1::Burned>().ok()?;
+                (decoded.data().caller == receipt.from).then_some(decoded)
+            })
+            .ok_or(VaultError::EventNotFound { tx_hash })?;
+        let burned = burned.data();
+
+        // The binding above establishes WHICH log is ours; the mined
+        // transaction's own calldata establishes WHAT the burn requested.
+        // `shares_burned` terminalizes 1:1 accounting, so the event's token
+        // and amount must equal the decoded `burn(token, amount, ..)` call
+        // (the hash pins our persisted bytes) before they are trusted.
+        let transaction = self
+            .provider
+            .get_transaction_by_hash(tx_hash)
+            .await?
+            .ok_or(VaultError::InvalidReceipt)?;
+        let burn_call =
+            IST0xOrchestratorV1::burnCall::abi_decode(transaction.input())
+                .map_err(|_| VaultError::NotABurn { tx_hash })?;
+        if burned.token != burn_call.token || burned.amount != burn_call.amount
+        {
+            return Err(VaultError::BurnedEventMismatch { tx_hash });
+        }
+
+        Ok(OrchestratorBurnResult {
+            tx_hash,
+            shares_burned: burned.amount,
+            burn_range: (burned.firstReceiptId, burned.nextBurnReceiptIdAfter),
+            gas_used: receipt.gas_used,
+            block_number,
+        })
     }
 }
 
@@ -2384,5 +2619,457 @@ mod tests {
 
         assert_eq!(sendable.dust_shares, U256::ZERO);
         assert!(!sendable.tx.is_empty());
+    }
+
+    fn test_orchestrator_address() -> Address {
+        address!("0x00000000000000000000000000000000000000aa")
+    }
+
+    fn test_orchestrator_burn_params(
+        owner: Address,
+    ) -> super::OrchestratorBurnParams {
+        super::OrchestratorBurnParams {
+            orchestrator: test_orchestrator_address(),
+            token: test_vault_address(),
+            amount: U256::from(1_000_000u64),
+            owner,
+            issuer_request_id: test_issuer_redemption_id(),
+            detected_tx_hash: b256!(
+                "0xabababababababababababababababababababababababababababababababab"
+            ),
+            external_tx_id: None,
+        }
+    }
+
+    fn create_burned_receipt(
+        tx_hash: B256,
+        caller: Address,
+        amount: U256,
+        burn_range: (U256, U256),
+        succeeded: bool,
+    ) -> TransactionReceipt {
+        create_burned_receipt_from(
+            tx_hash,
+            caller,
+            amount,
+            burn_range,
+            succeeded,
+            test_orchestrator_address(),
+        )
+    }
+
+    /// Like [`create_burned_receipt`], with the `Burned` log's emitting
+    /// contract chosen by the caller — for pinning that the confirm path
+    /// binds the event to the orchestrator the transaction targeted.
+    fn create_burned_receipt_from(
+        tx_hash: B256,
+        caller: Address,
+        amount: U256,
+        burn_range: (U256, U256),
+        succeeded: bool,
+        emitter: Address,
+    ) -> TransactionReceipt {
+        let burned_event = crate::bindings::IST0xOrchestratorV1::Burned {
+            caller,
+            token: test_vault_address(),
+            amount,
+            firstReceiptId: burn_range.0,
+            nextBurnReceiptIdAfter: burn_range.1,
+        };
+
+        let logs = if succeeded {
+            vec![alloy::rpc::types::Log {
+                inner: alloy::primitives::Log {
+                    address: emitter,
+                    data: burned_event.into_log_data(),
+                },
+                block_hash: Some(b256!(
+                    "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                )),
+                block_number: Some(0x9c4),
+                block_timestamp: None,
+                transaction_hash: Some(tx_hash),
+                transaction_index: Some(0),
+                log_index: Some(0),
+                removed: false,
+            }]
+        } else {
+            vec![]
+        };
+
+        let consensus_receipt: Receipt<alloy::rpc::types::Log> = Receipt {
+            status: Eip658Value::Eip658(succeeded),
+            cumulative_gas_used: 0x8000,
+            logs,
+        };
+
+        TransactionReceipt {
+            transaction_hash: tx_hash,
+            transaction_index: Some(0),
+            block_hash: Some(fixed_bytes!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            )),
+            block_number: Some(0x9c4),
+            // The sender is the burn's `caller` — the confirm path binds the
+            // decoded event's `caller` to `receipt.from`.
+            from: caller,
+            to: Some(test_orchestrator_address()),
+            gas_used: 0x8000,
+            effective_gas_price: 0x3b9a_ca00,
+            contract_address: None,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                consensus_receipt,
+                Bloom::default(),
+            )),
+        }
+    }
+
+    /// A same-signature `Burned` event emitted by a contract other than the
+    /// orchestrator the transaction targeted must never terminalize the
+    /// burn's accounting: the confirm path binds the log to `receipt.to` and
+    /// reads anything else as `EventNotFound`.
+    #[tokio::test]
+    async fn confirm_orchestrator_burn_ignores_foreign_burned_logs() {
+        let tx_hash = b256!(
+            "0x7777777777777777777777777777777777777777777777777777777777777777"
+        );
+        let receipt = create_burned_receipt_from(
+            tx_hash,
+            address!("2222222222222222222222222222222222222222"),
+            U256::from(5u8),
+            (U256::ZERO, U256::ONE),
+            true,
+            test_vault_address(),
+        );
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result =
+            service.confirm_orchestrator_burn(&TxId::Hash(tx_hash)).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(VaultError::EventNotFound { tx_hash: hash })
+                    if hash == tx_hash
+            ),
+            "a foreign contract's Burned log must not confirm the burn, \
+             got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn orchestrator_burn_prepare_submit_confirm_round_trip() {
+        use alloy::sol_types::SolCall;
+
+        let asserter = Asserter::new();
+        setup_asserter_for_fill(&asserter, 7);
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let service = create_service_with_signer(asserter.clone(), signer);
+
+        let params = test_orchestrator_burn_params(owner);
+
+        let prepared = service
+            .prepare_orchestrator_burn_tx(&params)
+            .await
+            .expect("expected SendableTxWithHash");
+
+        assert_eq!(prepared.nonce, 7);
+        assert_eq!(
+            prepared.dust_shares,
+            U256::ZERO,
+            "orchestrator burns never encode a dust return"
+        );
+        let envelope = TxEnvelope::decode_2718(&mut prepared.tx.as_slice())
+            .expect("prepared orchestrator burn must decode");
+        assert_eq!(*envelope.tx_hash(), prepared.hash);
+        assert_eq!(envelope.to(), Some(test_orchestrator_address()));
+        let expected_calldata =
+            crate::bindings::IST0xOrchestratorV1::burnCall {
+                token: params.token,
+                amount: params.amount,
+                burnInfo: Bytes::new(),
+            }
+            .abi_encode();
+        assert_eq!(
+            envelope.input().as_ref(),
+            expected_calldata.as_slice(),
+            "calldata must be burn(token, amount, empty burnInfo)"
+        );
+
+        let receipt = create_burned_receipt(
+            prepared.hash,
+            owner,
+            params.amount,
+            (U256::from(3u8), U256::from(6u8)),
+            true,
+        );
+        setup_asserter_for_transaction(&asserter, prepared.hash, &receipt);
+        // Confirm cross-checks the Burned event against the mined calldata.
+        asserter.push_success(&Some(rpc_transaction(&prepared.tx, owner)));
+
+        let submitted = service
+            .submit_orchestrator_burn(&params, &prepared)
+            .await
+            .expect("expected SubmittedTx");
+        assert_eq!(submitted.tx_id, TxId::Hash(prepared.hash));
+        assert_eq!(
+            submitted.external_tx_id,
+            format!("burn-{}", params.detected_tx_hash),
+            "deterministic externalTxId must derive from the detected transfer"
+        );
+
+        let result = service
+            .confirm_orchestrator_burn(&submitted.tx_id)
+            .await
+            .expect("expected OrchestratorBurnResult");
+        assert_eq!(result.tx_hash, prepared.hash);
+        assert_eq!(result.shares_burned, params.amount);
+        assert_eq!(result.burn_range, (U256::from(3u8), U256::from(6u8)));
+        assert_eq!(result.gas_used, 0x8000);
+        assert_eq!(result.block_number, 0x9c4);
+    }
+
+    #[tokio::test]
+    async fn confirm_orchestrator_burn_without_burned_event_is_not_found() {
+        let tx_hash = b256!(
+            "0x9999999999999999999999999999999999999999999999999999999999999999"
+        );
+        let mut receipt = create_burned_receipt(
+            tx_hash,
+            test_receiver(),
+            U256::from(1u8),
+            (U256::ZERO, U256::ZERO),
+            true,
+        );
+        receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+            Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 0x8000,
+                logs: vec![],
+            },
+            Bloom::default(),
+        ));
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result =
+            service.confirm_orchestrator_burn(&TxId::Hash(tx_hash)).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::EventNotFound { tx_hash: hash }) if hash == tx_hash
+        ));
+    }
+
+    /// A `Burned` event whose amount diverges from the mined transaction's
+    /// own `burn(token, amount, ..)` calldata must never terminalize
+    /// accounting: `shares_burned` backs 1:1 bookkeeping, so the confirm
+    /// path cross-checks the event against the decoded calldata and refuses
+    /// on divergence.
+    #[tokio::test]
+    async fn confirm_orchestrator_burn_refuses_diverging_burned_event() {
+        let asserter = Asserter::new();
+        setup_asserter_for_fill(&asserter, 7);
+        let signer = PrivateKeySigner::random();
+        let owner = signer.address();
+        let service = create_service_with_signer(asserter.clone(), signer);
+
+        let params = test_orchestrator_burn_params(owner);
+        let prepared = service
+            .prepare_orchestrator_burn_tx(&params)
+            .await
+            .expect("expected prepared burn");
+
+        // The event reports MORE shares burned than the calldata requested.
+        let receipt = create_burned_receipt(
+            prepared.hash,
+            owner,
+            params.amount + U256::ONE,
+            (U256::from(3u8), U256::from(6u8)),
+            true,
+        );
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        asserter.push_success(&Some(rpc_transaction(&prepared.tx, owner)));
+
+        let result =
+            service.confirm_orchestrator_burn(&TxId::Hash(prepared.hash)).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(VaultError::BurnedEventMismatch { tx_hash })
+                    if tx_hash == prepared.hash
+            ),
+            "a diverging Burned amount must refuse confirmation, \
+             got {result:?}"
+        );
+    }
+
+    /// A mined-but-reverted orchestrator burn replays the transaction as an
+    /// `eth_call` at its mined block and decodes the typed revert reason.
+    #[tokio::test]
+    async fn confirm_orchestrator_burn_decodes_typed_revert_reasons() {
+        use alloy::rpc::json_rpc::ErrorPayload;
+        use alloy::sol_types::SolError;
+
+        let shortfall_error =
+            crate::bindings::IST0xOrchestratorV1::InsufficientReceipts {
+                token: test_vault_address(),
+                shortfall: U256::from(250u64),
+            };
+        let cases = [
+            (
+                Bytes::from(shortfall_error.abi_encode()),
+                super::OrchestratorRevertReason::InsufficientReceipts {
+                    token: test_vault_address(),
+                    shortfall: U256::from(250u64),
+                },
+            ),
+            (
+                Bytes::from(
+                    crate::bindings::IST0xOrchestratorV1::VaultLogicMismatch {
+                        expected: test_receiver(),
+                        actual: test_vault_address(),
+                    }
+                    .abi_encode(),
+                ),
+                super::OrchestratorRevertReason::VaultLogicMismatch,
+            ),
+            (
+                Bytes::from(
+                    crate::bindings::IST0xOrchestratorV1::ReceiptLogicMismatch {
+                        expected: test_receiver(),
+                        actual: test_vault_address(),
+                    }
+                    .abi_encode(),
+                ),
+                super::OrchestratorRevertReason::ReceiptLogicMismatch,
+            ),
+            (
+                Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
+                super::OrchestratorRevertReason::Unknown,
+            ),
+        ];
+
+        for (revert_data, expected_reason) in cases {
+            let persisted = SendableTxWithHash::valid_for_test(
+                17,
+                test_orchestrator_address(),
+                Bytes::from_static(&[0xde, 0xad]),
+            );
+            let owner = persisted.signer_for_test();
+            let receipt = create_burned_receipt(
+                persisted.hash,
+                owner,
+                U256::ZERO,
+                (U256::ZERO, U256::ZERO),
+                false,
+            );
+            let transaction = rpc_transaction(&persisted.tx, owner);
+
+            let asserter = Asserter::new();
+            asserter.push_success(&receipt); // eth_getTransactionReceipt
+            asserter.push_success(&receipt); // eth_getTransactionReceipt (polling)
+            asserter.push_success(&transaction); // eth_getTransactionByHash
+            asserter.push_failure(ErrorPayload {
+                code: 3,
+                message: "execution reverted".into(),
+                data: Some(
+                    serde_json::value::to_raw_value(&format!("{revert_data}"))
+                        .expect("revert data must serialize"),
+                ),
+            }); // eth_call replay
+            let service = create_service_with_asserter(asserter);
+
+            let result = service
+                .confirm_orchestrator_burn(&TxId::Hash(persisted.hash))
+                .await;
+
+            assert!(
+                matches!(
+                    &result,
+                    Err(VaultError::OrchestratorReverted { tx_hash, reason })
+                        if *tx_hash == persisted.hash
+                            && *reason == expected_reason
+                ),
+                "expected {expected_reason:?}, got {result:?}"
+            );
+        }
+    }
+
+    /// The allowance gate is evaluated before the orchestrator health gate,
+    /// so an approval shortfall is reported even while the orchestrator is
+    /// halted.
+    #[tokio::test]
+    async fn orchestrator_readiness_checks_allowance_before_health() {
+        let owner = test_receiver();
+        let amount = U256::from(1_000u64);
+
+        // Allowance below the amount: readiness must report the shortfall
+        // without ever querying vaultLogicIsExpected (a second eth_call
+        // would fail the asserter with a missing response).
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 999u64));
+        let service = create_service_with_asserter(asserter);
+        let readiness = service
+            .check_orchestrator_burn_readiness(
+                test_orchestrator_address(),
+                test_vault_address(),
+                owner,
+                amount,
+            )
+            .await
+            .expect("readiness check should succeed");
+        assert_eq!(
+            readiness,
+            super::OrchestratorBurnReadiness::AllowanceInsufficient {
+                required: amount,
+                current: U256::from(999u64),
+            }
+        );
+
+        // Sufficient allowance but halted orchestrator.
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{}", "f".repeat(64)));
+        asserter.push_success(&format!("0x{:064x}", 0u64));
+        let service = create_service_with_asserter(asserter);
+        let readiness = service
+            .check_orchestrator_burn_readiness(
+                test_orchestrator_address(),
+                test_vault_address(),
+                owner,
+                amount,
+            )
+            .await
+            .expect("readiness check should succeed");
+        assert_eq!(
+            readiness,
+            super::OrchestratorBurnReadiness::VaultLogicMismatch
+        );
+
+        // Sufficient allowance and healthy orchestrator.
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{}", "f".repeat(64)));
+        asserter.push_success(&format!("0x{:064x}", 1u64));
+        let service = create_service_with_asserter(asserter);
+        let readiness = service
+            .check_orchestrator_burn_readiness(
+                test_orchestrator_address(),
+                test_vault_address(),
+                owner,
+                amount,
+            )
+            .await
+            .expect("readiness check should succeed");
+        assert_eq!(readiness, super::OrchestratorBurnReadiness::Ready);
     }
 }

--- a/tests/orchestrator_smoke.rs
+++ b/tests/orchestrator_smoke.rs
@@ -84,7 +84,10 @@ async fn orchestrator_mint_burn_roundtrip()
         .get_receipt()
         .await?;
 
-    orchestrator
+    let pre_burn_pointer =
+        orchestrator.nextBurnReceiptId(evm.vault_address).call().await?;
+
+    let burn_receipt = orchestrator
         .burn(evm.vault_address, balance_after_mint, Bytes::new())
         .send()
         .await?
@@ -96,6 +99,48 @@ async fn orchestrator_mint_burn_roundtrip()
         balance_after_burn,
         U256::ZERO,
         "expected zero share balance after burn, got {balance_after_burn}"
+    );
+
+    // The RAI-1220 acceptance assertion, against a REAL `Burned` log (SPEC
+    // "Contract Summary"): `nextBurnReceiptIdAfter` is the half-open end of
+    // the consumed range — exclusive of the receipts this burn fully
+    // drained, and exactly the pointer `nextBurnReceiptId(token)` reports
+    // for the next burn to resume from.
+    let burned = burn_receipt
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| log.log_decode::<IST0xOrchestratorV1::Burned>().ok())
+        .expect("the burn must emit a Burned event");
+    let burned = burned.data();
+    assert_eq!(burned.token, evm.vault_address);
+    assert_eq!(burned.caller, evm.wallet_address);
+    assert_eq!(
+        burned.amount, balance_after_mint,
+        "Burned.amount is the authoritative burned quantity"
+    );
+    // Empirical semantics pinned against the real contract:
+    // `firstReceiptId` echoes the PRE-burn pointer (0 on a fresh
+    // orchestrator — the pointer's initial value, not the first receipt's
+    // id), and `nextBurnReceiptIdAfter` is the half-open end the pointer
+    // advanced to, exclusive of the receipts this burn fully drained.
+    assert_eq!(
+        burned.firstReceiptId, pre_burn_pointer,
+        "firstReceiptId must echo the pre-burn nextBurnReceiptId pointer"
+    );
+    // The mint above created this fresh vault's first receipt (id 1) and
+    // the burn fully drained it, so the pointer must have advanced past it.
+    assert_eq!(
+        burned.nextBurnReceiptIdAfter,
+        U256::from(2u8),
+        "a fully drained receipt 1 must advance the half-open end past it"
+    );
+    let post_burn_pointer =
+        orchestrator.nextBurnReceiptId(evm.vault_address).call().await?;
+    assert_eq!(
+        post_burn_pointer, burned.nextBurnReceiptIdAfter,
+        "nextBurnReceiptIdAfter must equal the post-burn \
+         nextBurnReceiptId(token) the next burn resumes from"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

The redemption pipeline needs to support burning shares via the `ST0xOrchestrator` contract, which walks on-chain receipts itself rather than requiring the bot to plan per-receipt burns. Without this, orchestrator-mode redemptions cannot be executed.

## Solution

Adds four new methods to the `VaultService` trait covering the full orchestrator burn lifecycle:

- `check_orchestrator_burn_readiness` — evaluates the ERC-20 allowance gate first, then `vaultLogicIsExpected()`, returning a typed `OrchestratorBurnReadiness` outcome. Allowance is checked before the health gate so an approval shortfall is always surfaced even when the orchestrator is halted.
- `prepare_orchestrator_burn_tx` — builds and signs the `ST0xOrchestrator.burn()` transaction without broadcasting it.
- `submit_orchestrator_burn` — broadcasts the pre-signed transaction, tolerating a node-already-holds-it error on retry.
- `confirm_orchestrator_burn` — polls for the receipt, parses the `Burned` event, and on a mined-but-reverted transaction replays it as an `eth_call` at the mined block to decode the typed revert reason (`InsufficientReceipts`, `VaultLogicMismatch`, `ReceiptLogicMismatch`, or `Unknown`) into `VaultError::OrchestratorReverted`.

The supporting types (`OrchestratorBurnParams`, `OrchestratorBurnResult`, `OrchestratorBurnReadiness`, `OrchestratorRevertReason`) are introduced in a new `vault/orchestrator.rs` module. The `MockVaultService` is extended with full implementations of all four methods and test-only builder methods (`with_orchestrator_readiness`, `with_orchestrator_confirm_revert`, `with_orchestrator_burn_result`) and call-count accessors for unit test assertions.

NOTE: `#[allow(dead_code)]` are used to pass clippy, and will be removed on upstack PRs as implementation completes

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end orchestrated burn support, including readiness checks, transaction preparation, submission, and confirmation.
  * Confirmation now provides burned amount, receipt range, gas usage, and block details.
  * Added clear handling for failed burns caused by insufficient receipts, vault or receipt logic mismatches, and unknown errors.
  * Validated burn event data and receipt boundaries for accurate results.

* **Bug Fixes**
  * Definitive burn failures are no longer treated as retryable or uncertain outcomes.

* **Tests**
  * Expanded coverage for successful flows, event validation, readiness checks, and revert scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->