### PR TITLE
feat: automate orchestrator burn-failed recovery with existing tx

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -18,6 +18,7 @@ use crate::alpaca::{
     AlpacaError, AlpacaService, RedeemRequestStatus, TokenizationRequest,
 };
 use crate::auth::InternalAuth;
+use crate::config::VaultMode;
 use crate::mint::{
     IssuerMintRequestId, ManualRecoveryDecision, Mint, MintCommand, MintEvent,
     MintView, TokenizationRequestId, find_stuck as find_stuck_mints,
@@ -32,7 +33,7 @@ use crate::redemption::burn_manager::{
     RecoveryOutcome,
 };
 use crate::redemption::{
-    BurnExternalTxId, BurnFailureClassification, BurnRecord,
+    BurnExternalTxId, BurnFailureClassification, BurnRecord, ExistingBurnProof,
     IssuerRedemptionRequestId, RedemptionCommand, RedemptionError,
     RedemptionEvent, RedemptionMetadata, RedemptionView,
     find_stuck as find_stuck_redemptions,
@@ -619,10 +620,10 @@ async fn recover_post_alpaca(
         store,
         vault_service,
         &aggregate_id,
-        &issuer_request_id,
-        &metadata.detected_tx_hash,
+        &metadata,
         burning_failed.as_ref(),
         burn_retry_external_tx_id,
+        &alpaca_data.dust_quantity,
     )
     .await?
     {
@@ -710,16 +711,21 @@ enum PriorBurnDisposition {
 /// Inspects the prior tx (if any) from a previous `BurningFailed` event to
 /// decide whether the on-chain burn already succeeded (record it), conclusively
 /// reverted (resume with a fresh replacement `externalTxId`), or remains
-/// ambiguous (require manual intervention).
+/// ambiguous (require manual intervention). The confirmation is mode-scoped on
+/// the redemption's persisted `burn_mode`: vault-direct confirms via a receipt
+/// lookup, orchestrator via the orchestrator's `Burned` event.
 async fn inspect_prior_burn(
     store: &Store<Redemption>,
     vault_service: &Arc<dyn VaultService>,
     aggregate_id: &str,
-    issuer_request_id: &IssuerRedemptionRequestId,
-    detected_tx_hash: &B256,
+    metadata: &RedemptionMetadata,
     burning_failed: Option<&BurningFailedData>,
     burn_retry_external_tx_id: Option<BurnExternalTxId>,
+    dust_quantity: &Quantity,
 ) -> Result<PriorBurnDisposition, Status> {
+    let issuer_request_id = &metadata.issuer_request_id;
+    let detected_tx_hash = &metadata.detected_tx_hash;
+
     let Some(bf_data) = burning_failed else {
         return Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id));
     };
@@ -727,98 +733,200 @@ async fn inspect_prior_burn(
         return Ok(PriorBurnDisposition::ResumeWith(burn_retry_external_tx_id));
     };
 
-    match vault_service.check_tx(tx_id).await {
-        Ok(receipt) => {
-            let Some(block_number) = receipt.block_number() else {
-                error!(target: "admin", aggregate_id = %aggregate_id,
+    match metadata.burn_mode {
+        VaultMode::VaultDirect => match vault_service.check_tx(tx_id).await {
+            Ok(receipt) => {
+                let Some(block_number) = receipt.block_number() else {
+                    error!(target: "admin", aggregate_id = %aggregate_id,
+                        tx_hash = ?tx_id,
+                        "Completed burn transaction receipt is missing block number"
+                    );
+                    return Err(Status::InternalServerError);
+                };
+
+                if bf_data.planned_burns.is_empty() {
+                    warn!(target: "admin", aggregate_id = %aggregate_id,
+                        tx_hash = ?tx_id,
+                        "BurningFailed event has no planned_burns — \
+                         burn records will be empty. Manual receipt inventory \
+                         reconciliation may be needed after recovery."
+                    );
+                }
+
+                info!(target: "admin", aggregate_id = %aggregate_id,
                     tx_hash = ?tx_id,
-                    "Completed burn transaction receipt is missing block number"
+                    "Transaction already completed on-chain, recording existing burn"
                 );
-                return Err(Status::InternalServerError);
-            };
 
-            if bf_data.planned_burns.is_empty() {
-                warn!(target: "admin", aggregate_id = %aggregate_id,
-                    tx_hash = ?tx_id,
-                    "BurningFailed event has no planned_burns — \
-                     burn records will be empty. Manual receipt inventory \
-                     reconciliation may be needed after recovery."
-                );
-            }
-
-            info!(target: "admin", aggregate_id = %aggregate_id,
-                tx_hash = ?tx_id,
-                "Transaction already completed on-chain, recording existing burn"
-            );
-
-            store
-                .send(
+                record_existing_burn(
+                    store,
+                    aggregate_id,
                     issuer_request_id,
-                    RedemptionCommand::RecordExistingBurn {
-                        issuer_request_id: issuer_request_id.clone(),
-                        tx_id: tx_id.clone(),
-                        tx_hash: receipt.transaction_hash(),
-                        planned_burns: bf_data.planned_burns.clone(),
-                        block_number,
+                    tx_id,
+                    receipt.transaction_hash(),
+                    ExistingBurnProof::VaultDirect {
+                        burns: bf_data.planned_burns.clone(),
                     },
+                    block_number,
                 )
                 .await
-                .map_err(|err| {
-                    error!(target: "admin", aggregate_id = %aggregate_id,
-                        error = %err,
-                        "Failed to record existing burn"
+            }
+            Err(VaultError::Reverted { .. }) => Ok(resume_after_reverted_burn(
+                aggregate_id,
+                detected_tx_hash,
+                tx_id,
+                burn_retry_external_tx_id,
+            )),
+            Err(error) => Err(ambiguous_prior_burn_status(
+                aggregate_id,
+                issuer_request_id,
+                tx_id,
+                &error,
+            )),
+        },
+        VaultMode::Orchestrator { .. } => {
+            match vault_service.confirm_orchestrator_burn(tx_id).await {
+                Ok(result) => {
+                    let dust_retained = dust_quantity
+                        .to_u256_with_18_decimals()
+                        .map_err(|err| {
+                            error!(target: "admin", aggregate_id = %aggregate_id,
+                                error = %err,
+                                "Failed to convert dust quantity for orchestrator recovery"
+                            );
+                            Status::InternalServerError
+                        })?;
+
+                    info!(target: "admin", aggregate_id = %aggregate_id,
+                        tx_hash = %result.tx_hash,
+                        "Orchestrator burn already completed on-chain, recording existing burn"
                     );
-                    map_redemption_error(&err)
-                })?;
 
-            Ok(PriorBurnDisposition::AlreadyRecorded(ReprocessResponse {
-                aggregate_type: AggregateKind::Redemption,
-                aggregate_id: aggregate_id.to_string(),
-                previous_state: "Failed".to_string(),
-                message: "Existing on-chain burn recorded via tx lookup"
-                    .to_string(),
-            }))
+                    record_existing_burn(
+                        store,
+                        aggregate_id,
+                        issuer_request_id,
+                        tx_id,
+                        result.tx_hash,
+                        ExistingBurnProof::Orchestrator {
+                            shares_burned: result.shares_burned,
+                            burn_range: result.burn_range,
+                            dust_retained,
+                        },
+                        result.block_number,
+                    )
+                    .await
+                }
+                Err(
+                    VaultError::OrchestratorReverted { .. }
+                    | VaultError::Reverted { .. },
+                ) => Ok(resume_after_reverted_burn(
+                    aggregate_id,
+                    detected_tx_hash,
+                    tx_id,
+                    burn_retry_external_tx_id,
+                )),
+                Err(error) => Err(ambiguous_prior_burn_status(
+                    aggregate_id,
+                    issuer_request_id,
+                    tx_id,
+                    &error,
+                )),
+            }
         }
-        Err(VaultError::Reverted { .. }) => {
-            // The terminally failed tx permanently reserves its externalTxId,
-            // so the replacement burn must never reuse the base id. When event
-            // history has no recorded retry id, fall back to retry-1 — mirror
-            // of the startup recovery path in BurnManager.
-            let retry_external_tx_id =
-                burn_retry_external_tx_id.or_else(|| {
-                    Some(Redemption::retry_burn_external_tx_id_typed(
-                        detected_tx_hash,
-                        1,
-                    ))
-                });
+    }
+}
 
-            info!(target: "admin", aggregate_id = %aggregate_id,
-                tx_hash = %tx_id,
-                retry_external_tx_id = ?retry_external_tx_id,
-                "Transaction reverted onchain, proceeding with ResumeBurn"
-            );
-
-            Ok(PriorBurnDisposition::ResumeWith(retry_external_tx_id))
-        }
-        Err(VaultError::MissingBlockNumber { tx_hash }) => {
-            // A successful receipt without inclusion proof is a data-integrity
-            // failure, not an ambiguous prior-burn outcome — operators must
-            // investigate the RPC/receipt, not treat it as a 422 resume block.
+/// Sends `RecordExistingBurn` for a prior burn confirmed on-chain and returns
+/// the `AlreadyRecorded` disposition. Shared by both modes; the proof variant
+/// is already mode-specific.
+async fn record_existing_burn(
+    store: &Store<Redemption>,
+    aggregate_id: &str,
+    issuer_request_id: &IssuerRedemptionRequestId,
+    tx_id: &TxId,
+    tx_hash: B256,
+    proof: ExistingBurnProof,
+    block_number: u64,
+) -> Result<PriorBurnDisposition, Status> {
+    store
+        .send(
+            issuer_request_id,
+            RedemptionCommand::RecordExistingBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: tx_id.clone(),
+                tx_hash,
+                proof,
+                block_number,
+            },
+        )
+        .await
+        .map_err(|err| {
             error!(target: "admin", aggregate_id = %aggregate_id,
-                %tx_hash,
-                "Completed burn transaction receipt is missing block number"
+                error = %err,
+                "Failed to record existing burn"
             );
-            Err(Status::InternalServerError)
-        }
-        Err(error) => {
-            warn!(target: "admin", aggregate_id = %aggregate_id,
-                issuer_request_id = %issuer_request_id,
-                %tx_id,
-                error = %error,
-                "Prior burn outcome is ambiguous; manual intervention required"
-            );
-            Err(Status::UnprocessableEntity)
-        }
+            map_redemption_error(&err)
+        })?;
+
+    Ok(PriorBurnDisposition::AlreadyRecorded(ReprocessResponse {
+        aggregate_type: AggregateKind::Redemption,
+        aggregate_id: aggregate_id.to_string(),
+        previous_state: "Failed".to_string(),
+        message: "Existing on-chain burn recorded via tx lookup".to_string(),
+    }))
+}
+
+/// Resolves a conclusively reverted prior burn to a `ResumeWith` disposition
+/// carrying a fresh replacement `externalTxId`. The terminally failed tx
+/// permanently reserves its `externalTxId`, so the replacement burn must never
+/// reuse the base id; when event history has no recorded retry id, fall back to
+/// retry-1 — mirror of the startup recovery path in `BurnManager`.
+fn resume_after_reverted_burn(
+    aggregate_id: &str,
+    detected_tx_hash: &B256,
+    tx_id: &TxId,
+    burn_retry_external_tx_id: Option<BurnExternalTxId>,
+) -> PriorBurnDisposition {
+    let retry_external_tx_id = burn_retry_external_tx_id.or_else(|| {
+        Some(Redemption::retry_burn_external_tx_id_typed(detected_tx_hash, 1))
+    });
+
+    info!(target: "admin", aggregate_id = %aggregate_id,
+        tx_hash = %tx_id,
+        retry_external_tx_id = ?retry_external_tx_id,
+        "Transaction reverted onchain, proceeding with ResumeBurn"
+    );
+
+    PriorBurnDisposition::ResumeWith(retry_external_tx_id)
+}
+
+/// Maps a non-revert confirmation error to the operator-facing status: a
+/// missing block number is an internal fault, anything else is an ambiguous
+/// outcome needing manual intervention. Shared by both modes.
+fn ambiguous_prior_burn_status(
+    aggregate_id: &str,
+    issuer_request_id: &IssuerRedemptionRequestId,
+    tx_id: &TxId,
+    error: &VaultError,
+) -> Status {
+    if let VaultError::MissingBlockNumber { tx_hash } = error {
+        // A successful receipt without inclusion proof is a data-integrity
+        // failure, not an ambiguous prior-burn outcome — operators must
+        // investigate the RPC/receipt, not treat it as a 422 resume block.
+        error!(target: "admin", aggregate_id = %aggregate_id,
+            %tx_hash,
+            "Completed burn transaction receipt is missing block number"
+        );
+        Status::InternalServerError
+    } else {
+        warn!(target: "admin", aggregate_id = %aggregate_id,
+            issuer_request_id = %issuer_request_id,
+            %tx_id,
+            error = %error,
+            "Prior burn outcome is ambiguous; manual intervention required"
+        );
+        Status::UnprocessableEntity
     }
 }
 
@@ -2109,7 +2217,9 @@ mod tests {
     use alloy::consensus::{
         Eip658Value, Receipt, ReceiptEnvelope, ReceiptWithBloom,
     };
-    use alloy::primitives::{Address, B256, Bloom, Bytes, U256, address, b256};
+    use alloy::primitives::{
+        Address, B256, Bloom, Bytes, U256, address, b256, uint,
+    };
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
     use chrono::{DateTime, Duration as ChronoDuration, Utc};
@@ -2155,8 +2265,8 @@ mod tests {
     use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        MultiBurnEntry, NetworkVaultServices, SendableTxWithHash, TxId,
-        VaultService,
+        BurnRange, MultiBurnEntry, NetworkVaultServices,
+        OrchestratorBurnResult, SendableTxWithHash, TxId, VaultService,
     };
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
@@ -3791,6 +3901,272 @@ mod tests {
         assert!(logs_contain_at!(
             Level::INFO,
             &[&aggregate_id, "recording existing burn"]
+        ));
+    }
+
+    /// Drives an orchestrator-mode redemption to `BurnFailed` with the given
+    /// submitted transaction id, mirroring `setup_burn_failure` but on the
+    /// orchestrator burn path.
+    async fn setup_orchestrator_burn_failure(
+        store: &Store<Redemption>,
+        tx_id: TxId,
+    ) -> (RedemptionMetadata, AlpacaCalledData) {
+        let metadata = RedemptionMetadata {
+            burn_mode: VaultMode::Orchestrator {
+                address: address!("0x00000000000000000000000000000000000000aa"),
+            },
+            ..test_metadata()
+        };
+        // 10⁻⁹ tokens of dust, retained in the bot wallet, so the recorded
+        // `dust_retained` proves the 18-decimal conversion.
+        let alpaca_data = AlpacaCalledData {
+            dust_quantity: Quantity::new(Decimal::new(1, 9)),
+            ..test_alpaca_data()
+        };
+        let token = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let external_tx_id =
+            Some(BurnExternalTxId::base(&metadata.detected_tx_hash));
+        // The aggregate binds the orchestrator burn amount to the persisted
+        // alpaca_quantity in share-wei; the fixture must agree with it.
+        let burn_amount = alpaca_data
+            .alpaca_quantity
+            .to_u256_with_18_decimals()
+            .expect("test alpaca_quantity must scale to share-wei");
+
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::Detect {
+                    burn_mode: metadata.burn_mode,
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    underlying: metadata.underlying.clone(),
+                    token: metadata.token.clone(),
+                    wallet: metadata.wallet,
+                    quantity: metadata.quantity.clone(),
+                    tx_hash: metadata.detected_tx_hash,
+                    block_number: metadata.block_number,
+                    network: Network::Base,
+                },
+            )
+            .await
+            .expect("Detect failed");
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::RecordAlpacaCall {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    tokenization_request_id: alpaca_data
+                        .tokenization_request_id
+                        .clone(),
+                    alpaca_quantity: alpaca_data.alpaca_quantity.clone(),
+                    dust_quantity: alpaca_data.dust_quantity.clone(),
+                },
+            )
+            .await
+            .expect("RecordAlpacaCall failed");
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::ConfirmAlpacaComplete {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                },
+            )
+            .await
+            .expect("ConfirmAlpacaComplete failed");
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    params: BurnParams::Orchestrator {
+                        token,
+                        amount: burn_amount,
+                        owner: Address::ZERO,
+                    },
+                    external_tx_id: external_tx_id.clone(),
+                },
+            )
+            .await
+            .expect("IntendBurn failed");
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::BurnTokens {
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    params: BurnParams::Orchestrator {
+                        token,
+                        amount: burn_amount,
+                        owner: Address::ZERO,
+                    },
+                    external_tx_id,
+                },
+            )
+            .await
+            .expect("BurnTokens failed");
+        store
+            .send(
+                &metadata.issuer_request_id,
+                RedemptionCommand::RecordBurnFailure {
+                    classification: BurnFailureClassification::Unclassified,
+                    issuer_request_id: metadata.issuer_request_id.clone(),
+                    error: "orchestrator burn terminally failed".to_string(),
+                    tx_id: Some(tx_id),
+                    planned_burns: vec![],
+                },
+            )
+            .await
+            .expect("RecordBurnFailure failed");
+
+        (metadata, alpaca_data)
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_records_orchestrator_burn_when_already_landed() {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let tx_id = TxId::random();
+        let (metadata, alpaca_data) =
+            setup_orchestrator_burn_failure(&store, tx_id).await;
+        let aggregate_id = metadata.issuer_request_id.to_string();
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        // The recovery binds the confirmed shares to the redemption's own
+        // persisted alpaca_quantity (100 tokens); the mock's confirm result
+        // must agree with the fixture.
+        vault_mock.seed_orchestrator_burn_result(OrchestratorBurnResult {
+            tx_hash: B256::random(),
+            shares_burned: alpaca_data
+                .alpaca_quantity
+                .to_u256_with_18_decimals()
+                .expect("test alpaca_quantity must scale to share-wei"),
+            burn_range: BurnRange {
+                first_receipt_id: U256::ZERO,
+                next_burn_receipt_id_after: U256::ONE,
+            },
+            gas_used: 50_000,
+            block_number: 5_000,
+        });
+        let vault_service: Arc<dyn VaultService> = vault_mock;
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+        let rocket = post_alpaca_rocket(
+            store.clone(),
+            pool.clone(),
+            alpaca,
+            vault_service,
+            burn_recovery_state,
+        );
+
+        let (status, body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        assert!(body.contains("Existing on-chain burn recorded"));
+        assert_eq!(burn_recovery.calls(), 0);
+        let redemption =
+            store.load(&metadata.issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(redemption, Redemption::Completed { .. }));
+        // `fetch_one` fails on zero rows, so this doubles as the
+        // exactly-one-recovery-event existence check.
+        let payload: String = sqlx::query_scalar(
+            "
+            SELECT payload
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+              AND event_type = 'RedemptionEvent::OrchestratorBurnRecovered'
+            ",
+        )
+        .bind(&aggregate_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        let event: RedemptionEvent = serde_json::from_str(&payload).unwrap();
+        let RedemptionEvent::OrchestratorBurnRecovered {
+            dust_retained, ..
+        } = event
+        else {
+            panic!("expected OrchestratorBurnRecovered event");
+        };
+        // The redemption's own persisted 10⁻⁹-token dust in 18-decimal
+        // share-wei — recorded from state, not from the on-chain result.
+        assert_eq!(dust_retained, uint!(1_000_000_000_U256));
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&aggregate_id, "recording existing burn"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn endpoint_resumes_orchestrator_burn_when_reverted() {
+        let pool = setup_pool().await;
+        let store = setup_store(&pool);
+        let tx_id = TxId::random();
+        let (metadata, alpaca_data) =
+            setup_orchestrator_burn_failure(&store, tx_id).await;
+        let aggregate_id = metadata.issuer_request_id.to_string();
+        let alpaca: Arc<dyn AlpacaService> = Arc::new(PollMockAlpaca {
+            response: PollResponse::Ok(redeem_response(
+                RedeemRequestStatus::Completed,
+                &metadata,
+                &alpaca_data,
+            )),
+        });
+        let vault_service: Arc<dyn VaultService> = Arc::new(
+            MockVaultService::new_success().with_orchestrator_confirm_revert(
+                crate::vault::OrchestratorRevertReason::Unknown,
+            ),
+        );
+        let burn_recovery = Arc::new(MockBurnRecovery::default());
+        let burn_recovery_state: Arc<dyn super::RedemptionBurnRecovery> =
+            burn_recovery.clone();
+        let rocket = post_alpaca_rocket(
+            store.clone(),
+            pool.clone(),
+            alpaca,
+            vault_service,
+            burn_recovery_state,
+        );
+
+        let (status, _body) =
+            dispatch_recover_redemption(rocket, &metadata.issuer_request_id)
+                .await;
+
+        assert_eq!(status, Status::Ok);
+        assert_eq!(
+            burn_recovery.calls(),
+            1,
+            "a reverted prior burn must resume and re-drive the burn"
+        );
+        let redemption =
+            store.load(&metadata.issuer_request_id).await.unwrap().unwrap();
+        let Redemption::Burning { external_tx_id, .. } = redemption else {
+            panic!("expected Burning state, got {redemption:?}");
+        };
+        // The reverted transaction permanently reserves the base externalTxId,
+        // so the resume must carry the retry-1 fallback (mirrors the
+        // vault-direct counterpart assertion).
+        assert_eq!(
+            external_tx_id,
+            Some(Redemption::retry_burn_external_tx_id_typed(
+                &metadata.detected_tx_hash,
+                1,
+            )),
+            "a reverted orchestrator burn must not reuse the base externalTxId"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&aggregate_id, "reverted onchain, proceeding with ResumeBurn"]
         ));
     }
 

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -11,7 +11,7 @@ use super::view::{
     RedemptionView, RedemptionViewError, find_burn_failed, find_burning,
 };
 use super::{
-    BurnExternalTxId, BurnParams, BurnRecoveryAction,
+    BurnExternalTxId, BurnParams, BurnRecoveryAction, ExistingBurnProof,
     IssuerRedemptionRequestId, Redemption, RedemptionCommand, RedemptionError,
     RedemptionEvent, next_burn_retry_external_tx_id_from_history,
 };
@@ -631,21 +631,6 @@ impl BurnManager {
             return Ok(());
         }
 
-        // Orchestrator-mode failures with a submitted transaction need the
-        // orchestrator-shaped recovery (`OrchestratorBurnRecovered`), which
-        // lands with the recovery/admin work — defer rather than run the
-        // vault-direct confirm path against an orchestrator transaction.
-        if matches!(burn_mode, VaultMode::Orchestrator { .. })
-            && tx_id.is_some()
-        {
-            warn!(target: "redemption", issuer_request_id = %issuer_request_id,
-                tx_id = ?tx_id,
-                "Skipping orchestrator burn failure with a submitted \
-                 transaction; orchestrator recovery is not yet automated"
-            );
-            return Ok(());
-        }
-
         let vault = find_vault(&self.view_pool, underlying, network)
             .await?
             .ok_or_else(|| BurnManagerError::AssetNotFound {
@@ -655,18 +640,33 @@ impl BurnManager {
 
         let vault_service = self.vault_for(*network)?;
 
-        // If a tx was already submitted before failure, inspect it
-        // before deciding whether to confirm, wait, or submit a replacement.
-        let retry_external_tx_id = if let Some(fb_tx_id) = tx_id {
-            return self
-                .recover_burn_failed_with_existing_tx(
-                    issuer_request_id,
-                    network,
-                    vault,
-                    fb_tx_id,
-                    dust_quantity,
-                )
-                .await;
+        // If a tx was already submitted before failure, inspect it before
+        // deciding whether to confirm, wait, or submit a replacement. The
+        // confirm path is mode-scoped: each mode confirms via its own
+        // on-chain shape and records its own success event.
+        let retry_external_tx_id = if let Some(existing_tx_id) = tx_id {
+            return match burn_mode {
+                VaultMode::VaultDirect => {
+                    self.recover_burn_failed_with_existing_tx(
+                        issuer_request_id,
+                        network,
+                        vault,
+                        existing_tx_id,
+                        dust_quantity,
+                    )
+                    .await
+                }
+                VaultMode::Orchestrator { .. } => {
+                    self.recover_orchestrator_burn_failed_with_existing_tx(
+                        *network,
+                        issuer_request_id,
+                        existing_tx_id,
+                        alpaca_quantity,
+                        dust_quantity,
+                    )
+                    .await
+                }
+            };
         } else {
             self.next_burn_retry_external_tx_id(issuer_request_id, tx_hash)
                 .await?
@@ -846,7 +846,9 @@ impl BurnManager {
                             issuer_request_id: issuer_request_id.clone(),
                             tx_id: tx_id.clone(),
                             tx_hash: result.tx_hash,
-                            planned_burns: actual_burns,
+                            proof: ExistingBurnProof::VaultDirect {
+                                burns: actual_burns,
+                            },
                             block_number: result.block_number,
                         },
                     )
@@ -897,6 +899,127 @@ impl BurnManager {
                     %tx_id,
                     error = %err,
                     "Failed to confirm previously submitted burn"
+                );
+                Ok(())
+            }
+        }
+    }
+
+    /// Orchestrator-mode counterpart of `recover_burn_failed_with_existing_tx`.
+    /// Confirms a previously submitted `orchestrator.burn()` and records the
+    /// outcome as an `OrchestratorBurnRecovered` (via the `RecordExistingBurn`
+    /// orchestrator proof). No reservation exists in orchestrator mode, so
+    /// none is settled or released.
+    async fn recover_orchestrator_burn_failed_with_existing_tx(
+        &self,
+        network: Network,
+        issuer_request_id: &IssuerRedemptionRequestId,
+        tx_id: &TxId,
+        alpaca_quantity: &Quantity,
+        dust_quantity: &Quantity,
+    ) -> Result<(), BurnManagerError> {
+        info!(target: "redemption", issuer_request_id = %issuer_request_id,
+            %tx_id,
+            "BurnFailed recovery — confirming previously submitted orchestrator burn"
+        );
+
+        match self
+            .vaults
+            .service(network)?
+            .confirm_orchestrator_burn(tx_id)
+            .await
+        {
+            Ok(result) => {
+                info!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    tx_hash = %result.tx_hash,
+                    "Previously submitted orchestrator burn confirmed on-chain"
+                );
+
+                // Bind the confirmed economics to THIS redemption before any
+                // terminal command: `shares_burned` must equal the persisted
+                // alpaca_quantity in share-wei. (Token and caller are bound
+                // transitively — `tx_id` is this redemption's own persisted
+                // submission, and confirm cross-checks the `Burned` event
+                // against that transaction's mined calldata.) A divergence
+                // is an integrity anomaly: leave the redemption in BurnFailed
+                // for the operator, never terminalize on it.
+                let expected_shares =
+                    alpaca_quantity.to_u256_with_18_decimals()?;
+                if result.shares_burned != expected_shares {
+                    error!(target: "redemption",
+                        issuer_request_id = %issuer_request_id,
+                        tx_hash = %result.tx_hash,
+                        expected_shares = %expected_shares,
+                        shares_burned = %result.shares_burned,
+                        "Confirmed orchestrator burn diverges from the \
+                         persisted alpaca_quantity; refusing existing-burn \
+                         recovery"
+                    );
+                    return Err(BurnManagerError::Redemption(
+                        RedemptionError::OrchestratorAmountMismatch {
+                            expected: expected_shares,
+                            actual: result.shares_burned,
+                        },
+                    ));
+                }
+
+                // dust_retained is derived from the redemption's own persisted
+                // dust_quantity — the orchestrator has no multicall to return
+                // it on-chain — matching OrchestratorTokensBurned.
+                let dust_retained = dust_quantity.to_u256_with_18_decimals()?;
+
+                // Safe: BurningFailed always transitions the aggregate to
+                // Failed, so RecordExistingBurn (which requires Failed) is valid.
+                self.store
+                    .send(
+                        issuer_request_id,
+                        RedemptionCommand::RecordExistingBurn {
+                            issuer_request_id: issuer_request_id.clone(),
+                            tx_id: tx_id.clone(),
+                            tx_hash: result.tx_hash,
+                            proof: ExistingBurnProof::Orchestrator {
+                                shares_burned: result.shares_burned,
+                                burn_range: result.burn_range,
+                                dust_retained,
+                            },
+                            block_number: result.block_number,
+                        },
+                    )
+                    .await?;
+
+                Ok(())
+            }
+            Err(err) => {
+                if should_release_reserved_burn(&err) {
+                    // Definitive on-chain revert. No reservation exists in
+                    // orchestrator mode, so there is nothing to release — just
+                    // terminalize with the decoded reason.
+                    let reason = format!(
+                        "Orchestrator burn confirmation failed for tx {tx_id}: {err}"
+                    );
+
+                    self.store
+                        .send(
+                            issuer_request_id,
+                            RedemptionCommand::MarkFailed {
+                                issuer_request_id: issuer_request_id.clone(),
+                                reason,
+                            },
+                        )
+                        .await?;
+
+                    return Err(BurnManagerError::Vault(err));
+                }
+
+                // Non-terminal error (RPC blip, pending-receipt timeout): the
+                // tx may still be in-flight. Keep the redemption in BurnFailed
+                // with tx_id intact so the next recovery pass retries
+                // confirmation rather than submitting a replacement while the
+                // original is still pending, which would risk double-burning.
+                warn!(target: "redemption", issuer_request_id = %issuer_request_id,
+                    %tx_id,
+                    error = %err,
+                    "Failed to confirm previously submitted orchestrator burn"
                 );
                 Ok(())
             }
@@ -2541,9 +2664,11 @@ impl BurnManager {
     /// mined revert, so the transaction can never land, and a tx-id-less
     /// `BurnFailed` routes the next recovery pass into the mode-aware
     /// preparation retry (`ResumeBurn` -> `handle_burning_started`). The
-    /// orchestrator deferral gate in `recover_single_burn_failed` guards the
-    /// complementary kept-tx-id case, where the transaction's outcome is
-    /// still ambiguous and the vault-direct confirm path must not run.
+    /// complementary kept-tx-id case is handled in `recover_single_burn_failed`,
+    /// which confirms the still-submitted transaction through the matching
+    /// mode's confirm path (`recover_burn_failed_with_existing_tx` for
+    /// vault-direct, `recover_orchestrator_burn_failed_with_existing_tx` for
+    /// orchestrator).
     async fn record_definitive_confirm_failure(
         &self,
         network: Network,
@@ -2833,10 +2958,10 @@ mod tests {
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        BurnTxStatus, MultiBurnEntry, NetworkVaultServices,
-        OrchestratorBurnReadiness, OrchestratorRevertReason,
-        ReceiptInformation, SendableTxWithHash, TxId, VaultError, VaultService,
-        VerifiedBurn, VerifiedShareTransfer,
+        BurnRange, BurnTxStatus, MultiBurnEntry, NetworkVaultServices,
+        OrchestratorBurnReadiness, OrchestratorBurnResult,
+        OrchestratorRevertReason, ReceiptInformation, SendableTxWithHash, TxId,
+        VaultError, VaultService, VerifiedBurn, VerifiedShareTransfer,
     };
 
     const TEST_WALLET: Address =
@@ -3857,20 +3982,12 @@ mod tests {
         ));
     }
 
-    /// An orchestrator burn failure with a submitted transaction — even an
-    /// `Unclassified` one that would normally retry — must be deferred, not
-    /// routed into `recover_burn_failed_with_existing_tx`, whose confirm and
-    /// settle logic assumes vault-direct receipt semantics.
-    #[traced_test]
-    #[tokio::test]
-    async fn reconciler_defers_orchestrator_burn_failure_with_submitted_tx() {
-        let setup = setup_orchestrator_burning(Arc::new(
-            MockVaultService::new_success(),
-        ))
-        .await;
-
-        // Reach BurnSubmitted through the aggregate commands, then record an
-        // Unclassified failure carrying the submitted transaction id.
+    /// Drives an orchestrator redemption to `BurnFailed` with the submitted
+    /// transaction id retained on the `BurningFailed` event, so the reconciler
+    /// takes the kept-tx-id confirm path.
+    async fn drive_orchestrator_to_burn_failed_with_tx(
+        setup: &OrchestratorTestSetup,
+    ) {
         setup
             .harness
             .store
@@ -3905,7 +4022,6 @@ mod tests {
             )
             .await
             .expect("orchestrator submission should persist");
-        assert_eq!(setup.vault_mock.orchestrator_submit_call_count(), 1);
 
         let Redemption::BurnSubmitted { tx_id, .. } =
             load_aggregate(&setup.harness.store, &setup.issuer_request_id)
@@ -3928,35 +4044,170 @@ mod tests {
             )
             .await
             .expect("burn failure should persist");
+    }
+
+    /// A landed orchestrator burn failure with a submitted transaction is now
+    /// confirmed on-chain (no longer deferred): the reconciler records the
+    /// existing burn and completes the redemption, without resubmitting or
+    /// touching the receipt lifecycle.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciler_confirms_orchestrator_burn_failed_with_submitted_tx() {
+        let setup = setup_orchestrator_burning(Arc::new(
+            MockVaultService::new_success(),
+        ))
+        .await;
+        drive_orchestrator_to_burn_failed_with_tx(&setup).await;
 
         setup.manager.recover_unresolved_burns().await;
 
-        // The success-behavior mock's vault-direct confirm_burn would have
-        // recorded an existing burn and completed the redemption, so staying
-        // Failed proves the vault-direct recovery path never ran.
+        let aggregate =
+            load_aggregate(&setup.harness.store, &setup.issuer_request_id)
+                .await;
+        assert!(
+            matches!(aggregate, Redemption::Completed { .. }),
+            "a mined orchestrator burn must be confirmed and completed, \
+             got {aggregate:?}"
+        );
+        assert_eq!(
+            setup.vault_mock.orchestrator_submit_call_count(),
+            1,
+            "recovery must confirm the existing burn, not resubmit"
+        );
+        assert_eq!(
+            setup.recording.call_count(),
+            0,
+            "orchestrator recovery must not touch the receipt lifecycle"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Previously submitted orchestrator burn confirmed on-chain"]
+        ));
+    }
+
+    /// A confirmed orchestrator burn whose `Burned.amount` diverges from the
+    /// redemption's own persisted `alpaca_quantity` must never terminalize:
+    /// the recovery refuses before `RecordExistingBurn`, the redemption stays
+    /// `Failed` for the operator, and the anomaly is logged at ERROR.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciler_refuses_diverging_confirmed_orchestrator_burn() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let setup = setup_orchestrator_burning(vault_mock.clone()).await;
+        // Seed the confirm result BEFORE the drive: submit preserves a
+        // pre-seeded result, so confirm reports one share-wei more than the
+        // redemption's persisted quantity.
+        vault_mock.seed_orchestrator_burn_result(OrchestratorBurnResult {
+            tx_hash: B256::random(),
+            shares_burned: uint!(100_000000000000000001_U256),
+            burn_range: BurnRange {
+                first_receipt_id: U256::ZERO,
+                next_burn_receipt_id_after: U256::ONE,
+            },
+            gas_used: 50_000,
+            block_number: 5_000,
+        });
+        drive_orchestrator_to_burn_failed_with_tx(&setup).await;
+
+        setup.manager.recover_unresolved_burns().await;
+
         let aggregate =
             load_aggregate(&setup.harness.store, &setup.issuer_request_id)
                 .await;
         assert!(
             matches!(aggregate, Redemption::Failed { .. }),
-            "orchestrator failure with a submitted tx must stay Failed for \
-             manual recovery, got {aggregate:?}"
+            "a diverging confirmed burn must never terminalize, \
+             got {aggregate:?}"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &[
+                "diverges from the",
+                "persisted alpaca_quantity",
+                "refusing existing-burn",
+                "recovery"
+            ]
+        ));
+    }
+
+    /// A pending (non-terminal) orchestrator confirmation keeps the redemption
+    /// in `BurnFailed` with its tx id intact so the next reconciler pass
+    /// retries confirmation rather than submitting a replacement.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciler_defers_pending_orchestrator_burn_failed() {
+        let setup = setup_orchestrator_burning(Arc::new(
+            MockVaultService::new_confirm_pending(),
+        ))
+        .await;
+        drive_orchestrator_to_burn_failed_with_tx(&setup).await;
+
+        setup.manager.recover_unresolved_burns().await;
+
+        let aggregate =
+            load_aggregate(&setup.harness.store, &setup.issuer_request_id)
+                .await;
+        assert!(
+            matches!(aggregate, Redemption::Failed { .. }),
+            "a pending orchestrator confirmation must stay Failed, \
+             got {aggregate:?}"
         );
         assert_eq!(
             setup.vault_mock.orchestrator_submit_call_count(),
             1,
-            "the deferral must not resubmit the orchestrator burn"
+            "a pending confirmation must not resubmit the burn"
+        );
+        assert_eq!(setup.recording.call_count(), 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Failed to confirm previously submitted orchestrator burn"]
+        ));
+    }
+
+    /// A definitively reverted orchestrator confirmation terminalizes the
+    /// redemption via `MarkFailed` (no reservation to release in orchestrator
+    /// mode) and never resubmits or touches the receipt lifecycle.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciler_marks_reverted_orchestrator_burn_failed() {
+        let setup = setup_orchestrator_burning(Arc::new(
+            MockVaultService::new_success().with_orchestrator_confirm_revert(
+                OrchestratorRevertReason::Unknown,
+            ),
+        ))
+        .await;
+        drive_orchestrator_to_burn_failed_with_tx(&setup).await;
+
+        setup.manager.recover_unresolved_burns().await;
+
+        let aggregate =
+            load_aggregate(&setup.harness.store, &setup.issuer_request_id)
+                .await;
+        assert!(
+            matches!(aggregate, Redemption::Failed { .. }),
+            "a reverted orchestrator burn stays Failed, got {aggregate:?}"
         );
         assert_eq!(
             setup.recording.call_count(),
             0,
-            "the deferral must not touch the receipt lifecycle"
+            "orchestrator mode has no reservation to release"
         );
         assert!(logs_contain_at!(
             tracing::Level::WARN,
-            &["Skipping orchestrator burn failure with a submitted \
-                 transaction",]
+            &["Failed to recover BurnFailed redemption"]
         ));
+
+        // MarkFailed moved the view out of BurnFailed, so a second reconciler
+        // pass must not re-confirm the reverted transaction — the parked
+        // redemption would otherwise loop confirm/MarkFailed on every pass.
+        let confirms_after_first_pass =
+            setup.vault_mock.orchestrator_confirm_call_count();
+        setup.manager.recover_unresolved_burns().await;
+        assert_eq!(
+            setup.vault_mock.orchestrator_confirm_call_count(),
+            confirms_after_first_pass,
+            "a MarkFailed-parked redemption must leave the reconciler's scan"
+        );
     }
 
     /// A definitively reverted orchestrator burn with an `Unclassified`

