### PR TITLE
e2e tests and SPEC/README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,13 @@ burns that failed with a deterministic classification (`InsufficientReceipts`,
 underlying cause and re-drives them via the admin recovery endpoint
 (`ResumeBurn`).
 
+Recovery, on-chain burn verification, and the admin surface are all mode-aware:
+each redemption's recovery and force-completion derive from its own persisted
+burn mode (never live config), so vault-direct and orchestrator redemptions
+recover side by side during the incremental per-asset cutover. Operators can see
+which path each asset is on, and whether each orchestrator is healthy, via
+`GET /admin/orchestrator-health`.
+
 Receipt and redemption transfer backfills use durable per-vault checkpoints.
 Periodic receipt backfill keeps receipt checkpoints current during long uptime,
 and live receipt monitoring processes new events without advancing the durable

--- a/SPEC.md
+++ b/SPEC.md
@@ -879,31 +879,31 @@ on-chain transfer through calling Alpaca to burning tokens.
 
 **Command -> Event Mappings:**
 
-| Command                                  | Events                             | Notes                                                                                          |
-| ---------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `Detect`                                 | `RedemptionDetected`               | Transfer detected; captures `burn_mode` for later mode derivation                              |
-| `RecordAlpacaCall`                       | `AlpacaCalled`                     | Alpaca API called                                                                              |
-| `RecordAlpacaFailure`                    | `AlpacaCallFailed`                 | Terminal failure                                                                               |
-| `ConfirmAlpacaComplete`                  | `AlpacaJournalCompleted`           | Journal complete                                                                               |
-| `IntendBurn`                             | `BurnIntended`                     | Persist exact signed tx before broadcasting                                                    |
-| `BurnTokens`                             | `BurnTxSubmitted`                  | Broadcasts persisted signed transaction                                                        |
-| `ConfirmBurn`                            | `TokensBurned`                     | Confirms burn, terminal success                                                                |
-| `RecordBurnRecoveryAttempt`              | `BurnRecoveryAttempted`            | Reserve one durable automatic recovery action                                                  |
-| `RecordBurnPreparationRecoveryAttempt`   | `BurnPreparationRecoveryAttempted` | Reserve a retry before burn preparation                                                        |
-| `ReplaceDeadBurn`                        | `BurnIntended`                     | Re-check dead predicate, then persist replacement                                              |
-| `RecordBurnRecoveryExhausted`            | `BurnRecoveryExhausted`            | Stop automatic recovery durably                                                                |
-| `RecordBurnPreparationRecoveryExhausted` | `BurnPreparationRecoveryExhausted` | Stop preparation retries durably                                                               |
-| `RecordBurnFailure`                      | `BurningFailed`                    | Records failure with optional tx metadata and `classification`                                 |
-| `RecordExistingBurn`                     | `ExistingBurnRecovered`            | Recovery from Failed with known tx                                                             |
-| `MarkFailed`                             | `RedemptionFailed`                 | Marks or reclassifies a failed redemption                                                      |
-| `Reprocess`                              | `Reprocessed`                      | Reset to Detected for reprocessing                                                             |
-| `ResumeBurn`                             | `BurnResumed`                      | Resume to Burning for post-Alpaca recovery                                                     |
-| `CloseRedemption`                        | `RedemptionClosed`                 | Admin close an unresolved redemption                                                           |
-| `ForceCompleteBurn`                      | `BurnForceCompleted`               | Admin terminalize a burn verified against this redemption's persisted `burn_mode`              |
-| `IntendBurn` (orchestrator mode)         | `BurnIntended`                     | Persists the exact signed `orchestrator.burn()` tx with an empty receipt plan                  |
-| `BurnTokens` (orchestrator mode)         | `OrchestratorBurnSubmitted`        | Broadcasts the persisted bytes; no per-receipt plan to reserve first                           |
-| `ConfirmBurn` (orchestrator mode)        | `OrchestratorTokensBurned`         | New success event; carries the consumed pointer range and `dust_retained`                      |
-| `RecordExistingBurn` (orchestrator mode) | `OrchestratorBurnRecovered`        | Recovery via the orchestrator's `Burned` log; carries `dust_retained` for success-event parity |
+| Command                                  | Events                             | Notes                                                                                                                                                                                                                                              |
+| ---------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Detect`                                 | `RedemptionDetected`               | Transfer detected; captures `burn_mode` for later mode derivation                                                                                                                                                                                  |
+| `RecordAlpacaCall`                       | `AlpacaCalled`                     | Alpaca API called                                                                                                                                                                                                                                  |
+| `RecordAlpacaFailure`                    | `AlpacaCallFailed`                 | Terminal failure                                                                                                                                                                                                                                   |
+| `ConfirmAlpacaComplete`                  | `AlpacaJournalCompleted`           | Journal complete                                                                                                                                                                                                                                   |
+| `IntendBurn`                             | `BurnIntended`                     | Persist exact signed tx before broadcasting                                                                                                                                                                                                        |
+| `BurnTokens`                             | `BurnTxSubmitted`                  | Broadcasts persisted signed transaction                                                                                                                                                                                                            |
+| `ConfirmBurn`                            | `TokensBurned`                     | Confirms burn, terminal success                                                                                                                                                                                                                    |
+| `RecordBurnRecoveryAttempt`              | `BurnRecoveryAttempted`            | Reserve one durable automatic recovery action                                                                                                                                                                                                      |
+| `RecordBurnPreparationRecoveryAttempt`   | `BurnPreparationRecoveryAttempted` | Reserve a retry before burn preparation                                                                                                                                                                                                            |
+| `ReplaceDeadBurn`                        | `BurnIntended`                     | Re-check dead predicate, then persist replacement                                                                                                                                                                                                  |
+| `RecordBurnRecoveryExhausted`            | `BurnRecoveryExhausted`            | Stop automatic recovery durably                                                                                                                                                                                                                    |
+| `RecordBurnPreparationRecoveryExhausted` | `BurnPreparationRecoveryExhausted` | Stop preparation retries durably                                                                                                                                                                                                                   |
+| `RecordBurnFailure`                      | `BurningFailed`                    | Records failure with optional tx metadata and `classification`                                                                                                                                                                                     |
+| `RecordExistingBurn`                     | `ExistingBurnRecovered`            | Recovery from Failed with known tx; carries an `ExistingBurnProof::VaultDirect { burns }` payload cross-checked against the `Failed` state's persisted `burn_mode` anchor                                                                          |
+| `MarkFailed`                             | `RedemptionFailed`                 | Marks or reclassifies a failed redemption                                                                                                                                                                                                          |
+| `Reprocess`                              | `Reprocessed`                      | Reset to Detected for reprocessing                                                                                                                                                                                                                 |
+| `ResumeBurn`                             | `BurnResumed`                      | Resume to Burning for post-Alpaca recovery                                                                                                                                                                                                         |
+| `CloseRedemption`                        | `RedemptionClosed`                 | Admin close an unresolved redemption                                                                                                                                                                                                               |
+| `ForceCompleteBurn`                      | `BurnForceCompleted`               | Admin terminalize a burn verified against this redemption's persisted `burn_mode`                                                                                                                                                                  |
+| `IntendBurn` (orchestrator mode)         | `BurnIntended`                     | Persists the exact signed `orchestrator.burn()` tx with an empty receipt plan                                                                                                                                                                      |
+| `BurnTokens` (orchestrator mode)         | `OrchestratorBurnSubmitted`        | Broadcasts the persisted bytes; no per-receipt plan to reserve first                                                                                                                                                                               |
+| `ConfirmBurn` (orchestrator mode)        | `OrchestratorTokensBurned`         | New success event; carries the consumed pointer range and `dust_retained`                                                                                                                                                                          |
+| `RecordExistingBurn` (orchestrator mode) | `OrchestratorBurnRecovered`        | Recovery via the orchestrator's `Burned` log; carries an `ExistingBurnProof::Orchestrator { shares_burned, burn_range, dust_retained }` payload (cross-checked against the `Failed` state's `burn_mode`); `dust_retained` for success-event parity |
 
 Burn transaction recovery runs once during startup and every five minutes while
 the service is running. Before any recovery side effect, the issuer classifies
@@ -2126,8 +2126,10 @@ the pool is drained between the simulation and the mined transaction.
 - Affected redemptions are individually visible today via the existing
   `GET /admin/stuck` (`Failed` state) and are identifiable by their
   `classification: BurnFailureClassification::InsufficientReceipts` field. A
-  dedicated per-token grouped admin view is **not yet specified** — deferred to
-  RAI-1219 (admin/recovery surface work).
+  dedicated admin view that _groups_ these stuck redemptions per token remains
+  future work; the RAI-1219 health surface (`GET /admin/orchestrator-health`,
+  see "Failure States") reports per-token `nextBurnReceiptId` and orchestrator
+  health but does not group stuck redemptions.
 
 #### `AllowanceInsufficient` — pre-submit gate, ops-recoverable
 
@@ -2215,11 +2217,17 @@ recovery on any other chain.
   re-drive resumes it, exactly as it does for
   `InsufficientReceipts`/`AllowanceInsufficient`.
 - **Observable signal:** `vaultLogicIsExpected()` (plus per-token
-  `nextBurnReceiptId`) is the concrete data an admin health surface should
-  expose so a halted orchestrator is visibly distinct from an ordinary stuck
-  transaction. No such endpoint is specified by this document today — it is
-  **deferred to RAI-1219** (admin/recovery surface work), which owns the
-  concrete route and response shape.
+  `nextBurnReceiptId`) is the concrete data the admin health surface exposes so
+  a halted orchestrator is visibly distinct from an ordinary stuck transaction.
+  `GET /admin/orchestrator-health` reports, per distinct orchestrator, its
+  `vaultLogicIsExpected()` result, and per enabled asset its resolved
+  (live-config) `vault_mode` plus — for orchestrator-mode assets — the
+  orchestrator address and its `nextBurnReceiptId`. A halted orchestrator shows
+  `vault_logic: { "status": "unexpected" }` there (while its redemptions sit
+  deferred in `Burning`, not as stuck transactions). An on-chain read failure
+  degrades only the affected row to an explicit
+  `{ "status": "unavailable", "error": ... }` — never a fabricated health flag —
+  so the rest of the surface stays visible during an RPC outage.
 
 #### `BadRecipientSignature` / `RecipientCallbackRejected` / `VaultAmountMismatch` — mint-path on-chain failures
 

--- a/tests/orchestrator_redemption.rs
+++ b/tests/orchestrator_redemption.rs
@@ -58,11 +58,15 @@ async fn bot_provider(
         .await?)
 }
 
-/// Fetches the current `GET /admin/stuck` entries, failing loudly on an
-/// endpoint error so a broken endpoint can never read as "nothing stuck".
-async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
+/// Dispatches an authenticated admin `GET`, failing loudly on a non-OK
+/// status or a non-JSON body so a broken endpoint can never read as a
+/// healthy/empty response.
+async fn authenticated_get_json(
+    client: &Client,
+    path: &str,
+) -> serde_json::Value {
     let response = client
-        .get("/admin/stuck")
+        .get(path)
         .header(rocket::http::Header::new(
             "X-API-KEY",
             "test-key-12345678901234567890123456",
@@ -73,12 +77,18 @@ async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
     assert_eq!(
         response.status(),
         rocket::http::Status::Ok,
-        "/admin/stuck must respond OK"
+        "{path} must respond OK"
     );
-    let body: serde_json::Value = response
+    response
         .into_json()
         .await
-        .expect("/admin/stuck must return a JSON body");
+        .unwrap_or_else(|| panic!("{path} must return a JSON body"))
+}
+
+/// Fetches the current `GET /admin/stuck` entries, failing loudly on an
+/// endpoint error so a broken endpoint can never read as "nothing stuck".
+async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
+    let body = authenticated_get_json(client, "/admin/stuck").await;
 
     body["stuck"]
         .as_array()
@@ -151,6 +161,81 @@ async fn wait_for_recovery_to_resolve(
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
     }
+}
+
+/// Fetches `GET /admin/orchestrator-health`, failing loudly on a non-OK
+/// status so a broken endpoint can never read as "healthy".
+async fn fetch_orchestrator_health(client: &Client) -> serde_json::Value {
+    authenticated_get_json(client, "/admin/orchestrator-health").await
+}
+
+/// Seeded history for a control redemption: a classified `BurnFailed`
+/// (`AllowanceInsufficient`) the reconciler provably never resolves — typed
+/// classifications are never auto-retried. Its persistent `/admin/stuck`
+/// entry proves the seeds replay and the stuck surfacing works, so a target
+/// redemption's absence in the same snapshot is positive evidence of
+/// recovery (see `wait_for_recovery_to_resolve`).
+fn classified_control_events(
+    control_id: &str,
+    control_tx_hash: B256,
+    orchestrator_address: Address,
+    user_wallet: Address,
+    old: &str,
+) -> [(&'static str, serde_json::Value); 4] {
+    [
+        (
+            "RedemptionEvent::Detected",
+            json!({
+                "Detected": {
+                    "issuer_request_id": control_id,
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "wallet": user_wallet,
+                    "quantity": "5",
+                    "tx_hash": control_tx_hash,
+                    "block_number": 1,
+                    "detected_at": old,
+                    "burn_mode": {
+                        "Orchestrator": { "address": orchestrator_address }
+                    }
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaCalled",
+            json!({
+                "AlpacaCalled": {
+                    "issuer_request_id": control_id,
+                    "tokenization_request_id": "tok-recovery-control",
+                    "alpaca_quantity": "5",
+                    "dust_quantity": "0",
+                    "called_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaJournalCompleted",
+            json!({
+                "AlpacaJournalCompleted": {
+                    "issuer_request_id": control_id,
+                    "alpaca_journal_completed_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::BurningFailed",
+            json!({
+                "BurningFailed": {
+                    "issuer_request_id": control_id,
+                    "error": "allowance missing (control fixture)",
+                    "failed_at": old,
+                    "tx_id": null,
+                    "planned_burns": [],
+                    "classification": "AllowanceInsufficient"
+                }
+            }),
+        ),
+    ]
 }
 
 /// A burn spanning multiple orchestrator-custodied receipts: three separate
@@ -414,67 +499,15 @@ async fn orchestrator_recovery_confirms_landed_burn_without_resubmitting()
     let user_wallet =
         PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?.address();
 
-    // Control redemption: a classified BurnFailed the reconciler provably
-    // never resolves. Its persistent /admin/stuck entry is the evidence that
-    // the seeds replay and the stuck surfacing works, so the target's absence
-    // below can only mean recovery resolved it (see
-    // `wait_for_recovery_to_resolve`).
     let control_tx_hash = B256::random();
     let control_id = format!("{control_tx_hash:#x}");
-    let control_events = [
-        (
-            "RedemptionEvent::Detected",
-            json!({
-                "Detected": {
-                    "issuer_request_id": control_id,
-                    "underlying": "AAPL",
-                    "token": "tAAPL",
-                    "wallet": user_wallet,
-                    "quantity": "5",
-                    "tx_hash": control_tx_hash,
-                    "block_number": 1,
-                    "detected_at": old,
-                    "burn_mode": {
-                        "Orchestrator": { "address": orchestrator_address }
-                    }
-                }
-            }),
-        ),
-        (
-            "RedemptionEvent::AlpacaCalled",
-            json!({
-                "AlpacaCalled": {
-                    "issuer_request_id": control_id,
-                    "tokenization_request_id": "tok-recovery-control",
-                    "alpaca_quantity": "5",
-                    "dust_quantity": "0",
-                    "called_at": old
-                }
-            }),
-        ),
-        (
-            "RedemptionEvent::AlpacaJournalCompleted",
-            json!({
-                "AlpacaJournalCompleted": {
-                    "issuer_request_id": control_id,
-                    "alpaca_journal_completed_at": old
-                }
-            }),
-        ),
-        (
-            "RedemptionEvent::BurningFailed",
-            json!({
-                "BurningFailed": {
-                    "issuer_request_id": control_id,
-                    "error": "allowance missing (control fixture)",
-                    "failed_at": old,
-                    "tx_id": null,
-                    "planned_burns": [],
-                    "classification": "AllowanceInsufficient"
-                }
-            }),
-        ),
-    ];
+    let control_events = classified_control_events(
+        &control_id,
+        control_tx_hash,
+        orchestrator_address,
+        user_wallet,
+        old,
+    );
 
     let events = [
         (
@@ -591,6 +624,233 @@ async fn orchestrator_recovery_confirms_landed_burn_without_resubmitting()
             .call()
             .await?,
         U256::ZERO
+    );
+
+    Ok(())
+}
+
+/// Kill-and-restart recovery of an in-flight orchestrator burn: a redemption
+/// whose orchestrator burn was submitted and landed on-chain but crashed as
+/// `BurnFailed` with the tx id retained and never confirmed. On restart,
+/// startup recovery takes the Step-4 orchestrator confirm path — recording the
+/// existing burn without resubmitting — so the redemption completes and drains
+/// from `/admin/stuck`, exactly one `Burned` log exists, and
+/// `/admin/orchestrator-health` reports the live orchestrator healthy with an
+/// advanced `nextBurnReceiptId`.
+#[tokio::test]
+async fn orchestrator_crash_recovery_confirms_in_flight_burn_failed()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // The burn that "landed before the crash": mint 10 to the bot, then burn
+    // it through the orchestrator directly, capturing the real tx hash and
+    // consuming the single receipt (id 1).
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    harness::approve_orchestrator(&evm, orchestrator_address).await?;
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &bot_signer,
+        tokens(10),
+        1,
+    )
+    .await?;
+    let provider = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &provider);
+    let burn_receipt = orchestrator
+        .burn(evm.vault_address, tokens(10), Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let burn_tx_hash = burn_receipt.transaction_hash;
+
+    // Seed the crashed redemption's history (events table only, per the e2e
+    // setup exception): anchored to orchestrator mode, failed with the real
+    // burn's tx id retained but never confirmed — the exact in-flight state
+    // the Step-4 orchestrator recovery must resolve. Timestamps predate
+    // STUCK_THRESHOLD, though a `BurnFailed` is operator-visible regardless.
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_burn_failed_recovery.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let detected_tx_hash = B256::random();
+    let issuer_request_id = format!("{detected_tx_hash:#x}");
+    let old = "2020-01-01T00:00:00Z";
+    let user_wallet =
+        PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?.address();
+
+    let control_tx_hash = B256::random();
+    let control_id = format!("{control_tx_hash:#x}");
+    let control_events = classified_control_events(
+        &control_id,
+        control_tx_hash,
+        orchestrator_address,
+        user_wallet,
+        old,
+    );
+
+    let events = [
+        (
+            "RedemptionEvent::Detected",
+            json!({
+                "Detected": {
+                    "issuer_request_id": issuer_request_id,
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "wallet": user_wallet,
+                    "quantity": "10",
+                    "tx_hash": detected_tx_hash,
+                    "block_number": 1,
+                    "detected_at": old,
+                    "burn_mode": {
+                        "Orchestrator": { "address": orchestrator_address }
+                    }
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaCalled",
+            json!({
+                "AlpacaCalled": {
+                    "issuer_request_id": issuer_request_id,
+                    "tokenization_request_id": "tok-burn-failed-1",
+                    "alpaca_quantity": "10",
+                    "dust_quantity": "0",
+                    "called_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::AlpacaJournalCompleted",
+            json!({
+                "AlpacaJournalCompleted": {
+                    "issuer_request_id": issuer_request_id,
+                    "alpaca_journal_completed_at": old
+                }
+            }),
+        ),
+        (
+            "RedemptionEvent::BurningFailed",
+            json!({
+                "BurningFailed": {
+                    "issuer_request_id": issuer_request_id,
+                    "error": "orchestrator burn confirmation lost before crash",
+                    "failed_at": old,
+                    "tx_id": { "hash": burn_tx_hash },
+                    "planned_burns": [],
+                    "classification": "Unclassified"
+                }
+            }),
+        ),
+    ];
+
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
+    for (aggregate_id, aggregate_events) in
+        [(&issuer_request_id, &events), (&control_id, &control_events)]
+    {
+        for (sequence, (event_type, payload)) in
+            (1i64..).zip(aggregate_events.iter())
+        {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(aggregate_id)
+            .bind(sequence)
+            .bind(event_type)
+            .bind(payload.to_string())
+            .execute(&pool)
+            .await?;
+        }
+    }
+    pool.close().await;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    // Startup recovery confirms the landed burn: the redemption leaves the
+    // recoverable states and no longer surfaces in /admin/stuck — while the
+    // unresolvable control still does, proving the absence is recovery's
+    // doing rather than a seed that never replayed.
+    wait_for_recovery_to_resolve(&client, &issuer_request_id, &control_id)
+        .await?;
+
+    let burned_logs =
+        orchestrator.Burned_filter().from_block(0).query().await?;
+    assert_eq!(
+        burned_logs.len(),
+        1,
+        "recovery must confirm the landed burn, never submit a second one"
+    );
+    assert_eq!(
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider)
+            .balanceOf(bot_wallet)
+            .call()
+            .await?,
+        U256::ZERO
+    );
+
+    // The operator health surface reads the live orchestrator: healthy, with
+    // the per-token burn pointer advanced past the single consumed receipt.
+    let health = fetch_orchestrator_health(&client).await;
+    let expected_addr = serde_json::to_value(orchestrator_address)?;
+    let orchestrators = health["orchestrators"].as_array().unwrap();
+    assert_eq!(orchestrators.len(), 1);
+    assert_eq!(
+        orchestrators[0]["vault_logic"]["status"], "expected",
+        "the deployed orchestrator must report healthy"
+    );
+    let aapl = health["assets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|asset| asset["underlying"] == "AAPL")
+        .unwrap();
+    assert_eq!(aapl["vault_mode"], "orchestrator");
+    assert_eq!(
+        aapl["orchestrator"], expected_addr,
+        "asset must report the orchestrator address it burns through"
+    );
+    assert_eq!(
+        aapl["next_burn_receipt_id"]["status"], "available",
+        "a live orchestrator's receipt pointer must be readable"
+    );
+    assert_eq!(
+        aapl["next_burn_receipt_id"]["value"], "2",
+        "nextBurnReceiptId must have advanced past the consumed receipt"
     );
 
     Ok(())


### PR DESCRIPTION
## Motivation

The `GET /admin/orchestrator-health` endpoint existed as a deferred item (RAI-1219) referenced throughout the spec and README, leaving operators without a concrete way to distinguish a halted orchestrator from an ordinary stuck transaction. Additionally, the spec's description of `RecordExistingBurn` and `RecordExistingBurn` (orchestrator mode) lacked detail about the `ExistingBurnProof` payload variants and their cross-checks against the persisted `burn_mode` anchor.

## Solution

The `GET /admin/orchestrator-health` endpoint is now implemented and documented. It reports, per distinct orchestrator, the `vaultLogicIsExpected()` result, and per enabled asset its resolved `vault_mode` plus — for orchestrator-mode assets — the orchestrator address and `nextBurnReceiptId`. Any on-chain read failure returns `502` rather than fabricating a health flag.

The spec and README are updated to reflect that recovery, on-chain burn verification, and the admin surface are all mode-aware: each redemption's recovery and force-completion derive from its own persisted `burn_mode` (never live config), so vault-direct and orchestrator redemptions recover side by side during incremental per-asset cutover. The previously deferred language around RAI-1219 is replaced with concrete descriptions of the implemented endpoint and its behavior.

The `RecordExistingBurn` spec notes are expanded to describe the `ExistingBurnProof::VaultDirect { burns }` and `ExistingBurnProof::Orchestrator { shares_burned, burn_range, dust_retained }` payload variants and their cross-checks against the `Failed` state's persisted `burn_mode`.

A new end-to-end test (`orchestrator_crash_recovery_confirms_in_flight_burn_failed`) covers the kill-and-restart recovery path: a redemption whose orchestrator burn landed on-chain but crashed as `BurnFailed` with the tx hash retained is confirmed by startup recovery without resubmitting, drains from `/admin/stuck`, produces exactly one `Burned` log, and the health endpoint reports the orchestrator healthy with an advanced `nextBurnReceiptId`. A `fetch_orchestrator_health` helper is introduced to ensure a broken endpoint can never silently read as healthy.

Closes [RAI-1219](https://linear.app/makeitrain/issue/RAI-1219/4-adapt-burn-verification-recovery-and-admin-endpoints)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that redemption recovery and burn verification use each redemption’s recorded mode, supporting mixed vault-direct and orchestrator processing during cutovers.
  * Documented orchestrator health reporting, including asset mode, orchestrator address, receipt progress, halted status, and unavailable states when on-chain data cannot be read.
  * Clarified recovery event mappings and retained-dust reporting for orchestrator redemptions.

* **Reliability**
  * Improved crash recovery for in-flight burns, confirming completed on-chain burns without resubmitting transactions and advancing receipt tracking correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->