### PR TITLE
fix(redemption): force-complete a landed burn with no persisted intent (RAI-1490)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -584,8 +584,8 @@ on-chain transfer through calling Alpaca to burning tokens.
   landed. Emits `RedemptionClosed`.
 - `ForceCompleteBurn { issuer_request_id, burn_tx_hash, block_number, reason,
   acknowledged_unresolved_burn_tx_hash }` -
-  Admin-terminalize a redemption stuck in `BurnIntended`/`BurnSubmitted` whose
-  persisted exact burn transaction **already landed on-chain** but was never
+  Admin-terminalize a redemption stuck in `Burning`/`BurnIntended`/`BurnSubmitted`
+  whose burn **already landed on-chain** but was never
   recorded (e.g. the bot crashed between the burn and `TokensBurned`). The admin
   layer verifies the operator-supplied `burn_tx_hash` on-chain first — the
   receipt must have succeeded and contain a real burn
@@ -614,8 +614,15 @@ on-chain transfer through calling Alpaca to burning tokens.
   burn on the redemption's vault whose per-receipt withdrawals match the burn
   plan persisted by the latest `BurningFailed` event exactly, with the owner
   recovered from the transaction's own signature, and refuses a hash any other
-  redemption's history already mentions. Pre-intent states with no persisted
-  burn plan at all are **not** force-completed; ops use `CloseRedemption` after
+  redemption's history already mentions. When the redemption never persisted a
+  burn transaction and has no burn plan either — the recovery timeout orphaned
+  it in bare `Burning` before any burn event was written — there is no persisted
+  identity to anchor against; the proving tx is instead bound to the redemption
+  **by amount**: it must burn exactly the shares owed (`alpaca_quantity`) and
+  return exactly the dust (`dust_quantity`), else it is rejected (`422`). No
+  acknowledgement is accepted when nothing was persisted, as there is nothing to
+  acknowledge. Truly ambiguous states with no verifiable on-chain burn are still
+  **not** force-completed; ops use `CloseRedemption` after
   off-chain reconciliation instead.
 
 **Events:**
@@ -2446,6 +2453,7 @@ stateDiagram-v2
     AlpacaCalled --> Failed: RecordAlpacaFailure / MarkFailed
     Burning --> BurnIntended: IntendBurn
     Burning --> Failed: RecordBurnFailure / MarkFailed
+    Burning --> Completed: ForceCompleteBurn (admin, verified on-chain by amount)
     Burning --> Closed: CloseRedemption (admin)
     BurnIntended --> BurnSubmitted: BurnTokens (BurnTxSubmitted)
     BurnIntended --> Completed: ConfirmBurn (TokensBurned, crash recovery)

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -941,6 +941,12 @@ pub(crate) struct ForceCompleteRedemptionRequest {
 /// shares) before the redemption is moved to `Completed`, recording the proving
 /// tx hash for audit. Ambiguous cases with no verifiable on-chain burn are
 /// rejected (`422`) — use `/admin/close/redemption` for those.
+///
+/// When the redemption persisted a burn tx (it reached `BurnIntended`), the
+/// proving hash is checked against that persisted identity. When it did not —
+/// the recovery timeout orphaned it in bare `Burning` before any burn event was
+/// written — the proving tx is bound to the redemption by amount: it must burn
+/// exactly the shares owed and return exactly the dust, else `422`.
 #[utoipa::path(
     post,
     path = "/admin/force-complete/redemption/{issuer_request_id}",
@@ -1096,7 +1102,10 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
             | VaultError::Reverted { .. },
         )
         | BurnManagerError::InvalidAggregateState { .. }