--- a/src/redemption/cmd.rs
+++ b/src/redemption/cmd.rs
@@ -7,7 +7,7 @@ use crate::config::VaultMode;
 use crate::mint::TokenizationRequestId;
 use crate::redemption::event::BurnFailureClassification;
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
-use crate::vault::{MultiBurnEntry, TxId};
+use crate::vault::{BurnRange, MultiBurnEntry, TxId};
 
 /// Mode-specific burn parameters carried by `IntendBurn` and `BurnTokens`.
 ///
@@ -31,6 +31,23 @@ pub(crate) enum BurnParams {
         /// wallet).
         amount: U256,
         owner: Address,
+    },
+}
+
+/// Mode-specific proof of an existing on-chain burn carried by
+/// `RecordExistingBurn`. Cross-checked against the redemption's persisted
+/// `burn_mode` anchor by the command handler. `dust_retained` is supplied by
+/// the caller (derived from the redemption's persisted `dust_quantity`)
+/// because the `Failed` state does not retain it.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum ExistingBurnProof {
+    VaultDirect {
+        burns: Vec<super::BurnRecord>,
+    },
+    Orchestrator {
+        shares_burned: U256,
+        burn_range: BurnRange,
+        dust_retained: U256,
     },
 }
 
@@ -113,12 +130,15 @@ pub(crate) enum RedemptionCommand {
     },
     /// Records an existing on-chain burn discovered via tx lookup.
     /// Only valid from `Failed` state. Used when the transaction
