### PR TITLE
feat: add `BurnParams` enum and orchestrator burn mode support

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1721,6 +1721,7 @@ fn redemption_history_summary_from_events(
                 summary.tokenization_request_id = Some(tokenization_request_id);
             }
             RedemptionEvent::BurnTxSubmitted { tx_id, .. }
+            | RedemptionEvent::OrchestratorBurnSubmitted { tx_id, .. }
             | RedemptionEvent::ExistingBurnRecovered { tx_id, .. }
             | RedemptionEvent::BurningFailed { tx_id: Some(tx_id), .. } => {
                 summary.tx_id = Some(tx_id);
@@ -2077,6 +2078,7 @@ mod tests {
         AlpacaCalledData, PostAlpacaRecoveryInput, load_reprocess_context,
         recover_post_alpaca,
     };
+    use crate::VaultModeConfig;
     use crate::admin::BurningFailedData;
     use crate::alpaca::{
         AlpacaError, AlpacaService, MintCallbackRequest, RedeemRequest,
@@ -2093,7 +2095,7 @@ mod tests {
     };
     use crate::redemption::{BurnExternalTxId, RedemptionServices};
     use crate::redemption::{
-        BurnFailureClassification, BurnRecord, BurnRecoveryAction,
+        BurnFailureClassification, BurnParams, BurnRecord, BurnRecoveryAction,
         IssuerRedemptionRequestId, Redemption, RedemptionCommand,
         RedemptionEvent, RedemptionMetadata, RedemptionView,
     };
@@ -2672,17 +2674,19 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault: address!(
-                        "0xcccccccccccccccccccccccccccccccccccccccc"
-                    ),
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: U256::from(99),
-                        burn_shares: U256::from(100),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: Address::ZERO,
+                    params: BurnParams::VaultDirect {
+                        vault: address!(
+                            "0xcccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: U256::from(99),
+                            burn_shares: U256::from(100),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: Address::ZERO,
+                    },
                     external_tx_id: Some(BurnExternalTxId::base(
                         &metadata.detected_tx_hash,
                     )),
@@ -2696,17 +2700,19 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault: address!(
-                        "0xcccccccccccccccccccccccccccccccccccccccc"
-                    ),
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: U256::from(99),
-                        burn_shares: U256::from(100),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: Address::ZERO,
+                    params: BurnParams::VaultDirect {
+                        vault: address!(
+                            "0xcccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: U256::from(99),
+                            burn_shares: U256::from(100),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: Address::ZERO,
+                    },
                     external_tx_id: Some(BurnExternalTxId::base(
                         &metadata.detected_tx_hash,
                     )),
@@ -3263,12 +3269,14 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault: address!(
-                        "0xcccccccccccccccccccccccccccccccccccccccc"
-                    ),
-                    burns: burns.clone(),
-                    dust_shares: U256::ZERO,
-                    owner: Address::ZERO,
+                    params: BurnParams::VaultDirect {
+                        vault: address!(
+                            "0xcccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                        burns: burns.clone(),
+                        dust_shares: U256::ZERO,
+                        owner: Address::ZERO,
+                    },
                     external_tx_id: external_tx_id.clone(),
                 },
             )
@@ -3280,12 +3288,14 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault: address!(
-                        "0xcccccccccccccccccccccccccccccccccccccccc"
-                    ),
-                    burns,
-                    dust_shares: U256::ZERO,
-                    owner: Address::ZERO,
+                    params: BurnParams::VaultDirect {
+                        vault: address!(
+                            "0xcccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                        burns,
+                        dust_shares: U256::ZERO,
+                        owner: Address::ZERO,
+                    },
                     external_tx_id,
                 },
             )
@@ -4352,7 +4362,7 @@ mod tests {
             subgraph_url: Url::parse("http://localhost:0/subgraph").unwrap(),
             receipt_poll_interval: crate::RECEIPT_POLL_INTERVAL,
             chains: Vec::new(),
-            vault_mode_config: crate::config::VaultModeConfig::default(),
+            vault_mode_config: VaultModeConfig::default(),
         };
 
         rocket::build()
@@ -4411,15 +4421,17 @@ mod tests {
                 &metadata.issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: metadata.issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: U256::from(42),
-                        burn_shares: U256::from(17),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: persisted_tx.signer_for_test(),
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: U256::from(42),
+                            burn_shares: U256::from(17),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: persisted_tx.signer_for_test(),
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5162,6 +5174,37 @@ mod tests {
         );
         // tokenization_request_id is preserved (it doesn't reset).
         assert_eq!(summary.tokenization_request_id, Some(tok_id));
+    }
+
+    /// `OrchestratorBurnSubmitted` leaves the view in `Burning` exactly like
+    /// `BurnTxSubmitted`, so the stuck-row detail branches on the history
+    /// summary's `tx_id` alone. The summary must therefore extract the
+    /// orchestrator submission's `tx_id` too — otherwise a submitted
+    /// orchestrator burn reads "Waiting for burn submission" with no
+    /// transaction id.
+    #[test]
+    fn redemption_history_summary_records_orchestrator_submission_tx_id() {
+        use crate::redemption::{BurnExternalTxId, RedemptionEvent};
+
+        let issuer = IssuerRedemptionRequestId::random();
+        let tx_id = TxId::random();
+
+        let events = vec![RedemptionEvent::OrchestratorBurnSubmitted {
+            issuer_request_id: issuer,
+            external_tx_id: BurnExternalTxId::from_string(
+                "burn-orch-1".to_string(),
+            ),
+            tx_id: tx_id.clone(),
+            submitted_at: Utc::now(),
+        }];
+
+        let summary = super::redemption_history_summary_from_events(events);
+
+        assert_eq!(
+            summary.tx_id,
+            Some(tx_id),
+            "orchestrator submission must surface its tx_id in the summary"
+        );
     }
 
     fn freeze_schedule_rocket(

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,37 @@ pub enum VaultMode {
     },
 }
 
+impl VaultMode {
+    #[must_use]
+    pub const fn kind(&self) -> VaultModeKind {
+        match self {
+            Self::VaultDirect => VaultModeKind::VaultDirect,
+            Self::Orchestrator { .. } => VaultModeKind::Orchestrator,
+        }
+    }
+}
+
+/// The backend kind of a [`VaultMode`], without the orchestrator's address
+/// payload — for mode-mismatch errors and logs where only the kind matters
+/// and a free-form string would let call sites invent labels the compiler
+/// cannot check.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize,
+)]
+pub enum VaultModeKind {
+    VaultDirect,
+    Orchestrator,
+}
+
+impl std::fmt::Display for VaultModeKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VaultDirect => write!(formatter, "VaultDirect"),
+            Self::Orchestrator => write!(formatter, "Orchestrator"),
+        }
+    }
+}
+
 /// Resolved per-asset vault-mode configuration loaded from the optional TOML
 /// config file. Defaults to all-`VaultDirect` when no file is provided.
 #[derive(Debug, Clone, Default)]

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -11,9 +11,9 @@ use super::view::{
     RedemptionView, RedemptionViewError, find_burn_failed, find_burning,
 };
 use super::{
-    BurnExternalTxId, BurnRecoveryAction, IssuerRedemptionRequestId,
-    Redemption, RedemptionCommand, RedemptionError, RedemptionEvent,
-    next_burn_retry_external_tx_id_from_history,
+    BurnExternalTxId, BurnParams, BurnRecoveryAction,
+    IssuerRedemptionRequestId, Redemption, RedemptionCommand, RedemptionError,
+    RedemptionEvent, next_burn_retry_external_tx_id_from_history,
 };
 use crate::burn_excess::has_unresolved_excess_burn_intent;
 use crate::mint::QuantityConversionError;
@@ -882,6 +882,7 @@ impl BurnManager {
                     message: err,
                     release_reservation,
                     tx_id: None,
+                    classification: BurnFailureClassification::Unclassified,
                 }))
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
@@ -992,22 +993,15 @@ impl BurnManager {
             return Ok(RecoveryOutcome::SkippedManualIntervention);
         }
 
-        let burns = planned_burns
-            .iter()
-            .map(|burn| MultiBurnEntry {
-                receipt_id: burn.receipt_id,
-                burn_shares: burn.shares_burned,
-                receipt_info: None,
-                receipt_info_bytes: None,
-            })
-            .collect::<Vec<_>>();
         let command = match status {
             BurnTxStatus::StillMineable => RedemptionCommand::BurnTokens {
                 issuer_request_id: issuer_request_id.clone(),
-                vault,
-                burns,
-                dust_shares: sendable_tx.dust_shares,
-                owner: self.bot_wallet,
+                params: BurnParams::VaultDirect {
+                    vault,
+                    burns: planned_to_burn_entries(planned_burns),
+                    dust_shares: sendable_tx.dust_shares,
+                    owner: self.bot_wallet,
+                },
                 external_tx_id,
             },
             BurnTxStatus::ProvablyDead => RedemptionCommand::ReplaceDeadBurn {
@@ -1023,39 +1017,7 @@ impl BurnManager {
         self.store.send(issuer_request_id, command).await?;
 
         if status == BurnTxStatus::ProvablyDead {
-            let Some(Redemption::BurnIntended {
-                planned_burns,
-                sendable_tx,
-                external_tx_id,
-                ..
-            }) = self.store.load(issuer_request_id).await?
-            else {
-                return Err(BurnManagerError::InvalidAggregateState {
-                    current_state: "expected replacement BurnIntended"
-                        .to_string(),
-                });
-            };
-            let replacement_burns = planned_burns
-                .iter()
-                .map(|burn| MultiBurnEntry {
-                    receipt_id: burn.receipt_id,
-                    burn_shares: burn.shares_burned,
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                })
-                .collect();
-            self.store
-                .send(
-                    issuer_request_id,
-                    RedemptionCommand::BurnTokens {
-                        issuer_request_id: issuer_request_id.clone(),
-                        vault,
-                        burns: replacement_burns,
-                        dust_shares: sendable_tx.dust_shares,
-                        owner: self.bot_wallet,
-                        external_tx_id,
-                    },
-                )
+            self.submit_replacement_after_dead_burn(issuer_request_id, vault)
                 .await?;
         }
         drop(wallet_guard);
@@ -1067,6 +1029,46 @@ impl BurnManager {
             "Automatic burn recovery action accepted"
         );
         Ok(RecoveryOutcome::Executed)
+    }
+
+    /// Broadcasts the replacement transaction `ReplaceDeadBurn` just
+    /// persisted: re-loads the aggregate to pick up the freshly intended
+    /// replacement (its plan, signed bytes, and retry `externalTxId`) and
+    /// submits it.
+    async fn submit_replacement_after_dead_burn(
+        &self,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        vault: Address,
+    ) -> Result<(), BurnManagerError> {
+        let Some(Redemption::BurnIntended {
+            planned_burns,
+            sendable_tx,
+            external_tx_id,
+            ..
+        }) = self.store.load(issuer_request_id).await?
+        else {
+            return Err(BurnManagerError::InvalidAggregateState {
+                current_state: "expected replacement BurnIntended".to_string(),
+            });
+        };
+
+        self.store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::BurnTokens {
+                    issuer_request_id: issuer_request_id.clone(),
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: planned_to_burn_entries(&planned_burns),
+                        dust_shares: sendable_tx.dust_shares,
+                        owner: self.bot_wallet,
+                    },
+                    external_tx_id,
+                },
+            )
+            .await?;
+
+        Ok(())
     }
 
     async fn recover_single_burning(
@@ -1763,10 +1765,12 @@ impl BurnManager {
                 issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault: execution.vault,
-                    burns: execution.burns.clone(),
-                    dust_shares: execution.dust_shares,
-                    owner: self.bot_wallet,
+                    params: BurnParams::VaultDirect {
+                        vault: execution.vault,
+                        burns: execution.burns.clone(),
+                        dust_shares: execution.dust_shares,
+                        owner: self.bot_wallet,
+                    },
                     external_tx_id: execution.external_tx_id.clone(),
                 },
             )