-        | BurnManagerError::Cqrs(AggregateError::UserError(_)) => {
+        | BurnManagerError::Cqrs(AggregateError::UserError(_))
+        | BurnManagerError::Redemption(_)
+        | BurnManagerError::ForceCompleteBurnAmountMismatch { .. }
+        | BurnManagerError::ForceCompleteDustMismatch { .. } => {
             Status::UnprocessableEntity
         }
         BurnManagerError::Vault(_) => Status::BadGateway,
@@ -4517,6 +4526,17 @@ mod tests {
         assert_eq!(
             map_burn_manager_error(&super::BurnManagerError::SharesOverflow),
             Status::InternalServerError
+        );
+        // A proving tx that burns the wrong amount is an unverifiable
+        // operator-supplied input, not an upstream failure.
+        assert_eq!(
+            map_burn_manager_error(
+                &super::BurnManagerError::ForceCompleteBurnAmountMismatch {
+                    expected: alloy::primitives::U256::from(2u8),
+                    found: alloy::primitives::U256::from(1u8),
+                }
+            ),
+            Status::UnprocessableEntity
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -967,7 +967,7 @@ async fn run_redemption_recovery(
 /// **cancelled** — not left running — so no concurrent side effects can
 /// race with incoming HTTP requests. Stuck aggregates that weren't recovered
 /// in time require manual intervention via `/admin/recover` or `/admin/close`.
-const RECOVERY_TIMEOUT: Duration = Duration::from_secs(30);
+const RECOVERY_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Runs mint and redemption recovery with a timeout, then starts the HTTP
 /// server. Recovery that completes within [`RECOVERY_TIMEOUT`] runs to

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -294,25 +294,65 @@ impl BurnManager {
                 }
             })?;
 
-        let persisted_burn_tx = redemption.persisted_burn_tx()?;
-        persisted_burn_tx.validate_for_owner(self.bot_wallet)?;
-        let acknowledged_unresolved_burn_tx_hash = redemption
-            .validate_force_complete_burn_hash(
+        let (underlying, network, alpaca_quantity, dust_quantity) =
+            match &redemption {
+                Redemption::Burning {
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                    ..
+                }
+                | Redemption::BurnIntended {
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                    ..
+                }
+                | Redemption::BurnSubmitted {
+                    metadata,
+                    alpaca_quantity,
+                    dust_quantity,
+                    ..
+                } => (
+                    metadata.underlying.clone(),
+                    metadata.network,
+                    alpaca_quantity.clone(),
+                    dust_quantity.clone(),
+                ),
+                other => {
+                    return Err(BurnManagerError::InvalidAggregateState {
+                        current_state: aggregate_state_name(other).to_string(),
+                    });
+                }
+            };
+
+        // A redemption that reached `BurnIntended` persisted its signed burn
+        // tx; that persisted identity anchors force-complete via the owner
+        // check and hash/acknowledgement guard. A redemption the recovery
+        // timeout orphaned in bare `Burning` never persisted one, so there is
+        // nothing to anchor against — the on-chain proof is bound to this
+        // redemption by amount instead (see below).
+        let persisted_burn_tx = redemption
+            .persisted_unresolved_burn_tx()
+            .filter(|sendable_tx| !sendable_tx.tx.is_empty());
+        let persisted_burn_hash = persisted_burn_tx.map(|tx| tx.hash);
+        let acknowledged_unresolved_burn_tx_hash = if let Some(sendable_tx) =
+            persisted_burn_tx
+        {
+            sendable_tx.validate_for_owner(self.bot_wallet)?;
+            redemption.validate_force_complete_burn_hash(
                 burn_tx_hash,
                 acknowledged_unresolved_burn_tx_hash,
-            )?;
-
-        let (underlying, network) = match &redemption {
-            Redemption::Burning { metadata, .. }
-            | Redemption::BurnIntended { metadata, .. }
-            | Redemption::BurnSubmitted { metadata, .. } => {
-                (metadata.underlying.clone(), metadata.network)
-            }
-            other => {
-                return Err(BurnManagerError::InvalidAggregateState {
-                    current_state: aggregate_state_name(other).to_string(),
-                });
-            }
+            )?
+        } else if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
+            return Err(
+                RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
+                    provided,
+                }
+                .into(),
+            );
+        } else {
+            None
         };
 
         let vault =
@@ -325,9 +365,39 @@ impl BurnManager {
             .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
             .await?;
 
+        // Without a persisted burn tx, the on-chain proof is the only anchor to
+        // THIS redemption. Bind it by amount: the proving tx must burn exactly
+        // the shares this redemption owes and return exactly its dust.
+        if persisted_burn_hash.is_none() {
+            let expected_burn = alpaca_quantity.to_u256_with_18_decimals()?;
+            if verification.shares_burned != expected_burn {
+                return Err(
+                    BurnManagerError::ForceCompleteBurnAmountMismatch {
+                        expected: expected_burn,
+                        found: verification.shares_burned,
+                    },
+                );
+            }
+
+            let expected_dust = dust_quantity.to_u256_with_18_decimals()?;
+            let returned_dust = verification
+                .share_transfers
+                .iter()
+                .try_fold(U256::ZERO, |total, transfer| {
+                    total.checked_add(transfer.shares)
+                })
+                .ok_or(BurnManagerError::SharesOverflow)?;
+            if returned_dust != expected_dust {
+                return Err(BurnManagerError::ForceCompleteDustMismatch {
+                    expected: expected_dust,
+                    found: returned_dust,
+                });
+            }
+        }
+
         info!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_tx_hash = ?burn_tx_hash,
-            persisted_burn_tx_hash = ?persisted_burn_tx.hash,
+            persisted_burn_tx_hash = ?persisted_burn_hash,
             acknowledged_unresolved_burn_tx_hash = ?acknowledged_unresolved_burn_tx_hash,
             block_number = verification.block_number,
             shares_burned = %verification.shares_burned,
@@ -2289,6 +2359,16 @@ pub(crate) enum BurnManagerError {
          {issuer_request_id}; deferred to recovery"
     )]
     WalletIntentWaitExhausted { issuer_request_id: IssuerRedemptionRequestId },
+    #[error(
+        "Force-complete burn amount mismatch: redemption owes {expected} shares, \
+         proving tx burned {found}"
+    )]
+    ForceCompleteBurnAmountMismatch { expected: U256, found: U256 },
+    #[error(
+        "Force-complete dust mismatch: redemption returns {expected} dust shares, \
+         proving tx transferred {found}"
+    )]
+    ForceCompleteDustMismatch { expected: U256, found: U256 },
 }
 
 #[cfg(test)]