-    /// succeeded on-chain but the bot timed out before recording it.
+    /// succeeded on-chain but the bot timed out before recording it. The
+    /// `proof` variant is cross-checked against the redemption's persisted
+    /// `burn_mode` anchor, so a vault-direct redemption can never be recorded
+    /// with an orchestrator proof or vice versa.
     RecordExistingBurn {
         issuer_request_id: IssuerRedemptionRequestId,
         tx_id: TxId,
         tx_hash: B256,
-        planned_burns: Vec<super::BurnRecord>,
+        proof: ExistingBurnProof,
         block_number: u64,
     },
     /// Admin-closes a redemption that cannot be automatically recovered.

--- a/src/redemption/event.rs
+++ b/src/redemption/event.rs
@@ -325,6 +325,21 @@ pub(crate) enum RedemptionEvent {
         block_number: u64,
         burned_at: DateTime<Utc>,
     },
+    /// Orchestrator-mode counterpart of `ExistingBurnRecovered`: an existing
+    /// on-chain orchestrator burn discovered during recovery, decoded from the
+    /// orchestrator's `Burned` event. Transitions to `Completed`. Carries
+    /// `dust_retained` derived the same way as `OrchestratorTokensBurned`
+    /// (from the redemption's own persisted `AlpacaCalled.dust_quantity`), so
+    /// both paths to terminal success carry identical audit data.
+    OrchestratorBurnRecovered {
+        issuer_request_id: IssuerRedemptionRequestId,
+        tx_hash: B256,
+        shares_burned: U256,
+        burn_range: BurnRange,
+        dust_retained: U256,
+        block_number: u64,
+        recovered_at: DateTime<Utc>,
+    },
     BurnRecoveryAttempted {
         issuer_request_id: IssuerRedemptionRequestId,
         tx_hash: B256,
@@ -399,6 +414,9 @@ impl DomainEvent for RedemptionEvent {
             }
             Self::OrchestratorTokensBurned { .. } => {
                 "RedemptionEvent::OrchestratorTokensBurned".to_string()
+            }
+            Self::OrchestratorBurnRecovered { .. } => {
+                "RedemptionEvent::OrchestratorBurnRecovered".to_string()
             }
             Self::BurnRecoveryAttempted { .. } => {
                 "RedemptionEvent::BurnRecoveryAttempted".to_string()
@@ -925,6 +943,33 @@ mod tests {
                 serde_json::from_str(&serialized).unwrap();
             assert_eq!(event, deserialized);
         }
+    }
+
+    #[test]
+    fn orchestrator_burn_recovered_event_type_and_round_trip() {
+        let event = RedemptionEvent::OrchestratorBurnRecovered {
+            issuer_request_id: test_redemption_id(),
+            tx_hash: B256::random(),
+            shares_burned: uint!(17_000000000000000000_U256),
+            burn_range: BurnRange {
+                first_receipt_id: uint!(0_U256),
+                next_burn_receipt_id_after: uint!(3_U256),
+            },
+            dust_retained: uint!(1_000_000_000_U256),
+            block_number: 45_000_100,
+            recovered_at: Utc::now(),
+        };
+
+        assert_eq!(
+            event.event_type(),
+            "RedemptionEvent::OrchestratorBurnRecovered"
+        );
+        assert_eq!(event.event_version(), "1.0");
+
+        let serialized = serde_json::to_string(&event).unwrap();
+        let deserialized: RedemptionEvent =
+            serde_json::from_str(&serialized).unwrap();
+        assert_eq!(event, deserialized);
     }
 
     /// Tests that old BurnResumed events without external_tx_id default to None.

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -231,7 +231,7 @@ impl RedemptionServices {
     }
 }
 