@@ -1872,10 +1876,12 @@ impl BurnManager {
                 issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault: execution.vault,
-                    burns: execution.burns.clone(),
-                    dust_shares: execution.dust_shares,
-                    owner: self.bot_wallet,
+                    params: BurnParams::VaultDirect {
+                        vault: execution.vault,
+                        burns: execution.burns.clone(),
+                        dust_shares: execution.dust_shares,
+                        owner: self.bot_wallet,
+                    },
                     external_tx_id: execution.external_tx_id.clone(),
                 },
             )
@@ -1889,7 +1895,12 @@ impl BurnManager {
                 self.load_submitted_tx_id(issuer_request_id).await
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
-                RedemptionError::Vault { message, release_reservation, tx_id },
+                RedemptionError::Vault {
+                    message,
+                    release_reservation,
+                    tx_id,
+                    classification,
+                },
             ))) => {
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %message,
@@ -1915,6 +1926,7 @@ impl BurnManager {
                             message,
                             release_reservation: false,
                             tx_id,
+                            classification,
                         },
                     ));
                 }
@@ -1923,8 +1935,7 @@ impl BurnManager {
                     .send(
                         issuer_request_id,
                         RedemptionCommand::RecordBurnFailure {
-                            classification:
-                                BurnFailureClassification::Unclassified,
+                            classification: classification.clone(),
                             issuer_request_id: issuer_request_id.clone(),
                             error: message.clone(),
                             tx_id: tx_id.clone(),
@@ -1936,6 +1947,7 @@ impl BurnManager {
                     message,
                     release_reservation,
                     tx_id,
+                    classification,
                 }))
             }
             Err(error) => Err(error.into()),
