### PR TITLE
feat: classify `InsufficientReceipts` via burn simulation before submission

### DIFF
--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -1573,6 +1573,50 @@ impl BurnManager {
                 );
                 return Ok(());
             }
+            OrchestratorBurnReadiness::InsufficientReceipts { shortfall } => {
+                // Token-global anomaly: the orchestrator's receipt walk
+                // cannot cover this burn for ANY redemption of this token.
+                // Never submitted, never auto-retried — recovery is a manual
+                // EMERGENCY_ROLE action followed by admin ResumeBurn.
+                error!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    token = %token,
+                    orchestrator = %orchestrator,
+                    shortfall = %shortfall,
+                    "Orchestrator receipts insufficient to cover burn; \
+                     manual EMERGENCY_ROLE recovery required"
+                );
+                let error_msg = format!(
+                    "Orchestrator receipts insufficient: shortfall \
+                     {shortfall}"
+                );
+                self.store
+                    .send(
+                        issuer_request_id,
+                        RedemptionCommand::RecordBurnFailure {
+                            classification:
+                                BurnFailureClassification::InsufficientReceipts {
+                                    shortfall,
+                                },
+                            issuer_request_id: issuer_request_id.clone(),
+                            error: error_msg.clone(),
+                            tx_id: None,
+                            planned_burns: vec![],
+                        },
+                    )
+                    .await?;
+                return Err(BurnManagerError::Redemption(
+                    RedemptionError::Vault {
+                        message: error_msg,
+                        release_reservation: false,
+                        tx_id: None,
+                        classification:
+                            BurnFailureClassification::InsufficientReceipts {
+                                shortfall,
+                            },
+                    },
+                ));
+            }
         }
 
         let execution = BurnExecutionPlan::orchestrator(
@@ -3451,6 +3495,62 @@ mod tests {
         assert!(logs_contain_at!(
             tracing::Level::WARN,
             &["Orchestrator halted", "deferring"]
+        ));
+    }
+
+    /// The pre-submit shortfall gate (burn simulation reverting with
+    /// `InsufficientReceipts`) records a classified failure without ever
+    /// signing or submitting.
+    #[traced_test]
+    #[tokio::test]
+    async fn orchestrator_shortfall_gate_records_classified_failure() {
+        let setup = setup_orchestrator_burning(Arc::new(
+            MockVaultService::new_success().with_orchestrator_readiness(
+                OrchestratorBurnReadiness::InsufficientReceipts {
+                    shortfall: uint!(250_U256),
+                },
+            ),
+        ))
+        .await;
+
+        let result = setup
+            .manager
+            .handle_burning_started(&setup.issuer_request_id, &setup.aggregate)
+            .await;
+        assert!(result.is_err(), "the shortfall gate must fail the burn");
+        assert_eq!(
+            setup.vault_mock.orchestrator_submit_call_count(),
+            0,
+            "a shortfall burn must never be submitted"
+        );
+
+        let failed = find_burn_failed(&setup.harness.pool)
+            .await
+            .expect("burn-failed query should succeed");
+        let (_, view) = failed
+            .iter()
+            .find(|(id, _)| *id == setup.issuer_request_id)
+            .expect("redemption must be in BurnFailed view state");
+        assert!(
+            matches!(
+                view,
+                RedemptionView::BurnFailed {
+                    classification:
+                        BurnFailureClassification::InsufficientReceipts {
+                            shortfall,
+                        },
+                    ..
+                } if *shortfall == uint!(250_U256)
+            ),
+            "expected InsufficientReceipts classification, got {view:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &[
+                "Orchestrator receipts insufficient",
+                "manual EMERGENCY_ROLE recovery required",
+            ]
         ));
     }
 