@@ -3006,13 +3086,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_force_complete_burn_rejects_burning_without_persisted_hash() {
+    async fn test_force_complete_burn_without_persisted_tx_rejects_amount_mismatch()
+     {
+        // The seeded redemption owes 100e18 shares. With no persisted tx to
+        // anchor against, a proving tx that burned a different amount must be
+        // rejected — the amount is the only binding to this redemption.
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
         let vault_mock = Arc::new(
             MockVaultService::new_success()
                 .with_verified_burn(45_989_009, uint!(17_U256)),
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
         let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
         let manager = BurnManager::new_for_tests(
             vault_mock,
             pool.clone(),
@@ -3036,13 +3122,88 @@ mod tests {
 
         assert!(matches!(
             result,
-            Err(BurnManagerError::Redemption(
-                RedemptionError::PersistedBurnHashUnavailable
-            ))
+            Err(BurnManagerError::ForceCompleteBurnAmountMismatch {
+                expected,
+                found,
+            }) if expected == uint!(100_000000000000000000_U256)
+                && found == uint!(17_U256)
         ));
         assert!(matches!(
             load_aggregate(store, &issuer_request_id).await,
             Redemption::Burning { .. }
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_force_complete_burn_without_persisted_tx_records_matching_burn()
+     {
+        // The recovery-timeout case: the burn landed on-chain but no burn event
+        // was ever persisted. A proving tx burning exactly the owed shares
+        // terminalizes the redemption and settles its reservation.
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let expected_shares = uint!(100_000000000000000000_U256);
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burn(45_989_009, expected_shares),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        harness.add_asset(&underlying, vault).await;
+        let manager = BurnManager::new_for_tests(
+            vault_mock,
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+            ANVIL_CHAIN_ID,
+        );
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        // Seed a held reservation so the test fails if force-complete stops
+        // settling inventory after terminalizing the aggregate.
+        harness.discover_receipt(vault, uint!(42_U256), expected_shares).await;
+        receipt_service
+            .reserve_burn(
+                ANVIL_CHAIN_ID,
+                vault,
+                issuer_request_id.clone(),
+                vec![BurnRecord {
+                    receipt_id: uint!(42_U256),
+                    shares_burned: expected_shares,
+                }],
+            )
+            .await
+            .expect("seeding reservation should succeed");
+
+        let verification = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                B256::random(),
+                "burn landed on-chain, never recorded".to_string(),
+                None,
+            )
+            .await
+            .expect("force-complete should succeed");
+
+        assert_eq!(verification.shares_burned, expected_shares);
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+        assert!(
+            receipt_service
+                .reserved_redemptions(ANVIL_CHAIN_ID, vault)
+                .await
+                .unwrap()
+                .is_empty(),
+            "force-complete must leave no dangling reservation"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Force-completing stuck Burning redemption", "verified on-chain"]
         ));
     }
 

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -837,6 +837,13 @@ impl Redemption {
     /// verifies `burn_tx_hash` on-chain before issuing this command, so the
     /// aggregate trusts the supplied tx hash and block number and records the
     /// proving terminal event, transitioning to `Completed`.
+    ///
+    /// When a burn tx was persisted (`BurnIntended`, or `Burning`/`Failed` with
+    /// a retained prior tx), that identity anchors the guard: the supplied hash
+    /// must match it, or the operator must acknowledge the mismatch. A
+    /// redemption the recovery timeout orphaned in bare `Burning` never
+    /// persisted one — the admin layer binds the on-chain proof by amount
+    /// instead, so here there is nothing to acknowledge.
     fn handle_force_complete_burn(
         &self,
         issuer_request_id: IssuerRedemptionRequestId,
@@ -866,41 +873,34 @@ impl Redemption {
             });
         }
 
-        // A legacy `Failed` redemption has no persisted signed transaction to
-        // bind the proving hash against — the burn went out through a
-        // custodian's API, identified only by a backend transaction id the
-        // current backend cannot look up. For that shape the caller's
-        // on-chain verification of the planned burns is the entire proof, so
-        // there is no hash to bind and nothing unresolved to acknowledge.
-        // `Closed` joins the same split: its state retains whatever signed
-        // burn survived to the moment of closure (recorded acknowledgement or
-        // not — pre-acknowledgement closures recorded nothing), so a closure
-        // that still carries one keeps the full binding and acknowledgement
-        // guard, and only a closure of a custodian-era burn with nothing
-        // persisted goes through as legacy.
-        let legacy_burn_without_persisted_tx =
-            matches!(self, Self::Failed { .. } | Self::Closed { .. })
-                && self
-                    .persisted_unresolved_burn_tx()
-                    .filter(|sendable_tx| !sendable_tx.tx.is_empty())
-                    .is_none();
-        let acknowledged_unresolved_burn_tx_hash =
-            if legacy_burn_without_persisted_tx {
-                if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
-                    return Err(
-                    RedemptionError::RedundantUnresolvedBurnAcknowledgement {
-                        provided,
-                    },
-                );
-                }
-
-                None
-            } else {
-                self.validate_force_complete_burn_hash(
-                    burn_tx_hash,
-                    acknowledged_unresolved_burn_tx_hash,
-                )?
-            };
+        // Without a persisted signed transaction there is no identity to bind
+        // the proving hash against, so the caller's on-chain verification is
+        // the entire proof and nothing is left unresolved to acknowledge. Two
+        // shapes reach here: a custodian-era burn identified only by a backend
+        // transaction id the current backend cannot look up, and a redemption
+        // the recovery timeout orphaned in bare `Burning` before any burn
+        // event was written. A `Failed` or `Closed` redemption that still
+        // retains a signed burn keeps the full binding and acknowledgement
+        // guard.
+        let persisted_burn_tx = self
+            .persisted_unresolved_burn_tx()
+            .filter(|sendable_tx| !sendable_tx.tx.is_empty());
+        let acknowledged_unresolved_burn_tx_hash = if persisted_burn_tx
+            .is_some()
+        {
+            self.validate_force_complete_burn_hash(
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash,
+            )?
+        } else if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
+            return Err(
+                RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
+                    provided,
+                },
+            );
+        } else {
+            None
+        };
 
         Ok(vec![RedemptionEvent::BurnForceCompleted {
             issuer_request_id,
@@ -4485,16 +4485,75 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_force_complete_burn_without_persisted_hash_fails() {
+    async fn test_force_complete_burn_without_persisted_tx_records_event() {
+        // A redemption orphaned in bare `Burning` (recovery timeout killed the
+        // task before any burn event) has no persisted tx to anchor against.
+        // The admin layer binds the proof by amount, so the aggregate trusts
+        // the supplied hash and records the terminal event.
         let issuer_request_id = IssuerRedemptionRequestId::random();
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 45_989_009,
+                reason: "amount-verified by admin layer".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted {
+                acknowledged_unresolved_burn_tx_hash: None,
+                ..
+            }]
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_force_complete_legacy_submitted_burn_without_tx_records_event()
+     {
+        // A legacy `BurnSubmitted` with an empty persisted tx is likewise
+        // unanchored — force-complete records the amount-verified burn.
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(burn_submitted_given_events(&issuer_request_id))
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 45_989_009,
+                reason: "amount-verified by admin layer".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted {
+                acknowledged_unresolved_burn_tx_hash: None,
+                ..
+            }]
+        ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_without_persisted_tx_rejects_acknowledgement() {
+        // With no persisted tx there is nothing to acknowledge, so supplying an
+        // acknowledgement is a caller error.
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let provided = B256::random();
+
         let error = TestHarness::<Redemption>::with(mock_services())
             .given(burning_given_events(&issuer_request_id))
             .when(RedemptionCommand::ForceCompleteBurn {
                 issuer_request_id,
                 burn_tx_hash: B256::random(),
                 block_number: 45_989_009,
-                reason: "another redemption's verified burn".to_string(),
-                acknowledged_unresolved_burn_tx_hash: None,
+                reason: "no persisted tx to acknowledge".to_string(),
+                acknowledged_unresolved_burn_tx_hash: Some(provided),
             })
             .await
             .then_expect_error();
@@ -4502,31 +4561,10 @@ mod tests {
         assert!(matches!(
             error,
             LifecycleError::Apply(
-                RedemptionError::PersistedBurnHashUnavailable
-            )
-        ));
-    }
-
-    #[tokio::test]
-    async fn test_force_complete_legacy_submitted_burn_without_hash_fails() {
-        let issuer_request_id = IssuerRedemptionRequestId::random();
-        let error = TestHarness::<Redemption>::with(mock_services())
-            .given(burn_submitted_given_events(&issuer_request_id))
-            .when(RedemptionCommand::ForceCompleteBurn {
-                issuer_request_id,
-                burn_tx_hash: B256::random(),
-                block_number: 45_989_009,
-                reason: "another redemption's verified burn".to_string(),
-                acknowledged_unresolved_burn_tx_hash: None,
-            })
-            .await
-            .then_expect_error();
-
-        assert!(matches!(
-            error,
-            LifecycleError::Apply(
-                RedemptionError::PersistedBurnHashUnavailable
-            )
+                RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
+                    provided: got,
+                }
+            ) if got == provided
         ));
     }
 
@@ -4644,8 +4682,7 @@ mod tests {
     /// acknowledgement could refer to — supplying one anyway must be refused
     /// rather than recorded as a meaningless fact on the terminal event.
     #[tokio::test]
-    async fn force_complete_of_legacy_failed_burn_refuses_redundant_acknowledgement()
-     {
+    async fn force_complete_of_legacy_failed_burn_refuses_acknowledgement() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
         let mut history = burning_given_events(&issuer_request_id);
         history.push(RedemptionEvent::BurningFailed {
@@ -4687,7 +4724,7 @@ mod tests {
         };
         assert_eq!(
             error,
-            RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+            RedemptionError::UnexpectedUnresolvedBurnAcknowledgement {
                 provided,
             }
         );


### PR DESCRIPTION
https://linear.app/makeitrain/issue/RAI-1490

## Motivation

- A redemption whose burn landed on-chain but was never recorded cannot be recovered today. No admin tool accepts that state.
- It happens when the startup recovery timeout cancels the burn task after the burn lands, but before any burn event is written. The aggregate then sits in bare `Burning`. We hit it in prod on MSTR `0xcd3731…de359` (tx `0xad55f30f…`).
- Every tool rejects that state. `/admin/recover` returns 422, it needs `Failed`. A restart skips it forever, the on-chain balance is 0. `/admin/force-complete` returns 422 `PersistedBurnHashUnavailable`, it needs a persisted tx. `/admin/close` sets `Closed` instead of `Completed`, and strands the receipt reservation.
- The 30 second timeout has orphaned in-flight burns 3 times now (06-27, 07-17, and 07-20).

## Solution

- `force-complete` now accepts a redemption that never persisted a burn tx. It skips the persisted-identity checks in that case.
- Instead it binds the operator-supplied proving tx to the redemption **by amount**. The tx must burn exactly the shares owed (`alpaca_quantity`). It must return exactly the dust (`dust_quantity`). If not, the endpoint returns 422.
- `verify_burn_tx` already proves 3 things: the tx succeeded, the bot wallet signed it, and it burned the right vault's shares. The amount check replaces the persisted-hash anchor. The endpoint takes no new input, it already accepts `burn_tx_hash`.
- New errors `BurnManagerError::{ForceCompleteBurnAmountMismatch, ForceCompleteDustMismatch}` map to 422.
- **Wider than the fix:** `BurnManagerError::Redemption(_)` now maps to 422 too. It used to fall through to 500. That covers every redemption error, not just the new ones. Shout if you want it narrowed.
- `handle_force_complete_burn` skips the acknowledgement guard when there is no persisted tx. It rejects an acknowledgement supplied in that case, because there is nothing to acknowledge.
- `RECOVERY_TIMEOUT` goes from 30 seconds to 2 minutes (`src/lib.rs`).
- `SPEC.md` records the new `Burning -> Completed` admin transition and the by-amount rule.

Safety: the persisted-tx path does not change. The new path only runs when no tx was persisted. It needs an exact-amount on-chain burn, signed by the bot wallet, against the correct vault. Same binding guarantee, different anchor.

## Tests

- Aggregate: bare `Burning` and legacy `BurnSubmitted` with no persisted tx now record `BurnForceCompleted`. A supplied acknowledgement is rejected.
- Service: a matching amount moves the redemption to `Completed` and settles the reservation. A wrong amount returns `ForceCompleteBurnAmountMismatch`, and the state stays `Burning`.
- `map_burn_manager_error` maps the new error to 422.
- No e2e test. The path needs an orphaned aggregate that the public API cannot produce.

Follow-up, not in this PR: find the root cause of the recovery timeout, and teach the `recover-issuance` runbook to sum per-receipt burns (this one was a 4-receipt multicall).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic
- [ ] made this PR as small as possible
- [x] linked any relevant issues or PRs

https://claude.ai/code/session_01PnV5AJumthRk57FVpevrW6



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added force completion for redemptions stuck in the Burning state, including cases where the burn was completed on-chain but not recorded.
  - Supports legacy redemptions without a persisted burn transaction, provided the burned and returned amounts match exactly.

- **Bug Fixes**
  - Invalid burn or dust amounts now return a clear validation error.
  - Extended recovery time to better handle slow startup recovery processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->