@@ -1995,7 +2007,12 @@ impl BurnManager {
                 Ok(())
             }
             Err(AggregateError::UserError(LifecycleError::Apply(
-                RedemptionError::Vault { message, release_reservation, .. },
+                RedemptionError::Vault {
+                    message,
+                    release_reservation,
+                    classification,
+                    ..
+                },
             ))) => {
                 warn!(target: "redemption", issuer_request_id = %issuer_request_id,
                     error = %message,
@@ -2015,8 +2032,7 @@ impl BurnManager {
                         .send(
                             issuer_request_id,
                             RedemptionCommand::RecordBurnFailure {
-                                classification:
-                                    BurnFailureClassification::Unclassified,
+                                classification: classification.clone(),
                                 issuer_request_id: issuer_request_id.clone(),
                                 error: message.clone(),
                                 tx_id: exact_recovery
@@ -2038,6 +2054,7 @@ impl BurnManager {
                     message,
                     release_reservation,
                     tx_id: None,
+                    classification,
                 }))
             }
             Err(error) => Err(error.into()),
@@ -2239,10 +2256,23 @@ const fn aggregate_state_name(aggregate: &Redemption) -> &'static str {
 }
 
 /// Extracts the transaction hash from a `VaultError`.
+fn planned_to_burn_entries(planned: &[BurnRecord]) -> Vec<MultiBurnEntry> {
+    planned
+        .iter()
+        .map(|burn| MultiBurnEntry {
+            receipt_id: burn.receipt_id,
+            burn_shares: burn.shares_burned,
+            receipt_info: None,
+            receipt_info_bytes: None,
+        })
+        .collect()
+}
+
 pub(crate) const fn extract_tx_hash(error: &VaultError) -> Option<B256> {
     match error {
         VaultError::Reverted { tx_hash }
-        | VaultError::EventNotFound { tx_hash } => Some(*tx_hash),
+        | VaultError::EventNotFound { tx_hash }
+        | VaultError::OrchestratorReverted { tx_hash, .. } => Some(*tx_hash),
         _ => None,
     }
 }
@@ -2339,7 +2369,7 @@ mod tests {
     use crate::redemption::RedemptionServices;
     use crate::redemption::view::{RedemptionViewReactor, find_burn_failed};
     use crate::redemption::{
-        BurnFailureClassification, BurnRecord, BurnRecoveryAction,
+        BurnFailureClassification, BurnParams, BurnRecord, BurnRecoveryAction,
         IssuerRedemptionRequestId, RedemptionError,
     };
     use crate::test_utils::{ANVIL_CHAIN_ID, log_count_at, logs_contain_at};
@@ -2724,15 +2754,17 @@ mod tests {
                 issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(42_U256),
-                        burn_shares: uint!(17_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(42_U256),
+                            burn_shares: uint!(17_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5008,15 +5040,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: recovery_owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: recovery_owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5188,10 +5222,12 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![],
-                    dust_shares: U256::ZERO,
-                    owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5307,15 +5343,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: recovery_owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: recovery_owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5374,10 +5412,12 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![],
-                    dust_shares: U256::ZERO,
-                    owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5568,11 +5608,13 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![],
-                    dust_shares: U256::ZERO,
-                    owner,
                     external_tx_id: None,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                 },
             )
             .await
@@ -5771,15 +5813,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(42_U256),
-                        burn_shares: uint!(17_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(42_U256),
+                            burn_shares: uint!(17_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5850,10 +5894,12 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![],
-                    dust_shares: U256::ZERO,
-                    owner,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![],
+                        dust_shares: U256::ZERO,
+                        owner,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -5933,15 +5979,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: TEST_WALLET,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: TEST_WALLET,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -6013,12 +6061,14 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault: address!(
-                        "0xcccccccccccccccccccccccccccccccccccccccc"
-                    ),
-                    burns: vec![],
-                    dust_shares: U256::ZERO,
-                    owner: TEST_WALLET,
+                    params: BurnParams::VaultDirect {
+                        vault: address!(
+                            "0xcccccccccccccccccccccccccccccccccccccccc"
+                        ),
+                        burns: vec![],
+                        dust_shares: U256::ZERO,
+                        owner: TEST_WALLET,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -6097,15 +6147,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: TEST_WALLET,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: TEST_WALLET,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -6481,15 +6533,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::IntendBurn {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![crate::vault::MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: TEST_WALLET,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![crate::vault::MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: TEST_WALLET,
+                    },
                     external_tx_id: None,
                 },
             )
@@ -6501,15 +6555,17 @@ mod tests {
                 &issuer_request_id,
                 RedemptionCommand::BurnTokens {
                     issuer_request_id: issuer_request_id.clone(),
-                    vault,
-                    burns: vec![crate::vault::MultiBurnEntry {
-                        receipt_id: uint!(99_U256),
-                        burn_shares: uint!(100_000000000000000000_U256),
-                        receipt_info: None,
-                        receipt_info_bytes: None,
-                    }],
-                    dust_shares: U256::ZERO,
-                    owner: TEST_WALLET,
+                    params: BurnParams::VaultDirect {
+                        vault,
+                        burns: vec![crate::vault::MultiBurnEntry {
+                            receipt_id: uint!(99_U256),
+                            burn_shares: uint!(100_000000000000000000_U256),
+                            receipt_info: None,
+                            receipt_info_bytes: None,
+                        }],
+                        dust_shares: U256::ZERO,
+                        owner: TEST_WALLET,
+                    },
                     external_tx_id: None,
                 },
             )

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -9,6 +9,31 @@ use crate::redemption::event::BurnFailureClassification;
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{MultiBurnEntry, TxId};
 
+/// Mode-specific burn parameters carried by `IntendBurn` and `BurnTokens`.
+///
+/// The handler cross-checks the variant against the redemption's persisted
+/// `burn_mode` anchor and rejects a mismatch, so a caller can never drive a
+/// vault-direct redemption down the orchestrator path or vice versa.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum BurnParams {
+    VaultDirect {
+        vault: Address,
+        /// Burns to execute (receipt_id + amount for each)
+        burns: Vec<MultiBurnEntry>,
+        /// Dust to return to user
+        dust_shares: U256,
+        owner: Address,
+    },
+    Orchestrator {
+        /// The vault contract, which is also the ERC-20 share token.
+        token: Address,
+        /// Burn amount in 18-decimal share-wei (dust stays in the bot
+        /// wallet).
+        amount: U256,
+        owner: Address,
+    },
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum RedemptionCommand {
     Detect {
@@ -46,16 +71,13 @@ pub(crate) enum RedemptionCommand {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
     },
-    /// Submits burn transaction to the signing backend.
-    /// Produces `BurnTxSubmitted` on success, or the caller records failure.
+    /// Broadcasts the exact transaction persisted by `IntendBurn`.
+    /// Produces `BurnTxSubmitted` (vault-direct) or
+    /// `OrchestratorBurnSubmitted` (orchestrator) on success, or the caller
+    /// records failure.
     BurnTokens {
         issuer_request_id: IssuerRedemptionRequestId,
-        vault: Address,
-        /// Burns to execute (receipt_id + amount for each)
-        burns: Vec<MultiBurnEntry>,
-        /// Dust to return to user
-        dust_shares: U256,
-        owner: Address,
+        params: BurnParams,
         /// Optional deterministic transaction `externalTxId` override.
         /// Used when retrying a replacement burn after a prior accepted
         /// transaction burn terminally failed.
@@ -148,12 +170,7 @@ pub(crate) enum RedemptionCommand {
     },
     IntendBurn {
         issuer_request_id: IssuerRedemptionRequestId,
-        vault: Address,
-        /// Burns to execute (receipt_id + amount for each)
-        burns: Vec<MultiBurnEntry>,
-        /// Dust to return to user
-        dust_shares: U256,
-        owner: Address,
+        params: BurnParams,
         /// Optional deterministic `externalTxId` override.
         #[serde(default)]
         external_tx_id: Option<BurnExternalTxId>,

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::config::VaultMode;
 use crate::mint::{Quantity, TokenizationRequestId};
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
-use crate::vault::{SendableTxWithHash, TxId};
+use crate::vault::{BurnRange, SendableTxWithHash, TxId};
 
 /// Typed classification of an on-chain or pre-submit burn failure.
 ///
@@ -296,6 +296,35 @@ pub(crate) enum RedemptionEvent {
         sendable_tx: SendableTxWithHash,
         planned_burns: Vec<BurnRecord>,
     },
+    /// Orchestrator-mode burn transaction broadcast (the counterpart of
+    /// `BurnTxSubmitted`). Carries no `planned_burns` — there is no
+    /// per-receipt plan to reserve; the orchestrator walks receipts on-chain.
+    OrchestratorBurnSubmitted {
+        issuer_request_id: IssuerRedemptionRequestId,
+        external_tx_id: BurnExternalTxId,
+        tx_id: TxId,
+        submitted_at: DateTime<Utc>,
+    },
+    /// Orchestrator-mode burn succeeded on-chain, redemption complete
+    /// (terminal success). Carries the consumed receipt pointer range from
+    /// the orchestrator's `Burned` event instead of a per-receipt `burns`
+    /// list.
+    OrchestratorTokensBurned {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        shares_burned: U256,
+        /// Consumed receipt-pointer range from the `Burned` event
+        /// (`firstReceiptId` / `nextBurnReceiptIdAfter`), half-open.
+        burn_range: BurnRange,
+        /// Sub-10⁻⁹-token residue retained in the bot wallet, derived from
+        /// this redemption's own persisted `AlpacaCalled.dust_quantity`
+        /// converted to share-wei — the orchestrator has no multicall to
+        /// atomically return dust through (SPEC Decision 6).
+        dust_retained: U256,
+        gas_used: u64,
+        block_number: u64,
+        burned_at: DateTime<Utc>,
+    },
     BurnRecoveryAttempted {
         issuer_request_id: IssuerRedemptionRequestId,
         tx_hash: B256,
@@ -364,6 +393,12 @@ impl DomainEvent for RedemptionEvent {
             }
             Self::BurnIntended { .. } => {
                 "RedemptionEvent::BurnIntended".to_string()
+            }
+            Self::OrchestratorBurnSubmitted { .. } => {
+                "RedemptionEvent::OrchestratorBurnSubmitted".to_string()
+            }
+            Self::OrchestratorTokensBurned { .. } => {
+                "RedemptionEvent::OrchestratorTokensBurned".to_string()
             }
             Self::BurnRecoveryAttempted { .. } => {
                 "RedemptionEvent::BurnRecoveryAttempted".to_string()
@@ -847,6 +882,49 @@ mod tests {
             serde_json::from_str(&serialized).unwrap();
 
         assert_eq!(event, deserialized);
+    }
+
+    #[test]
+    fn orchestrator_event_types_and_round_trips() {
+        let submitted = RedemptionEvent::OrchestratorBurnSubmitted {
+            issuer_request_id: test_redemption_id(),
+            external_tx_id: BurnExternalTxId::from_string(
+                "burn-0xabcd".to_string(),
+            ),
+            tx_id: TxId::random(),
+            submitted_at: Utc::now(),
+        };
+        let burned = RedemptionEvent::OrchestratorTokensBurned {
+            issuer_request_id: test_redemption_id(),
+            tx_hash: B256::random(),
+            shares_burned: uint!(17_000000000000000000_U256),
+            burn_range: BurnRange {
+                first_receipt_id: uint!(3_U256),
+                next_burn_receipt_id_after: uint!(6_U256),
+            },
+            dust_retained: uint!(1_000_000_000_U256),
+            gas_used: 50_000,
+            block_number: 45_000_100,
+            burned_at: Utc::now(),
+        };
+
+        assert_eq!(
+            submitted.event_type(),
+            "RedemptionEvent::OrchestratorBurnSubmitted"
+        );
+        assert_eq!(
+            burned.event_type(),
+            "RedemptionEvent::OrchestratorTokensBurned"
+        );
+        assert_eq!(submitted.event_version(), "1.0");
+        assert_eq!(burned.event_version(), "1.0");
+
+        for event in [submitted, burned] {
+            let serialized = serde_json::to_string(&event).unwrap();
+            let deserialized: RedemptionEvent =
+                serde_json::from_str(&serialized).unwrap();
+            assert_eq!(event, deserialized);
+        }
     }
 
     /// Tests that old BurnResumed events without external_tx_id default to None.

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 use tracing::warn;
 
 use crate::Quantity;
-use crate::config::VaultMode;
+use crate::config::{VaultMode, VaultModeKind};
 use crate::mint::TokenizationRequestId;
 use crate::redemption::burn_manager::{
     extract_tx_hash, is_pending_burn_confirmation, should_release_reserved_burn,
@@ -192,9 +192,9 @@ impl std::fmt::Display for BurnExternalTxId {
 }
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{
-    BurnRequestOrigin, BurnTxStatus, MultiBurnEntry, MultiBurnParams,
-    NetworkVaultServices, SendableTxWithHash, TxId, UnconfiguredNetworkError,
-    VaultError, VaultService,
+    BurnRequestOrigin, BurnTxStatus, MultiBurnParams, NetworkVaultServices,
+    OrchestratorBurnParams, OrchestratorRevertReason, SendableTxWithHash, TxId,
+    UnconfiguredNetworkError, VaultError, VaultService,
 };
 
 pub(super) const fn default_redemption_network() -> Network {
@@ -231,7 +231,7 @@ impl RedemptionServices {
     }
 }
 
-pub(crate) use cmd::RedemptionCommand;
+pub(crate) use cmd::{BurnParams, RedemptionCommand};
 pub(crate) use event::{
     BurnFailureClassification, BurnRecord, RedemptionEvent, TokensBurnedData,
 };
@@ -354,16 +354,55 @@ pub(crate) enum BurnRecoveryAction {
     Replace,
 }
 
-/// Input parameters for the BurnTokens command handler.
+/// Input parameters for the IntendBurn/BurnTokens command handlers.
 ///
 /// Groups burn-related parameters to reduce argument count. The `user` field
 /// is derived from aggregate state, not passed in the command.
 struct BurnInput {
-    vault: Address,
-    burns: Vec<MultiBurnEntry>,
-    dust_shares: U256,
-    owner: Address,
+    params: BurnParams,
     external_tx_id: Option<BurnExternalTxId>,
+}
+
+/// Maps a `VaultError` into the serializable `RedemptionError::Vault`,
+/// computing the reservation-release flag, recoverable tx id, and typed
+/// classification at the aggregate boundary where the typed error is last
+/// visible.
+fn vault_error_to_redemption(error: &VaultError) -> RedemptionError {
+    RedemptionError::Vault {
+        release_reservation: should_release_reserved_burn(error),
+        tx_id: extract_tx_hash(error).map(Into::into),
+        classification: burn_failure_classification(error),
+        message: error.to_string(),
+    }
+}
+
+/// Maps a typed `VaultError` to the burn-failure classification persisted on
+/// `BurningFailed`. Only decoded orchestrator reverts classify; everything
+/// else stays `Unclassified` (including `OrchestratorRevertReason::Unknown`,
+/// which proves a revert but not its reason).
+const fn burn_failure_classification(
+    error: &VaultError,
+) -> BurnFailureClassification {
+    match error {
+        VaultError::OrchestratorReverted { reason, .. } => match reason {
+            OrchestratorRevertReason::InsufficientReceipts {
+                shortfall,
+                ..
+            } => BurnFailureClassification::InsufficientReceipts {
+                shortfall: *shortfall,
+            },
+            OrchestratorRevertReason::VaultLogicMismatch => {
+                BurnFailureClassification::VaultLogicMismatch
+            }
+            OrchestratorRevertReason::ReceiptLogicMismatch => {
+                BurnFailureClassification::ReceiptLogicMismatch
+            }
+            OrchestratorRevertReason::Unknown => {
+                BurnFailureClassification::Unclassified
+            }
+        },
+        _ => BurnFailureClassification::Unclassified,
+    }
 }
 
 struct ResumeBurnInput {
@@ -514,8 +553,10 @@ impl Redemption {
         }])
     }
 
-    /// Submits the burn transaction to the signing backend.
-    /// Produces `BurnTxSubmitted` on success; failure is propagated to caller.
+    /// Broadcasts the persisted burn transaction.
+    /// Produces `BurnTxSubmitted` (vault-direct) or
+    /// `OrchestratorBurnSubmitted` (orchestrator) on success; failure is
+    /// propagated to the caller.
     async fn handle_burn_tokens(
         &self,
         services: &RedemptionServices,
@@ -531,50 +572,92 @@ impl Redemption {
             });
         };
 
-        let user_wallet = metadata.wallet;
-        let vault_service = services.vault_for(metadata.network)?;
+        match input.params {
+            BurnParams::VaultDirect { vault, burns, dust_shares, owner } => {
+                if let VaultMode::Orchestrator { .. } = metadata.burn_mode {
+                    return Err(RedemptionError::BurnModeMismatch {
+                        expected: VaultModeKind::Orchestrator,
+                        found: VaultModeKind::VaultDirect,
+                    });
+                }
 
-        let planned_burns: Vec<BurnRecord> = input
-            .burns
-            .iter()
-            .map(|entry| BurnRecord {
-                receipt_id: entry.receipt_id,
-                shares_burned: entry.burn_shares,
-            })
-            .collect();
+                let planned_burns: Vec<BurnRecord> = burns
+                    .iter()
+                    .map(|entry| BurnRecord {
+                        receipt_id: entry.receipt_id,
+                        shares_burned: entry.burn_shares,
+                    })
+                    .collect();
 
-        let params = MultiBurnParams {
-            vault: input.vault,
-            burns: input.burns,
-            dust_shares: input.dust_shares,
-            owner: input.owner,
-            user: user_wallet,
-            origin: BurnRequestOrigin::Redemption(issuer_request_id.clone()),
-            detected_tx_hash: metadata.detected_tx_hash,
-            external_tx_id: input.external_tx_id,
-        };
+                let params = MultiBurnParams {
+                    vault,
+                    burns,
+                    dust_shares,
+                    owner,
+                    user: metadata.wallet,
+                    origin: BurnRequestOrigin::Redemption(
+                        issuer_request_id.clone(),
+                    ),
+                    detected_tx_hash: metadata.detected_tx_hash,
+                    external_tx_id: input.external_tx_id,
+                };
 
-        let submitted = vault_service
-            .submit_burn(params, sendable_tx.clone())
-            .await
-            .map_err(|error: VaultError| RedemptionError::Vault {
-                release_reservation: should_release_reserved_burn(&error),
-                tx_id: extract_tx_hash(&error).map(Into::into),
-                message: error.to_string(),
-            })?;
+                let submitted = services
+                    .vault_for(metadata.network)?
+                    .submit_burn(params, sendable_tx.clone())
+                    .await
+                    .map_err(|error| vault_error_to_redemption(&error))?;
 
-        Ok(vec![RedemptionEvent::BurnTxSubmitted {
-            issuer_request_id,
-            external_tx_id: BurnExternalTxId::from_string(
-                submitted.external_tx_id,
-            ),
-            tx_id: submitted.tx_id,
-            planned_burns,
-            submitted_at: Utc::now(),
-        }])
+                Ok(vec![RedemptionEvent::BurnTxSubmitted {
+                    issuer_request_id,
+                    external_tx_id: BurnExternalTxId::from_string(
+                        submitted.external_tx_id,
+                    ),
+                    tx_id: submitted.tx_id,
+                    planned_burns,
+                    submitted_at: Utc::now(),
+                }])
+            }
+            BurnParams::Orchestrator { token, amount, owner } => {
+                let VaultMode::Orchestrator { address: orchestrator } =
+                    metadata.burn_mode
+                else {
+                    return Err(RedemptionError::BurnModeMismatch {
+                        expected: VaultModeKind::VaultDirect,
+                        found: VaultModeKind::Orchestrator,
+                    });
+                };
+
+                let params = OrchestratorBurnParams {
+                    orchestrator,
+                    token,
+                    amount,
+                    owner,
+                    issuer_request_id: issuer_request_id.clone(),
+                    detected_tx_hash: metadata.detected_tx_hash,
+                    external_tx_id: input.external_tx_id,
+                };
+
+                let submitted = services
+                    .vault_for(metadata.network)?
+                    .submit_orchestrator_burn(&params, sendable_tx)
+                    .await
+                    .map_err(|error| vault_error_to_redemption(&error))?;
+
+                Ok(vec![RedemptionEvent::OrchestratorBurnSubmitted {
+                    issuer_request_id,
+                    external_tx_id: BurnExternalTxId::from_string(
+                        submitted.external_tx_id,
+                    ),
+                    tx_id: submitted.tx_id,
+                    submitted_at: Utc::now(),
+                }])
+            }
+        }
     }
 
-    /// Confirms a previously submitted burn transaction.
+    /// Confirms a previously submitted burn transaction, branching on this
+    /// redemption's persisted `burn_mode` anchor.
     async fn handle_confirm_burn(
         &self,
         services: &RedemptionServices,
@@ -582,20 +665,34 @@ impl Redemption {
         tx_id: TxId,
         dust_shares: U256,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let (metadata, stored_tx_id) = match self {
-            Self::BurnSubmitted { metadata, tx_id, .. } => {
-                (metadata, tx_id.clone())
-            }
-            Self::BurnIntended { metadata, sendable_tx, .. } => {
-                (metadata, sendable_tx.hash.into())
-            }
-            _ => {
-                return Err(RedemptionError::InvalidState {
-                    expected: "BurnSubmitted or BurnIntended".to_string(),
-                    found: self.state_name().to_string(),
-                });
-            }
-        };
+        let (stored_tx_id, metadata, alpaca_quantity, dust_quantity) =
+            match self {
+                Self::BurnSubmitted {
+                    tx_id,
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                    ..
+                } => (tx_id.clone(), metadata, alpaca_quantity, dust_quantity),
+                Self::BurnIntended {
+                    sendable_tx,
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                    ..
+                } => (
+                    sendable_tx.hash.into(),
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                ),
+                _ => {
+                    return Err(RedemptionError::InvalidState {
+                        expected: "BurnSubmitted or BurnIntended".to_string(),
+                        found: self.state_name().to_string(),
+                    });
+                }
+            };
 
         if stored_tx_id != tx_id {
             return Err(RedemptionError::TxIdMismatch {
@@ -604,25 +701,66 @@ impl Redemption {
             });
         }
 
-        let vault_service = services.vault_for(metadata.network)?;
+        let map_confirm_error = |error: VaultError| {
+            if is_pending_burn_confirmation(&error) {
+                return RedemptionError::BurnConfirmationPending {
+                    tx_id: tx_id.clone(),
+                    message: error.to_string(),
+                };
+            }
 
-        let result = vault_service
+            vault_error_to_redemption(&error)
+        };
+
+        if let VaultMode::Orchestrator { .. } = metadata.burn_mode {
+            // `dust_shares` is vault-direct-shaped and always 0 here; dust
+            // is retained in the bot wallet and recorded from this
+            // redemption's own persisted `dust_quantity` (SPEC Decision 6).
+            let result = services
+                .vault_for(metadata.network)?
+                .confirm_orchestrator_burn(&tx_id)
+                .await
+                .map_err(map_confirm_error)?;
+
+            // `shares_burned` terminalizes 1:1 accounting: it must equal
+            // this redemption's own persisted `alpaca_quantity` in
+            // share-wei, or terminal success would record an economic value
+            // the journal never backed.
+            let expected_shares = alpaca_quantity
+                .to_u256_with_18_decimals()
+                .map_err(|error| RedemptionError::QuantityConversion {
+                    message: error.to_string(),
+                })?;
+            if result.shares_burned != expected_shares {
+                return Err(RedemptionError::OrchestratorAmountMismatch {
+                    expected: expected_shares,
+                    actual: result.shares_burned,
+                });
+            }
+
+            let dust_retained = dust_quantity
+                .to_u256_with_18_decimals()
+                .map_err(|error| RedemptionError::QuantityConversion {
+                    message: error.to_string(),
+                })?;
+
+            return Ok(vec![RedemptionEvent::OrchestratorTokensBurned {
+                issuer_request_id,
+                tx_hash: result.tx_hash,
+                shares_burned: result.shares_burned,
+                burn_range: result.burn_range,
+                dust_retained,
+                gas_used: result.gas_used,
+                block_number: result.block_number,
+                burned_at: Utc::now(),
+            }]);
+        }
+
+        let result = services
+            .vault_for(metadata.network)?
             .confirm_burn(&tx_id, dust_shares)
             .await
-            .map_err(|error| {
-                if is_pending_burn_confirmation(&error) {
-                    return RedemptionError::BurnConfirmationPending {
-                        tx_id: tx_id.clone(),
-                        message: error.to_string(),
-                    };
-                }
-
-                RedemptionError::Vault {
-                    release_reservation: should_release_reserved_burn(&error),
-                    tx_id: extract_tx_hash(&error).map(Into::into),
-                    message: error.to_string(),
-                }
-            })?;
+            .map_err(map_confirm_error)?;
 
         let burns = result
             .burns
@@ -1033,48 +1171,123 @@ impl Redemption {
         // from it would sign a replacement that could burn twice if the
         // original already reached the node. Recovery re-broadcasts the
         // persisted transaction instead.
-        let Self::Burning { metadata, .. } = self else {
+        let Self::Burning { metadata, alpaca_quantity, .. } = self else {
             return Err(RedemptionError::InvalidState {
                 expected: "Burning".to_string(),
                 found: self.state_name().to_string(),
             });
         };
 
-        let user_wallet = metadata.wallet;
-        let vault_service = services.vault_for(metadata.network)?;
+        match input.params {
+            BurnParams::VaultDirect { vault, burns, dust_shares, owner } => {
+                if let VaultMode::Orchestrator { .. } = metadata.burn_mode {
+                    return Err(RedemptionError::BurnModeMismatch {
+                        expected: VaultModeKind::Orchestrator,
+                        found: VaultModeKind::VaultDirect,
+                    });
+                }
 
-        let planned_burns: Vec<BurnRecord> = input
-            .burns
-            .iter()
-            .map(|entry| BurnRecord {
-                receipt_id: entry.receipt_id,
-                shares_burned: entry.burn_shares,
-            })
-            .collect();
+                let planned_burns: Vec<BurnRecord> = burns
+                    .iter()
+                    .map(|entry| BurnRecord {
+                        receipt_id: entry.receipt_id,
+                        shares_burned: entry.burn_shares,
+                    })
+                    .collect();
 
-        let params = MultiBurnParams {
-            vault: input.vault,
-            burns: input.burns,
-            dust_shares: input.dust_shares,
-            owner: input.owner,
-            user: user_wallet,
-            origin: BurnRequestOrigin::Redemption(issuer_request_id.clone()),
-            detected_tx_hash: metadata.detected_tx_hash,
-            external_tx_id: input.external_tx_id,
-        };
+                let params = MultiBurnParams {
+                    vault,
+                    burns,
+                    dust_shares,
+                    owner,
+                    user: metadata.wallet,
+                    origin: BurnRequestOrigin::Redemption(
+                        issuer_request_id.clone(),
+                    ),
+                    detected_tx_hash: metadata.detected_tx_hash,
+                    external_tx_id: input.external_tx_id,
+                };
 
-        let sendable_tx =
-            vault_service.prepare_burn_tx(&params).await.map_err(
-                |error: VaultError| RedemptionError::PreparingBurnTxFailed {
-                    message: error.to_string(),
-                },
-            )?;
+                let sendable_tx = services
+                    .vault_for(metadata.network)?
+                    .prepare_burn_tx(&params)
+                    .await
+                    .map_err(|error: VaultError| {
+                        RedemptionError::PreparingBurnTxFailed {
+                            message: error.to_string(),
+                        }
+                    })?;
 
-        Ok(vec![RedemptionEvent::BurnIntended {
-            issuer_request_id,
-            sendable_tx,
-            planned_burns,
-        }])
+                Ok(vec![RedemptionEvent::BurnIntended {
+                    issuer_request_id,
+                    sendable_tx,
+                    planned_burns,
+                }])
+            }
+            BurnParams::Orchestrator { token, amount, owner } => {
+                let VaultMode::Orchestrator { address: orchestrator } =
+                    metadata.burn_mode
+                else {
+                    return Err(RedemptionError::BurnModeMismatch {
+                        expected: VaultModeKind::VaultDirect,
+                        found: VaultModeKind::Orchestrator,
+                    });
+                };
+
+                // Bind the command's economic value to this redemption's own
+                // persisted facts before anything is signed: `amount` must
+                // equal the state's `alpaca_quantity` in share-wei. `token`
+                // and `owner` have no persisted counterparts to bind against
+                // — the aggregate stores symbols, not addresses — so their
+                // authority is the BurnManager's vault-view resolution for
+                // this redemption's underlying+network, exactly as the
+                // vault-direct arm trusts its command-supplied `vault`. The
+                // signed calldata (including the token) is persisted in
+                // `BurnIntended.sendable_tx`, and confirmation cross-checks
+                // the mined `Burned` event against that same calldata —
+                // proving the recorded outcome matches what was signed,
+                // though not re-deriving which asset it was.
+                let expected_amount = alpaca_quantity
+                    .to_u256_with_18_decimals()
+                    .map_err(|error| RedemptionError::QuantityConversion {
+                        message: error.to_string(),
+                    })?;
+                if amount != expected_amount {
+                    return Err(RedemptionError::OrchestratorAmountMismatch {
+                        expected: expected_amount,
+                        actual: amount,
+                    });
+                }
+
+                let params = OrchestratorBurnParams {
+                    orchestrator,
+                    token,
+                    amount,
+                    owner,
+                    issuer_request_id: issuer_request_id.clone(),
+                    detected_tx_hash: metadata.detected_tx_hash,
+                    external_tx_id: input.external_tx_id,
+                };
+
+                let sendable_tx = services
+                    .vault_for(metadata.network)?
+                    .prepare_orchestrator_burn_tx(&params)
+                    .await
+                    .map_err(|error: VaultError| {
+                        RedemptionError::PreparingBurnTxFailed {
+                            message: error.to_string(),
+                        }
+                    })?;
+
+                // No per-receipt plan: the orchestrator walks its own
+                // receipts on-chain.
+                Ok(vec![RedemptionEvent::BurnIntended {
+                    issuer_request_id,
+                    sendable_tx,
+                    planned_burns: vec![],
+                }])
+            }
+        }
     }
 
     const fn current_sendable_tx(&self) -> Option<&SendableTxWithHash> {
@@ -1342,12 +1555,14 @@ pub(crate) fn next_burn_retry_external_tx_id_from_history<'a>(
                 external_tx_id: Some(external_tx_id),
                 ..
             } => Some(Ok(external_tx_id.clone())),
-            RedemptionEvent::BurnTxSubmitted { external_tx_id, .. } => {
-                Some(Redemption::next_burn_retry_external_tx_id(
-                    detected_tx_hash,
-                    external_tx_id,
-                ))
-            }
+            RedemptionEvent::BurnTxSubmitted { external_tx_id, .. }
+            | RedemptionEvent::OrchestratorBurnSubmitted {
+                external_tx_id,
+                ..
+            } => Some(Redemption::next_burn_retry_external_tx_id(
+                detected_tx_hash,
+                external_tx_id,
+            )),
             _ => None,
         })
         .transpose()
@@ -1375,7 +1590,24 @@ pub(crate) enum RedemptionError {
         /// Transaction id pulled from the `VaultError`, if any, so a
         /// possibly-in-flight burn stays recoverable after the type is erased.
         tx_id: Option<TxId>,
+        /// Typed burn-failure classification derived from the `VaultError`
+        /// at the same boundary, so retry-exclusion and `BurningFailed`
+        /// recording key off it rather than parsing `message`.
+        #[serde(default)]
+        classification: BurnFailureClassification,
     },
+    #[error(
+        "Burn params mode does not match this redemption's persisted \
+         burn_mode anchor: expected {expected}, found {found}"
+    )]
+    BurnModeMismatch { expected: VaultModeKind, found: VaultModeKind },
+    #[error(
+        "Orchestrator burn amount {actual} diverges from the persisted \
+         alpaca_quantity {expected} in share-wei"
+    )]
+    OrchestratorAmountMismatch { expected: U256, actual: U256 },
+    #[error("Quantity conversion failed: {message}")]
+    QuantityConversion { message: String },
     #[error(
         "Transaction ID mismatch. Expected: {expected}, provided: {provided}"
     )]
@@ -1653,22 +1885,13 @@ impl EventSourced for Redemption {
             }
             RedemptionCommand::BurnTokens {
                 issuer_request_id,
-                vault,
-                burns,
-                dust_shares,
-                owner,
+                params,
                 external_tx_id,
             } => {
                 self.handle_burn_tokens(
                     services,
                     issuer_request_id,
-                    BurnInput {
-                        vault,
-                        burns,
-                        dust_shares,
-                        owner,
-                        external_tx_id,
-                    },
+                    BurnInput { params, external_tx_id },
                 )
                 .await
             }
@@ -1757,22 +1980,13 @@ impl EventSourced for Redemption {
             }),
             RedemptionCommand::IntendBurn {
                 issuer_request_id,
-                vault,
-                burns,
-                dust_shares,
-                owner,
+                params,
                 external_tx_id,
             } => {
                 self.handle_intend_burn(
                     services,
                     issuer_request_id,
-                    BurnInput {
-                        vault,
-                        burns,
-                        dust_shares,
-                        owner,
-                        external_tx_id,
-                    },
+                    BurnInput { params, external_tx_id },
                 )
                 .await
             }
@@ -1859,10 +2073,14 @@ impl Redemption {
             RedemptionEvent::BurnTxSubmitted { .. } => {
                 self.apply_burn_submitted_event(event);
             }
+            RedemptionEvent::OrchestratorBurnSubmitted { .. } => {
+                self.apply_orchestrator_burn_submitted_event(event);
+            }
             RedemptionEvent::BurnResumed { .. } => {
                 self.apply_burn_resumed_event(event);
             }
             RedemptionEvent::TokensBurned(_)
+            | RedemptionEvent::OrchestratorTokensBurned { .. }
             | RedemptionEvent::ExistingBurnRecovered { .. }
             | RedemptionEvent::RedemptionClosed { .. }
             | RedemptionEvent::BurnForceCompleted { .. } => {
@@ -2007,6 +2225,60 @@ impl Redemption {
         };
     }
 
+    /// Mirrors `apply_burn_submitted_event` for the orchestrator-mode
+    /// submission event, which carries no per-receipt plan.
+    fn apply_orchestrator_burn_submitted_event(
+        &mut self,
+        event: RedemptionEvent,
+    ) {
+        let RedemptionEvent::OrchestratorBurnSubmitted {
+            external_tx_id,
+            tx_id,
+            ..
+        } = event
+        else {
+            return;
+        };
+
+        let (Self::Burning {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            ..
+        }
+        | Self::BurnIntended {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            ..
+        }) = self.clone()
+        else {
+            return;
+        };
+
+        let sendable_tx =
+            self.current_sendable_tx().cloned().unwrap_or_default();
+
+        *self = Self::BurnSubmitted {
+            metadata,
+            tokenization_request_id,
+            alpaca_quantity,
+            dust_quantity,
+            called_at,
+            alpaca_journal_completed_at,
+            external_tx_id,
+            tx_id,
+            planned_burns: vec![],
+            sendable_tx,
+        };
+    }
+
     fn apply_burn_resumed_event(&mut self, event: RedemptionEvent) {
         let prior_burn_tx = match self {
             Self::Failed { unresolved_burn_tx, .. } => {
@@ -2067,7 +2339,13 @@ impl Redemption {
                 tx_hash,
                 burned_at,
                 ..
-            }) => {
+            })
+            | RedemptionEvent::OrchestratorTokensBurned {
+                issuer_request_id,
+                tx_hash,
+                burned_at,
+                ..
+            } => {
                 *self = Self::Completed {
                     issuer_request_id,
                     burn_tx_hash: tx_hash,
@@ -2222,21 +2500,22 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        BurnExternalTxId, BurnRecord, BurnRecoveryAction,
-        IssuerRedemptionRequestId, Redemption, RedemptionCommand,
-        RedemptionError, RedemptionEvent, RedemptionMetadata,
-        RedemptionServices, TokensBurnedData, has_unresolved_signer_intent,
+        BurnExternalTxId, BurnFailureClassification, BurnParams, BurnRecord,
+        BurnRecoveryAction, IssuerRedemptionRequestId, Redemption,
+        RedemptionCommand, RedemptionError, RedemptionEvent,
+        RedemptionMetadata, RedemptionServices, TokensBurnedData,
+        has_unresolved_signer_intent,
         next_burn_retry_external_tx_id_from_history,
     };
     use crate::config::VaultMode;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::prepare_event_sourced_startup;
-    use crate::redemption::BurnFailureClassification;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        BurnTxStatus, MultiBurnEntry, SendableTxWithHash, TxId, VaultService,
+        BurnRange, BurnTxStatus, MultiBurnEntry, OrchestratorBurnParams,
+        OrchestratorRevertReason, SendableTxWithHash, TxId, VaultService,
     };
 
     fn mock_services() -> RedemptionServices {
@@ -3455,15 +3734,17 @@ mod tests {
             ])
             .when(RedemptionCommand::IntendBurn {
                 issuer_request_id: issuer_request_id.clone(),
-                vault,
-                burns: vec![MultiBurnEntry {
-                    receipt_id,
-                    burn_shares,
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                }],
-                dust_shares: U256::ZERO,
-                owner,
+                params: BurnParams::VaultDirect {
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id,
+                        burn_shares,
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner,
+                },
                 external_tx_id: None,
             })
             .await
@@ -3509,15 +3790,17 @@ mod tests {
             }])
             .when(RedemptionCommand::IntendBurn {
                 issuer_request_id,
-                vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                burns: vec![MultiBurnEntry {
-                    receipt_id: uint!(1_U256),
-                    burn_shares: uint!(25_000000000000000000_U256),
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                }],
-                dust_shares: U256::ZERO,
-                owner: address!("0x1111111111111111111111111111111111111111"),
+                params: BurnParams::VaultDirect {
+                    vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(1_U256),
+                        burn_shares: uint!(25_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: address!("0x1111111111111111111111111111111111111111"),
+                },
                 external_tx_id: None,
             })
             .await
@@ -3957,15 +4240,17 @@ mod tests {
             ])
             .when(RedemptionCommand::BurnTokens {
                 issuer_request_id: issuer_request_id.clone(),
-                vault,
-                burns: vec![MultiBurnEntry {
-                    receipt_id,
-                    burn_shares,
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                }],
-                dust_shares: U256::ZERO,
-                owner,
+                params: BurnParams::VaultDirect {
+                    vault,
+                    burns: vec![MultiBurnEntry {
+                        receipt_id,
+                        burn_shares,
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner,
+                },
                 external_tx_id: None,
             })
             .await
@@ -4011,15 +4296,17 @@ mod tests {
             }])
             .when(RedemptionCommand::BurnTokens {
                 issuer_request_id,
-                vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                burns: vec![MultiBurnEntry {
-                    receipt_id: uint!(1_U256),
-                    burn_shares: uint!(25_000000000000000000_U256),
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                }],
-                dust_shares: U256::ZERO,
-                owner: address!("0x1111111111111111111111111111111111111111"),
+                params: BurnParams::VaultDirect {
+                    vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(1_U256),
+                        burn_shares: uint!(25_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: address!("0x1111111111111111111111111111111111111111"),
+                },
                 external_tx_id: None,
             })
             .await
@@ -4082,15 +4369,21 @@ mod tests {
             ))
             .when(RedemptionCommand::IntendBurn {
                 issuer_request_id,
-                vault: address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
-                burns: vec![MultiBurnEntry {
-                    receipt_id: uint!(1_U256),
-                    burn_shares: uint!(17_000000000000000000_U256),
-                    receipt_info: None,
-                    receipt_info_bytes: None,
-                }],
-                dust_shares: U256::ZERO,
-                owner: address!("0x1111111111111111111111111111111111111111"),
+                params: BurnParams::VaultDirect {
+                    vault: address!(
+                        "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                    ),
+                    burns: vec![MultiBurnEntry {
+                        receipt_id: uint!(1_U256),
+                        burn_shares: uint!(17_000000000000000000_U256),
+                        receipt_info: None,
+                        receipt_info_bytes: None,
+                    }],
+                    dust_shares: U256::ZERO,
+                    owner: address!(
+                        "0x1111111111111111111111111111111111111111"
+                    ),
+                },
                 external_tx_id: None,
             })
             .await
@@ -4294,6 +4587,537 @@ mod tests {
             planned_burns: vec![],
         });
         events
+    }
+
+    /// Orchestrator-anchored lifecycle up to `Burning`, with a non-zero dust
+    /// quantity so `dust_retained` derivation is observable.
+    fn orchestrator_burning_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Vec<RedemptionEvent> {
+        vec![
+            RedemptionEvent::Detected {
+                burn_mode: orchestrator_mode(),
+                issuer_request_id: issuer_request_id.clone(),
+                underlying: UnderlyingSymbol::new("RKLB").unwrap(),
+                token: TokenSymbol::new("tRKLB"),
+                wallet: address!("0xcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcdcd"),
+                quantity: Quantity::new(Decimal::from(17)),
+                tx_hash: b256!(
+                    "0x4444444444444444444444444444444444444444444444444444444444444444"
+                ),
+                block_number: 45_000_000,
+                detected_at: Utc::now(),
+                network: Network::Base,
+            },
+            RedemptionEvent::AlpacaCalled {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new(
+                    "alp-rklb-799",
+                ),
+                alpaca_quantity: Quantity::new(Decimal::from(17)),
+                // 10⁻⁹ tokens of dust, retained in the bot wallet.
+                dust_quantity: Quantity::new(Decimal::new(1, 9)),
+                called_at: Utc::now(),
+            },
+            RedemptionEvent::AlpacaJournalCompleted {
+                issuer_request_id: issuer_request_id.clone(),
+                alpaca_journal_completed_at: Utc::now(),
+            },
+        ]
+    }
+
+    fn orchestrator_burn_intended_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+        tx_hash: B256,
+    ) -> Vec<RedemptionEvent> {
+        let mut events = orchestrator_burning_given_events(issuer_request_id);
+        events.push(RedemptionEvent::BurnIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            sendable_tx: SendableTxWithHash {
+                tx: vec![1, 2, 3],
+                hash: tx_hash,
+                nonce: 7,
+                signed_at: Utc::now(),
+                dust_shares: U256::ZERO,
+            },
+            planned_burns: vec![],
+        });
+        events
+    }
+
+    fn orchestrator_burn_submitted_given_events(
+        issuer_request_id: &IssuerRedemptionRequestId,
+        tx_hash: B256,
+    ) -> Vec<RedemptionEvent> {
+        let mut events =
+            orchestrator_burn_intended_given_events(issuer_request_id, tx_hash);
+        events.push(RedemptionEvent::OrchestratorBurnSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: BurnExternalTxId::base(&b256!(
+                "0x4444444444444444444444444444444444444444444444444444444444444444"
+            )),
+            tx_id: TxId::Hash(tx_hash),
+            submitted_at: Utc::now(),
+        });
+        events
+    }
+
+    fn orchestrator_burn_params() -> BurnParams {
+        BurnParams::Orchestrator {
+            token: address!("0x1111111111111111111111111111111111111111"),
+            amount: uint!(17_000000000000000000_U256),
+            owner: address!("0x2222222222222222222222222222222222222222"),
+        }
+    }
+
+    fn vault_direct_burn_params() -> BurnParams {
+        BurnParams::VaultDirect {
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            burns: vec![],
+            dust_shares: U256::ZERO,
+            owner: address!("0x2222222222222222222222222222222222222222"),
+        }
+    }
+
+    #[tokio::test]
+    async fn intend_burn_orchestrator_mode_persists_empty_plan() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(orchestrator_burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::IntendBurn {
+                issuer_request_id,
+                params: orchestrator_burn_params(),
+                external_tx_id: None,
+            })
+            .await
+            .events();
+
+        assert!(
+            matches!(
+                events.as_slice(),
+                [RedemptionEvent::BurnIntended { planned_burns, .. }]
+                    if planned_burns.is_empty()
+            ),
+            "orchestrator intent must persist an empty receipt plan, \
+             got {events:?}"
+        );
+    }
+
+    /// The command's economic value is bound to the aggregate's own
+    /// persisted `alpaca_quantity` before anything is signed: a diverging
+    /// `amount` must be rejected, never signed into a transaction.
+    #[tokio::test]
+    async fn intend_burn_rejects_diverging_orchestrator_amount() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(orchestrator_burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::IntendBurn {
+                issuer_request_id,
+                params: BurnParams::Orchestrator {
+                    token: address!(
+                        "0x1111111111111111111111111111111111111111"
+                    ),
+                    // One share-wei above the persisted 17-token quantity.
+                    amount: uint!(17_000000000000000001_U256),
+                    owner: address!(
+                        "0x2222222222222222222222222222222222222222"
+                    ),
+                },
+                external_tx_id: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(
+                    RedemptionError::OrchestratorAmountMismatch { .. }
+                )
+            ),
+            "a diverging amount must be rejected before signing, \
+             got {error:?}"
+        );
+    }
+
+    /// Terminal success records `shares_burned` as the economic value the
+    /// journal backed: a confirmation whose on-chain `Burned.amount`
+    /// diverges from the persisted `alpaca_quantity` must be rejected, not
+    /// terminalized.
+    #[tokio::test]
+    async fn confirm_burn_rejects_diverging_burned_shares() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = b256!(
+            "0x4545454545454545454545454545454545454545454545454545454545454545"
+        );
+
+        // The mock's submit fills its pending confirm result from the
+        // submitted params, so a diverging submit here poisons the confirm
+        // the aggregate must then reject.
+        let services = mock_services();
+        let vault = services.vault_for(Network::Base).unwrap();
+        let diverging_params = OrchestratorBurnParams {
+            orchestrator: address!(
+                "0x00000000000000000000000000000000000000aa"
+            ),
+            token: address!("0x1111111111111111111111111111111111111111"),
+            amount: uint!(16_000000000000000000_U256),
+            owner: address!("0x2222222222222222222222222222222222222222"),
+            issuer_request_id: issuer_request_id.clone(),
+            detected_tx_hash: tx_hash,
+            external_tx_id: None,
+        };
+        let prepared = vault
+            .prepare_orchestrator_burn_tx(&diverging_params)
+            .await
+            .unwrap();
+        vault
+            .submit_orchestrator_burn(&diverging_params, &prepared)
+            .await
+            .unwrap();
+
+        let error = TestHarness::<Redemption>::with(services)
+            .given(orchestrator_burn_submitted_given_events(
+                &issuer_request_id,
+                tx_hash,
+            ))
+            .when(RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                tx_id: TxId::Hash(tx_hash),
+                dust_shares: U256::ZERO,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(
+                    RedemptionError::OrchestratorAmountMismatch { .. }
+                )
+            ),
+            "a diverging Burned.amount must not terminalize the redemption, \
+             got {error:?}"
+        );
+    }
+
+    /// The persisted `burn_mode` anchor is authoritative: params of the other
+    /// mode are rejected in both directions, for both `IntendBurn` and
+    /// `BurnTokens`.
+    #[tokio::test]
+    async fn burn_commands_reject_mode_mismatched_params() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+
+        let intend_cases = [
+            (
+                orchestrator_burning_given_events(&issuer_request_id),
+                vault_direct_burn_params(),
+            ),
+            (
+                burning_given_events(&issuer_request_id),
+                orchestrator_burn_params(),
+            ),
+        ];
+        for (given, params) in intend_cases {
+            let error = TestHarness::<Redemption>::with(mock_services())
+                .given(given)
+                .when(RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    params,
+                    external_tx_id: None,
+                })
+                .await
+                .then_expect_error();
+
+            assert!(
+                matches!(
+                    &error,
+                    LifecycleError::Apply(
+                        RedemptionError::BurnModeMismatch { .. }
+                    )
+                ),
+                "expected BurnModeMismatch, got {error:?}"
+            );
+        }
+
+        let submit_cases = [
+            (
+                orchestrator_burn_intended_given_events(
+                    &issuer_request_id,
+                    tx_hash,
+                ),
+                vault_direct_burn_params(),
+            ),
+            (
+                burn_intended_given_events(&issuer_request_id, tx_hash),
+                orchestrator_burn_params(),
+            ),
+        ];
+        for (given, params) in submit_cases {
+            let error = TestHarness::<Redemption>::with(mock_services())
+                .given(given)
+                .when(RedemptionCommand::BurnTokens {
+                    issuer_request_id: issuer_request_id.clone(),
+                    params,
+                    external_tx_id: None,
+                })
+                .await
+                .then_expect_error();
+
+            assert!(
+                matches!(
+                    &error,
+                    LifecycleError::Apply(
+                        RedemptionError::BurnModeMismatch { .. }
+                    )
+                ),
+                "expected BurnModeMismatch, got {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn burn_tokens_orchestrator_mode_emits_orchestrator_submitted() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let detected_tx_hash = b256!(
+            "0x4444444444444444444444444444444444444444444444444444444444444444"
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(orchestrator_burn_intended_given_events(
+                &issuer_request_id,
+                tx_hash,
+            ))
+            .when(RedemptionCommand::BurnTokens {
+                issuer_request_id,
+                params: orchestrator_burn_params(),
+                external_tx_id: None,
+            })
+            .await
+            .events();
+
+        let [
+            RedemptionEvent::OrchestratorBurnSubmitted {
+                external_tx_id,
+                tx_id,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected OrchestratorBurnSubmitted, got {events:?}");
+        };
+        assert_eq!(
+            *external_tx_id,
+            BurnExternalTxId::base(&detected_tx_hash),
+            "externalTxId must derive from the detected transfer hash"
+        );
+        assert_eq!(*tx_id, TxId::Hash(tx_hash));
+    }
+
+    /// `ConfirmBurn` in orchestrator mode ignores the vault-direct-shaped
+    /// `dust_shares` input and derives `dust_retained` from this redemption's
+    /// own persisted `AlpacaCalled.dust_quantity` (SPEC Decision 6).
+    #[tokio::test]
+    async fn confirm_burn_orchestrator_mode_derives_dust_retained_from_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let bogus_dust_shares = uint!(777_U256);
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(orchestrator_burn_submitted_given_events(
+                &issuer_request_id,
+                tx_hash,
+            ))
+            .when(RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                tx_id: TxId::Hash(tx_hash),
+                dust_shares: bogus_dust_shares,
+            })
+            .await
+            .events();
+
+        let [
+            RedemptionEvent::OrchestratorTokensBurned {
+                dust_retained,
+                shares_burned,
+                burn_range,
+                ..
+            },
+        ] = events.as_slice()
+        else {
+            panic!("Expected OrchestratorTokensBurned, got {events:?}");
+        };
+        // 10⁻⁹ tokens of persisted dust_quantity in 18-decimal share-wei.
+        assert_eq!(*dust_retained, uint!(1_000_000_000_U256));
+        assert_ne!(
+            *dust_retained, bogus_dust_shares,
+            "dust must not come from the command input"
+        );
+        assert!(*shares_burned > U256::ZERO);
+        assert!(
+            burn_range.next_burn_receipt_id_after > burn_range.first_receipt_id
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_burn_orchestrator_revert_carries_classification() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let vault: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success().with_orchestrator_confirm_revert(
+                OrchestratorRevertReason::InsufficientReceipts {
+                    token: address!(
+                        "0x1111111111111111111111111111111111111111"
+                    ),
+                    shortfall: uint!(250_U256),
+                },
+            ),
+        );
+        let services =
+            RedemptionServices::with_single_vault(Network::Base, vault);
+
+        let error = TestHarness::<Redemption>::with(services)
+            .given(orchestrator_burn_submitted_given_events(
+                &issuer_request_id,
+                tx_hash,
+            ))
+            .when(RedemptionCommand::ConfirmBurn {
+                issuer_request_id,
+                tx_id: TxId::Hash(tx_hash),
+                dust_shares: U256::ZERO,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(RedemptionError::Vault {
+                    classification:
+                        BurnFailureClassification::InsufficientReceipts {
+                            shortfall,
+                        },
+                    tx_id: Some(_),
+                    ..
+                }) if *shortfall == uint!(250_U256)
+            ),
+            "expected classified InsufficientReceipts carrying the reverted \
+             tx hash, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn orchestrator_events_replay_to_expected_states() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+
+        let submitted =
+            replay::<Redemption>(orchestrator_burn_submitted_given_events(
+                &issuer_request_id,
+                tx_hash,
+            ))
+            .unwrap()
+            .unwrap();
+        let Redemption::BurnSubmitted { metadata, planned_burns, .. } =
+            &submitted
+        else {
+            panic!("Expected BurnSubmitted, got {submitted:?}");
+        };
+        assert_eq!(metadata.burn_mode, orchestrator_mode());
+        assert!(planned_burns.is_empty());
+
+        let mut events = orchestrator_burn_submitted_given_events(
+            &issuer_request_id,
+            tx_hash,
+        );
+        events.push(RedemptionEvent::OrchestratorTokensBurned {
+            issuer_request_id,
+            tx_hash,
+            shares_burned: uint!(17_000000000000000000_U256),
+            burn_range: BurnRange {
+                first_receipt_id: uint!(3_U256),
+                next_burn_receipt_id_after: uint!(6_U256),
+            },
+            dust_retained: uint!(1_000_000_000_U256),
+            gas_used: 50_000,
+            block_number: 45_000_100,
+            burned_at: Utc::now(),
+        });
+        let completed = replay::<Redemption>(events).unwrap().unwrap();
+        assert!(
+            matches!(
+                &completed,
+                Redemption::Completed { burn_tx_hash, .. }
+                    if *burn_tx_hash == tx_hash
+            ),
+            "expected Completed, got {completed:?}"
+        );
+    }
+
+    /// An `OrchestratorBurnSubmitted` following a `BurnIntended` resolves the
+    /// wallet-intent gate the same way `BurnTxSubmitted` does: it falls
+    /// outside the release trigger's exclusion list, so the signer
+    /// reservation is dropped on submission.
+    #[tokio::test]
+    async fn orchestrator_submission_resolves_wallet_intent_gate() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+        let aggregate_id = IssuerRedemptionRequestId::random().to_string();
+
+        for (sequence, event_type, payload) in [
+            (
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+        ] {
+            insert_redemption_event(
+                &pool,
+                &aggregate_id,
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("test event should insert");
+        }
+
+        assert!(
+            has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "an intended orchestrator burn must hold the gate before \
+             submission"
+        );
+
+        insert_redemption_event(
+            &pool,
+            &aggregate_id,
+            3,
+            "RedemptionEvent::OrchestratorBurnSubmitted",
+            "{}",
+        )
+        .await
+        .expect("the submission event should insert");
+
+        assert!(
+            !has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "orchestrator submission must resolve the wallet-intent gate"
+        );
     }
 
     #[test]

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -439,7 +439,14 @@ impl RedemptionView {
                 block_number,
                 burned_at,
                 ..
-            }) => Self::Completed {
+            })
+            | RedemptionEvent::OrchestratorTokensBurned {
+                issuer_request_id,
+                tx_hash,
+                block_number,
+                burned_at,
+                ..
+            } => Self::Completed {
                 issuer_request_id: issuer_request_id.clone(),
                 burn_tx_hash: *tx_hash,
                 block_number: *block_number,
@@ -457,10 +464,11 @@ impl RedemptionView {
                 block_number: *block_number,
                 completed_at: *recovered_at,
             },
-            // View stays in Burning — BurnTxSubmitted and BurnIntended is an internal
-            // detail that doesn't change the query-facing state.
+            // View stays in Burning — BurnIntended and the submission events
+            // are internal details that don't change the query-facing state.
             RedemptionEvent::BurnIntended { .. }
             | RedemptionEvent::BurnTxSubmitted { .. }
+            | RedemptionEvent::OrchestratorBurnSubmitted { .. }
             | RedemptionEvent::BurnRecoveryAttempted { .. }
             | RedemptionEvent::BurnPreparationRecoveryAttempted { .. }
             | RedemptionEvent::BurnRecoveryExhausted { .. }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -16,10 +16,10 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
 
 use super::{
-    BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnParams,
-    MultiBurnResult, MultiBurnResultEntry, OrchestratorBurnParams,
-    OrchestratorBurnReadiness, OrchestratorBurnResult, PreparedMintTx,
-    ReceiptInformation, SubmittedTx, VaultError, VaultService,
+    BurnRange, BurnTxStatus, BurnVerification, MintResult, MintTxStatus,
+    MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
+    OrchestratorBurnParams, OrchestratorBurnReadiness, OrchestratorBurnResult,
+    PreparedMintTx, ReceiptInformation, SubmittedTx, VaultError, VaultService,
     WalletNonceGuard,
 };
 #[cfg(test)]
@@ -674,6 +674,17 @@ impl MockVaultService {
         *self.pending_burn_result.lock().unwrap() = Some(result);
         self
     }
+
+    /// Configures `confirm_orchestrator_burn` to fail with
+    /// `VaultError::OrchestratorReverted` carrying the given typed reason.
+    #[cfg(test)]
+    pub(crate) fn with_orchestrator_confirm_revert(
+        self,
+        reason: OrchestratorRevertReason,
+    ) -> Self {
+        *self.orchestrator.confirm_revert.lock().unwrap() = Some(reason);
+        self
+    }
 }
 
 const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