--- a/src/vault/orchestrator.rs
+++ b/src/vault/orchestrator.rs
@@ -64,9 +64,11 @@ pub(crate) struct OrchestratorBurnResult {
 
 /// Outcome of the pre-submit orchestrator burn gates (SPEC "Failure States").
 ///
-/// Evaluated allowance-first, then `vaultLogicIsExpected()`: an allowance
-/// shortfall is an actionable ops failure and must be reported even while the
-/// orchestrator is halted.
+/// Evaluated allowance-first, then `vaultLogicIsExpected()`, then a burn
+/// simulation: an allowance shortfall is an actionable ops failure and must
+/// be reported even while the orchestrator is halted, and a deterministic
+/// `InsufficientReceipts` revert must be classified without ever submitting
+/// (gas estimation would reject the transaction at signing anyway).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OrchestratorBurnReadiness {
     Ready,
@@ -79,6 +81,13 @@ pub(crate) enum OrchestratorBurnReadiness {
     /// `vaultLogicIsExpected()` returned `false` — the orchestrator is halted
     /// pending upgrade; defer without recording any failure.
     VaultLogicMismatch,
+    /// The burn simulation reverted with
+    /// `InsufficientReceipts(token, shortfall)` — the orchestrator's receipt
+    /// walk cannot cover the amount. Token-global anomaly; never submitted
+    /// and never auto-retried.
+    InsufficientReceipts {
+        shortfall: U256,
+    },
 }
 
 /// Typed revert reason decoded from a mined-but-reverted orchestrator burn.

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -13,6 +13,7 @@ use alloy::providers::{
 use alloy::rpc::json_rpc::ErrorPayload;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 use alloy::sol_types::SolCall;
+use alloy::sol_types::SolInterface;
 use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
@@ -29,6 +30,7 @@ use super::{
     SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
     WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
 };
+use crate::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Errors;
 use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
 use crate::redemption::BurnExternalTxId;
 
@@ -100,8 +102,6 @@ impl RealBlockchainService {
         tx_hash: alloy::primitives::B256,
         block_number: u64,
     ) -> OrchestratorRevertReason {
-        use alloy::sol_types::SolInterface;
-
         let Ok(Some(transaction)) =
             self.provider.get_transaction_by_hash(tx_hash).await
         else {
@@ -126,14 +126,9 @@ impl RealBlockchainService {
         error
             .as_error_resp()
             .and_then(ErrorPayload::as_revert_data)
-            .and_then(|data| {
-                IST0xOrchestratorV1::IST0xOrchestratorV1Errors::abi_decode(
-                    &data,
-                )
-                .ok()
-            })
+            .and_then(|data| IST0xOrchestratorV1Errors::abi_decode(&data).ok())
             .map_or(OrchestratorRevertReason::Unknown, |decoded| {
-                use IST0xOrchestratorV1::IST0xOrchestratorV1Errors::{
+                use IST0xOrchestratorV1Errors::{
                     InsufficientReceipts, ReceiptLogicMismatch,
                     VaultLogicMismatch,
                 };
@@ -838,7 +833,46 @@ impl VaultService for RealBlockchainService {
             return Ok(OrchestratorBurnReadiness::VaultLogicMismatch);
         }
 
-        Ok(OrchestratorBurnReadiness::Ready)
+        // Simulate the burn so a deterministic revert is classified before
+        // any signing: gas estimation would reject the transaction anyway,
+        // surfacing only an unclassified preparation failure.
+        let Err(error) = orchestrator_contract
+            .burn(token, amount, Bytes::new())
+            .from(owner)
+            .call()
+            .await
+        else {
+            return Ok(OrchestratorBurnReadiness::Ready);
+        };
+
+        // No revert data means the simulation itself failed (transport/RPC),
+        // not that the burn reverted — propagate so the reconciler retries
+        // the gate on its next pass.
+        let Some(revert_data) = error.as_revert_data() else {
+            return Err(error.into());
+        };
+
+        match IST0xOrchestratorV1Errors::abi_decode(&revert_data).ok() {
+            Some(IST0xOrchestratorV1Errors::InsufficientReceipts(revert)) => {
+                Ok(OrchestratorBurnReadiness::InsufficientReceipts {
+                    shortfall: revert.shortfall,
+                })
+            }
+            Some(
+                IST0xOrchestratorV1Errors::VaultLogicMismatch(_)
+                | IST0xOrchestratorV1Errors::ReceiptLogicMismatch(_),
+            ) => Ok(OrchestratorBurnReadiness::VaultLogicMismatch),
+            // A deterministic revert outside the classified set (another
+            // orchestrator error, or a foreign revert from the vault's
+            // transferFrom path): report Ready and let preparation fail
+            // instead. Its gas estimation replays the same revert before
+            // anything is signed, recording the failure as `Unclassified`
+            // under the bounded preparation-retry budget — the
+            // pre-simulation behavior. Erroring here would defer the
+            // redemption forever without ever parking it in an
+            // operator-visible BurnFailed state.
+            Some(_) | None => Ok(OrchestratorBurnReadiness::Ready),
+        }
     }
 
     async fn prepare_orchestrator_burn_tx(
@@ -1004,11 +1038,13 @@ mod tests {
     use alloy::providers::fillers::{BlobGasFiller, ChainIdFiller};
     use alloy::providers::mock::Asserter;
     use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::rpc::json_rpc::ErrorPayload;
     use alloy::rpc::types::{
         Block, FeeHistory, Transaction as RpcTransaction, TransactionReceipt,
         TransactionRequest,
     };
     use alloy::signers::local::PrivateKeySigner;
+    use alloy::sol_types::{SolCall, SolError};
     use chrono::Utc;
     use rust_decimal::Decimal;
     use std::sync::Arc;
@@ -1016,9 +1052,11 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        BurnRange, RealBlockchainService, RealBlockchainServiceProvider,
+        BurnRange, OrchestratorBurnParams, OrchestratorBurnReadiness,
+        OrchestratorRevertReason, RealBlockchainService,
+        RealBlockchainServiceProvider,
     };
-    use crate::bindings::OffchainAssetReceiptVault;
+    use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
@@ -2630,10 +2668,8 @@ mod tests {
         address!("0x00000000000000000000000000000000000000aa")
     }
 
-    fn test_orchestrator_burn_params(
-        owner: Address,
-    ) -> super::OrchestratorBurnParams {
-        super::OrchestratorBurnParams {
+    fn test_orchestrator_burn_params(owner: Address) -> OrchestratorBurnParams {
+        OrchestratorBurnParams {
             orchestrator: test_orchestrator_address(),
             token: test_vault_address(),
             amount: U256::from(1_000_000u64),
@@ -2674,7 +2710,7 @@ mod tests {
         succeeded: bool,
         emitter: Address,
     ) -> TransactionReceipt {
-        let burned_event = crate::bindings::IST0xOrchestratorV1::Burned {
+        let burned_event = IST0xOrchestratorV1::Burned {
             caller,
             token: test_vault_address(),
             amount,
@@ -2769,8 +2805,6 @@ mod tests {
 
     #[tokio::test]
     async fn orchestrator_burn_prepare_submit_confirm_round_trip() {
-        use alloy::sol_types::SolCall;
-
         let asserter = Asserter::new();
         setup_asserter_for_fill(&asserter, 7);
         let signer = PrivateKeySigner::random();
@@ -2794,13 +2828,12 @@ mod tests {
             .expect("prepared orchestrator burn must decode");
         assert_eq!(*envelope.tx_hash(), prepared.hash);
         assert_eq!(envelope.to(), Some(test_orchestrator_address()));
-        let expected_calldata =
-            crate::bindings::IST0xOrchestratorV1::burnCall {
-                token: params.token,
-                amount: params.amount,
-                burnInfo: Bytes::new(),
-            }
-            .abi_encode();
+        let expected_calldata = IST0xOrchestratorV1::burnCall {
+            token: params.token,
+            amount: params.amount,
+            burnInfo: Bytes::new(),
+        }
+        .abi_encode();
         assert_eq!(
             envelope.input().as_ref(),
             expected_calldata.as_slice(),
@@ -2929,31 +2962,27 @@ mod tests {
     /// `eth_call` at its mined block and decodes the typed revert reason.
     #[tokio::test]
     async fn confirm_orchestrator_burn_decodes_typed_revert_reasons() {
-        use alloy::rpc::json_rpc::ErrorPayload;
-        use alloy::sol_types::SolError;
-
-        let shortfall_error =
-            crate::bindings::IST0xOrchestratorV1::InsufficientReceipts {
-                token: test_vault_address(),
-                shortfall: U256::from(250u64),
-            };
+        let shortfall_error = IST0xOrchestratorV1::InsufficientReceipts {
+            token: test_vault_address(),
+            shortfall: U256::from(250u64),
+        };
         let cases = [
             (
                 Bytes::from(shortfall_error.abi_encode()),
-                super::OrchestratorRevertReason::InsufficientReceipts {
+                OrchestratorRevertReason::InsufficientReceipts {
                     token: test_vault_address(),
                     shortfall: U256::from(250u64),
                 },
             ),
             (
                 Bytes::from(
-                    crate::bindings::IST0xOrchestratorV1::VaultLogicMismatch {
+                    IST0xOrchestratorV1::VaultLogicMismatch {
                         expected: test_receiver(),
                         actual: test_vault_address(),
                     }
                     .abi_encode(),
                 ),
-                super::OrchestratorRevertReason::VaultLogicMismatch,
+                OrchestratorRevertReason::VaultLogicMismatch,
             ),
             (
                 Bytes::from(
@@ -2967,7 +2996,7 @@ mod tests {
             ),
             (
                 Bytes::from(vec![0xde, 0xad, 0xbe, 0xef]),
-                super::OrchestratorRevertReason::Unknown,
+                OrchestratorRevertReason::Unknown,
             ),
         ];
 
@@ -3042,7 +3071,7 @@ mod tests {
             .expect("readiness check should succeed");
         assert_eq!(
             readiness,
-            super::OrchestratorBurnReadiness::AllowanceInsufficient {
+            OrchestratorBurnReadiness::AllowanceInsufficient {
                 required: amount,
                 current: U256::from(999u64),
             }
@@ -3062,15 +3091,13 @@ mod tests {
             )
             .await
             .expect("readiness check should succeed");
-        assert_eq!(
-            readiness,
-            super::OrchestratorBurnReadiness::VaultLogicMismatch
-        );
+        assert_eq!(readiness, OrchestratorBurnReadiness::VaultLogicMismatch);
 
-        // Sufficient allowance and healthy orchestrator.
+        // Sufficient allowance, healthy orchestrator, burn simulation passes.
         let asserter = Asserter::new();
         asserter.push_success(&format!("0x{}", "f".repeat(64)));
         asserter.push_success(&format!("0x{:064x}", 1u64));
+        asserter.push_success(&"0x"); // burn simulation (empty return)
         let service = create_service_with_asserter(asserter);
         let readiness = service
             .check_orchestrator_burn_readiness(
@@ -3081,6 +3108,100 @@ mod tests {
             )
             .await
             .expect("readiness check should succeed");
-        assert_eq!(readiness, super::OrchestratorBurnReadiness::Ready);
+        assert_eq!(readiness, OrchestratorBurnReadiness::Ready);
+
+        // Simulation reverting with InsufficientReceipts classifies the
+        // shortfall before anything is signed.
+        {
+            let revert_data = Bytes::from(
+                IST0xOrchestratorV1::InsufficientReceipts {
+                    token: test_vault_address(),
+                    shortfall: U256::from(123u64),
+                }
+                .abi_encode(),
+            );
+            let asserter = Asserter::new();
+            asserter.push_success(&format!("0x{}", "f".repeat(64)));
+            asserter.push_success(&format!("0x{:064x}", 1u64));
+            asserter.push_failure(ErrorPayload {
+                code: 3,
+                message: "execution reverted".into(),
+                data: Some(
+                    serde_json::value::to_raw_value(&format!("{revert_data}"))
+                        .expect("revert data must serialize"),
+                ),
+            });
+            let service = create_service_with_asserter(asserter);
+            let readiness = service
+                .check_orchestrator_burn_readiness(
+                    test_orchestrator_address(),
+                    test_vault_address(),
+                    owner,
+                    amount,
+                )
+                .await
+                .expect("readiness check should succeed");
+            assert_eq!(
+                readiness,
+                OrchestratorBurnReadiness::InsufficientReceipts {
+                    shortfall: U256::from(123u64),
+                }
+            );
+        }
+
+        // A deterministic revert with undecodable data must fall through to
+        // Ready — preparation replays the same revert and records it as
+        // Unclassified — rather than erroring, which would defer the
+        // redemption forever.
+        {
+            let asserter = Asserter::new();
+            asserter.push_success(&format!("0x{}", "f".repeat(64)));
+            asserter.push_success(&format!("0x{:064x}", 1u64));
+            asserter.push_failure(ErrorPayload {
+                code: 3,
+                message: "execution reverted".into(),
+                data: Some(
+                    serde_json::value::to_raw_value("0xdeadbeef")
+                        .expect("revert data must serialize"),
+                ),
+            });
+            let service = create_service_with_asserter(asserter);
+            let readiness = service
+                .check_orchestrator_burn_readiness(
+                    test_orchestrator_address(),
+                    test_vault_address(),
+                    owner,
+                    amount,
+                )
+                .await
+                .expect("an undecodable revert must not error the gate");
+            assert_eq!(readiness, OrchestratorBurnReadiness::Ready);
+        }
+
+        // A simulation that fails without revert data is a transport fault,
+        // not a burn revert: it must propagate so the reconciler retries.
+        {
+            let asserter = Asserter::new();
+            asserter.push_success(&format!("0x{}", "f".repeat(64)));
+            asserter.push_success(&format!("0x{:064x}", 1u64));
+            asserter.push_failure(ErrorPayload {
+                code: -32603,
+                message: "internal error".into(),
+                data: None,
+            });
+            let service = create_service_with_asserter(asserter);
+            assert!(
+                service
+                    .check_orchestrator_burn_readiness(
+                        test_orchestrator_address(),
+                        test_vault_address(),
+                        owner,
+                        amount,
+                    )
+                    .await
+                    .is_err(),
+                "a transport failure must not be classified as a readiness outcome"
+            );
+        }
     }
 }

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -8,12 +8,15 @@
 pub mod alpaca_mocks;
 
 use alloy::hex;
-use alloy::primitives::{Address, U256};
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, GasFiller, JoinFill, NonceFiller,
     SimpleNonceManager,
 };
 use alloy::providers::{Identity, ProviderBuilder};
+use alloy::signers::SignerSync;
+use alloy::signers::local::PrivateKeySigner;
 use chrono::Utc;
 use httpmock::Mock;
 use httpmock::prelude::*;
@@ -25,6 +28,7 @@ use std::net::SocketAddr;
 use url::Url;
 
 use st0x_issuance::account::{AccountLinkResponse, RegisterAccountResponse};
+use st0x_issuance::bindings::IST0xOrchestratorV1;
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::mint::MintResponse;
@@ -108,6 +112,59 @@ pub async fn wait_for_mock_hit(
     mock: &Mock<'_>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     wait_for_mock_hits(mock, 1).await
+}
+
+/// Polls the event store until the mint's terminal `MintCompleted` event is
+/// COMMITTED. A callback-mock hit alone is not terminality: the mock counts
+/// the request on arrival, while the service still has to process the
+/// response and persist `RecordCallbackSent -> MintCompleted` — a window a
+/// fast test can win locally and lose on a loaded CI runner. Anything that
+/// gates on the mint being terminal (service shutdown before a custody
+/// migration's quiescence check, restarts asserting no recovery work) must
+/// wait on this, not on the mock.
+pub async fn wait_for_mint_completed(
+    db_url: &str,
+    issuer_request_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = sqlx::sqlite::SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(db_url)
+        .await?;
+    let start = tokio::time::Instant::now();
+    let timeout = tokio::time::Duration::from_secs(15);
+    let poll_interval = tokio::time::Duration::from_millis(50);
+
+    loop {
+        let count = sqlx::query_scalar::<_, i64>(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+              AND event_type = 'MintEvent::MintCompleted'
+            ",
+        )
+        .bind(issuer_request_id)
+        .fetch_one(&pool)
+        .await?;
+
+        if count >= 1 {
+            pool.close().await;
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            pool.close().await;
+            return Err(format!(
+                "Timeout waiting for MintCompleted on {issuer_request_id} \
+                 after {}s",
+                timeout.as_secs()
+            )
+            .into());
+        }
+
+        tokio::time::sleep(poll_interval).await;
+    }
 }
 
 pub async fn wait_for_mock_hits(
@@ -632,6 +689,86 @@ pub fn create_multichain_config_with_db(
     ];
 
     Ok((base_config, mock_subgraph))
+}
+
+/// Same as [`create_config_with_db`] but with a per-asset `VaultModeConfig`
+/// (orchestrator-mode overrides) instead of the all-vault-direct default.
+pub fn create_config_with_vault_modes(
+    db_path: &str,
+    mock_alpaca: &MockServer,
+    evm: &LocalEvm,
+    vault_mode_config: VaultModeConfig,
+) -> Result<(Config, MockServer), Box<dyn std::error::Error>> {
+    let (mut config, mock_subgraph) =
+        create_config_with_db(db_path, mock_alpaca, evm)?;
+    config.vault_mode_config = vault_mode_config;
+    Ok((config, mock_subgraph))
+}
+
+/// Mints `amount` share-wei of the primary vault's token to
+/// `recipient_signer`'s address through `orchestrator.mint()`, creating one
+/// orchestrator-custodied receipt per call. The recipient authorizes the mint
+/// by signing the orchestrator's EIP-712 digest; the bot wallet (deployer,
+/// `MINT_ROLE`) submits it.
+pub async fn orchestrator_mint_to(
+    evm: &LocalEvm,
+    orchestrator_address: Address,
+    recipient_signer: &PrivateKeySigner,
+    amount: U256,
+    nonce_seed: u8,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    let provider = create_provider()
+        .wallet(EthereumWallet::from(bot_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let orchestrator =
+        IST0xOrchestratorV1::new(orchestrator_address, &provider);
+
+    let recipient = recipient_signer.address();
+    let nonce = B256::with_last_byte(nonce_seed);
+    let digest = orchestrator
+        .mintAuthDigest(evm.vault_address, recipient, amount, nonce)
+        .call()
+        .await?;
+    let signature = recipient_signer.sign_hash_sync(&digest)?;
+    let auth = IST0xOrchestratorV1::MintAuthV1 {
+        nonce,
+        signature: Bytes::from(signature.as_bytes().to_vec()),
+    };
+
+    orchestrator
+        .mint(evm.vault_address, recipient, amount, auth, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    Ok(())
+}
+
+/// The one-time unlimited ERC-20 approval ops issues at token onboarding so
+/// the orchestrator can pull the bot wallet's shares via `transferFrom`.
+pub async fn approve_orchestrator(
+    evm: &LocalEvm,
+    orchestrator_address: Address,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    let provider = create_provider()
+        .wallet(EthereumWallet::from(bot_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
+
+    vault
+        .approve(orchestrator_address, U256::MAX)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    Ok(())
 }
 
 pub async fn setup_roles(

--- a/tests/orchestrator_redemption.rs
+++ b/tests/orchestrator_redemption.rs
@@ -1,0 +1,743 @@
+#![allow(clippy::unwrap_used)]
+
+//! End-to-end orchestrator-mode redemption flows on Anvil.
+//!
+//! Assets whose configured `vault_mode` resolves to `Orchestrator` burn via a
+//! single `ST0xOrchestrator.burn()` (the orchestrator walks its own receipts
+//! on-chain) instead of the vault-direct multicall. These tests drive the
+//! full HTTP service through the public API, with the orchestrator deployed
+//! on Anvil and only Alpaca mocked.
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, B256, Bytes, U256, b256};
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+use rocket::local::asynchronous::Client;
+use serde_json::json;
+use sqlx::sqlite::SqlitePoolOptions;
+use std::collections::HashMap;
+
+use st0x_issuance::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Instance;
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{Network, initialize_rocket};
+use st0x_issuance::{VaultMode, VaultModeConfig};
+
+use crate::harness::{MintFlowRequest, create_provider};
+
+const USER_PRIVATE_KEY: B256 =
+    b256!("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+
+fn tokens(amount: u64) -> U256 {
+    U256::from(amount) * U256::from(10u64).pow(U256::from(18u64))
+}
+
+fn orchestrator_vault_modes(
+    underlying: &str,
+    orchestrator_address: Address,
+) -> VaultModeConfig {
+    VaultModeConfig::new(
+        HashMap::from([(
+            underlying.to_string(),
+            VaultMode::Orchestrator { address: orchestrator_address },
+        )]),
+        VaultMode::VaultDirect,
+    )
+}
+
+async fn bot_provider(
+    evm: &LocalEvm,
+) -> Result<impl alloy::providers::Provider + Clone, Box<dyn std::error::Error>>
+{
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    Ok(create_provider()
+        .wallet(EthereumWallet::from(bot_signer))
+        .connect(&evm.endpoint)
+        .await?)
+}
+
+/// Fetches the current `GET /admin/stuck` entries, failing loudly on an
+/// endpoint error so a broken endpoint can never read as "nothing stuck".
+async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
+    let response = client
+        .get("/admin/stuck")
+        .header(rocket::http::Header::new(
+            "X-API-KEY",
+            "test-key-12345678901234567890123456",
+        ))
+        .remote("127.0.0.1:8000".parse().unwrap())
+        .dispatch()
+        .await;
+    assert_eq!(
+        response.status(),
+        rocket::http::Status::Ok,
+        "/admin/stuck must respond OK"
+    );
+    let body: serde_json::Value = response
+        .into_json()
+        .await
+        .expect("/admin/stuck must return a JSON body");
+
+    body["stuck"]
+        .as_array()
+        .expect("/admin/stuck must contain a stuck array")
+        .clone()
+}
+
+/// Polls `GET /admin/stuck` until a `BurnFailed` entry appears, returning it.
+async fn wait_for_burn_failed_entry(
+    client: &Client,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let start = tokio::time::Instant::now();
+    let timeout = tokio::time::Duration::from_secs(15);
+
+    loop {
+        if let Some(entry) = fetch_stuck_entries(client)
+            .await
+            .into_iter()
+            .find(|entry| entry["state"] == "BurnFailed")
+        {
+            return Ok(entry);
+        }
+
+        if start.elapsed() >= timeout {
+            return Err("Timeout waiting for a BurnFailed stuck entry".into());
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Polls `GET /admin/stuck` until one snapshot shows `control_id` present
+/// and `resolved_id` absent.
+///
+/// The bare absence of `resolved_id` would be vacuous: a seed that never
+/// replayed (or a broken view projection) also produces an empty stuck list.
+/// The control redemption is seeded in a state recovery provably never
+/// resolves (a classified `BurnFailed` — the reconciler skips typed
+/// classifications), so its presence in the SAME snapshot proves the seeds
+/// replay and the stuck surfacing works, making the target's absence positive
+/// evidence that recovery resolved it. Requiring both in one snapshot also
+/// sidesteps the startup race where recovery completes before the first poll
+/// could ever observe the target.
+async fn wait_for_recovery_to_resolve(
+    client: &Client,
+    resolved_id: &str,
+    control_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let start = tokio::time::Instant::now();
+    let timeout = tokio::time::Duration::from_secs(15);
+
+    loop {
+        let entries = fetch_stuck_entries(client).await;
+        let control_present =
+            entries.iter().any(|entry| entry["aggregate_id"] == control_id);
+        let resolved_absent =
+            !entries.iter().any(|entry| entry["aggregate_id"] == resolved_id);
+        if control_present && resolved_absent {
+            return Ok(());
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(format!(
+                "Timeout waiting for recovery: control {control_id} \
+                 present={control_present}, target {resolved_id} \
+                 absent={resolved_absent}"
+            )
+            .into());
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// A burn spanning multiple orchestrator-custodied receipts: three separate
+/// orchestrator mints create three receipts, and one redemption consumes all
+/// of them through the on-chain walk.
+#[tokio::test]
+async fn orchestrator_burn_walks_multiple_receipts()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    harness::approve_orchestrator(&evm, orchestrator_address).await?;
+    for nonce_seed in 1..=3u8 {
+        harness::orchestrator_mint_to(
+            &evm,
+            orchestrator_address,
+            &user_signer,
+            tokens(10),
+            nonce_seed,
+        )
+        .await?;
+    }
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_multi_receipt.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    harness::setup_account(&client, user_wallet).await;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+
+    assert_eq!(vault.balanceOf(user_wallet).call().await?, tokens(30));
+    vault.transfer(bot_wallet, tokens(30)).send().await?.get_receipt().await?;
+
+    harness::wait_for_burn(&vault, bot_wallet).await?;
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+
+    let burned_logs =
+        orchestrator.Burned_filter().from_block(0).query().await?;
+    assert_eq!(
+        burned_logs.len(),
+        1,
+        "exactly one orchestrator burn must have landed"
+    );
+    let (burned, _log) = &burned_logs[0];
+    assert_eq!(burned.token, evm.vault_address);
+    assert_eq!(burned.amount, tokens(30));
+    // A fresh vault's three deposits hold receipt IDs 1..=3; walking all
+    // three advances the per-token pointer past the last consumed receipt.
+    assert_eq!(
+        burned.nextBurnReceiptIdAfter,
+        U256::from(4u8),
+        "the walk must have consumed all three orchestrator receipts"
+    );
+    assert_eq!(
+        orchestrator.nextBurnReceiptId(evm.vault_address).call().await?,
+        burned.nextBurnReceiptIdAfter,
+        "the per-token burn pointer must have advanced past the walk"
+    );
+
+    Ok(())
+}
+
+/// A redemption larger than the orchestrator's receipt pool is classified as
+/// `InsufficientReceipts` before any submission and parked for manual
+/// recovery — never auto-retried.
+#[tokio::test]
+async fn orchestrator_shortfall_is_classified_without_submission()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    harness::approve_orchestrator(&evm, orchestrator_address).await?;
+    // The orchestrator custodies only 10 tokens of receipts...
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(10),
+        1,
+    )
+    .await?;
+    // ...but the user holds 30: 20 more minted with a receipt the user
+    // (not the orchestrator) owns, simulating a drained pool.
+    evm.grant_deposit_role(user_wallet).await?;
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    vault
+        .deposit(tokens(20), user_wallet, tokens(1), Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_shortfall.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    harness::setup_account(&client, user_wallet).await;
+
+    assert_eq!(vault.balanceOf(user_wallet).call().await?, tokens(30));
+    vault.transfer(bot_wallet, tokens(30)).send().await?.get_receipt().await?;
+
+    let stuck_entry = wait_for_burn_failed_entry(&client).await?;
+    assert!(
+        stuck_entry["detail"]
+            .as_str()
+            .unwrap()
+            .contains("receipts insufficient"),
+        "stuck detail must surface the shortfall, got {stuck_entry}"
+    );
+
+    // Let several reconciler passes elapse: the classified failure must not
+    // be auto-retried. The harness config polls every 500ms
+    // (`create_config_with_db`'s `receipt_poll_interval`), so 1.5s covers
+    // three passes.
+    tokio::time::sleep(tokio::time::Duration::from_millis(1_500)).await;
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let burned_logs =
+        orchestrator.Burned_filter().from_block(0).query().await?;
+    assert!(burned_logs.is_empty(), "a shortfall burn must never be submitted");
+    assert_eq!(
+        vault.balanceOf(bot_wallet).call().await?,
+        tokens(30),
+        "the bot must still hold the transferred shares"
+    );
+
+    Ok(())
+}
+
+/// Startup recovery of an orchestrator burn that already landed on-chain:
+/// the reconciler confirms the existing transaction instead of submitting a
+/// second burn.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn orchestrator_recovery_confirms_landed_burn_without_resubmitting()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // The burn that "already landed before the crash": mint 10 to the bot
+    // itself, then burn it through the orchestrator directly.
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    harness::approve_orchestrator(&evm, orchestrator_address).await?;
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &bot_signer,
+        tokens(10),
+        1,
+    )
+    .await?;
+    let provider = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &provider);
+    let burn_receipt = orchestrator
+        .burn(evm.vault_address, tokens(10), Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let burn_tx_hash = burn_receipt.transaction_hash;
+
+    // Seed the crashed redemption's history (events table only, per the e2e
+    // setup exception): anchored to orchestrator mode, submitted with the
+    // real burn's hash, never confirmed. Timestamps predate STUCK_THRESHOLD
+    // so a redemption stuck in Burning would be operator-visible.
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_recovery.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let detected_tx_hash = B256::random();
+    let issuer_request_id = format!("{detected_tx_hash:#x}");
+    let old = "2020-01-01T00:00:00Z";
+    let user_wallet =
+        PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?.address();
+
+    // Control redemption: a classified BurnFailed the reconciler provably
+    // never resolves. Its persistent /admin/stuck entry is the evidence that
+    // the seeds replay and the stuck surfacing works, so the target's absence
+    // below can only mean recovery resolved it (see
+    // `wait_for_recovery_to_resolve`).
+    let control_tx_hash = B256::random();
+    let control_id = format!("{control_tx_hash:#x}");
+    let control_events = [
+        (
+            "RedemptionEvent::Detected",
+            json!({
+                "Detected": {
+                    "issuer_request_id": control_id,
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "wallet": user_wallet,
+                    "quantity": "5",
+                    "tx_hash": control_tx_hash,
+                    "block_number": 1,
+                    "detected_at": old,
+                    "burn_mode": {
+                        "Orchestrator": { "address": orchestrator_address }
+                    }
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaCalled",
+            json!({
+                "AlpacaCalled": {
+                    "issuer_request_id": control_id,
+                    "tokenization_request_id": "tok-recovery-control",
+                    "alpaca_quantity": "5",
+                    "dust_quantity": "0",
+                    "called_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaJournalCompleted",
+            json!({
+                "AlpacaJournalCompleted": {
+                    "issuer_request_id": control_id,
+                    "alpaca_journal_completed_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::BurningFailed",
+            json!({
+                "BurningFailed": {
+                    "issuer_request_id": control_id,
+                    "error": "allowance missing (control fixture)",
+                    "failed_at": old,
+                    "tx_id": null,
+                    "planned_burns": [],
+                    "classification": "AllowanceInsufficient"
+                }
+            }),
+        ),
+    ];
+
+    let events = [
+        (
+            "RedemptionEvent::Detected",
+            json!({
+                "Detected": {
+                    "issuer_request_id": issuer_request_id,
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "wallet": user_wallet,
+                    "quantity": "10",
+                    "tx_hash": detected_tx_hash,
+                    "block_number": 1,
+                    "detected_at": old,
+                    "burn_mode": {
+                        "Orchestrator": { "address": orchestrator_address }
+                    }
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaCalled",
+            json!({
+                "AlpacaCalled": {
+                    "issuer_request_id": issuer_request_id,
+                    "tokenization_request_id": "tok-recovery-1",
+                    "alpaca_quantity": "10",
+                    "dust_quantity": "0",
+                    "called_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaJournalCompleted",
+            json!({
+                "AlpacaJournalCompleted": {
+                    "issuer_request_id": issuer_request_id,
+                    "alpaca_journal_completed_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::OrchestratorBurnSubmitted",
+            json!({
+                "OrchestratorBurnSubmitted": {
+                    "issuer_request_id": issuer_request_id,
+                    "external_tx_id": format!("burn-{detected_tx_hash:#x}"),
+                    "tx_id": { "hash": burn_tx_hash },
+                    "submitted_at": old
+                }
+            }),
+        ),
+    ];
+
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
+    for (aggregate_id, aggregate_events) in
+        [(&issuer_request_id, &events), (&control_id, &control_events)]
+    {
+        for (sequence, (event_type, payload)) in
+            (1i64..).zip(aggregate_events.iter())
+        {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(aggregate_id)
+            .bind(sequence)
+            .bind(event_type)
+            .bind(payload.to_string())
+            .execute(&pool)
+            .await?;
+        }
+    }
+    pool.close().await;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    // Startup recovery confirms the landed burn: once recovered, the
+    // redemption leaves the recoverable states, so it no longer surfaces in
+    // /admin/stuck despite its ancient (past-threshold) timestamps — while
+    // the unresolvable control redemption still does, proving the absence is
+    // recovery's doing rather than a seed that never replayed.
+    wait_for_recovery_to_resolve(&client, &issuer_request_id, &control_id)
+        .await?;
+
+    let burned_logs =
+        orchestrator.Burned_filter().from_block(0).query().await?;
+    assert_eq!(
+        burned_logs.len(),
+        1,
+        "recovery must confirm the landed burn, never submit a second one"
+    );
+    assert_eq!(
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider)
+            .balanceOf(bot_wallet)
+            .call()
+            .await?,
+        U256::ZERO
+    );
+
+    Ok(())
+}
+
+/// Two assets in one deployment — one orchestrator-mode, one vault-direct —
+/// each redemption takes its own burn path, side by side. This is the
+/// single-asset-pilot configuration.
+#[tokio::test]
+async fn mixed_mode_assets_each_take_their_own_burn_path()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    // Primary vault: RKLB, orchestrator mode.
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+    harness::approve_orchestrator(&evm, orchestrator_address).await?;
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(10),
+        1,
+    )
+    .await?;
+
+    // Second vault: AAPL, vault-direct with the full mint flow.
+    let (vault2_address, vault2_authorizer) =
+        evm.deploy_additional_vault().await?;
+    harness::setup_roles_on_vault(
+        &evm,
+        vault2_authorizer,
+        vault2_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mixed_mode.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "RKLB",
+        "tRKLB",
+    )
+    .await?;
+    harness::preseed_tokenized_asset(&db_url, vault2_address, "AAPL", "tAAPL")
+        .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("RKLB", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id: "alp-mint-aapl-mixed",
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let orchestrator_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let direct_vault =
+        OffchainAssetReceiptVaultInstance::new(vault2_address, &user_provider);
+
+    let aapl_shares =
+        harness::wait_for_shares(&direct_vault, user_wallet).await?;
+
+    // Redeem both concurrently: the orchestrator asset and the vault-direct
+    // asset each go down their own path.
+    orchestrator_vault
+        .transfer(bot_wallet, tokens(10))
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    direct_vault
+        .transfer(bot_wallet, aapl_shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    harness::wait_for_burn(&orchestrator_vault, bot_wallet).await?;
+    harness::wait_for_burn(&direct_vault, bot_wallet).await?;
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let burned_logs =
+        orchestrator.Burned_filter().from_block(0).query().await?;
+    assert_eq!(
+        burned_logs.len(),
+        1,
+        "only the orchestrator asset may burn through the orchestrator"
+    );
+    let (burned, _log) = &burned_logs[0];
+    assert_eq!(
+        burned.token, evm.vault_address,
+        "the orchestrator burn must be for the orchestrator-mode asset"
+    );
+    assert_eq!(burned.amount, tokens(10));
+
+    // The vault-direct asset burned through the untouched multicall path:
+    // its shares are gone without any orchestrator involvement.
+    assert_eq!(
+        direct_vault.balanceOf(bot_wallet).call().await?,
+        U256::ZERO,
+        "vault-direct burn must have completed"
+    );
+    assert_eq!(
+        orchestrator_vault.balanceOf(bot_wallet).call().await?,
+        U256::ZERO,
+        "orchestrator burn must have completed"
+    );
+
+    Ok(())
+}

--- a/tests/turnkey_cutover.rs
+++ b/tests/turnkey_cutover.rs
@@ -166,9 +166,10 @@ async fn mint_before_cutover(
     user_signer: &PrivateKeySigner,
     user_wallet: Address,
     mint_callback_mock: &Mock<'_>,
+    db_url: &str,
 ) -> Result<PreCutoverMint, Box<dyn std::error::Error>> {
     let account = harness::setup_account(client, user_wallet).await;
-    harness::perform_mint_and_confirm(
+    let issuer_request_id = harness::perform_mint_and_confirm(
         client,
         user_wallet,
         &account.client_id.to_string(),
@@ -188,6 +189,10 @@ async fn mint_before_cutover(
     let minted_shares =
         harness::wait_for_shares(&user_vault, user_wallet).await?;
     harness::wait_for_mock_hits(mint_callback_mock, 1).await?;
+    // The migration's quiescence gate counts non-terminal mints, so the
+    // service must not shut down until the terminal event is COMMITTED —
+    // the mock hit above only proves the callback request arrived.
+    harness::wait_for_mint_completed(db_url, &issuer_request_id).await?;
 
     Ok(PreCutoverMint {
         client_id: account.client_id.to_string(),
@@ -200,8 +205,9 @@ async fn mint_after_cutover(
     user_wallet: Address,
     client_id: &str,
     mint_callback_mock: &Mock<'_>,
+    db_url: &str,
 ) -> Result<U256, Box<dyn std::error::Error>> {
-    harness::perform_mint_and_confirm(
+    let issuer_request_id = harness::perform_mint_and_confirm(
         client,
         user_wallet,
         client_id,
@@ -210,6 +216,10 @@ async fn mint_after_cutover(
     )
     .await?;
     harness::wait_for_mock_hits(mint_callback_mock, 2).await?;
+    // Same terminality wait as `mint_before_cutover`: the rehearsal
+    // reverses the migration after the canaries, and its quiescence gate
+    // must find this mint terminal, not racing its final event write.
+    harness::wait_for_mint_completed(db_url, &issuer_request_id).await?;
 
     Ok(U256::from(25) * U256::from(10).pow(U256::from(18)))
 }
@@ -224,6 +234,7 @@ struct PostCutoverCanaries<'context, 'server> {
     mint_callback_mock: &'context Mock<'server>,
     redeem_mock: &'context Mock<'server>,
     poll_mock: &'context Mock<'server>,
+    db_url: &'context str,
 }
 
 impl PostCutoverCanaries<'_, '_> {
@@ -262,6 +273,7 @@ impl PostCutoverCanaries<'_, '_> {
             self.user_wallet,
             &self.pre_cutover_mint.client_id,
             self.mint_callback_mock,
+            self.db_url,
         )
         .await?;
         assert_eq!(
@@ -465,6 +477,7 @@ async fn test_wallet_cutover_redeems_pre_cutover_receipt_after_restart()
         &user_signer,
         user_wallet,
         &mint_callback_mock,
+        &databases.fireblocks_url,
     )
     .await?;
 
@@ -547,6 +560,7 @@ async fn test_wallet_cutover_redeems_pre_cutover_receipt_after_restart()
         mint_callback_mock: &mint_callback_mock,
         redeem_mock: &redeem_mock,
         poll_mock: &poll_mock,
+        db_url: &databases.turnkey_url,
     }
     .run()
     .await?;
@@ -835,6 +849,7 @@ async fn test_single_asset_rehearsal_operates_reverses_and_resumes()
         &user_signer,
         user_wallet,
         &mint_callback_mock,
+        &databases.fireblocks_url,
     )
     .await?;
     fireblocks_client.terminate().await;
@@ -873,6 +888,7 @@ async fn test_single_asset_rehearsal_operates_reverses_and_resumes()
         mint_callback_mock: &mint_callback_mock,
         redeem_mock: &redeem_mock,
         poll_mock: &poll_mock,
+        db_url: &databases.turnkey_url,
     }
     .run()
     .await?;
@@ -1044,6 +1060,7 @@ async fn test_cutover_without_receipt_transfer_cannot_burn_historical_shares()
         &user_signer,
         user_wallet,
         &mint_callback_mock,
+        &databases.fireblocks_url,
     )
     .await?;
     let (receipt_id, receipt_shares, _receipt_information) =


### PR DESCRIPTION
## Motivation

When an orchestrator-mode burn is attempted but the orchestrator's receipt pool cannot cover the requested amount, the transaction would revert deterministically with `InsufficientReceipts`. Previously this revert was only discoverable after gas estimation rejected the transaction at signing, surfacing as an unclassified preparation failure with no structured error state and no clear recovery path.

## Solution

A burn simulation (`eth_call`) is now performed as the final gate in `check_orchestrator_burn_readiness`, after the allowance and `vaultLogicIsExpected()` checks. If the simulation reverts with `InsufficientReceipts`, the new `OrchestratorBurnReadiness::InsufficientReceipts { shortfall }` variant is returned before any signing occurs. A `VaultLogicMismatch` or `ReceiptLogicMismatch` revert from the simulation is folded into the existing `VaultLogicMismatch` arm; any other revert propagates as an error.

In `BurnManager`, the new readiness variant is handled by recording a `BurnFailureClassification::InsufficientReceipts` failure and returning a non-retryable `BurnManagerError`. The failure is never auto-retried — recovery requires a manual `EMERGENCY_ROLE` action followed by an admin `ResumeBurn`.

Four end-to-end tests on Anvil cover the full orchestrator redemption surface:

- **`orchestrator_burn_walks_multiple_receipts`** — a burn spanning three orchestrator-custodied receipts completes in a single `burn()` call and advances the per-token receipt pointer correctly.
- **`orchestrator_shortfall_is_classified_without_submission`** — a redemption larger than the receipt pool is classified as `InsufficientReceipts`, parked in `BurnFailed`, and never submitted even after multiple reconciler passes.
- **`orchestrator_recovery_confirms_landed_burn_without_resubmitting`** — startup recovery of a burn that already landed on-chain confirms the existing transaction rather than submitting a second one.
- **`mixed_mode_assets_each_take_their_own_burn_path`** — an orchestrator-mode asset and a vault-direct asset redeem concurrently, each following its own burn path without interference.

Two harness helpers (`orchestrator_mint_to`, `approve_orchestrator`) and a `create_config_with_vault_modes` convenience constructor are added to support these tests.  
  
Closes [RAI-1489](https://linear.app/makeitrain/issue/RAI-1489/e2e-anvil-tests)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added pre-submit burn simulation to identify insufficient receipts before transactions are submitted.
  * Added support for orchestrator-mode redemptions, including multi-receipt burns, recovery, and mixed deployment paths.

* **Bug Fixes**
  * Prevented burns from being submitted when receipt balances are insufficient.
  * Improved classification and visibility of redemption failures, including receipt shortfalls.
  * Insufficient-receipt failures are now recorded as non-retryable, preventing repeated attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->