-pub(crate) use cmd::{BurnParams, RedemptionCommand};
+pub(crate) use cmd::{BurnParams, ExistingBurnProof, RedemptionCommand};
 pub(crate) use event::{
     BurnFailureClassification, BurnRecord, RedemptionEvent, TokensBurnedData,
 };
@@ -317,6 +317,18 @@ pub(crate) enum Redemption {
         /// so terminal admin actions cannot bypass the acknowledgement guard.
         #[serde(default)]
         unresolved_burn_tx: Option<SendableTxWithHash>,
+        /// Mode anchor carried through the failure so recovery can reject a
+        /// cross-mode existing-burn proof. Absent on pre-orchestrator events
+        /// (`VaultDirect`); rebuilt from the prior state's metadata on replay.
+        #[serde(default)]
+        burn_mode: VaultMode,
+        /// The persisted Alpaca quantity carried through the failure so
+        /// existing-burn recovery can bind a proof's `shares_burned` to this
+        /// redemption's own economics. `None` only for pre-Alpaca failures
+        /// and pre-change snapshots — replay from events rebuilds it from
+        /// the prior state.
+        #[serde(default)]
+        alpaca_quantity: Option<Quantity>,
     },
     Closed {
         issuer_request_id: IssuerRedemptionRequestId,
@@ -896,10 +908,10 @@ impl Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         tx_id: TxId,
         tx_hash: B256,
-        planned_burns: Vec<BurnRecord>,
+        proof: ExistingBurnProof,
         block_number: u64,
     ) -> Result<Vec<RedemptionEvent>, RedemptionError> {
-        let Self::Failed { .. } = self else {
+        let Self::Failed { burn_mode, alpaca_quantity, .. } = self else {
             return Err(match self {
                 Self::Completed { .. } | Self::Closed { .. } => {
                     RedemptionError::AlreadyCompleted { issuer_request_id }
@@ -911,14 +923,74 @@ impl Redemption {
             });
         };
 
-        Ok(vec![RedemptionEvent::ExistingBurnRecovered {
-            issuer_request_id,
-            tx_id,
-            tx_hash,
-            burns: planned_burns,
-            block_number,
-            recovered_at: Utc::now(),
-        }])
+        match (burn_mode, proof) {
+            (
+                VaultMode::VaultDirect,
+                ExistingBurnProof::VaultDirect { burns },
+            ) => Ok(vec![RedemptionEvent::ExistingBurnRecovered {
+                issuer_request_id,
+                tx_id,
+                tx_hash,
+                burns,
+                block_number,
+                recovered_at: Utc::now(),
+            }]),
+            (
+                VaultMode::Orchestrator { .. },
+                ExistingBurnProof::Orchestrator {
+                    shares_burned,
+                    burn_range,
+                    dust_retained,
+                },
+            ) => {
+                // Terminal recovery records `shares_burned` as the economic
+                // value the journal backed: bind the proof to this
+                // redemption's own persisted quantity before terminalizing.
+                // `None` only for pre-change snapshots (a post-Alpaca
+                // failure always carries the quantity on replay); the burn
+                // manager's own pre-command check covers that legacy gap.
+                if let Some(alpaca_quantity) = alpaca_quantity {
+                    let expected =
+                        alpaca_quantity.to_u256_with_18_decimals().map_err(
+                            |error| RedemptionError::QuantityConversion {
+                                message: error.to_string(),
+                            },
+                        )?;
+                    if shares_burned != expected {
+                        return Err(
+                            RedemptionError::OrchestratorAmountMismatch {
+                                expected,
+                                actual: shares_burned,
+                            },
+                        );
+                    }
+                }
+
+                Ok(vec![RedemptionEvent::OrchestratorBurnRecovered {
+                    issuer_request_id,
+                    tx_hash,
+                    shares_burned,
+                    burn_range,
+                    dust_retained,
+                    block_number,
+                    recovered_at: Utc::now(),
+                }])
+            }
+            (
+                VaultMode::VaultDirect,
+                ExistingBurnProof::Orchestrator { .. },
+            ) => Err(RedemptionError::BurnModeMismatch {
+                expected: VaultModeKind::VaultDirect,
+                found: VaultModeKind::Orchestrator,
+            }),
+            (
+                VaultMode::Orchestrator { .. },
+                ExistingBurnProof::VaultDirect { .. },
+            ) => Err(RedemptionError::BurnModeMismatch {
+                expected: VaultModeKind::Orchestrator,
+                found: VaultModeKind::VaultDirect,
+            }),
+        }
     }
 
     /// Admin-closes a redemption that cannot be auto-recovered. Valid from
@@ -1925,13 +1997,13 @@ impl EventSourced for Redemption {
                 issuer_request_id,
                 tx_id,
                 tx_hash,
-                planned_burns,
+                proof,
                 block_number,
             } => self.handle_record_existing_burn(
                 issuer_request_id,
                 tx_id,
                 tx_hash,
-                planned_burns,
+                proof,
                 block_number,
             ),
             RedemptionCommand::CloseRedemption {
@@ -2082,6 +2154,7 @@ impl Redemption {
             RedemptionEvent::TokensBurned(_)
             | RedemptionEvent::OrchestratorTokensBurned { .. }
             | RedemptionEvent::ExistingBurnRecovered { .. }
+            | RedemptionEvent::OrchestratorBurnRecovered { .. }
             | RedemptionEvent::RedemptionClosed { .. }
             | RedemptionEvent::BurnForceCompleted { .. } => {
                 self.apply_terminal_event(event);
@@ -2147,6 +2220,24 @@ impl Redemption {
             .persisted_unresolved_burn_tx()
             .filter(|sendable_tx| !sendable_tx.tx.is_empty())
             .cloned();
+        // Anchor the mode from the failing state's own metadata before the
+        // transition drops it, so existing-burn recovery can reject a
+        // cross-mode proof. A `Failed -> Failed` reclassification (via
+        // `MarkFailed`) has no metadata, so preserve the already-anchored
+        // mode; pre-orchestrator states default to VaultDirect.
+        let burn_mode = match &*self {
+            Self::Failed { burn_mode, .. } => *burn_mode,
+            other => other
+                .metadata()
+                .map_or(VaultMode::VaultDirect, |metadata| metadata.burn_mode),
+        };
+        // Carry the economic anchor the same way: a `Failed -> Failed`
+        // reclassification preserves it, otherwise it comes from the failing
+        // state (None for pre-Alpaca failures, which have no quantity yet).
+        let alpaca_quantity = match &*self {
+            Self::Failed { alpaca_quantity, .. } => alpaca_quantity.clone(),
+            other => other.alpaca_quantity().cloned(),
+        };
         let (issuer_request_id, reason, failed_at) = match event {
             RedemptionEvent::AlpacaCallFailed {
                 issuer_request_id,
@@ -2172,6 +2263,8 @@ impl Redemption {
             reason,
             failed_at,
             unresolved_burn_tx,
+            burn_mode,
+            alpaca_quantity,
         };
     }
 
@@ -2357,6 +2450,12 @@ impl Redemption {
                 tx_hash,
                 recovered_at,
                 ..
+            }
+            | RedemptionEvent::OrchestratorBurnRecovered {
+                issuer_request_id,
+                tx_hash,
+                recovered_at,
+                ..
             } => {
                 *self = Self::Completed {
                     issuer_request_id,
@@ -2501,8 +2600,8 @@ mod tests {
 
     use super::{
         BurnExternalTxId, BurnFailureClassification, BurnParams, BurnRecord,
-        BurnRecoveryAction, IssuerRedemptionRequestId, Redemption,
-        RedemptionCommand, RedemptionError, RedemptionEvent,
+        BurnRecoveryAction, ExistingBurnProof, IssuerRedemptionRequestId,
+        Redemption, RedemptionCommand, RedemptionError, RedemptionEvent,
         RedemptionMetadata, RedemptionServices, TokensBurnedData,
         has_unresolved_signer_intent,
         next_burn_retry_external_tx_id_from_history,
@@ -4879,6 +4978,316 @@ mod tests {
         }
     }
 
+    fn failed_from(
+        burning: Vec<RedemptionEvent>,
+        issuer_request_id: &IssuerRedemptionRequestId,
+    ) -> Vec<RedemptionEvent> {
+        let mut events = burning;
+        events.push(RedemptionEvent::BurningFailed {
+            classification: BurnFailureClassification::Unclassified,
+            issuer_request_id: issuer_request_id.clone(),
+            error: "burn timed out".to_string(),
+            failed_at: Utc::now(),
+            tx_id: None,
+            planned_burns: vec![],
+        });
+        events
+    }
+
+    #[tokio::test]
+    async fn record_existing_burn_orchestrator_proof_emits_orchestrator_recovered()
+     {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let given = failed_from(
+            orchestrator_burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(given)
+            .when(RedemptionCommand::RecordExistingBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Hash(tx_hash),
+                tx_hash,
+                proof: ExistingBurnProof::Orchestrator {
+                    shares_burned: uint!(17_000000000000000000_U256),
+                    burn_range: BurnRange {
+                        first_receipt_id: uint!(0_U256),
+                        next_burn_receipt_id_after: uint!(3_U256),
+                    },
+                    dust_retained: uint!(1_000000000_U256),
+                },
+                block_number: 46_000_000,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::OrchestratorBurnRecovered {
+                tx_hash: recorded_hash,
+                shares_burned,
+                burn_range,
+                dust_retained,
+                block_number,
+                ..
+            }] if *recorded_hash == tx_hash
+                && *shares_burned == uint!(17_000000000000000000_U256)
+                && *burn_range == BurnRange { first_receipt_id: uint!(0_U256), next_burn_receipt_id_after: uint!(3_U256) }
+                && *dust_retained == uint!(1_000000000_U256)
+                && *block_number == 46_000_000
+        ));
+    }
+
+    /// An orchestrator existing-burn proof is bound to the aggregate's own
+    /// persisted `alpaca_quantity`: a proof whose `shares_burned` diverges
+    /// must be rejected, never terminalized.
+    #[tokio::test]
+    async fn record_existing_burn_rejects_diverging_orchestrator_shares() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let given = failed_from(
+            orchestrator_burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        );
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(given)
+            .when(RedemptionCommand::RecordExistingBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Hash(tx_hash),
+                tx_hash,
+                proof: ExistingBurnProof::Orchestrator {
+                    // One share-wei above the persisted 17-token quantity.
+                    shares_burned: uint!(17_000000000000000001_U256),
+                    burn_range: BurnRange {
+                        first_receipt_id: uint!(0_U256),
+                        next_burn_receipt_id_after: uint!(3_U256),
+                    },
+                    dust_retained: uint!(1_000000000_U256),
+                },
+                block_number: 46_000_000,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(
+                    RedemptionError::OrchestratorAmountMismatch { .. }
+                )
+            ),
+            "a diverging proof must not terminalize the redemption, \
+             got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn record_existing_burn_vault_direct_proof_emits_existing_recovered()
+    {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let given = failed_from(
+            burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        );
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(given)
+            .when(RedemptionCommand::RecordExistingBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Hash(tx_hash),
+                tx_hash,
+                proof: ExistingBurnProof::VaultDirect {
+                    burns: vec![BurnRecord {
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_000000000000000000_U256),
+                    }],
+                },
+                block_number: 46_000_000,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::ExistingBurnRecovered { burns, .. }]
+                if burns.len() == 1
+        ));
+    }
+
+    #[tokio::test]
+    async fn record_existing_burn_rejects_cross_mode_proofs() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+
+        let cross_mode_cases = [
+            (
+                failed_from(
+                    burning_given_events(&issuer_request_id),
+                    &issuer_request_id,
+                ),
+                ExistingBurnProof::Orchestrator {
+                    shares_burned: uint!(17_000000000000000000_U256),
+                    burn_range: BurnRange {
+                        first_receipt_id: uint!(0_U256),
+                        next_burn_receipt_id_after: uint!(3_U256),
+                    },
+                    dust_retained: U256::ZERO,
+                },
+            ),
+            (
+                failed_from(
+                    orchestrator_burning_given_events(&issuer_request_id),
+                    &issuer_request_id,
+                ),
+                ExistingBurnProof::VaultDirect {
+                    burns: vec![BurnRecord {
+                        receipt_id: uint!(42_U256),
+                        shares_burned: uint!(17_000000000000000000_U256),
+                    }],
+                },
+            ),
+        ];
+
+        for (given, proof) in cross_mode_cases {
+            let error = TestHarness::<Redemption>::with(mock_services())
+                .given(given)
+                .when(RedemptionCommand::RecordExistingBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tx_id: TxId::Hash(tx_hash),
+                    tx_hash,
+                    proof,
+                    block_number: 46_000_000,
+                })
+                .await
+                .then_expect_error();
+
+            assert!(
+                matches!(
+                    &error,
+                    LifecycleError::Apply(
+                        RedemptionError::BurnModeMismatch { .. }
+                    )
+                ),
+                "expected BurnModeMismatch, got {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn record_existing_burn_rejects_non_failed_state() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(burning_given_events(&issuer_request_id))
+            .when(RedemptionCommand::RecordExistingBurn {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Hash(tx_hash),
+                tx_hash,
+                proof: ExistingBurnProof::VaultDirect { burns: vec![] },
+                block_number: 46_000_000,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(RedemptionError::InvalidState { .. })
+            ),
+            "expected InvalidState, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn orchestrator_burn_recovered_replays_to_completed() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let tx_hash = B256::random();
+        let mut history = failed_from(
+            orchestrator_burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        );
+        history.push(RedemptionEvent::OrchestratorBurnRecovered {
+            issuer_request_id,
+            tx_hash,
+            shares_burned: uint!(17_000000000000000000_U256),
+            burn_range: BurnRange {
+                first_receipt_id: uint!(0_U256),
+                next_burn_receipt_id_after: uint!(3_U256),
+            },
+            dust_retained: uint!(1_000000000_U256),
+            block_number: 46_000_000,
+            recovered_at: Utc::now(),
+        });
+
+        let redemption = replay::<Redemption>(history)
+            .expect("history should replay")
+            .expect("redemption should exist");
+
+        assert!(matches!(
+            redemption,
+            Redemption::Completed { burn_tx_hash, .. } if burn_tx_hash == tx_hash
+        ));
+    }
+
+    #[test]
+    fn failed_state_anchors_orchestrator_burn_mode() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let orchestrator_failed = replay::<Redemption>(failed_from(
+            orchestrator_burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        ))
+        .expect("history should replay")
+        .expect("redemption should exist");
+        assert!(matches!(
+            orchestrator_failed,
+            Redemption::Failed {
+                burn_mode: VaultMode::Orchestrator { .. },
+                ..
+            }
+        ));
+
+        let vault_direct_failed = replay::<Redemption>(failed_from(
+            burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        ))
+        .expect("history should replay")
+        .expect("redemption should exist");
+        assert!(matches!(
+            vault_direct_failed,
+            Redemption::Failed { burn_mode: VaultMode::VaultDirect, .. }
+        ));
+
+        // `MarkFailed` from `Failed` carries no metadata (the reconciler's
+        // reclassification after a definitive orchestrator revert); the
+        // already-anchored orchestrator mode must survive it — a downgrade to
+        // VaultDirect would reject a later valid orchestrator proof with
+        // BurnModeMismatch.
+        let mut reclassified = failed_from(
+            orchestrator_burning_given_events(&issuer_request_id),
+            &issuer_request_id,
+        );
+        reclassified.push(RedemptionEvent::RedemptionFailed {
+            issuer_request_id,
+            reason: "orchestrator burn reverted on-chain".to_string(),
+            failed_at: Utc::now(),
+        });
+        let remarked = replay::<Redemption>(reclassified)
+            .expect("history should replay")
+            .expect("redemption should exist");
+        assert!(matches!(
+            remarked,
+            Redemption::Failed {
+                burn_mode: VaultMode::Orchestrator { .. },
+                ..
+            }
+        ));
+    }
+
     #[tokio::test]
     async fn burn_tokens_orchestrator_mode_emits_orchestrator_submitted() {
         let issuer_request_id = IssuerRedemptionRequestId::random();
@@ -6284,6 +6693,8 @@ mod tests {
                 reason: error,
                 failed_at,
                 unresolved_burn_tx: None,
+                burn_mode: VaultMode::VaultDirect,
+                alpaca_quantity: Some(Quantity::new(Decimal::from(150))),
             }
         );
     }
@@ -7077,17 +7488,22 @@ mod tests {
 
         let mut old_failed_snapshot =
             serde_json::to_value(failed).expect("snapshot should serialize");
-        old_failed_snapshot
+        let failed_fields = old_failed_snapshot
             .pointer_mut("/Failed")
             .and_then(serde_json::Value::as_object_mut)
-            .expect("failed snapshot should exist")
-            .remove("unresolved_burn_tx");
+            .expect("failed snapshot should exist");
+        failed_fields.remove("unresolved_burn_tx");
+        failed_fields.remove("burn_mode");
         let restored_failed: Redemption =
             serde_json::from_value(old_failed_snapshot)
                 .expect("old failed snapshot should deserialize");
         assert!(matches!(
             restored_failed,
-            Redemption::Failed { unresolved_burn_tx: None, .. }
+            Redemption::Failed {
+                unresolved_burn_tx: None,
+                burn_mode: VaultMode::VaultDirect,
+                ..
+            }
         ));
 
         let mut old_burning_snapshot =

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -295,6 +295,7 @@ impl RedemptionView {
 }
 
 impl RedemptionView {
+    #[allow(clippy::too_many_lines)]
     fn apply(self, event: &RedemptionEvent) -> Self {
         match event {
             RedemptionEvent::Detected {
@@ -453,6 +454,13 @@ impl RedemptionView {
                 completed_at: *burned_at,
             },
             RedemptionEvent::ExistingBurnRecovered {
+                issuer_request_id,
+                tx_hash,
+                block_number,
+                recovered_at,
+                ..
+            }
+            | RedemptionEvent::OrchestratorBurnRecovered {
                 issuer_request_id,
                 tx_hash,
                 block_number,

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -161,6 +161,8 @@ struct OrchestratorMockState {
     submit_call_count: AtomicUsize,
     #[cfg(test)]
     readiness_call_count: AtomicUsize,
+    #[cfg(test)]
+    confirm_call_count: AtomicUsize,
 }
 
 /// Mock blockchain service for testing.
@@ -473,8 +475,20 @@ impl MockVaultService {
         self.orchestrator.preparation_call_count.store(0, Ordering::Relaxed);
         self.orchestrator.submit_call_count.store(0, Ordering::Relaxed);
         self.orchestrator.readiness_call_count.store(0, Ordering::Relaxed);
+        self.orchestrator.confirm_call_count.store(0, Ordering::Relaxed);
         *self.orchestrator.pending_result.lock().unwrap() = None;
         *self.last_burn_proof_kind.lock().unwrap() = None;
+    }
+
+    /// Pre-seeds the orchestrator confirm result; `submit_orchestrator_burn`
+    /// preserves a seeded value instead of overwriting it, so tests can make
+    /// confirm report facts diverging from the submitted params.
+    #[cfg(test)]
+    pub(crate) fn seed_orchestrator_burn_result(
+        &self,
+        result: OrchestratorBurnResult,
+    ) {
+        *self.orchestrator.pending_result.lock().unwrap() = Some(result);
     }
 
     #[cfg(test)]
@@ -728,6 +742,11 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn orchestrator_submit_call_count(&self) -> usize {
         self.orchestrator.submit_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn orchestrator_confirm_call_count(&self) -> usize {
+        self.orchestrator.confirm_call_count.load(Ordering::Relaxed)
     }
 
     #[cfg(test)]
@@ -1388,6 +1407,9 @@ impl VaultService for MockVaultService {
     ) -> Result<OrchestratorBurnResult, VaultError> {
         #[cfg(test)]
         {
+            self.orchestrator
+                .confirm_call_count
+                .fetch_add(1, Ordering::Relaxed);
             let reason_opt = *self.orchestrator.confirm_revert.lock().unwrap();
             if let Some(reason) = reason_opt {
                 return Err(VaultError::OrchestratorReverted {


### PR DESCRIPTION
## Motivation

Orchestrator-mode redemptions that reached `BurnFailed` with a submitted transaction id were previously deferred entirely — the reconciler logged a warning and left them in `Failed` for manual intervention. This meant any orchestrator burn that timed out before being recorded required operator involvement even when the transaction had already landed on-chain.

## Solution

Automated orchestrator burn recovery is now wired end-to-end, mirroring the existing vault-direct path:

**Mode-scoped confirmation in** **`BurnManager`:** The early-exit guard that skipped orchestrator failures with a submitted transaction is replaced by a mode-aware branch. Vault-direct failures continue through `recover_burn_failed_with_existing_tx` (receipt lookup); orchestrator failures go through the new `recover_orchestrator_burn_failed_with_existing_tx`, which calls `confirm_orchestrator_burn`, records the result as a `RecordExistingBurn` with an `Orchestrator` proof, or terminalizes via `MarkFailed` on a definitive revert. Non-terminal errors (RPC blips, pending receipts) leave the redemption in `BurnFailed` with the tx id intact so the next pass retries confirmation rather than resubmitting.

**Mode-scoped confirmation in the admin recovery endpoint:** `inspect_prior_burn` now dispatches on `metadata.burn_mode` rather than always calling `vault_service.check_tx`. Orchestrator redemptions confirm via `confirm_orchestrator_burn`; vault-direct redemptions continue using the receipt path. Shared logic (`record_existing_burn`, `resume_after_reverted_burn`, `ambiguous_prior_burn_status`) is extracted into standalone helpers to eliminate duplication.

**`ExistingBurnProof`** **enum:** `RecordExistingBurn` now carries an `ExistingBurnProof` variant (`VaultDirect { burns }` or `Orchestrator { shares_burned, burn_range, dust_retained }`) instead of a flat `planned_burns` list. The command handler cross-checks the proof variant against the `Failed` state's anchored `burn_mode` and returns `BurnModeMismatch` if they disagree, preventing a vault-direct redemption from ever being recorded with an orchestrator proof or vice versa.

**`OrchestratorBurnRecovered`** **event:** A new terminal event carries the orchestrator-specific fields (`shares_burned`, `burn_range`, `dust_retained`) and transitions the aggregate to `Completed`, matching the audit shape of `OrchestratorTokensBurned`. `RedemptionView` and the terminal-event dispatch table are updated accordingly.

**`burn_mode`** **anchor on** **`Failed`:** The `Failed` variant now carries a `burn_mode` field (defaulting to `VaultDirect` for pre-orchestrator snapshots) so recovery can reject cross-mode proofs without replaying the full event history. The anchor is populated from the failing state's metadata on every transition into `Failed`, and preserved across `Failed → Failed` reclassifications.  
  
Closes [RAI-1513](https://linear.app/makeitrain/issue/RAI-1513/orchestrator-burn-recovery)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved redemption recovery for previously submitted orchestrator transactions.
  * Correctly handles confirmed, pending, and reverted burns without unnecessary retries.
  * Validates recovery proof against the redemption’s burn mode.
  * Preserves legacy redemption data with a safe default mode.

* **New Features**
  * Added mode-specific recovery tracking and events for orchestrator burns.
  * Recovered orchestrator burns now transition redemptions to completed with transaction details, burned shares, receipt range, and retained dust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->