### PR TITLE
Scope burn verification by `BurnProofKind` for orchestrator vs vault-direct modes

### DIFF
--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -23,6 +23,9 @@ use crate::receipt_inventory::{
     BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
     Shares,
 };
+use crate::redemption::force_complete::{
+    ForceCompleteRefusal, bind_verified_burns,
+};
 use crate::redemption::{
     BurnFailureClassification, BurnRecord, RedemptionMetadata,
     has_unresolved_signer_intent,
@@ -341,12 +344,25 @@ impl BurnManager {
                 acknowledged_unresolved_burn_tx_hash,
             )?;
 
-        let (underlying, network) = match &redemption {
-            Redemption::Burning { metadata, .. }
-            | Redemption::BurnIntended { metadata, .. }
-            | Redemption::BurnSubmitted { metadata, .. } => {
-                (metadata.underlying.clone(), metadata.network)
+        let (metadata, planned_burns, alpaca_quantity) = match &redemption {
+            // Burning carries no persisted transaction, so the
+            // `persisted_burn_tx` guard above already rejected it; the arm
+            // exists only to keep the state match exhaustive.
+            Redemption::Burning { metadata, alpaca_quantity, .. } => {
+                (metadata, &[][..], alpaca_quantity)
             }
+            Redemption::BurnIntended {
+                metadata,
+                planned_burns,
+                alpaca_quantity,
+                ..
+            }
+            | Redemption::BurnSubmitted {
+                metadata,
+                planned_burns,
+                alpaca_quantity,
+                ..
+            } => (metadata, planned_burns.as_slice(), alpaca_quantity),
             other => {
                 return Err(BurnManagerError::InvalidAggregateState {
                     current_state: aggregate_state_name(other).to_string(),
@@ -354,15 +370,68 @@ impl BurnManager {
             }
         };
 
-        let vault =
-            find_vault(&self.view_pool, &underlying, &network).await?.ok_or(
-                BurnManagerError::AssetNotFound { underlying, network },
-            )?;
+        let vault = find_vault(
+            &self.view_pool,
+            &metadata.underlying,
+            &metadata.network,
+        )
+        .await?
+        .ok_or_else(|| BurnManagerError::AssetNotFound {
+            network: metadata.network,
+            underlying: metadata.underlying.clone(),
+        })?;
 
         let verification = self
-            .vault_for(network)?
-            .verify_burn_tx(vault, self.bot_wallet, burn_tx_hash)
+            .vault_for(metadata.network)?
+            .verify_burn_tx(
+                vault,
+                self.bot_wallet,
+                burn_tx_hash,
+                metadata.burn_mode.into(),
+            )
             .await?;
+
+        // SPEC "ForceCompleteBurn": the proving transaction's signer nonce
+        // must equal the persisted transaction's nonce — an alternate proof
+        // must be the mined replacement at that exact nonce, ensuring the
+        // acknowledged transaction can never land and another redemption's
+        // same-vault burn can never be used as proof.
+        if verification.nonce != persisted_burn_tx.nonce {
+            return Err(BurnManagerError::ForceCompleteNonceMismatch {
+                proof_nonce: verification.nonce,
+                persisted_nonce: persisted_burn_tx.nonce,
+            });
+        }
+
+        // Bind the proof to this redemption's persisted burn semantics: the
+        // per-receipt plan for vault-direct (the same rule the offline CLI
+        // enforces), and the burned amount plus transfer-free shape for
+        // orchestrator mode, which has no receipt plan — the amount is its
+        // only binding, and an orchestrator burn moves nothing besides the
+        // pull-and-burn legs (dust is retained, never returned on-chain).
+        match metadata.burn_mode {
+            VaultMode::VaultDirect => {
+                bind_verified_burns(planned_burns, &verification.burns)?;
+            }
+            VaultMode::Orchestrator { .. } => {
+                let required_shares =
+                    alpaca_quantity.to_u256_with_18_decimals()?;
+                if verification.shares_burned != required_shares {
+                    return Err(
+                        BurnManagerError::ForceCompleteAmountMismatch {
+                            proof_shares: verification.shares_burned,
+                            required_shares,
+                        },
+                    );
+                }
+                if let Some(stray) = verification.share_transfers.first() {
+                    return Err(BurnManagerError::ForceCompleteStrayTransfer {
+                        recipient: stray.recipient,
+                        shares: stray.shares,
+                    });
+                }
+            }
+        }
 
         info!(target: "redemption", issuer_request_id = %issuer_request_id,
             burn_tx_hash = ?burn_tx_hash,
@@ -386,8 +455,12 @@ impl BurnManager {
             )
             .await?;
 
-        let chain_id = self.chain_id_for(network)?;
-        self.settle_reserved_burn(chain_id, vault, issuer_request_id).await;
+        // Orchestrator redemptions never reserved receipts, so there is
+        // nothing to settle and the receipt service must not be touched.
+        let chain_id = self.chain_id_for(metadata.network)?;
+        if matches!(metadata.burn_mode, VaultMode::VaultDirect) {
+            self.settle_reserved_burn(chain_id, vault, issuer_request_id).await;
+        }
 
         Ok(verification)
     }
@@ -2675,6 +2748,25 @@ pub(crate) enum BurnManagerError {
     QuantityConversion(#[from] QuantityConversionError),
     #[error("Insufficient balance: required {required}, available {available}")]
     InsufficientBalance { required: Shares, available: Shares },
+    #[error(transparent)]
+    ForceCompleteRefusal(#[from] ForceCompleteRefusal),
+    #[error(
+        "Force-complete proof nonce {proof_nonce} does not match the \
+         persisted burn transaction's nonce {persisted_nonce}; an alternate \
+         proof must be the mined replacement at that exact nonce"
+    )]
+    ForceCompleteNonceMismatch { proof_nonce: u64, persisted_nonce: u64 },
+    #[error(
+        "Force-complete proof burned {proof_shares} share-wei but this \
+         redemption requires exactly {required_shares}"
+    )]
+    ForceCompleteAmountMismatch { proof_shares: U256, required_shares: U256 },
+    #[error(
+        "Force-complete proof also transferred {shares} share-wei to \
+         {recipient}; an orchestrator burn moves nothing besides the \
+         pull-and-burn legs"
+    )]
+    ForceCompleteStrayTransfer { recipient: Address, shares: U256 },
     #[error("Receipt inventory error: {0}")]
     BurnTracking(#[from] BurnTrackingError),
     #[error("Redemption view error: {0}")]
@@ -2744,6 +2836,7 @@ mod tests {
         BurnTxStatus, MultiBurnEntry, NetworkVaultServices,
         OrchestratorBurnReadiness, OrchestratorRevertReason,
         ReceiptInformation, SendableTxWithHash, TxId, VaultError, VaultService,
+        VerifiedBurn, VerifiedShareTransfer,
     };
 
     const TEST_WALLET: Address =
@@ -4184,7 +4277,20 @@ mod tests {
         let owner = persisted_tx.signer_for_test();
         let vault_mock = Arc::new(
             MockVaultService::new_success()
-                .with_verified_burn(45_989_009, uint!(17_U256))
+                // The proof must carry the persisted transaction's nonce and
+                // the exact per-receipt plan — force-complete binds both.
+                .with_verified_burns_and_total(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    uint!(17_U256),
+                    vec![VerifiedBurn {
+                        sender: owner,
+                        receiver: owner,
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_U256),
+                    }],
+                    vec![],
+                )
                 .with_prepared_tx(persisted_tx.clone()),
         );
         let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
@@ -4277,6 +4383,368 @@ mod tests {
             tracing::Level::INFO,
             &["Force-completing stuck Burning redemption", "verified on-chain"]
         ));
+    }
+
+    /// Amount an orchestrator redemption seeded by
+    /// [`create_orchestrator_redemption_in_burning_state`] burns:
+    /// `alpaca_quantity` (100) converted to 18-decimal share-wei.
+    const ORCHESTRATOR_BURN_AMOUNT: U256 = uint!(100_000000000000000000_U256);
+
+    async fn persist_test_orchestrator_burn_intent(
+        store: &Store<Redemption>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        token: Address,
+        owner: Address,
+    ) {
+        store
+            .send(
+                issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    params: BurnParams::Orchestrator {
+                        token,
+                        amount: ORCHESTRATOR_BURN_AMOUNT,
+                        owner,
+                    },
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("orchestrator burn intent should persist");
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn force_complete_orchestrator_persisted_hash_skips_receipt_lifecycle()
+     {
+        let vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns_and_total(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    ORCHESTRATOR_BURN_AMOUNT,
+                    vec![],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
+        let recording = Arc::new(RecordingReceiptService::new(
+            harness.receipt_service.clone(),
+        ));
+        let manager = BurnManager::new_for_tests(
+            vault_mock.clone(),
+            harness.pool.clone(),
+            harness.store.clone(),
+            recording.clone(),
+            owner,
+            ANVIL_CHAIN_ID,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_orchestrator_redemption_in_burning_state(
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        persist_test_orchestrator_burn_intent(
+            &harness.store,
+            &issuer_request_id,
+            vault,
+            owner,
+        )
+        .await;
+
+        let verification = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                persisted_tx.hash,
+                "orchestrator burn confirmed".to_string(),
+                None,
+            )
+            .await
+            .expect("orchestrator force-complete should succeed");
+
+        assert_eq!(verification.shares_burned, ORCHESTRATOR_BURN_AMOUNT);
+        assert!(matches!(
+            load_aggregate(&harness.store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+        assert_eq!(
+            recording.call_count(),
+            0,
+            "orchestrator force-complete must never touch the receipt service"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Force-completing stuck Burning redemption", "verified on-chain"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn force_complete_orchestrator_accepts_matching_alternate_hash() {
+        let vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_verified_burns_and_total(
+                    45_989_009,
+                    persisted_tx.nonce,
+                    ORCHESTRATOR_BURN_AMOUNT,
+                    vec![],
+                    vec![],
+                )
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
+        let recording = Arc::new(RecordingReceiptService::new(
+            harness.receipt_service.clone(),
+        ));
+        let manager = BurnManager::new_for_tests(
+            vault_mock.clone(),
+            harness.pool.clone(),
+            harness.store.clone(),
+            recording.clone(),
+            owner,
+            ANVIL_CHAIN_ID,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_orchestrator_redemption_in_burning_state(
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        persist_test_orchestrator_burn_intent(
+            &harness.store,
+            &issuer_request_id,
+            vault,
+            owner,
+        )
+        .await;
+
+        manager
+            .force_complete_burn(
+                &issuer_request_id,
+                B256::random(),
+                "alternate orchestrator burn".to_string(),
+                Some(persisted_tx.hash),
+            )
+            .await
+            .expect("matching alternate orchestrator burn should complete");
+
+        assert!(matches!(
+            load_aggregate(&harness.store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+        assert_eq!(recording.call_count(), 0);
+    }
+
+    /// Force-complete binds an orchestrator proof to this redemption per
+    /// SPEC "ForceCompleteBurn": a proof at the wrong nonce (could be
+    /// another redemption's burn, and the acknowledged transaction could
+    /// still land), with the wrong burned amount, or carrying stray share
+    /// transfers (an orchestrator burn moves nothing besides the
+    /// pull-and-burn legs) is rejected before any state change — and the
+    /// receipt service is never touched either way.
+    #[tokio::test]
+    async fn force_complete_orchestrator_rejects_unbound_proofs() {
+        let recipient = address!("0x1234567890abcdef1234567890abcdef12345678");
+        for (scenario, verified_nonce, verified_shares, verified_transfers) in [
+            ("nonce mismatch", 8, ORCHESTRATOR_BURN_AMOUNT, vec![]),
+            ("amount mismatch", 7, uint!(99_000000000000000000_U256), vec![]),
+            (
+                "stray share transfer",
+                7,
+                ORCHESTRATOR_BURN_AMOUNT,
+                vec![VerifiedShareTransfer {
+                    recipient,
+                    shares: uint!(1_U256),
+                }],
+            ),
+        ] {
+            let vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+            let persisted_tx = SendableTxWithHash::valid_for_test(
+                7,
+                vault,
+                Bytes::from_static(&[0xde, 0xad]),
+            );
+            let owner = persisted_tx.signer_for_test();
+            let vault_mock = Arc::new(
+                MockVaultService::new_success()
+                    .with_verified_burns_and_total(
+                        45_989_009,
+                        verified_nonce,
+                        verified_shares,
+                        vec![],
+                        verified_transfers,
+                    )
+                    .with_prepared_tx(persisted_tx.clone()),
+            );
+            let harness =
+                TestHarness::with_vault_mock(vault_mock.clone()).await;
+            harness
+                .add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault)
+                .await;
+            let recording = Arc::new(RecordingReceiptService::new(
+                harness.receipt_service.clone(),
+            ));
+            let manager = BurnManager::new_for_tests(
+                vault_mock.clone(),
+                harness.pool.clone(),
+                harness.store.clone(),
+                recording.clone(),
+                owner,
+                ANVIL_CHAIN_ID,
+            );
+
+            let issuer_request_id = IssuerRedemptionRequestId::random();
+            create_orchestrator_redemption_in_burning_state(
+                &harness.store,
+                &issuer_request_id,
+            )
+            .await;
+            persist_test_orchestrator_burn_intent(
+                &harness.store,
+                &issuer_request_id,
+                vault,
+                owner,
+            )
+            .await;
+
+            let err = manager
+                .force_complete_burn(
+                    &issuer_request_id,
+                    B256::random(),
+                    scenario.to_string(),
+                    Some(persisted_tx.hash),
+                )
+                .await
+                .unwrap_err();
+
+            let rejected_as_expected = match scenario {
+                "nonce mismatch" => matches!(
+                    err,
+                    BurnManagerError::ForceCompleteNonceMismatch {
+                        proof_nonce: 8,
+                        persisted_nonce: 7,
+                    }
+                ),
+                "amount mismatch" => matches!(
+                    err,
+                    BurnManagerError::ForceCompleteAmountMismatch { .. }
+                ),
+                "stray share transfer" => matches!(
+                    err,
+                    BurnManagerError::ForceCompleteStrayTransfer { .. }
+                ),
+                _ => false,
+            };
+            assert!(
+                rejected_as_expected,
+                "scenario {scenario}: unexpected error {err:?}"
+            );
+
+            assert!(
+                matches!(
+                    load_aggregate(&harness.store, &issuer_request_id).await,
+                    Redemption::BurnIntended { .. }
+                ),
+                "scenario {scenario} must leave the redemption BurnIntended"
+            );
+            assert_eq!(
+                recording.call_count(),
+                0,
+                "scenario {scenario} touched the receipt service"
+            );
+        }
+    }
+
+    /// An orchestrator force-complete whose burn does not verify on-chain is
+    /// rejected before any state change: `verify_burn_tx` fails, so the
+    /// `ForceCompleteBurn` command is never sent, the redemption stays
+    /// `BurnIntended`, and the receipt service is never touched.
+    #[tokio::test]
+    async fn force_complete_orchestrator_rejects_unverifiable_burn() {
+        let vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let persisted_tx = SendableTxWithHash::valid_for_test(
+            7,
+            vault,
+            Bytes::from_static(&[0xde, 0xad]),
+        );
+        let owner = persisted_tx.signer_for_test();
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_unverifiable_burn()
+                .with_prepared_tx(persisted_tx.clone()),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
+        let recording = Arc::new(RecordingReceiptService::new(
+            harness.receipt_service.clone(),
+        ));
+        let manager = BurnManager::new_for_tests(
+            vault_mock.clone(),
+            harness.pool.clone(),
+            harness.store.clone(),
+            recording.clone(),
+            owner,
+            ANVIL_CHAIN_ID,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_orchestrator_redemption_in_burning_state(
+            &harness.store,
+            &issuer_request_id,
+        )
+        .await;
+        persist_test_orchestrator_burn_intent(
+            &harness.store,
+            &issuer_request_id,
+            vault,
+            owner,
+        )
+        .await;
+
+        let result = manager
+            .force_complete_burn(
+                &issuer_request_id,
+                persisted_tx.hash,
+                "operator hash is not a burn".to_string(),
+                None,
+            )
+            .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            BurnManagerError::Vault(VaultError::NotABurn { .. })
+        ));
+        assert!(
+            matches!(
+                load_aggregate(&harness.store, &issuer_request_id).await,
+                Redemption::BurnIntended { .. }
+            ),
+            "an unverifiable burn must leave the redemption BurnIntended"
+        );
+        assert_eq!(
+            recording.call_count(),
+            0,
+            "a rejected force-complete must not touch the receipt service"
+        );
     }
 
     #[tokio::test]

--- a/src/redemption/force_complete.rs
+++ b/src/redemption/force_complete.rs
@@ -31,6 +31,7 @@ use crate::receipt_inventory::{
     ReceiptInventory, ReceiptInventoryCommand, send_receipt_inventory_command,
 };
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
+use crate::vault::orchestrator::BurnProofKind;
 use crate::vault::{
     BurnVerification, NetworkVaultServices, VerifiedBurn,
     verify_burn_in_receipt,
@@ -118,12 +119,16 @@ pub(crate) async fn verify_landed_burn<P: Provider>(
             || anyhow::anyhow!("transaction {burn_tx_hash} has no receipt"),
         )?;
 
+    // Custodian-era burns predate orchestrator mode, so the offline CLI
+    // force-complete only ever proves the vault-direct shape (see
+    // `ForceCompleteBurn` in SPEC.md).
     let verification = verify_burn_in_receipt(
         &receipt,
         vault,
         owner,
         burn_tx_hash,
         transaction.nonce(),
+        BurnProofKind::VaultDirect,
     )?;
     bind_verified_burns(planned_burns, &verification.burns)?;
 

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -25,6 +25,7 @@ use super::{
 #[cfg(test)]
 use super::{OrchestratorRevertReason, VerifiedBurn, VerifiedShareTransfer};
 use crate::redemption::BurnExternalTxId;
+use crate::vault::orchestrator::BurnProofKind;
 use crate::vault::{SendableTxWithHash, TxId};
 
 #[cfg(test)]
@@ -225,6 +226,8 @@ pub(crate) struct MockVaultService {
     /// Optional forced `submit_mint` error (e.g. uncertain broadcast).
     #[cfg(test)]
     submit_mint_error: Arc<Mutex<Option<VaultError>>>,
+    #[cfg(test)]
+    last_burn_proof_kind: Arc<Mutex<Option<BurnProofKind>>>,
 }
 
 impl MockVaultService {
@@ -281,6 +284,8 @@ impl MockVaultService {
             confirm_mint_outcomes: Arc::new(Mutex::new(Vec::new())),
             #[cfg(test)]
             submit_mint_error: Arc::new(Mutex::new(None)),
+            #[cfg(test)]
+            last_burn_proof_kind: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -469,6 +474,7 @@ impl MockVaultService {
         self.orchestrator.submit_call_count.store(0, Ordering::Relaxed);
         self.orchestrator.readiness_call_count.store(0, Ordering::Relaxed);
         *self.orchestrator.pending_result.lock().unwrap() = None;
+        *self.last_burn_proof_kind.lock().unwrap() = None;
     }
 
     #[cfg(test)]
@@ -727,6 +733,11 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn orchestrator_readiness_call_count(&self) -> usize {
         self.orchestrator.readiness_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_last_burn_proof_kind(&self) -> Option<BurnProofKind> {
+        *self.last_burn_proof_kind.lock().unwrap()
     }
 }
 
@@ -1121,11 +1132,13 @@ impl VaultService for MockVaultService {
         _vault: Address,
         _owner: Address,
         tx_hash: B256,
+        expected_proof: BurnProofKind,
     ) -> Result<BurnVerification, VaultError> {
         #[cfg(test)]
         {
             use MockVerifyBurn::{NotABurn, Reverted, Verified};
 
+            *self.last_burn_proof_kind.lock().unwrap() = Some(expected_proof);
             self.verify_burn_call_count.fetch_add(1, Ordering::Relaxed);
             let outcome = self.verify_burn.lock().unwrap().clone();
             match outcome {
@@ -1447,6 +1460,7 @@ mod tests {
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::redemption::IssuerRedemptionRequestId;
+    use crate::vault::orchestrator::BurnProofKind;
     use crate::vault::{
         BurnRequestOrigin, MultiBurnEntry, MultiBurnParams, ReceiptInformation,
         SendableTxWithHash, VaultError, VaultService,
@@ -1724,9 +1738,14 @@ mod tests {
         mock.prepare_replacement_burn_tx(params.owner, &sendable_tx)
             .await
             .unwrap();
-        mock.verify_burn_tx(test_vault(), test_receiver(), B256::ZERO)
-            .await
-            .unwrap();
+        mock.verify_burn_tx(
+            test_vault(),
+            test_receiver(),
+            B256::ZERO,
+            BurnProofKind::VaultDirect,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(mock.get_multi_burn_call_count(), 2);
         assert!(mock.get_last_multi_burn_params().is_some());
@@ -1735,6 +1754,10 @@ mod tests {
         assert_eq!(mock.burn_classification_call_count(), 1);
         assert_eq!(mock.burn_preparation_call_count(), 1);
         assert_eq!(mock.replacement_preparation_call_count(), 1);
+        assert_eq!(
+            mock.get_last_burn_proof_kind(),
+            Some(BurnProofKind::VaultDirect)
+        );
 
         mock.reset();
 
@@ -1745,9 +1768,33 @@ mod tests {
         assert_eq!(mock.burn_classification_call_count(), 0);
         assert_eq!(mock.burn_preparation_call_count(), 0);
         assert_eq!(mock.replacement_preparation_call_count(), 0);
+        assert!(mock.get_last_burn_proof_kind().is_none());
         assert_eq!(
             mock.prepare_burn_tx(&test_multi_burn_params()).await.unwrap(),
             SendableTxWithHash::default(),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_verify_burn_tx_records_last_proof_kind() {
+        let mock = MockVaultService::new_success();
+        let orchestrator =
+            address!("0xcccccccccccccccccccccccccccccccccccccccc");
+
+        assert!(mock.get_last_burn_proof_kind().is_none());
+
+        mock.verify_burn_tx(
+            test_vault(),
+            test_receiver(),
+            B256::ZERO,
+            BurnProofKind::Orchestrator { address: orchestrator },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mock.get_last_burn_proof_kind(),
+            Some(BurnProofKind::Orchestrator { address: orchestrator })
         );
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -25,6 +25,7 @@ use crate::mint::{
     IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
 };
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
+use crate::vault::orchestrator::BurnProofKind;
 
 pub(crate) mod mock;
 pub(crate) mod network_services;
@@ -164,6 +165,7 @@ pub(crate) trait VaultService: Send + Sync {
         vault: Address,
         owner: Address,
         tx_hash: B256,
+        expected_proof: BurnProofKind,
     ) -> Result<BurnVerification, VaultError>;
 
     /// Prepares a signed raw transaction for `eth_sendRawTransaction`.
@@ -490,6 +492,12 @@ pub(crate) struct SendableTxWithHash {
 
 /// Proof that a burn transaction landed on-chain, returned by
 /// [`VaultService::verify_burn_tx`].
+///
+/// Field semantics depend on the [`BurnProofKind`] the verification was
+/// checked against: for [`BurnProofKind::VaultDirect`] the "burner" is the
+/// owner (bot wallet) itself; for [`BurnProofKind::Orchestrator`] the burner
+/// is the orchestrator contract, which receives the owner's shares via
+/// `transferFrom` and burns them in the same transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BurnVerification {
     /// Block number the burn transaction was included in.
@@ -497,15 +505,19 @@ pub(crate) struct BurnVerification {
     /// Signer nonce of the mined transaction. An alternate proof must replace
     /// the persisted transaction at this exact nonce.
     pub(crate) nonce: u64,
-    /// Total shares burned by the owner in this transaction (sum of all
-    /// matching `Transfer(owner -> 0x0)` events). Alternate-burn recovery
-    /// requires this to equal the persisted burn plan's aggregate total.
+    /// Total shares burned by the burner in this transaction (sum of all
+    /// matching `Transfer(burner -> 0x0)` events — `burner` is the owner for
+    /// `VaultDirect`, the orchestrator for `Orchestrator`). Alternate-burn
+    /// recovery requires this to equal the persisted burn plan's aggregate
+    /// total.
     pub(crate) shares_burned: U256,
-    /// Per-receipt withdrawals emitted for this owner. Admin recovery uses
+    /// Per-receipt withdrawals emitted for the burner (owner for
+    /// `VaultDirect`, orchestrator for `Orchestrator`). Admin recovery uses
     /// these to bind an alternate proving transaction to the redemption's
     /// persisted burn plan.
     pub(crate) burns: Vec<VerifiedBurn>,
-    /// Non-burn share transfers sent by the owner in the same transaction.
+    /// Non-burn share transfers sent by the owner in the same transaction
+    /// (excludes the orchestrator pull leg, which is verified separately).
     /// A redemption's dust return must match these exactly.
     pub(crate) share_transfers: Vec<VerifiedShareTransfer>,
 }
@@ -524,20 +536,32 @@ pub(crate) struct VerifiedShareTransfer {
     pub(crate) shares: U256,
 }
 
-/// Verifies that `receipt` proves `owner` burned shares of the `vault` share
-/// token (one or more `Transfer(owner -> 0x0)` events emitted by `vault`).
+/// Verifies that `receipt` proves a burn of `vault` shares matching
+/// `expected_proof`.
 ///
-/// A burn emits an ERC-20 `Transfer(owner, address(0), shares)` from the vault
-/// share token. Reference chain: `redeem()` -> `ReceiptVault._withdraw()` ->
+/// For [`BurnProofKind::VaultDirect`], a burn emits an ERC-20
+/// `Transfer(owner, address(0), shares)` from the vault share token directly.
+/// Reference chain: `redeem()` -> `ReceiptVault._withdraw()` ->
 /// `_burn(owner, shares)` -> `ERC20Upgradeable._update(owner, 0x0, shares)`
 /// emits `Transfer(owner, 0x0, shares)`. Mirrors the mint-skip check in
 /// `redemption/transfer.rs`, which treats `from == 0x0` as a mint.
+///
+/// For [`BurnProofKind::Orchestrator`], the proof is two legs in the same
+/// transaction: `Transfer(owner, address, shares)` (the orchestrator's
+/// `transferFrom` pull) followed by `Transfer(address, 0x0, shares)` (the
+/// orchestrator burning what it pulled). Verification fails closed unless
+/// the pull total equals the burn total AND every pull precedes the first
+/// burn leg (receipt logs preserve execution order), so a transaction that
+/// only partially matches the orchestrator shape, matches the other mode's
+/// shape, or burns pre-existing orchestrator shares with the pull trailing
+/// the burn is rejected as [`VaultError::NotABurn`].
 pub(crate) fn verify_burn_in_receipt(
     receipt: &TransactionReceipt,
     vault: Address,
     owner: Address,
     tx_hash: B256,
     nonce: u64,
+    expected_proof: BurnProofKind,
 ) -> Result<BurnVerification, VaultError> {
     if !receipt.status() {
         return Err(VaultError::Reverted { tx_hash });
@@ -547,6 +571,12 @@ pub(crate) fn verify_burn_in_receipt(
     let mut found_burn = false;
     let mut burns = Vec::new();
     let mut share_transfers = Vec::new();
+    let mut pulled = U256::ZERO;
+
+    let burner = match expected_proof {
+        BurnProofKind::VaultDirect => owner,
+        BurnProofKind::Orchestrator { address } => address,
+    };
 
     for log in receipt.inner.logs() {
         if log.address() != vault {
@@ -557,9 +587,28 @@ pub(crate) fn verify_burn_in_receipt(
             log.log_decode::<OffchainAssetReceiptVault::Transfer>()
         {
             let transfer = decoded.data();
-            if transfer.from == owner && transfer.to == Address::ZERO {
+            if transfer.from == burner && transfer.to == Address::ZERO {
                 found_burn = true;
                 shares_burned = shares_burned
+                    .checked_add(transfer.value)
+                    .ok_or(VaultError::InvalidReceipt)?;
+            } else if matches!(
+                expected_proof,
+                BurnProofKind::Orchestrator { .. }
+            ) && transfer.from == owner
+                && transfer.to == burner
+            {
+                // Receipt logs preserve execution order, and the
+                // orchestrator's burn pulls the owner's shares BEFORE
+                // burning them (`transferFrom` then the receipt walk's
+                // burn legs). A pull appearing after a burn leg means the
+                // burn consumed shares the orchestrator already held while
+                // the owner's shares merely moved to the orchestrator —
+                // totals match, but nothing of the owner's was burned.
+                if found_burn {
+                    return Err(VaultError::NotABurn { tx_hash });
+                }
+                pulled = pulled
                     .checked_add(transfer.value)
                     .ok_or(VaultError::InvalidReceipt)?;
             } else if transfer.from == owner {
@@ -574,7 +623,7 @@ pub(crate) fn verify_burn_in_receipt(
             log.log_decode::<OffchainAssetReceiptVault::Withdraw>()
         {
             let withdrawal = decoded.data();
-            if withdrawal.owner == owner {
+            if withdrawal.owner == burner {
                 burns.push(VerifiedBurn {
                     sender: withdrawal.sender,
                     receiver: withdrawal.receiver,
@@ -585,7 +634,10 @@ pub(crate) fn verify_burn_in_receipt(
         }
     }
 
-    if !found_burn {
+    if !found_burn
+        || (matches!(expected_proof, BurnProofKind::Orchestrator { .. })
+            && (pulled != shares_burned || shares_burned.is_zero()))
+    {
         return Err(VaultError::NotABurn { tx_hash });
     }
 
@@ -1171,6 +1223,9 @@ mod tests {
     const VAULT: Address = alloy::primitives::address!(
         "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
     );
+    const ORCHESTRATOR: Address = alloy::primitives::address!(
+        "0xcccccccccccccccccccccccccccccccccccccccc"
+    );
     const BURN_TX: B256 = alloy::primitives::b256!(
         "0x3601e281d321344b9569b44159996ae179c44e8d733cab7f81cb0424d0375ccf"
     );
@@ -1246,9 +1301,15 @@ mod tests {
             vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
         );
 
-        let verification =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
-                .unwrap();
+        let verification = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap();
 
         assert_eq!(verification.block_number, 45_989_009);
         assert_eq!(verification.shares_burned, U256::from(17u64));
@@ -1295,9 +1356,15 @@ mod tests {
         .collect();
         let receipt = receipt_with_logs(true, 45_989_009, logs);
 
-        let verification =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
-                .unwrap();
+        let verification = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap();
 
         assert_eq!(
             verification.burns,
@@ -1343,9 +1410,15 @@ mod tests {
             ],
         );
 
-        let verification =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
-                .unwrap();
+        let verification = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap();
 
         assert_eq!(verification.shares_burned, U256::from(15u64));
     }
@@ -1358,9 +1431,15 @@ mod tests {
             vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
         );
 
-        let err =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
-                .unwrap_err();
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap_err();
 
         assert!(matches!(err, VaultError::Reverted { .. }));
     }
@@ -1375,9 +1454,206 @@ mod tests {
             vec![(VAULT, BOT_WALLET, user, U256::from(17u64))],
         );
 
-        let err =
-            verify_burn_in_receipt(&receipt, VAULT, BOT_WALLET, BURN_TX, 7)
-                .unwrap_err();
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_accepts_orchestrator_pull_and_burn_legs() {
+        let pull = OffchainAssetReceiptVault::Transfer {
+            from: BOT_WALLET,
+            to: ORCHESTRATOR,
+            value: U256::from(17u64),
+        };
+        let burn = OffchainAssetReceiptVault::Transfer {
+            from: ORCHESTRATOR,
+            to: Address::ZERO,
+            value: U256::from(17u64),
+        };
+        let withdrawal = OffchainAssetReceiptVault::Withdraw {
+            sender: ORCHESTRATOR,
+            receiver: address!("0x3333333333333333333333333333333333333333"),
+            owner: ORCHESTRATOR,
+            assets: U256::from(17u64),
+            shares: U256::from(17u64),
+            id: U256::from(42u64),
+            receiptInformation: Bytes::new(),
+        };
+        let logs = [
+            pull.into_log_data(),
+            burn.into_log_data(),
+            withdrawal.into_log_data(),
+        ]
+        .into_iter()
+        .enumerate()
+        .map(|(index, data)| alloy::rpc::types::Log {
+            inner: alloy::primitives::Log { address: VAULT, data },
+            block_hash: None,
+            block_number: Some(45_989_009),
+            block_timestamp: None,
+            transaction_hash: Some(BURN_TX),
+            transaction_index: Some(0),
+            log_index: Some(index as u64),
+            removed: false,
+        })
+        .collect();
+        let receipt = receipt_with_logs(true, 45_989_009, logs);
+
+        let verification = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::Orchestrator { address: ORCHESTRATOR },
+        )
+        .unwrap();
+
+        assert_eq!(verification.shares_burned, U256::from(17u64));
+        assert_eq!(
+            verification.burns,
+            vec![VerifiedBurn {
+                sender: ORCHESTRATOR,
+                receiver: address!(
+                    "0x3333333333333333333333333333333333333333"
+                ),
+                receipt_id: U256::from(42u64),
+                shares_burned: U256::from(17u64),
+            }]
+        );
+        assert!(verification.share_transfers.is_empty());
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_vault_direct_tx_under_orchestrator_proof()
+    {
+        // Vault-direct shape: Transfer(owner -> 0x0) with no orchestrator legs.
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![(VAULT, BOT_WALLET, Address::ZERO, U256::from(17u64))],
+        );
+
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::Orchestrator { address: ORCHESTRATOR },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_orchestrator_tx_under_vault_direct_proof()
+    {
+        // Orchestrator shape: pull + burn legs, no direct owner-burn.
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![
+                (VAULT, BOT_WALLET, ORCHESTRATOR, U256::from(17u64)),
+                (VAULT, ORCHESTRATOR, Address::ZERO, U256::from(17u64)),
+            ],
+        );
+
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::VaultDirect,
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_orchestrator_pull_burn_mismatch() {
+        // Pulled 10, but burned 17 — the orchestrator's receipt walk cannot
+        // have consumed more than it pulled from the owner.
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![
+                (VAULT, BOT_WALLET, ORCHESTRATOR, U256::from(10u64)),
+                (VAULT, ORCHESTRATOR, Address::ZERO, U256::from(17u64)),
+            ],
+        );
+
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::Orchestrator { address: ORCHESTRATOR },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_orchestrator_pull_after_burn() {
+        // Totals match, but the burn precedes the pull: the burn consumed
+        // shares the orchestrator ALREADY held, and the owner's shares
+        // merely moved to the orchestrator afterwards — nothing of the
+        // owner's was burned, so this is not the pull-then-burn proof
+        // shape.
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![
+                (VAULT, ORCHESTRATOR, Address::ZERO, U256::from(17u64)),
+                (VAULT, BOT_WALLET, ORCHESTRATOR, U256::from(17u64)),
+            ],
+        );
+
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::Orchestrator { address: ORCHESTRATOR },
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, VaultError::NotABurn { .. }));
+    }
+
+    #[test]
+    fn verify_burn_in_receipt_rejects_orchestrator_zero_value_burn() {
+        let receipt = transfer_receipt(
+            true,
+            100,
+            vec![(VAULT, ORCHESTRATOR, Address::ZERO, U256::ZERO)],
+        );
+
+        let err = verify_burn_in_receipt(
+            &receipt,
+            VAULT,
+            BOT_WALLET,
+            BURN_TX,
+            7,
+            BurnProofKind::Orchestrator { address: ORCHESTRATOR },
+        )
+        .unwrap_err();
 
         assert!(matches!(err, VaultError::NotABurn { .. }));
     }

--- a/src/vault/orchestrator.rs
+++ b/src/vault/orchestrator.rs
@@ -1,6 +1,7 @@
 use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 
+use crate::VaultMode;
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
 
 /// Parameters for a single `ST0xOrchestrator.burn()` call.
@@ -105,4 +106,42 @@ pub(crate) enum OrchestratorRevertReason {
     /// Revert data was unavailable or did not decode to one of the
     /// orchestrator's typed errors.
     Unknown,
+}
+
+/// Which on-chain proof shape [`super::verify_burn_tx`] must accept when
+/// verifying a burn transaction.
+///
+/// The two [`crate::VaultMode`]s emit structurally different burn proofs, and
+/// a proof of one shape must never satisfy the other: a vault-direct
+/// redemption's burn is never confirmed by an orchestrator-shaped
+/// transaction, or vice versa. Callers always derive this from the
+/// redemption's own persisted `burn_mode` (captured on `RedemptionDetected`),
+/// never re-resolved from the asset's current `VaultMode` — that per-redemption
+/// mode stays authoritative even while both modes are live side by side
+/// during the incremental per-asset cutover (see `From<VaultMode>` below).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BurnProofKind {
+    /// A single `Transfer(owner -> 0x0)` of vault shares, emitted directly by
+    /// `ReceiptVault.withdraw()`.
+    VaultDirect,
+    /// Two legs in the same transaction: `Transfer(owner -> address)` (the
+    /// orchestrator's `transferFrom` pull) followed by
+    /// `Transfer(address -> 0x0)` (the orchestrator's burn). The pull total
+    /// must equal the burn total, or the proof is rejected.
+    Orchestrator {
+        /// The `ST0xOrchestrator` contract address that performed the pull
+        /// and burn.
+        address: Address,
+    },
+}
+
+impl From<VaultMode> for BurnProofKind {
+    fn from(value: VaultMode) -> Self {
+        match value {
+            VaultMode::VaultDirect => Self::VaultDirect,
+            VaultMode::Orchestrator { address } => {
+                Self::Orchestrator { address }
+            }
+        }
+    }
 }

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -33,6 +33,7 @@ use super::{
 use crate::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Errors;
 use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
 use crate::redemption::BurnExternalTxId;
+use crate::vault::orchestrator::BurnProofKind;
 
 pub type RealBlockchainServiceProvider = FillProvider<
     JoinFill<
@@ -561,6 +562,7 @@ impl VaultService for RealBlockchainService {
         vault: Address,
         owner: Address,
         tx_hash: B256,
+        expected_proof: BurnProofKind,
     ) -> Result<BurnVerification, VaultError> {
         let transaction = self
             .provider
@@ -592,6 +594,7 @@ impl VaultService for RealBlockchainService {
             owner,
             tx_hash,
             transaction.nonce(),
+            expected_proof,
         )
     }
 
@@ -1065,6 +1068,7 @@ mod tests {
     };
     use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
     use crate::test_utils::{LocalEvm, logs_contain_at};
+    use crate::vault::orchestrator::BurnProofKind;
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
         BurnRequestOrigin, BurnTxStatus, MintTxStatus, MultiBurnEntry,
@@ -1892,7 +1896,12 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let verification = service
-            .verify_burn_tx(vault_address, owner, persisted.hash)
+            .verify_burn_tx(
+                vault_address,
+                owner,
+                persisted.hash,
+                BurnProofKind::VaultDirect,
+            )
             .await
             .expect("matching transaction and receipt should verify");
 
@@ -1913,7 +1922,12 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let result = service
-            .verify_burn_tx(test_vault_address(), owner, requested_tx_hash)
+            .verify_burn_tx(
+                test_vault_address(),
+                owner,
+                requested_tx_hash,
+                BurnProofKind::VaultDirect,
+            )
             .await;
 
         assert!(matches!(result, Err(VaultError::InvalidReceipt)));
@@ -1929,7 +1943,12 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let result = service
-            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .verify_burn_tx(
+                test_vault_address(),
+                owner,
+                persisted.hash,
+                BurnProofKind::VaultDirect,
+            )
             .await;
 
         assert!(matches!(result, Err(VaultError::InvalidReceipt)));
@@ -1945,7 +1964,12 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let result = service
-            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .verify_burn_tx(
+                test_vault_address(),
+                owner,
+                persisted.hash,
+                BurnProofKind::VaultDirect,
+            )
             .await;
 
         assert!(matches!(
@@ -1967,7 +1991,12 @@ mod tests {
         let service = create_service_with_asserter(asserter);
 
         let result = service
-            .verify_burn_tx(test_vault_address(), owner, persisted.hash)
+            .verify_burn_tx(
+                test_vault_address(),
+                owner,
+                persisted.hash,
+                BurnProofKind::VaultDirect,
+            )
             .await;
 
         assert!(matches!(result, Err(VaultError::InvalidReceipt)));


### PR DESCRIPTION
## Motivation

Burn verification was mode-agnostic: `verify_burn_in_receipt` and `VaultService::verify_burn_tx` always looked for a `Transfer(owner -> 0x0)` event, which is the vault-direct proof shape. Orchestrator burns have a structurally different two-leg shape — `Transfer(owner -> orchestrator)` (the `transferFrom` pull) followed by `Transfer(orchestrator -> 0x0)` (the burn) — so verifying them against the vault-direct shape always fails. Additionally, alternate-burn recovery in `BurnManager::force_complete_burn` was comparing orchestrator redemptions against a per-receipt plan that doesn't exist for orchestrator mode, and was unconditionally calling `settle_reserved_burn` even though orchestrator redemptions never reserve receipts.

## Solution

Introduces `BurnProofKind` (in `vault/orchestrator.rs`) with two variants — `VaultDirect` and `Orchestrator { address }` — and threads it through `verify_burn_in_receipt`, `VaultService::verify_burn_tx`, and `BurnManager::force_complete_burn`.

`verify_burn_in_receipt` now dispatches on `BurnProofKind`: vault-direct verification is unchanged; orchestrator verification accumulates the pull leg (`Transfer(owner -> orchestrator)`) and the burn leg (`Transfer(orchestrator -> 0x0)`) separately and rejects the proof unless the pull total equals the burn total and neither is zero. A vault-direct-shaped transaction is rejected under an orchestrator proof, and vice versa.

`force_complete_burn` now branches on `metadata.burn_mode` when an alternate proving hash is supplied. Vault-direct alternate proofs are still validated against the per-receipt plan. Orchestrator alternate proofs are validated by checking that the verified nonce matches the persisted transaction's nonce, the verified shares equal the redemption's `alpaca_quantity` converted to 18-decimal share-wei, and no owner share transfers are present (orchestrator mode returns no dust on-chain). `settle_reserved_burn` is skipped entirely for orchestrator redemptions.

`BurnProofKind` is always derived from the redemption's own persisted `burn_mode` via `From<VaultMode>`, never re-resolved from the asset's current vault mode, so the proof kind stays authoritative through the incremental per-asset cutover period.

The mock records the last `BurnProofKind` passed to `verify_burn_tx` for assertion in tests.  
  
Closes [RAI-1510](https://linear.app/makeitrain/issue/RAI-1510/orchestrator-burn-proof)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved force-complete burn verification across vault-direct and orchestrated redemption flows.
  * Added validation for transaction nonce, burn amount, transfer details, and proof type.
  * Prevented invalid, unverifiable, or mismatched burn transactions from completing recovery.
  * Orchestrated force-completion now skips unnecessary receipt settlement.
* **Tests**
  * Expanded coverage for valid and invalid burn proofs, alternate transaction hashes, mismatched values, and suppressed receipt-service calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->