@@ -682,11 +693,18 @@ const MOCK_MINT_TX_HASH: alloy::primitives::B256 =
 const MOCK_BURN_TX_HASH: alloy::primitives::B256 =
     b256!("0x4545454545454545454545454545454545454545454545454545454545454545");
 
+/// Matches the canonical orchestrator test fixture's `alpaca_quantity` of
+/// 17 tokens in share-wei: the confirm handler rejects a `shares_burned`
+/// that diverges from the persisted quantity, so the fallback result must
+/// agree with the fixture for confirm-path tests that never ran prepare.
 fn default_orchestrator_burn_result() -> OrchestratorBurnResult {
     OrchestratorBurnResult {
         tx_hash: MOCK_BURN_TX_HASH,
-        shares_burned: U256::from(100_000_000_000_000_000_000u128),
-        burn_range: (U256::from(1u8), U256::from(2u8)),
+        shares_burned: U256::from(17_000_000_000_000_000_000u128),
+        burn_range: BurnRange {
+            first_receipt_id: U256::from(1u8),
+            next_burn_receipt_id_after: U256::from(2u8),
+        },
         gas_used: 50000,
         block_number: 5000,
     }
@@ -1286,7 +1304,10 @@ impl VaultService for MockVaultService {
                 *pending = Some(OrchestratorBurnResult {
                     tx_hash: MOCK_BURN_TX_HASH,
                     shares_burned: params.amount,
-                    burn_range: (U256::from(1u8), U256::from(2u8)),
+                    burn_range: BurnRange {
+                        first_receipt_id: U256::from(1u8),
+                        next_burn_receipt_id_after: U256::from(2u8),
+                    },
                     gas_used: 50000,
                     block_number: 5000,
                 });

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -37,8 +37,8 @@ pub(crate) use network_services::{
 };
 
 pub(crate) use orchestrator::{
-    OrchestratorBurnParams, OrchestratorBurnReadiness, OrchestratorBurnResult,
-    OrchestratorRevertReason,
+    BurnRange, OrchestratorBurnParams, OrchestratorBurnReadiness,
+    OrchestratorBurnResult, OrchestratorRevertReason,
 };
 
 /// Service abstraction for vault operations.
@@ -233,7 +233,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// Builds and signs the `ST0xOrchestrator.burn()` transaction without
     /// broadcasting it. The returned bytes must be persisted (via
     /// `BurnIntended`) before [`VaultService::submit_orchestrator_burn`].
-    #[allow(dead_code)]
     async fn prepare_orchestrator_burn_tx(
         &self,
         _params: &OrchestratorBurnParams,
@@ -244,7 +243,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// Broadcasts the exact signed orchestrator burn persisted before this
     /// call. Repeated calls must rebroadcast the same bytes rather than sign
     /// a replacement.
-    #[allow(dead_code)]
     async fn submit_orchestrator_burn(
         &self,
         _params: &OrchestratorBurnParams,
@@ -257,7 +255,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// orchestrator's `Burned` event. A mined-but-reverted burn fails with
     /// [`VaultError::OrchestratorReverted`] carrying the decoded typed
     /// reason.
-    #[allow(dead_code)]
     async fn confirm_orchestrator_burn(
         &self,
         _tx_id: &TxId,

--- a/src/vault/orchestrator.rs
+++ b/src/vault/orchestrator.rs
@@ -34,6 +34,22 @@ pub(crate) struct OrchestratorBurnParams {
     pub(crate) external_tx_id: Option<BurnExternalTxId>,
 }
 
+/// Consumed receipt-pointer range from the `Burned` event, half-open:
+/// receipts strictly inside
+/// `[first_receipt_id, next_burn_receipt_id_after)` were drained by the
+/// burn. Named fields (not a tuple) because this is embedded in persisted
+/// redemption events — the payload must self-describe which bound is which,
+/// permanently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct BurnRange {
+    /// `Burned.firstReceiptId` — the pre-burn pointer value (may itself
+    /// have been partially consumed by an earlier burn).
+    pub(crate) first_receipt_id: U256,
+    /// `Burned.nextBurnReceiptIdAfter` — the pointer's new value, the
+    /// receipt the next burn resumes from (exclusive end).
+    pub(crate) next_burn_receipt_id_after: U256,
+}
+
 /// Result of a confirmed `ST0xOrchestrator.burn()`, parsed from the
 /// orchestrator's `Burned` event.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -41,9 +57,7 @@ pub(crate) struct OrchestratorBurnResult {
     pub(crate) tx_hash: B256,
     /// `Burned.amount` — total shares pulled and burned.
     pub(crate) shares_burned: U256,
-    /// Consumed receipt pointer range:
-    /// `(Burned.firstReceiptId, Burned.nextBurnReceiptIdAfter)`.
-    pub(crate) burn_range: (U256, U256),
+    pub(crate) burn_range: BurnRange,
     pub(crate) gas_used: u64,
     pub(crate) block_number: u64,
 }

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -22,12 +22,12 @@ use tracing::debug;
 
 use super::rain_meta::OaSchemaCache;
 use super::{
-    BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnResult,
-    MultiBurnResultEntry, OrchestratorBurnParams, OrchestratorBurnReadiness,
-    OrchestratorBurnResult, OrchestratorRevertReason, PreparedMintTx,
-    ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId, VaultError,
-    VaultService, WalletNonceGuard, classify_checked_receipt,
-    verify_burn_in_receipt,
+    BurnRange, BurnTxStatus, BurnVerification, MintResult, MintTxStatus,
+    MultiBurnResult, MultiBurnResultEntry, OrchestratorBurnParams,
+    OrchestratorBurnReadiness, OrchestratorBurnResult,
+    OrchestratorRevertReason, PreparedMintTx, ReceiptInformation,
+    SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
+    WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
 };
 use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
 use crate::redemption::BurnExternalTxId;
@@ -978,7 +978,10 @@ impl VaultService for RealBlockchainService {
         Ok(OrchestratorBurnResult {
             tx_hash,
             shares_burned: burned.amount,
-            burn_range: (burned.firstReceiptId, burned.nextBurnReceiptIdAfter),
+            burn_range: BurnRange {
+                first_receipt_id: burned.firstReceiptId,
+                next_burn_receipt_id_after: burned.nextBurnReceiptIdAfter,
+            },
             gas_used: receipt.gas_used,
             block_number,
         })
@@ -1012,7 +1015,9 @@ mod tests {
     use tracing::Level;
     use tracing_test::traced_test;
 
-    use super::{RealBlockchainService, RealBlockchainServiceProvider};
+    use super::{
+        BurnRange, RealBlockchainService, RealBlockchainServiceProvider,
+    };
     use crate::bindings::OffchainAssetReceiptVault;
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
@@ -2830,7 +2835,13 @@ mod tests {
             .expect("expected OrchestratorBurnResult");
         assert_eq!(result.tx_hash, prepared.hash);
         assert_eq!(result.shares_burned, params.amount);
-        assert_eq!(result.burn_range, (U256::from(3u8), U256::from(6u8)));
+        assert_eq!(
+            result.burn_range,
+            BurnRange {
+                first_receipt_id: U256::from(3u8),
+                next_burn_receipt_id_after: U256::from(6u8),
+            }
+        );
         assert_eq!(result.gas_used, 0x8000);
         assert_eq!(result.block_number, 0x9c4);
     }


### PR DESCRIPTION
## Motivation

The redemption pipeline previously only supported vault-direct burns, where burn parameters (`vault`, `burns`, `dust_shares`, `owner`) were flat fields on `IntendBurn` and `BurnTokens` commands. Adding orchestrator-mode burns requires a different parameter shape (`token`, `amount`, `owner`) and different on-chain interactions (`submit_orchestrator_burn`, `confirm_orchestrator_burn`), with no per-receipt plan and dust retained in the bot wallet rather than returned atomically.

## Solution

Introduces a `BurnParams` enum with `VaultDirect` and `Orchestrator` variants that replaces the flat burn fields on `IntendBurn` and `BurnTokens`. The command handlers cross-check the variant against the redemption's persisted `burn_mode` anchor and return a `BurnModeMismatch` error on mismatch, preventing a caller from driving a vault-direct redemption down the orchestrator path or vice versa.

Two new events are added to the orchestrator path:

- `OrchestratorBurnSubmitted` — the counterpart of `BurnTxSubmitted`, carrying no per-receipt plan since the orchestrator walks receipts on-chain.
- `OrchestratorTokensBurned` — terminal success carrying `shares_burned`, a `burn_range` from the on-chain `Burned` event, and `dust_retained` derived from the redemption's own persisted `AlpacaCalled.dust_quantity` rather than from the command input (SPEC Decision 6).

`RedemptionError::Vault` gains a `classification` field populated at the `VaultError` boundary via a new `vault_error_to_redemption` helper, so orchestrator revert reasons (`InsufficientReceipts`, `VaultLogicMismatch`, `ReceiptLogicMismatch`) are carried through to `RecordBurnFailure` without parsing the error message string. Previously the classification was always hardcoded to `Unclassified` at the call sites.

The view and event-sourced state machine are updated to treat `OrchestratorBurnSubmitted` as an internal detail (view stays `Burning`) and `OrchestratorTokensBurned` as a terminal success transition to `Completed`, mirroring the vault-direct equivalents. The `next_burn_retry_external_tx_id_from_history` function is extended to derive the retry `externalTxId` from `OrchestratorBurnSubmitted` the same way it does from `BurnTxSubmitted`.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for orchestrator-based token burns alongside direct vault burns.
  * Added event and status tracking for orchestrator burn submissions and completions.
  * Added receipt-range tracking, dust retention, and transaction metadata for orchestrator burns.
* **Bug Fixes**
  * Improved burn failure classification and transaction handling.
  * Enhanced recovery, retry, and replacement processing.
  * Added validation for mismatched burn modes and invalid quantities.
* **Reliability**
  * Improved replay of older incomplete burns and preserved unresolved transactions for follow-up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->