### PR TITLE
feat: receipt custody migration engine - gates and invariants only, executors land upstack

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,9 +65,9 @@ clarifies.
 ## Project Overview
 
 Rust **Issuer** bot for Alpaca's Instant Tokenization Network (ITN). It serves
-Alpaca's mint/redeem endpoints and coordinates Rain
-`OffchainAssetReceiptVault` contracts. This is general infrastructure for any
-Authorized Participant, bridging Alpaca equity holdings and Rain SFTs.
+Alpaca's mint/redeem endpoints and coordinates Rain `OffchainAssetReceiptVault`
+contracts. This is general infrastructure for any Authorized Participant,
+bridging Alpaca equity holdings and Rain SFTs.
 
 The system uses **Event Sourcing (ES)** and **CQRS** to maintain a complete
 audit trail, enable time-travel debugging, and provide a single source of truth.
@@ -81,7 +81,8 @@ audit trail, enable time-travel debugging, and provide a single source of truth.
 
 ### Dependency Management
 
-- **CRITICAL: Always use `cargo add`; NEVER manually choose Cargo.toml versions.**
+- **CRITICAL: Always use `cargo add`; NEVER manually choose Cargo.toml
+  versions.**
   - It selects the latest compatible version; Cargo.toml may then be modified
     with that version if needed
   - Example: `cargo add chrono` (NOT manually adding `chrono = "0.4.40"`)
@@ -333,6 +334,11 @@ to `RealBlockchainService`:
 
 Key files: `wallet/mod.rs` (SignerConfig, ResolvedSigner), `wallet/local.rs`,
 `wallet/turnkey.rs`, `config.rs` (backend selection, Provider construction)
+
+**Receipt custody migration (`receipt_inventory/migration.rs`, temporary):**
+rotating the signer strands the vault's receipts at the old address. **Stop the
+service before moving custody** — startup reconciliation depletes receipts the
+old signer no longer holds.
 
 ### Core Flows
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -731,6 +731,41 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
 - `issuer freeze <UNDERLYING>` — dispatch the `Freeze` command.
 - `issuer unfreeze <UNDERLYING>` — dispatch the `Unfreeze` command.
 - `issuer status <UNDERLYING>` — print the underlying's current freeze status.
+  The receipt-custody **migration engine**
+  (`receipt_inventory::migration::migrate_vault_receipts`) moves a vault's
+  ERC-1155 deposit receipts from their holding wallet to a replacement wallet.
+  Temporary, for the Turnkey signing-backend cutover; removed once every vault
+  has migrated. The operator command that executes it ships with the execution
+  work; the engine and its gates are specified here because every execution path
+  must run through them unchanged.
+
+The transfer is signed by the holding wallet itself: ERC-1155 lets a balance be
+moved only by its holder or by an operator the holder has approved via
+`setApprovalForAll`, and the migration relies on the holder case rather than
+granting any operator approval — ERC-1155 approval is all-or-nothing across
+every token the holder owns, so granting it for a one-shot transfer would be a
+far wider authorization than the operation needs. The recipient must clear an
+on-chain corroboration witness (an address the chain has never seen is refused),
+since an ERC-1155 transfer is final, with no counterparty and no recovery. The
+engine refuses while any burn is reserved against the vault's receipts, refuses
+while any mint or redemption of the migrating asset sits between initiation and
+a terminal state (in-flight work resumes against the wrong wallet after a
+custody move; work that cannot be attributed to an asset counts against every
+vault), and refuses when the vault has no tracked receipts rather than reporting
+an unverified no-op. Quiescence is deliberately not a freeze check: the
+corporate-action freeze has its own lifecycle, and a migration neither requires
+declaring one nor ends one that is real. The tracked inventory is cross-checked
+against on-chain balances, the vault's certification and owner-freeze gates are
+re-read immediately before submission, and post-conditions are verified per
+receipt identifier afterwards. Re-running after a successful move reports
+`AlreadyMigrated` instead of submitting a second transfer.
+
+The operator sequence around the engine is **stop the issuer service** → move
+custody → swap the signer configuration → start the service. Stopping first is
+not optional: startup reconciliation reads `balanceOf(bot_wallet)` for every
+tracked receipt, so a service still configured with the outgoing signer that
+restarts after custody has moved reads zero for every one of them, reconciles
+that as depletion, and drops the receipts from the aggregate.
 
 Freeze, unfreeze, and status address the `Underlying` aggregate, so they take no
 network argument: one freeze covers every listing of the underlying. The CLI

--- a/docs/fireblocks-migration-authorization.md
+++ b/docs/fireblocks-migration-authorization.md
@@ -1,0 +1,260 @@
+# Fireblocks authorization for the receipt custody migration
+
+What the Fireblocks-held wallet must be authorized to do before the Turnkey
+cutover can run, who has to grant it, and which approvals are involved.
+
+Audience: whoever administers the Fireblocks workspace. Every claim below is
+cited to Fireblocks documentation. Items we could not verify from the public
+docs are called out as questions rather than guessed at, because getting them
+wrong wastes an approval cycle.
+
+## The one operation that needs authorizing
+
+The Fireblocks wallet must send a single transaction per vault:
+
+```
+safeBatchTransferFrom(fireblocksWallet, turnkeyWallet, ids[], amounts[], "")
+```
+
+called on the vault's **Receipt** contract (an ERC-1155). It moves no native
+value. It is not a transfer of a Fireblocks-held asset, so it does not fit the
+ordinary "send funds to a whitelisted address" flow. In Fireblocks terms it is a
+**contract call**.
+
+Note the target: the **Receipt contract, not the vault contract**. They are
+different addresses. The Receipt address is obtained per vault by calling the
+vault's `receipt()` view function. The bot has only ever called the vault
+contract, which is why the Receipt contract is not whitelisted today and why
+this work is needed at all.
+
+## Two routes, and why the choice is not free
+
+### Route A: contract call to a whitelisted contract
+
+This is what the issuer bot did for mints and burns before the Turnkey work: it
+submitted `CONTRACT_CALL` operations whose destination was a whitelisted
+contract, resolved by querying `GET /v1/contracts`. The relevant Fireblocks
+concept is a **contract wallet** — documented as "a deposit address of an
+on-chain smart contract", one of the three whitelist types alongside internal
+and external wallets
+([Whitelist addresses](https://developers.fireblocks.com/docs/whitelist-addresses)).
+
+Requires: whitelisting work plus a policy rule, both detailed below.
+
+### Route B: raw signing
+
+Fireblocks `RAW` is "an off-chain message used to sign any message with your
+private key"
+([Configure Policies](https://developers.fireblocks.com/reference/configure-transaction-authorization-policy)).
+The Fireblocks integration was originally built this way before being refactored
+to contract calls. If the workspace policy still permits `RAW` for this vault
+account, the transfer can be signed without whitelisting the Receipt contract
+and without a new contract-call rule.
+
+**This does not make the migration free.** Route B removes the Fireblocks
+whitelisting and policy work; it does not remove the engineering work, because
+the raw-signing code was deleted along with the rest of the Fireblocks
+integration. Either route needs code re-added on our side. Route B is worth
+asking about only because it removes an approval cycle from the critical path,
+not because it removes effort.
+
+Route B also leaves the entire transaction pipeline client-side: `RAW` only
+returns a signature over a hash, so our code would have to build the exact
+`safeBatchTransferFrom` transaction, have Fireblocks sign its hash, assemble the
+signed transaction, and broadcast it through an RPC. The Receipt contract has no
+meta-transaction path, so the transaction must genuinely originate from the
+Fireblocks wallet — nothing about submission can be delegated.
+
+Also relevant if a raw rule is being written: `RAW` rule types are an exception
+that "should not include a destination limitation", and the rule's
+`rawMessageSigning` object takes a mandatory `derivationPath` and an optional
+`algorithm`.
+
+## Route A, step by step
+
+### Step 1: whitelist the Receipt contract as a contract wallet
+
+| Operation                       | Method and path                               |
+| ------------------------------- | --------------------------------------------- |
+| Add a contract                  | `POST /v1/contracts`                          |
+| Add an asset to that contract   | `POST /v1/contracts/{contractId}/{assetId}`   |
+| Remove an asset from a contract | `DELETE /v1/contracts/{contractId}/{assetId}` |
+| List whitelisted contracts      | `GET /v1/contracts`                           |
+| Find one contract               | `GET /v1/contracts/{contractId}`              |
+| Delete a contract               | `DELETE /v1/contracts/{contractId}`           |
+
+The asset identifier is a bare path segment on the contract, per the API
+reference. Prefer the Fireblocks SDK method over hand-rolling the request — the
+SDK is versioned against the API. Cleanup mirrors setup: delete the asset entry
+before deleting the contract container.
+
+Endpoint permissions, per the Fireblocks API reference: adding a contract and
+adding an asset to a contract are both available to **Admin, Non-Signing Admin,
+Signer, Approver, or Editor**. Listing additionally allows Viewer. The same
+objects are manageable from the Console; the API paths are given because they
+are unambiguous and scriptable.
+
+Two calls are needed, not one: the contract object is created first, then the
+asset entry carrying the chain's asset identifier and the on-chain address is
+attached to it. The bot's lookup matched on **both** the asset identifier and
+the address, so both must be correct or the resolution fails and the migration
+refuses to run rather than falling back to an unwhitelisted destination.
+
+The asset identifier for Base is `BASECHAIN_ETH` — that was the default in the
+deleted configuration's chain-to-asset mapping. Confirm it against the workspace
+rather than trusting this document.
+
+### Step 2: add a Transaction Authorization Policy rule
+
+The Transaction Authorization Policy, referred to throughout Fireblocks as the
+TAP, is the rule set that decides whether a submitted transaction is allowed. A
+rule of this shape permits a given vault account to make contract calls to
+whitelisted contract destinations:
+
+```json
+{
+  "type": "TRANSFER",
+  "action": "ALLOW",
+  "transactionType": "CONTRACT_CALL",
+  "dstAddressType": "WHITELISTED",
+  "src": { "ids": [["<VAULT_ACCOUNT_ID>", "VAULT", "*"]] },
+  "dst": { "ids": [["<CONTRACT_WALLET_ID>", "UNMANAGED", "CONTRACT"]] },
+  "asset": "BASECHAIN_ETH",
+  "amount": 0,
+  "amountScope": "SINGLE_TX",
+  "amountCurrency": "USD",
+  "periodSec": 0,
+  "operators": { "usersGroups": ["<GROUP_ID>"] }
+}
+```
+
+Notes for whoever writes it:
+
+- `src` is the bot's vault account. The deleted configuration defaulted to
+  account `"0"`; confirm the account actually in use.
+- `dst` should name the specific whitelisted Receipt contract. The Fireblocks
+  documentation example uses a wildcard; scoping it to the one contract is safer
+  and costs nothing here, since this is a one-shot migration.
+- `amount` is 0 because the call moves no native value. **This does not mean the
+  wallet needs no funds.** `amount` is the transferred value, not the fee: the
+  transaction is still an on-chain contract call, and the network fee is paid
+  from the source vault account's native balance. The Fireblocks vault account
+  must hold enough ETH on Base to cover gas for one `safeBatchTransferFrom` per
+  vault, or the transfer fails with insufficient funds. Confirm the balance
+  before the window, and note Fireblocks' Gas Station can fund vault accounts
+  automatically if it is configured.
+- `operators.usersGroups` takes Fireblocks **user group IDs**, not user IDs: add
+  the bot's API user to an authorized user group and put that group's ID in the
+  rule. An automated run then initiates as that API user, authorized through its
+  group membership.
+- **Rule order matters.** Fireblocks evaluates policy rules in the order they
+  are defined, so this rule must sit above any broader rule that would block it.
+
+Policies can be edited in the Console Policy Editor or through the API, which
+offers both direct publication and a draft workflow (get the active draft,
+update it, publish it by identifier) for organizations that want a review step
+before deployment
+([Set Policies](https://developers.fireblocks.com/docs/set-transaction-authorization-policy)).
+
+### What the rule does and does not restrict
+
+The rule matches on transaction type and destination contract. There is **no
+function-selector field** in this rule shape, so whitelisting the Receipt
+contract permits the vault account to call _any_ method on it, including
+`setApprovalForAll` — not just the batch transfer we need.
+
+That is a wider grant than the operation requires. Mitigations, in order of
+preference: scope `dst` to the single Receipt contract rather than a wildcard;
+ask Fireblocks whether method-level restriction is available on this workspace
+tier, since the public rule schema does not appear to express it; and remove
+both the rule and the whitelisting once the migration completes, since the grant
+has no ongoing purpose after cutover.
+
+## Approvals: the part that decides whether this can happen without you
+
+Both required changes fall inside domains that Fireblocks gates behind approval.
+Per
+[Define Approval Quorums](https://developers.fireblocks.com/docs/define-approval-quorums),
+Admin Quorum approval covers, among others:
+
+- **"Whitelisting addresses"** and other external destination addresses —
+  presumed to cover Step 1, but whether **contract** wallet creation falls under
+  it is exactly open question 1 below; treat Step 1's approval path as
+  unconfirmed until that is answered.
+- **"Changes to Policies"** — Step 2
+
+The Admin Quorum "lists all users with Admin privileges (users assigned to
+either an Owner, Admin, or Non-Signing Admin role)", and the threshold "defines
+the number of Admins required to approve new workspace connections and changes".
+Any Admin can deny a request outright before the threshold is met.
+
+Separately, **approval groups** can replace the Admin Quorum for specific
+domains, drawn from "a designated user group", explicitly to "segregate and
+delegate responsibilities". External accounts and security/policy are named
+domains.
+
+### The question that has to be answered before anything is scheduled
+
+Whether this can be completed without the workspace Owner personally approving
+depends entirely on how this workspace is configured. The documentation states
+that "you can remove owner approval from certain actions", while cautioning that
+"key changes in your workspace will still require owner involvement" — and does
+not enumerate which are which.
+
+So, before scheduling the migration, confirm with the workspace administrator:
+
+1. What is the current Admin Quorum threshold, and who is in it?
+2. Are approval groups configured for external accounts (whitelisting) and for
+   policy changes? If so, who is in them?
+3. Given those answers, can both changes be approved without the Owner acting?
+4. If the Owner must act, that is a hard dependency and the migration cannot be
+   scheduled as an unattended operation.
+
+Question 3 is the one that determines whether the scheduled migration window
+holds.
+
+## What the bot's API user needs
+
+Nothing new is created for the bot itself. It authenticates as an existing API
+user with its own API key and secret. What matters is that this user is named in
+the `operators` of the new policy rule, and that its credentials are still
+provisioned and valid — the integration was removed from the codebase, so the
+credentials have not been exercised recently. Verify before the run, not during.
+
+## Before the run
+
+- Confirm the Receipt contract address per vault by calling `receipt()` on the
+  vault, and confirm it against the whitelisted entry.
+- Confirm the vault account identifier the bot signs from.
+- Confirm the chain asset identifier for Base.
+- Confirm the API credentials still authenticate.
+- Confirm the receipt inventory has recorded holdings for every vault being
+  migrated — the migration refuses to run against an empty inventory, so the
+  backfill must have discovered the receipts before the window opens.
+- Confirm the vault's certification is not expired and no owner freeze blocks
+  the pair; both revert the transfer on-chain and neither is a Fireblocks
+  concern — the migration engine re-checks both immediately before submission.
+
+## After the run
+
+Remove the policy rule and the whitelisted contract (asset entry first, then the
+contract container) — but only after the migration is **verified successful**:
+custody confirmed at the incoming wallet and the replacement service operating
+on it, for **every** vault. A vault that refused to migrate (in-flight work,
+balance mismatch) stays on Fireblocks until a later pass, and removing the rule
+before that pass strands it. Once the last vault has migrated, the grant has no
+remaining purpose, and leaving a rule that permits arbitrary method calls on the
+Receipt contract is a standing risk with no benefit.
+
+## Open questions for Fireblocks support
+
+These could not be settled from the public documentation and are worth asking
+directly, since each one can cost an approval cycle:
+
+1. Does creating a **contract** wallet require Admin Quorum approval, or does
+   the approval requirement documented for "whitelisting addresses" apply only
+   to internal and external wallets?
+2. Is method-level (function selector) restriction available for `CONTRACT_CALL`
+   rules on this workspace tier?
+3. Does the workspace currently permit `RAW` operations for the bot's vault
+   account, and if so, under which rule?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,14 @@ pub async fn initialize_rocket(
     spawn_mint_recovery_reconciler(pool.clone(), apalis_pool.clone());
     spawn_burn_recovery_reconciler(managers.burn.clone());
 
+    // Flipped by the rocket shutdown fairing so the spawned chain-scanning
+    // loops stop with the server instead of outliving it. In production the
+    // whole process exits and takes them along; this matters when a server is
+    // shut down in-process — the cutover e2e stops and restarts services on
+    // one database, and a leaked poller from a "stopped" service keeps
+    // scanning and races the replacement.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
     for (network, runtime) in chain_registry.runtimes() {
         spawn_periodic_receipt_backfills(PeriodicBackfillSpawn {
             pool: pool.clone(),
@@ -417,6 +425,7 @@ pub async fn initialize_rocket(
                 pool.clone(),
                 apalis_pool.clone(),
             ),
+            shutdown: shutdown_rx.clone(),
         });
     }
 
@@ -440,8 +449,12 @@ pub async fn initialize_rocket(
                 burn_manager: managers.burn.clone(),
             });
 
+            let mut poller_shutdown = shutdown_rx.clone();
             tokio::spawn(async move {
-                poller.run().await;
+                tokio::select! {
+                    () = poller.run() => {}
+                    _ = poller_shutdown.changed() => {}
+                }
             });
         }
     }
@@ -488,6 +501,7 @@ pub async fn initialize_rocket(
         vault_services: network_vault_services,
         configured_networks,
         freeze_scheduler,
+        shutdown: shutdown_tx,
     }))
 }
 
@@ -505,6 +519,8 @@ struct RocketState {
     vault_services: NetworkVaultServices,
     configured_networks: ConfiguredNetworks,
     freeze_scheduler: tokenized_asset::schedule::FreezeScheduler,
+    /// Stops the spawned chain-scanning loops when the server shuts down.
+    shutdown: tokio::sync::watch::Sender<bool>,
 }
 
 fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
@@ -520,7 +536,16 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
     // Read before `state.config` is moved into management below.
     let environment = state.config.environment;
 
+    let stop_pollers = state.shutdown;
     let rocket = rocket::custom(figment)
+        .attach(rocket::fairing::AdHoc::on_shutdown(
+            "stop background pollers",
+            |_| {
+                Box::pin(async move {
+                    let _ = stop_pollers.send(true);
+                })
+            },
+        ))
         .manage(state.config)
         .manage(state.rate_limiter)
         .manage(state.account_store)
@@ -1315,6 +1340,7 @@ struct PeriodicBackfillSpawn<P, H> {
     backfill_start_block: u64,
     receipt_poll_interval: Duration,
     handler: H,
+    shutdown: tokio::sync::watch::Receiver<bool>,
 }
 
 /// Spawns the periodic receipt-backfill reconciliation loop. Each pass re-reads
@@ -1337,6 +1363,7 @@ where
         backfill_start_block,
         receipt_poll_interval,
         handler,
+        mut shutdown,
     } = spawn;
 
     tokio::spawn(async move {
@@ -1362,7 +1389,10 @@ where
         interval.tick().await;
 
         loop {
-            interval.tick().await;
+            tokio::select! {
+                _ = interval.tick() => {}
+                _ = shutdown.changed() => break,
+            }
 
             // Re-read the enabled vault set each pass so runtime-added assets
             // are reconciled without a restart.

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -168,6 +168,23 @@ impl MintView {
         serde_json::from_value(serde_json::to_value(mint)?)
     }
 
+    /// The asset this mint is for, when the state still carries it.
+    pub(crate) const fn underlying(&self) -> Option<&UnderlyingSymbol> {
+        match self {
+            Self::Initiated { underlying, .. }
+            | Self::JournalConfirmed { underlying, .. }
+            | Self::JournalRejected { underlying, .. }
+            | Self::Minting { underlying, .. }
+            | Self::MintIntended { underlying, .. }
+            | Self::MintTxSubmitted { underlying, .. }
+            | Self::MintingFailed { underlying, .. }
+            | Self::CallbackPending { underlying, .. } => Some(underlying),
+            Self::NotFound | Self::Completed { .. } | Self::Closed { .. } => {
+                None
+            }
+        }
+    }
+
     #[cfg(test)]
     pub(crate) const fn state_name(&self) -> &'static str {
         match self {

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -1,0 +1,2026 @@
+//! Moving receipt custody from a retiring signing wallet to its replacement.
+//!
+//! The issuer burns against receipts held by its own signing address
+//! (`balanceOf(bot_wallet, receipt_id)` in [`super::backfill`] and
+//! [`super::reconcile`]), so rotating the signing backend strands every receipt
+//! at the old address: the new wallet holds shares it cannot redeem because the
+//! matching receipt sits elsewhere. Custody has to follow the rotation.
+//!
+//! This is a one-shot capability for the Turnkey cutover and is expected to be
+//! removed once every vault has migrated.
+//!
+//! **The issuer service must be stopped before this runs.** Startup
+//! reconciliation reads `balanceOf(bot_wallet)` for every tracked receipt
+//! ([`super::reconcile`], reached from `run_startup_reconciliation`). Once
+//! custody has moved but the service is still configured with the outgoing
+//! signer, every one of those reads returns zero, which reconciles as a
+//! depletion and drops the receipts from the aggregate outright. Freezing the
+//! underlying does not prevent this: a freeze rejects new mints, it does not
+//! stop the service or serialize against it. The order is stop the service,
+//! migrate, swap the signer configuration, start again.
+
+use alloy::eips::BlockId;
+use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::{PendingTransactionError, Provider};
+use async_trait::async_trait;
+use event_sorcery::StoreBuilder;
+use itertools::izip;
+use sqlx::{Pool, Sqlite};
+use std::time::Duration;
+use tracing::{debug, info};
+
+use super::{
+    ReceiptId, ReceiptInventory, Shares, SharesOverflow, load_inventory,
+};
+use crate::bindings::{OffchainAssetReceiptVault, Receipt};
+use crate::mint::find_stuck as find_stuck_mints;
+use crate::redemption::view::find_stuck as find_stuck_redemptions;
+use crate::redemption::{IssuerRedemptionRequestId, RedemptionEvent};
+use crate::tokenized_asset::UnderlyingSymbol;
+
+/// Refuses unless the deployment is quiescent: no burn reserved against this
+/// vault's receipts, and no mint or redemption anywhere between initiation and
+/// its terminal state.
+///
+/// Deliberately not a freeze check. The `Underlying` freeze means "corporate
+/// action in progress" — a different fact with its own lifecycle — and a custody
+/// migration must neither require declaring one nor end one that is real. What
+/// the migration actually needs is that no work is in flight:
+///
+/// - A **reserved burn** is about to consume the very receipts being moved.
+/// - A **non-terminal redemption** that holds no reservation yet (detected,
+///   Alpaca called) resumes on restart and plans a burn against the *new*
+///   wallet while the participant's money already moved — irreversibly, since
+///   Alpaca is called before the burn.
+/// - A **non-terminal mint** resumes by rebroadcasting a transaction signed by
+///   the *old* wallet, depositing a fresh receipt at an address the migrated
+///   deployment no longer watches.
+///
+/// The in-flight gates are scoped to the migrating asset: a stuck mint or
+/// redemption only ever resumes against its own vault, so live work on one
+/// asset proves nothing about another's receipts — and a permanently stuck
+/// aggregate (a legacy shape awaiting its own recovery feature) must not
+/// hold every other vault's migration hostage. Work that cannot be
+/// attributed to an asset counts against every vault instead of none.
+pub(crate) const fn require_quiescent(
+    vault: Address,
+    reserved: &[ReceiptId],
+    redemptions_in_flight: usize,
+    mints_in_flight: usize,
+) -> Result<(), MigrationRefusal> {
+    if !reserved.is_empty() {
+        return Err(MigrationRefusal::BurnReserved {
+            vault,
+            receipts: reserved.len(),
+        });
+    }
+
+    if redemptions_in_flight > 0 {
+        return Err(MigrationRefusal::RedemptionsInFlight {
+            count: redemptions_in_flight,
+        });
+    }
+
+    if mints_in_flight > 0 {
+        return Err(MigrationRefusal::MintsInFlight { count: mints_in_flight });
+    }
+
+    Ok(())
+}
+
+/// Custody of a vault's receipts, as the migration needs to see it.
+///
+/// The methods are one capability rather than several traits because a custody
+/// move is only safe when the balances are known, the vault permits the
+/// transfer, and the move itself lands. [`ReceiptCustody::transfer_custody`]
+/// takes a [`TransferPermit`], which only
+/// [`ReceiptCustody::transfer_permission`] can produce, so the ordering is
+/// enforced by the type system rather than by a caller remembering it.
+#[async_trait]
+pub(crate) trait ReceiptCustody {
+    /// On-chain balances held by `holder` for each identifier, in the order
+    /// given. This is the authoritative answer that our tracked inventory is
+    /// checked against.
+    async fn held_balances(
+        &self,
+        vault: Address,
+        holder: Address,
+        receipt_ids: &[ReceiptId],
+    ) -> Result<Vec<Shares>, ReceiptCustodyError>;
+
+    /// Whether the vault currently permits a receipt transfer between this
+    /// pair of addresses.
+    ///
+    /// Both refusal cases revert the transfer on-chain, so they are read
+    /// immediately before submission rather than trusted from an earlier check:
+    /// `OffchainAssetReceiptVault.authorizeReceiptTransfer3` runs
+    /// `ownerFreezeCheckTransaction(from, to)` and then delegates to the
+    /// authorizer, whose `TRANSFER_RECEIPT` branch reverts
+    /// `CertificationExpired(from, to)` when certification has lapsed.
+    async fn transfer_permission(
+        &self,
+        vault: Address,
+        from: Address,
+        to: Address,
+    ) -> Result<TransferPermission, ReceiptCustodyError>;
+
+    /// Move every holding to the permitted recipient in a single batch,
+    /// returning the transaction hash.
+    ///
+    /// One batch per vault rather than one transfer per receipt: a single
+    /// authorisation event, a single outcome, and no partially migrated vault
+    /// to reason about on failure.
+    ///
+    /// The sender and recipient come from `permit`, not from separate
+    /// arguments, so the addresses that were checked are necessarily the
+    /// addresses that are used.
+    async fn transfer_custody(
+        &self,
+        permit: &TransferPermit,
+        holdings: &MigratableHoldings,
+    ) -> Result<B256, ReceiptCustodyError>;
+}
+
+/// Whether a vault will accept a receipt transfer right now.
+///
+/// Modelled as the reason rather than a bool so the operator is told which gate
+/// closed, and so a new gate cannot be silently folded into a false.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TransferPermission {
+    Permitted(TransferPermit),
+    /// The vault's certification has lapsed. Renewing it is held by whoever
+    /// holds `CERTIFY` on the live vault, not by this service.
+    CertificationExpired,
+    /// An owner freeze covers this pair and neither address is exempt via the
+    /// vault's always-allowed lists.
+    OwnerFrozen {
+        until: U256,
+    },
+}
+
+/// Evidence that a vault accepted this exact sender and recipient at the moment
+/// it was asked.
+///
+/// The fields are private and the only constructor is module-private, so a
+/// permit cannot be conjured by a caller that skipped the check.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TransferPermit {
+    vault: Address,
+    from: Address,
+    to: Address,
+}
+
+impl TransferPermit {
+    const fn granted(vault: Address, from: Address, to: Address) -> Self {
+        Self { vault, from, to }
+    }
+
+    pub(crate) const fn from(&self) -> Address {
+        self.from
+    }
+
+    pub(crate) const fn to(&self) -> Address {
+        self.to
+    }
+
+    pub(crate) const fn vault(&self) -> Address {
+        self.vault
+    }
+}
+
+/// Receipts confirmed to sit with the outgoing wallet, agreed between our
+/// tracked inventory and the chain.
+///
+/// Existence implies agreement: the only constructor is
+/// [`reconcile_holdings`], which refuses on any divergence. A caller therefore
+/// cannot transfer a set of receipts we are not certain we hold.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct MigratableHoldings {
+    chain_id: u64,
+    vault: Address,
+    holder: Address,
+    holdings: Vec<ReceiptHolding>,
+}
+
+/// A single receipt identifier and the balance held against it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ReceiptHolding {
+    pub(crate) receipt_id: ReceiptId,
+    pub(crate) balance: Shares,
+}
+
+/// What the outgoing wallet turned out to be holding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SourceCustody {
+    /// The outgoing wallet still holds the tracked receipts, so there is a
+    /// migration to perform.
+    Holds(MigratableHoldings),
+    /// The outgoing wallet holds nothing and the incoming wallet holds at
+    /// least the tracked balances: a completed migration seen a second time.
+    /// See [`already_migrated_or_divergent`] for why "at least" rather than
+    /// "exactly".
+    AlreadyMigrated { receipts: usize },
+}
+
+impl MigratableHoldings {
+    pub(crate) const fn chain_id(&self) -> u64 {
+        self.chain_id
+    }
+
+    pub(crate) const fn vault(&self) -> Address {
+        self.vault
+    }
+
+    pub(crate) const fn holder(&self) -> Address {
+        self.holder
+    }
+
+    pub(crate) fn holdings(&self) -> &[ReceiptHolding] {
+        &self.holdings
+    }
+
+    pub(crate) fn receipt_ids(&self) -> Vec<ReceiptId> {
+        self.holdings.iter().map(|held| held.receipt_id).collect()
+    }
+
+    /// Identifiers and amounts as the parallel arrays
+    /// `safeBatchTransferFrom(from, to, ids, amounts, data)` expects. Built
+    /// together so the two can never fall out of step.
+    pub(crate) fn batch_arguments(&self) -> (Vec<U256>, Vec<U256>) {
+        self.holdings
+            .iter()
+            .map(|holding| {
+                (holding.receipt_id.inner(), holding.balance.inner())
+            })
+            .unzip()
+    }
+
+    /// Total balance across every holding, used to assert the recipient gained
+    /// exactly what the source gave up.
+    pub(crate) fn total(&self) -> Result<Shares, SharesOverflow> {
+        total_of(self.holdings.iter().map(|held| held.balance))
+    }
+}
+
+/// Why a migration must not proceed.
+///
+/// Every variant is a stop, not a warning: this moves the backing that redeemed
+/// tokens depend on, so an unclear picture is a reason to halt rather than to
+/// proceed on a best guess.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MigrationRefusal {
+    #[error(
+        "{count} redemption(s) are between detection and a terminal state; \
+         they resume against the wrong wallet after a custody move. Drain them \
+         to terminal (see /admin/stuck) before migrating"
+    )]
+    RedemptionsInFlight { count: usize },
+
+    #[error(
+        "{count} mint(s) are between initiation and a terminal state; recovery \
+         rebroadcasts their old-wallet-signed transactions after a custody \
+         move. Drain them to terminal (see /admin/stuck) before migrating"
+    )]
+    MintsInFlight { count: usize },
+
+    #[error(
+        "vault {vault} has {receipts} receipt(s) reserved for an in-flight \
+         redemption burn; that burn must settle or be released before custody \
+         moves"
+    )]
+    BurnReserved { vault: Address, receipts: usize },
+
+    #[error(
+        "vault {vault} has no tracked receipts on chain {chain_id}; refusing \
+         rather than reporting an unverified \"nothing to migrate\", since an \
+         un-backfilled inventory is indistinguishable from an empty one"
+    )]
+    InventoryEmpty { vault: Address, chain_id: u64 },
+
+    #[error(
+        "vault {vault} certification is expired; receipt transfers revert \
+         until whoever holds CERTIFY renews it"
+    )]
+    CertificationExpired { vault: Address },
+
+    #[error("vault {vault} owner freeze blocks {from} -> {to} until {until}")]
+    OwnerFrozen { vault: Address, from: Address, to: Address, until: U256 },
+
+    #[error(
+        "receipt {receipt_id} on vault {vault} diverges: inventory tracks \
+         {tracked}, chain holds {onchain}"
+    )]
+    InventoryDivergence {
+        vault: Address,
+        receipt_id: ReceiptId,
+        tracked: Shares,
+        onchain: Shares,
+    },
+
+    #[error(
+        "vault {vault} is empty at the outgoing wallet but receipt \
+         {receipt_id} sits at {at_recipient} with the incoming wallet, not \
+         the tracked {tracked}; custody is in a state this migration cannot \
+         explain"
+    )]
+    RecipientBalanceMismatch {
+        vault: Address,
+        receipt_id: ReceiptId,
+        tracked: Shares,
+        at_recipient: Shares,
+    },
+
+    #[error(
+        "vault {vault} returned {returned} balances for {requested} receipts"
+    )]
+    BalanceCountMismatch { vault: Address, requested: usize, returned: usize },
+
+    #[error(
+        "recipient {recipient} is the zero address; custody would be burned"
+    )]
+    RecipientIsZeroAddress { recipient: Address },
+
+    #[error(
+        "chain {chain_id} has never seen recipient {recipient}: it has sent no \
+         transaction and holds no native balance. That is what a mistyped \
+         address looks like, and receipts moved to one cannot be recovered by \
+         anyone. Check the address, and fund the incoming wallet for gas \
+         before migrating."
+    )]
+    RecipientUnknownToChain { recipient: Address, chain_id: u64 },
+
+    #[error(transparent)]
+    SharesOverflow(#[from] SharesOverflow),
+
+    #[error(transparent)]
+    Custody(Box<ReceiptCustodyError>),
+}
+
+// The alloy error types these wrap are large, so box on conversion to keep the
+// enum (and every `Result` carrying it) small, while `?` still works at the
+// call site without a hand-rolled `.map_err(Box::new)`.
+impl From<ReceiptCustodyError> for MigrationRefusal {
+    fn from(error: ReceiptCustodyError) -> Self {
+        Self::Custody(Box::new(error))
+    }
+}
+
+/// Why the custody move itself could not complete.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum ReceiptCustodyError {
+    #[error(transparent)]
+    Contract(Box<alloy::contract::Error>),
+
+    #[error(transparent)]
+    PendingTransaction(Box<PendingTransactionError>),
+
+    #[error(transparent)]
+    Rpc(Box<alloy::transports::TransportError>),
+
+    #[error("chain reported no latest block")]
+    NoLatestBlock,
+
+    #[error(
+        "custody was resolved for vault {expected} but asked about \
+         {requested}"
+    )]
+    WrongVault { expected: Address, requested: Address },
+
+    #[error(
+        "permit authorises {permitted} as the sender but the holdings belong \
+         to {holdings}"
+    )]
+    PermitHolderMismatch { permitted: Address, holdings: Address },
+
+    #[error("custody transfer {tx_hash} reverted on vault {vault}")]
+    Reverted { vault: Address, tx_hash: B256 },
+
+    #[error(transparent)]
+    RecipientBalanceDecreased(Box<RecipientBalanceDecrease>),
+
+    #[error(transparent)]
+    PostConditionFailed(Box<PostConditionFailure>),
+}
+
+/// A recipient balance that fell over a transfer that should only have raised
+/// it — a corrupt observation, not a zero gain.
+///
+/// Boxed inside [`ReceiptCustodyError`] for the same size reason as
+/// [`PostConditionFailure`].
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "transfer {tx_hash} on vault {vault}: receipt {receipt_id} balance at the \
+     recipient fell from {before} to {after} over a transfer that should only \
+     have increased it"
+)]
+pub(crate) struct RecipientBalanceDecrease {
+    pub(crate) vault: Address,
+    pub(crate) tx_hash: B256,
+    pub(crate) receipt_id: ReceiptId,
+    pub(crate) before: Shares,
+    pub(crate) after: Shares,
+}
+
+impl From<RecipientBalanceDecrease> for ReceiptCustodyError {
+    fn from(decrease: RecipientBalanceDecrease) -> Self {
+        Self::RecipientBalanceDecreased(Box::new(decrease))
+    }
+}
+
+/// A transfer that mined but left custody in a state the migration cannot
+/// call success.
+///
+/// Boxed inside [`ReceiptCustodyError`] because five inline fields push every
+/// `Result` in this module over clippy's large-error threshold.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "transfer {tx_hash} on vault {vault} mined but post-conditions failed: \
+     source retains {source_retained}, recipient gained {recipient_gained}, \
+     expected {expected}"
+)]
+pub(crate) struct PostConditionFailure {
+    pub(crate) vault: Address,
+    /// The transfer that may have partially succeeded. An operator reconciling
+    /// by hand needs it, so it belongs in the error rather than only in the log
+    /// line that never gets written on this path.
+    pub(crate) tx_hash: B256,
+    pub(crate) source_retained: Shares,
+    pub(crate) recipient_gained: Shares,
+    pub(crate) expected: Shares,
+}
+
+impl From<PostConditionFailure> for ReceiptCustodyError {
+    fn from(failure: PostConditionFailure) -> Self {
+        Self::PostConditionFailed(Box::new(failure))
+    }
+}
+
+// Same boxing rationale as `MigrationRefusal::Custody`: these alloy errors are
+// large enough that carrying them inline bloats every `Result` in the module.
+impl From<alloy::contract::Error> for ReceiptCustodyError {
+    fn from(error: alloy::contract::Error) -> Self {
+        Self::Contract(Box::new(error))
+    }
+}
+
+impl From<PendingTransactionError> for ReceiptCustodyError {
+    fn from(error: PendingTransactionError) -> Self {
+        Self::PendingTransaction(Box::new(error))
+    }
+}
+
+impl From<alloy::transports::TransportError> for ReceiptCustodyError {
+    fn from(error: alloy::transports::TransportError) -> Self {
+        Self::Rpc(Box::new(error))
+    }
+}
+
+/// What a completed migration did, so a re-run reads differently from a first
+/// run rather than both printing the same success.
+#[derive(Debug, PartialEq, Eq)]
+pub enum MigrationOutcome {
+    Migrated {
+        transaction: B256,
+        receipts: usize,
+    },
+    /// A completed migration observed again: the outgoing wallet holds nothing
+    /// and the incoming wallet holds at least the tracked balances.
+    AlreadyMigrated {
+        receipts: usize,
+    },
+}
+
+/// A destination the chain itself has already seen.
+///
+/// Existence implies corroboration: [`CorroboratedRecipient::verify`] is the
+/// only constructor, so no caller can reach [`migrate_vault_receipts`] with an
+/// address whose only evidence is that somebody typed it correctly. An ERC-1155
+/// transfer is final and has no counterparty to ask for it back, so a mistyped
+/// destination is not a recoverable mistake.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CorroboratedRecipient(Address);
+
+impl CorroboratedRecipient {
+    /// Confirms the chain has independent evidence that `recipient` exists.
+    ///
+    /// An address that has never sent a transaction and holds no native balance
+    /// has no on-chain existence at all — which is precisely what a
+    /// fat-fingered address looks like, since the odds of a typo landing on a
+    /// used address are negligible. Both legitimate destinations clear it: the
+    /// incoming signing wallet has to be funded for gas before it can run the
+    /// service, and the outgoing wallet a rollback returns custody to has been
+    /// signing for months.
+    ///
+    /// The error type is erased to `anyhow` for the same reason as
+    /// [`migrate_vault_receipts`]: [`MigrationRefusal`] stays crate-internal.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for the zero address, and when the chain has no record
+    /// of the address at all.
+    pub async fn verify<P: Provider>(
+        provider: &P,
+        recipient: Address,
+    ) -> anyhow::Result<Self> {
+        if recipient.is_zero() {
+            return Err(
+                MigrationRefusal::RecipientIsZeroAddress { recipient }.into()
+            );
+        }
+
+        let chain_id =
+            provider.get_chain_id().await.map_err(ReceiptCustodyError::from)?;
+
+        let nonce = provider
+            .get_transaction_count(recipient)
+            .await
+            .map_err(ReceiptCustodyError::from)?;
+
+        let balance = provider
+            .get_balance(recipient)
+            .await
+            .map_err(ReceiptCustodyError::from)?;
+
+        if nonce == 0 && balance.is_zero() {
+            return Err(MigrationRefusal::RecipientUnknownToChain {
+                recipient,
+                chain_id,
+            }
+            .into());
+        }
+
+        Ok(Self(recipient))
+    }
+
+    pub(crate) const fn address(self) -> Address {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CorroboratedRecipient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+/// The vault a custody operation addresses: its chain, its address, and the
+/// asset it belongs to. The asset scopes the in-flight quiescence gates —
+/// stuck work only ever resumes against its own vault.
+#[derive(Debug, Clone, Copy)]
+pub struct VaultIdentity<'a> {
+    pub chain_id: u64,
+    pub vault: Address,
+    pub underlying: &'a UnderlyingSymbol,
+}
+
+/// Migrates one vault's receipt custody to `recipient`, end to end.
+///
+/// Public so the operator CLI and the cutover end-to-end test drive the same
+/// code: a test exercising a hand-rolled transfer would prove nothing about
+/// what the operator actually runs.
+///
+/// `provider` must be signing as `holder`, the wallet whose custody moves —
+/// ERC-1155 only lets the holder or an approved operator move a balance.
+///
+/// Re-running after a successful migration is safe: the outgoing wallet is
+/// found empty with the incoming wallet holding the tracked balances, which
+/// reports [`MigrationOutcome::AlreadyMigrated`] rather than submitting a
+/// second transfer.
+///
+/// The error type is erased to `anyhow` at this boundary, matching the other
+/// operator entry point in this crate ([`crate::run_issuer_cli`]); the typed
+/// [`MigrationRefusal`] hierarchy is preserved for every caller inside the
+/// crate.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened, any burn is reserved or any
+/// mint/redemption is in flight, the vault has no tracked receipts, the tracked
+/// inventory disagrees with the chain, the vault refuses the transfer, the
+/// transfer reverts, or the post-conditions do not hold after submission.
+pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
+    pool: &Pool<Sqlite>,
+    provider: P,
+    identity: VaultIdentity<'_>,
+    holder: Address,
+    recipient: CorroboratedRecipient,
+) -> anyhow::Result<MigrationOutcome> {
+    let VaultIdentity { chain_id, vault, underlying } = identity;
+    let recipient = recipient.address();
+
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+    let tracked = quiescent_tracked_holdings(
+        pool, &inventory, chain_id, vault, underlying,
+    )
+    .await?;
+
+    let custody = OnchainReceiptCustody::resolve(provider, vault).await?;
+
+    match reconcile_holdings(
+        &custody, chain_id, vault, holder, recipient, &tracked,
+    )
+    .await?
+    {
+        SourceCustody::AlreadyMigrated { receipts } => {
+            info!(
+                target: "receipt_inventory",
+                chain_id,
+                %vault,
+                %holder,
+                %recipient,
+                receipts,
+                "Receipt custody already migrated"
+            );
+            Ok(MigrationOutcome::AlreadyMigrated { receipts })
+        }
+        SourceCustody::Holds(holdings) => {
+            Ok(migrate_vault_custody(&custody, &holdings, recipient).await?)
+        }
+    }
+}
+
+/// Loads the tracked holdings after proving the deployment is quiescent.
+///
+/// Shared by every operation that reads or moves custody: none of them may run
+/// over in-flight work, and all of them are meaningless on an empty inventory.
+async fn quiescent_tracked_holdings(
+    pool: &Pool<Sqlite>,
+    inventory: &ReceiptInventory,
+    chain_id: u64,
+    vault: Address,
+    underlying: &UnderlyingSymbol,
+) -> anyhow::Result<Vec<ReceiptHolding>> {
+    let redemptions_in_flight = stuck_redemptions_for(pool, underlying).await?;
+    let mints_in_flight = stuck_mints_for(pool, underlying).await?;
+
+    require_quiescent(
+        vault,
+        &inventory.reserved_receipts(),
+        redemptions_in_flight,
+        mints_in_flight,
+    )?;
+
+    // A zero balance is nothing to move, and a vault whose every balance is
+    // zero has nothing to migrate — treating it as migratable is how a
+    // fully-spent vault could "verify" a move on two zero readings.
+    let tracked: Vec<ReceiptHolding> = inventory
+        .receipts_with_balance()
+        .into_iter()
+        .map(|receipt| ReceiptHolding {
+            receipt_id: receipt.receipt_id,
+            balance: receipt.available_balance,
+        })
+        .filter(|holding| !holding.balance.is_zero())
+        .collect();
+
+    if tracked.is_empty() {
+        return Err(MigrationRefusal::InventoryEmpty { vault, chain_id }.into());
+    }
+
+    Ok(tracked)
+}
+
+/// Counts the stuck redemptions that could resume against `underlying`'s
+/// vault.
+///
+/// Terminal-looking view shapes (`Failed`) no longer carry the asset, so
+/// those are attributed from the aggregate's `Detected` event; a redemption
+/// that cannot be attributed at all counts against every vault rather than
+/// none.
+async fn stuck_redemptions_for(
+    pool: &Pool<Sqlite>,
+    underlying: &UnderlyingSymbol,
+) -> anyhow::Result<usize> {
+    let mut count = 0;
+
+    for (issuer_request_id, view) in find_stuck_redemptions(pool).await? {
+        let counts = match view.underlying() {
+            Some(asset) => asset == underlying,
+            None => detected_redemption_underlying(pool, &issuer_request_id)
+                .await?
+                .is_none_or(|asset| asset == *underlying),
+        };
+
+        if counts {
+            count += 1;
+        }
+    }
+
+    Ok(count)
+}
+
+/// Counts the stuck mints that could resume against `underlying`'s vault,
+/// counting any unattributable mint against every vault.
+async fn stuck_mints_for(
+    pool: &Pool<Sqlite>,
+    underlying: &UnderlyingSymbol,
+) -> anyhow::Result<usize> {
+    Ok(find_stuck_mints(pool)
+        .await?
+        .iter()
+        .filter(|(_, view)| {
+            view.underlying().is_none_or(|asset| asset == underlying)
+        })
+        .count())
+}
+
+/// Recovers a redemption's asset from its `Detected` event when the view has
+/// already dropped it.
+async fn detected_redemption_underlying(
+    pool: &Pool<Sqlite>,
+    issuer_request_id: &IssuerRedemptionRequestId,
+) -> anyhow::Result<Option<UnderlyingSymbol>> {
+    let aggregate_id = issuer_request_id.to_string();
+    let rows = sqlx::query!(
+        r#"
+        SELECT payload as "payload!: String"
+        FROM events
+        WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
+        ORDER BY sequence
+        "#,
+        aggregate_id
+    )
+    .fetch_all(pool)
+    .await?;
+
+    for row in rows {
+        if let RedemptionEvent::Detected { underlying, .. } =
+            serde_json::from_str(&row.payload)?
+        {
+            return Ok(Some(underlying));
+        }
+    }
+
+    Ok(None)
+}
+
+/// Cross-checks the tracked inventory against the chain, yielding the set to
+/// move only when the two agree.
+///
+/// Both sources are needed and neither is sufficient. Our inventory can be
+/// stale, so it cannot be trusted alone; the chain is authoritative but needs a
+/// candidate identifier set to ask about, which only the inventory supplies
+/// cheaply. Divergence means we do not know what we hold, which is a stop
+/// rather than something to reconcile in flight.
+///
+/// One divergence is benign and is reported as
+/// [`SourceCustody::AlreadyMigrated`]: the source holding nothing while the
+/// recipient holds at least the tracked balances is a completed migration seen
+/// again, not a corrupt inventory. The inventory is keyed by vault and chain
+/// with no holder dimension, so it describes whichever wallet the service is
+/// configured to sign as — which is why the service must not run against the
+/// outgoing signer after custody moves (see the module docs).
+pub(crate) async fn reconcile_holdings(
+    custody: &(impl ReceiptCustody + Sync),
+    chain_id: u64,
+    vault: Address,
+    holder: Address,
+    recipient: Address,
+    tracked: &[ReceiptHolding],
+) -> Result<SourceCustody, MigrationRefusal> {
+    let receipt_ids: Vec<ReceiptId> =
+        tracked.iter().map(|held| held.receipt_id).collect();
+    let onchain = custody.held_balances(vault, holder, &receipt_ids).await?;
+
+    if onchain.len() != receipt_ids.len() {
+        return Err(MigrationRefusal::BalanceCountMismatch {
+            vault,
+            requested: receipt_ids.len(),
+            returned: onchain.len(),
+        });
+    }
+
+    if !tracked.is_empty() && onchain.iter().all(Shares::is_zero) {
+        return already_migrated_or_divergent(
+            custody,
+            vault,
+            recipient,
+            tracked,
+            &receipt_ids,
+        )
+        .await;
+    }
+
+    let agreed = izip!(tracked, &onchain)
+        .map(|(held, onchain)| {
+            if held.balance == *onchain {
+                Ok(*held)
+            } else {
+                Err(MigrationRefusal::InventoryDivergence {
+                    vault,
+                    receipt_id: held.receipt_id,
+                    tracked: held.balance,
+                    onchain: *onchain,
+                })
+            }
+        })
+        .collect::<Result<Vec<_>, MigrationRefusal>>()?;
+
+    // A zero balance is nothing to move. Keeping it would put an identifier in
+    // the batch that transfers nothing and cannot be verified as having moved.
+    let holdings: Vec<ReceiptHolding> =
+        agreed.into_iter().filter(|held| !held.balance.is_zero()).collect();
+
+    debug!(
+        target: "receipt_inventory",
+        %vault,
+        %holder,
+        tracked = tracked.len(),
+        migratable = holdings.len(),
+        "Reconciled receipt holdings against the chain"
+    );
+
+    Ok(SourceCustody::Holds(MigratableHoldings {
+        chain_id,
+        vault,
+        holder,
+        holdings,
+    }))
+}
+
+/// Distinguishes "this migration already ran" from "our inventory is wrong".
+///
+/// Reached only when the source holds nothing for every tracked identifier. If
+/// the recipient holds at least what we tracked, custody moved; anything less
+/// is an inventory we cannot trust.
+async fn already_migrated_or_divergent(
+    custody: &(impl ReceiptCustody + Sync),
+    vault: Address,
+    recipient: Address,
+    tracked: &[ReceiptHolding],
+    receipt_ids: &[ReceiptId],
+) -> Result<SourceCustody, MigrationRefusal> {
+    let at_recipient =
+        custody.held_balances(vault, recipient, receipt_ids).await?;
+
+    if at_recipient.len() != receipt_ids.len() {
+        return Err(MigrationRefusal::BalanceCountMismatch {
+            vault,
+            requested: receipt_ids.len(),
+            returned: at_recipient.len(),
+        });
+    }
+
+    // `>=`, not `==`: a fresh run cannot know what the recipient held before
+    // the migration, and the forward path deliberately allows a recipient with
+    // a pre-existing balance. Requiring equality here would make every such
+    // migration un-rerunnable, reporting a mismatch for custody that did move.
+    // Combined with a source holding zero for every identifier, "the recipient
+    // holds at least what we tracked" is the strongest claim available.
+    for (held, at_recipient) in izip!(tracked, &at_recipient) {
+        if *at_recipient < held.balance {
+            return Err(MigrationRefusal::RecipientBalanceMismatch {
+                vault,
+                receipt_id: held.receipt_id,
+                tracked: held.balance,
+                at_recipient: *at_recipient,
+            });
+        }
+    }
+
+    Ok(SourceCustody::AlreadyMigrated { receipts: tracked.len() })
+}
+
+/// Moves one vault's receipts to the incoming wallet.
+///
+/// Re-reads the transfer permission immediately before submitting, because
+/// certification is maintained outside this service and can lapse between an
+/// earlier preflight and the transaction landing.
+pub(crate) async fn migrate_vault_custody(
+    custody: &(impl ReceiptCustody + Sync),
+    holdings: &MigratableHoldings,
+    recipient: Address,
+) -> Result<MigrationOutcome, MigrationRefusal> {
+    let vault = holdings.vault();
+
+    let permit = match custody
+        .transfer_permission(vault, holdings.holder(), recipient)
+        .await?
+    {
+        TransferPermission::Permitted(permit) => permit,
+        TransferPermission::CertificationExpired => {
+            return Err(MigrationRefusal::CertificationExpired { vault });
+        }
+        TransferPermission::OwnerFrozen { until } => {
+            return Err(MigrationRefusal::OwnerFrozen {
+                vault,
+                from: holdings.holder(),
+                to: recipient,
+                until,
+            });
+        }
+    };
+
+    // Captured before the transfer so the post-condition measures what this
+    // transfer delivered, not the recipient's absolute balance — which would
+    // wrongly pass if the recipient already held some of these identifiers.
+    let receipt_ids = holdings.receipt_ids();
+    let recipient_before =
+        custody.held_balances(vault, recipient, &receipt_ids).await?;
+
+    // Checked before submitting: a truncated response here would otherwise
+    // only surface in `verify_custody_moved`, after the irreversible
+    // transfer has already gone out.
+    if recipient_before.len() != receipt_ids.len() {
+        return Err(MigrationRefusal::BalanceCountMismatch {
+            vault,
+            requested: receipt_ids.len(),
+            returned: recipient_before.len(),
+        });
+    }
+
+    let expected = holdings.total()?;
+    let transaction = custody.transfer_custody(&permit, holdings).await?;
+
+    verify_custody_moved(
+        custody,
+        holdings,
+        recipient,
+        &recipient_before,
+        expected,
+        transaction,
+    )
+    .await?;
+
+    let receipts = holdings.holdings().len();
+    info!(
+        target: "receipt_inventory",
+        chain_id = holdings.chain_id(),
+        %vault,
+        %transaction,
+        receipts,
+        holder = %holdings.holder(),
+        %recipient,
+        "Migrated receipt custody"
+    );
+
+    Ok(MigrationOutcome::Migrated { transaction, receipts })
+}
+
+/// Re-reads both sides after the transfer and refuses to report success unless
+/// every identifier actually moved.
+///
+/// Checked per identifier rather than on the totals alone: equal totals can
+/// hide two receipts swapping balances, which would leave the inventory
+/// describing custody that does not exist. The recipient side is checked as a
+/// delta against `recipient_before` so a pre-existing balance neither masks a
+/// failed transfer nor is mistaken for one this migration delivered.
+async fn verify_custody_moved(
+    custody: &(impl ReceiptCustody + Sync),
+    holdings: &MigratableHoldings,
+    recipient: Address,
+    recipient_before: &[Shares],
+    expected: Shares,
+    transaction: B256,
+) -> Result<(), MigrationRefusal> {
+    let vault = holdings.vault();
+    let receipt_ids = holdings.receipt_ids();
+
+    let source =
+        custody.held_balances(vault, holdings.holder(), &receipt_ids).await?;
+    let destination =
+        custody.held_balances(vault, recipient, &receipt_ids).await?;
+
+    // `izip!` stops at the shortest input, so a truncated balance response
+    // would silently verify fewer identifiers than were transferred.
+    let expected_len = holdings.holdings().len();
+    if source.len() != expected_len
+        || destination.len() != expected_len
+        || recipient_before.len() != expected_len
+    {
+        return Err(MigrationRefusal::BalanceCountMismatch {
+            vault,
+            requested: expected_len,
+            returned: source
+                .len()
+                .min(destination.len())
+                .min(recipient_before.len()),
+        });
+    }
+
+    let (moved, gains) =
+        izip!(holdings.holdings(), &source, &destination, recipient_before)
+            .try_fold(
+                (true, Vec::with_capacity(expected_len)),
+                |(moved, mut gains), (held, retained, after, before)| {
+                    // A recipient balance that went *down* over a transfer meant to
+                    // increase it is a corrupt observation, not a zero gain. Capping it
+                    // would hide the anomaly, which the financial-integrity rule in
+                    // AGENTS.md forbids.
+                    let gained = after.checked_sub(*before).ok_or(
+                        RecipientBalanceDecrease {
+                            vault,
+                            tx_hash: transaction,
+                            receipt_id: held.receipt_id,
+                            before: *before,
+                            after: *after,
+                        },
+                    )?;
+                    gains.push(gained);
+                    Ok::<_, ReceiptCustodyError>((
+                        moved && retained.is_zero() && gained == held.balance,
+                        gains,
+                    ))
+                },
+            )?;
+
+    let source_retained = total_of(source.iter().copied())?;
+    let recipient_gained = total_of(gains.iter().copied())?;
+
+    if !moved || !source_retained.is_zero() || recipient_gained != expected {
+        return Err(ReceiptCustodyError::from(PostConditionFailure {
+            vault,
+            tx_hash: transaction,
+            source_retained,
+            recipient_gained,
+            expected,
+        })
+        .into());
+    }
+
+    Ok(())
+}
+
+/// Rejects a permit that does not authorise exactly these holdings.
+///
+/// A permit names a vault and a sender. Holdings for a different vault, or
+/// belonging to a different wallet, were never the subject of the vault's
+/// authorisation check, so submitting them would move custody the vault never
+/// approved. Free-standing rather than inline so the guard is exercisable
+/// without a chain.
+fn ensure_permit_covers(
+    permit: &TransferPermit,
+    holdings: &MigratableHoldings,
+) -> Result<(), ReceiptCustodyError> {
+    if permit.vault() != holdings.vault() {
+        return Err(ReceiptCustodyError::WrongVault {
+            expected: permit.vault(),
+            requested: holdings.vault(),
+        });
+    }
+
+    if permit.from() != holdings.holder() {
+        return Err(ReceiptCustodyError::PermitHolderMismatch {
+            permitted: permit.from(),
+            holdings: holdings.holder(),
+        });
+    }
+
+    Ok(())
+}
+
+fn total_of(
+    balances: impl IntoIterator<Item = Shares>,
+) -> Result<Shares, SharesOverflow> {
+    balances
+        .into_iter()
+        .try_fold(Shares::ZERO, |running, balance| running + balance)
+}
+
+/// [`ReceiptCustody`] against a live chain.
+///
+/// The provider must be signing as the outgoing wallet for
+/// [`ReceiptCustody::transfer_custody`] to succeed, since ERC-1155 only lets
+/// the holder or an approved operator move a balance.
+pub(crate) struct OnchainReceiptCustody<P> {
+    provider: P,
+    vault: Address,
+    receipt_contract: Address,
+}
+
+impl<P: Provider + Clone> OnchainReceiptCustody<P> {
+    pub(crate) const fn new(
+        provider: P,
+        vault: Address,
+        receipt_contract: Address,
+    ) -> Self {
+        Self { provider, vault, receipt_contract }
+    }
+
+    /// Resolves the vault's Receipt contract from the vault itself, so the
+    /// caller never has to carry an address that could drift out of step with
+    /// the vault it belongs to.
+    pub(crate) async fn resolve(
+        provider: P,
+        vault: Address,
+    ) -> Result<Self, ReceiptCustodyError> {
+        let receipt_contract = OffchainAssetReceiptVault::new(vault, &provider)
+            .receipt()
+            .call()
+            .await?;
+
+        Ok(Self::new(provider, vault, receipt_contract))
+    }
+
+    /// Rejects a vault other than the one this instance resolved its Receipt
+    /// contract from. Without it the `vault` argument would be silently
+    /// ignored and balances would be read from the wrong contract.
+    fn check_vault(&self, vault: Address) -> Result<(), ReceiptCustodyError> {
+        if vault != self.vault {
+            return Err(ReceiptCustodyError::WrongVault {
+                expected: self.vault,
+                requested: vault,
+            });
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<P: Provider + Clone + Send + Sync> ReceiptCustody
+    for OnchainReceiptCustody<P>
+{
+    async fn held_balances(
+        &self,
+        vault: Address,
+        holder: Address,
+        receipt_ids: &[ReceiptId],
+    ) -> Result<Vec<Shares>, ReceiptCustodyError> {
+        self.check_vault(vault)?;
+
+        let receipt = Receipt::new(self.receipt_contract, &self.provider);
+        let ids: Vec<U256> = receipt_ids.iter().map(ReceiptId::inner).collect();
+        let holders = vec![holder; ids.len()];
+
+        let balances = receipt.balanceOfBatch(holders, ids).call().await?;
+
+        Ok(balances.into_iter().map(Shares::from).collect())
+    }
+
+    async fn transfer_permission(
+        &self,
+        vault: Address,
+        from: Address,
+        to: Address,
+    ) -> Result<TransferPermission, ReceiptCustodyError> {
+        self.check_vault(vault)?;
+
+        let contract = OffchainAssetReceiptVault::new(vault, &self.provider);
+
+        if contract.isCertificationExpired().call().await? {
+            return Ok(TransferPermission::CertificationExpired);
+        }
+
+        // Mirrors `ownerFreezeCheckTransaction`, which reverts only when the
+        // freeze is live AND neither side is on an always-allowed list.
+        let frozen_until = contract.ownerFrozenUntil().call().await?;
+        let latest = self
+            .provider
+            .get_block(BlockId::latest())
+            .await?
+            .ok_or(ReceiptCustodyError::NoLatestBlock)?;
+        let now = U256::from(latest.header.timestamp);
+
+        if now <= frozen_until {
+            let allowed_from =
+                contract.ownerFreezeAlwaysAllowedFrom(from).call().await?;
+            let allowed_to =
+                contract.ownerFreezeAlwaysAllowedTo(to).call().await?;
+
+            // The always-allowed values are timestamps, not flags: an entry
+            // exempts its side only while `now` is within it, exactly as the
+            // vault's `ownerFreezeCheckTransaction` evaluates them. A stale
+            // (expired) entry is no exemption at all, so treating any
+            // non-zero value as exempt would report `Permitted` for a pair
+            // the transfer would revert on.
+            if allowed_from < now && allowed_to < now {
+                return Ok(TransferPermission::OwnerFrozen {
+                    until: frozen_until,
+                });
+            }
+        }
+
+        Ok(TransferPermission::Permitted(TransferPermit::granted(
+            vault, from, to,
+        )))
+    }
+
+    async fn transfer_custody(
+        &self,
+        permit: &TransferPermit,
+        holdings: &MigratableHoldings,
+    ) -> Result<B256, ReceiptCustodyError> {
+        self.check_vault(permit.vault())?;
+        ensure_permit_covers(permit, holdings)?;
+
+        let receipt = Receipt::new(self.receipt_contract, &self.provider);
+        let (ids, amounts) = holdings.batch_arguments();
+
+        let pending = receipt
+            .safeBatchTransferFrom(
+                permit.from(),
+                permit.to(),
+                ids,
+                amounts,
+                Bytes::new(),
+            )
+            .send()
+            .await?;
+
+        // Without a deadline a stalled or underpriced transfer leaves the
+        // operator's terminal blocked indefinitely with custody already
+        // submitted. 120s matches the vault flow's mint and burn watches
+        // (`crate::vault::service`); on timeout the error carries the hash so
+        // the transfer can be reconciled or re-run.
+        let confirmed = pending
+            .with_timeout(Some(Duration::from_secs(120)))
+            .get_receipt()
+            .await?;
+        let tx_hash = confirmed.transaction_hash;
+
+        // A mined-but-reverted transfer moved nothing, so it is a definitive
+        // failure rather than a hash to report as success.
+        if !confirmed.status() {
+            return Err(ReceiptCustodyError::Reverted {
+                vault: permit.vault(),
+                tx_hash,
+            });
+        }
+
+        Ok(tx_hash)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::address;
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::test_utils::logs_contain_at;
+
+    const VAULT: Address = address!("00000000000000000000000000000000000000aa");
+    const OUTGOING: Address =
+        address!("00000000000000000000000000000000000000bb");
+    const INCOMING: Address =
+        address!("00000000000000000000000000000000000000cc");
+    const CHAIN_ID: u64 = 8453;
+
+    /// Fake custody that actually moves balances on transfer, so the
+    /// post-condition assertions in `migrate_vault_custody` are exercised
+    /// rather than trivially satisfied.
+    struct FakeCustody {
+        balances: Mutex<HashMap<(Address, ReceiptId), Shares>>,
+        permission: Permission,
+        transfers: Mutex<Vec<(Address, usize)>>,
+        settle_transfer: bool,
+        /// Return one fewer balance than asked for, but only when querying this
+        /// holder, so a test can truncate the source and recipient reads
+        /// independently.
+        truncate_for: Option<Address>,
+        /// Credit the recipient with the balances rotated across identifiers.
+        /// The totals still match; only the per-identifier mapping is wrong.
+        swap_on_settle: bool,
+        /// Leave the recipient holding less than it did before the transfer,
+        /// modelling a corrupt or reorganised observation.
+        shrink_recipient_on_settle: bool,
+    }
+
+    /// The fake's scripted permission, kept separate from
+    /// [`TransferPermission`] because a permit may only be minted by the code
+    /// under test.
+    #[derive(Clone, PartialEq, Eq)]
+    enum Permission {
+        Permitted,
+        CertificationExpired,
+        OwnerFrozen { until: U256 },
+    }
+
+    impl FakeCustody {
+        fn holding(receipt_id: u64, balance: u64) -> ReceiptHolding {
+            ReceiptHolding {
+                receipt_id: ReceiptId::from(U256::from(receipt_id)),
+                balance: Shares::new(U256::from(balance)),
+            }
+        }
+
+        fn with_balances(held: &[(Address, u64, u64)]) -> Self {
+            let balances = held
+                .iter()
+                .map(|(holder, receipt_id, balance)| {
+                    (
+                        (*holder, ReceiptId::from(U256::from(*receipt_id))),
+                        Shares::new(U256::from(*balance)),
+                    )
+                })
+                .collect();
+
+            Self {
+                balances: Mutex::new(balances),
+                permission: Permission::Permitted,
+                transfers: Mutex::new(Vec::new()),
+                settle_transfer: true,
+                truncate_for: None,
+                swap_on_settle: false,
+                shrink_recipient_on_settle: false,
+            }
+        }
+
+        fn at_source(held: &[(u64, u64)]) -> Self {
+            let owned: Vec<(Address, u64, u64)> = held
+                .iter()
+                .map(|(receipt_id, balance)| (OUTGOING, *receipt_id, *balance))
+                .collect();
+            Self::with_balances(&owned)
+        }
+
+        fn refusing(permission: Permission) -> Self {
+            Self { permission, ..Self::at_source(&[(1, 100)]) }
+        }
+
+        fn transfer_count(&self) -> usize {
+            self.transfers.lock().expect("transfers lock").len()
+        }
+    }
+
+    #[async_trait]
+    impl ReceiptCustody for FakeCustody {
+        async fn held_balances(
+            &self,
+            _vault: Address,
+            holder: Address,
+            receipt_ids: &[ReceiptId],
+        ) -> Result<Vec<Shares>, ReceiptCustodyError> {
+            let balances = self.balances.lock().expect("balances lock");
+
+            let mut found: Vec<Shares> = receipt_ids
+                .iter()
+                .map(|receipt_id| {
+                    balances
+                        .get(&(holder, *receipt_id))
+                        .copied()
+                        .unwrap_or(Shares::ZERO)
+                })
+                .collect();
+
+            if self.truncate_for == Some(holder) {
+                found.pop();
+            }
+
+            Ok(found)
+        }
+
+        async fn transfer_permission(
+            &self,
+            vault: Address,
+            from: Address,
+            to: Address,
+        ) -> Result<TransferPermission, ReceiptCustodyError> {
+            Ok(match self.permission {
+                Permission::Permitted => TransferPermission::Permitted(
+                    TransferPermit::granted(vault, from, to),
+                ),
+                Permission::CertificationExpired => {
+                    TransferPermission::CertificationExpired
+                }
+                Permission::OwnerFrozen { until } => {
+                    TransferPermission::OwnerFrozen { until }
+                }
+            })
+        }
+
+        async fn transfer_custody(
+            &self,
+            permit: &TransferPermit,
+            holdings: &MigratableHoldings,
+        ) -> Result<B256, ReceiptCustodyError> {
+            self.transfers
+                .lock()
+                .expect("transfers lock")
+                .push((permit.to(), holdings.holdings().len()));
+
+            if self.settle_transfer {
+                let mut balances = self.balances.lock().expect("balances lock");
+                let moved = holdings.holdings();
+
+                for (index, held) in moved.iter().enumerate() {
+                    balances
+                        .insert((permit.from(), held.receipt_id), Shares::ZERO);
+
+                    if self.shrink_recipient_on_settle {
+                        balances.insert(
+                            (permit.to(), held.receipt_id),
+                            Shares::ZERO,
+                        );
+                        continue;
+                    }
+
+                    // Rotating the amounts by one keeps the total identical
+                    // while putting each amount against the wrong identifier.
+                    let credited = if self.swap_on_settle {
+                        moved[(index + 1) % moved.len()].balance
+                    } else {
+                        held.balance
+                    };
+                    let existing = balances
+                        .get(&(permit.to(), held.receipt_id))
+                        .copied()
+                        .unwrap_or(Shares::ZERO);
+                    balances.insert(
+                        (permit.to(), held.receipt_id),
+                        (existing + credited).expect("no overflow"),
+                    );
+                }
+            }
+
+            Ok(B256::repeat_byte(7))
+        }
+    }
+
+    async fn reconcile(
+        custody: &FakeCustody,
+        tracked: &[ReceiptHolding],
+    ) -> Result<SourceCustody, MigrationRefusal> {
+        reconcile_holdings(
+            custody, CHAIN_ID, VAULT, OUTGOING, INCOMING, tracked,
+        )
+        .await
+    }
+
+    fn post_condition_failure(
+        refusal: &MigrationRefusal,
+    ) -> &PostConditionFailure {
+        match refusal {
+            MigrationRefusal::Custody(boxed) => match &**boxed {
+                ReceiptCustodyError::PostConditionFailed(failure) => failure,
+                other => {
+                    panic!("expected a post-condition failure, got {other:?}")
+                }
+            },
+            other => panic!("expected a custody error, got {other:?}"),
+        }
+    }
+
+    fn holdings_of(source: SourceCustody) -> MigratableHoldings {
+        match source {
+            SourceCustody::Holds(holdings) => holdings,
+            SourceCustody::AlreadyMigrated { .. } => {
+                panic!("expected the source to still hold its receipts")
+            }
+        }
+    }
+
+    #[test]
+    fn quiescence_accepts_an_idle_deployment() {
+        require_quiescent(VAULT, &[], 0, 0).unwrap();
+    }
+
+    #[test]
+    fn quiescence_refuses_while_a_burn_is_reserved() {
+        // In-flight redemptions can outlive any operational pause, so a
+        // reservation is exactly the race that would burn against custody we
+        // just moved.
+        let reserved = [ReceiptId::from(U256::from(1))];
+
+        let refusal = require_quiescent(VAULT, &reserved, 0, 0).unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::BurnReserved { vault, receipts }
+                    if vault == VAULT && receipts == 1
+            ),
+            "a reserved burn must halt the migration, got {refusal:?}"
+        );
+    }
+
+    /// A redemption between detection and terminal holds no reservation yet,
+    /// but resumes on restart and plans a burn against the new wallet while
+    /// the participant's money already moved. The gate must catch it even
+    /// though the reservation gate cannot.
+    #[test]
+    fn quiescence_refuses_while_a_redemption_is_in_flight() {
+        let refusal = require_quiescent(VAULT, &[], 2, 0).unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::RedemptionsInFlight { count: 2 }
+            ),
+            "in-flight redemptions must halt the migration, got {refusal:?}"
+        );
+    }
+
+    /// A non-terminal mint's recovery rebroadcasts a transaction signed by the
+    /// old wallet, depositing a fresh receipt at an address the migrated
+    /// deployment no longer watches.
+    #[test]
+    fn quiescence_refuses_while_a_mint_is_in_flight() {
+        let refusal = require_quiescent(VAULT, &[], 0, 1).unwrap_err();
+
+        assert!(
+            matches!(refusal, MigrationRefusal::MintsInFlight { count: 1 }),
+            "in-flight mints must halt the migration, got {refusal:?}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn reconcile_accepts_inventory_agreeing_with_chain() {
+        let custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        assert_eq!(holdings.holdings().len(), 2);
+        assert_eq!(holdings.vault(), VAULT);
+        assert_eq!(holdings.holder(), OUTGOING);
+        assert_eq!(holdings.chain_id(), CHAIN_ID);
+        assert_eq!(holdings.total().unwrap(), Shares::new(U256::from(350)));
+
+        let (ids, amounts) = holdings.batch_arguments();
+        assert_eq!(ids, vec![U256::from(1), U256::from(2)]);
+        assert_eq!(amounts, vec![U256::from(100), U256::from(250)]);
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Reconciled receipt holdings against the chain", "migratable=2"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconcile_refuses_when_chain_disagrees_with_inventory() {
+        let custody = FakeCustody::at_source(&[(1, 40)]);
+        let tracked = [FakeCustody::holding(1, 100)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::InventoryDivergence {
+                    tracked, onchain, ..
+                } if tracked == Shares::new(U256::from(100))
+                    && onchain == Shares::new(U256::from(40))
+            ),
+            "divergence must halt the migration, got {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_refuses_a_short_balance_response() {
+        let mut custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        custody.truncate_for = Some(OUTGOING);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::BalanceCountMismatch {
+                    requested, returned, ..
+                } if requested == 2 && returned == 1
+            ),
+            "a short balance response must not be silently zero-padded, got \
+             {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reconcile_drops_receipts_the_wallet_no_longer_holds() {
+        let custody = FakeCustody::at_source(&[(1, 100), (2, 0)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 0)];
+
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        assert_eq!(
+            holdings.holdings().len(),
+            1,
+            "a zero balance is nothing to move and must not enter the batch"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn migrate_moves_every_receipt_and_verifies_post_conditions() {
+        let custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let outcome =
+            migrate_vault_custody(&custody, &holdings, INCOMING).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                transaction: B256::repeat_byte(7),
+                receipts: 2
+            }
+        );
+        assert_eq!(
+            custody.transfers.lock().unwrap().as_slice(),
+            [(INCOMING, 2)]
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Migrated receipt custody", "receipts=2"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn migrate_measures_the_recipients_gain_not_its_balance() {
+        // The recipient already holds receipt 1. A post-condition comparing the
+        // absolute balance would accept a transfer that never moved anything.
+        let custody = FakeCustody::with_balances(&[
+            (OUTGOING, 1, 100),
+            (INCOMING, 1, 100),
+        ]);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let outcome =
+            migrate_vault_custody(&custody, &holdings, INCOMING).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                transaction: B256::repeat_byte(7),
+                receipts: 1
+            },
+            "the recipient's pre-existing balance must not mask the transfer"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn rerunning_a_completed_migration_is_a_no_op() {
+        let custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        migrate_vault_custody(&custody, &holdings, INCOMING).await.unwrap();
+
+        // The inventory is unchanged — it is keyed by vault, not by holder — so
+        // a re-run sees tracked balances the source no longer has.
+        let rerun = reconcile(&custody, &tracked).await.unwrap();
+
+        assert_eq!(
+            rerun,
+            SourceCustody::AlreadyMigrated { receipts: 2 },
+            "a completed migration must re-run as a no-op, not a divergence"
+        );
+        assert_eq!(
+            custody.transfer_count(),
+            1,
+            "the re-run must not submit a second transfer"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_refuses_while_certification_is_expired() {
+        let custody = FakeCustody::refusing(Permission::CertificationExpired);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::CertificationExpired { vault } if vault == VAULT
+            ),
+            "expired certification must halt before submitting, got {refusal:?}"
+        );
+        assert_eq!(
+            custody.transfer_count(),
+            0,
+            "no transaction may be submitted into a reverting gate"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_refuses_while_the_owner_freeze_blocks_the_pair() {
+        let custody = FakeCustody::refusing(Permission::OwnerFrozen {
+            until: U256::from(1_800_000_000_u64),
+        });
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::OwnerFrozen { from, to, .. }
+                    if from == OUTGOING && to == INCOMING
+            ),
+            "an owner freeze must halt before submitting, got {refusal:?}"
+        );
+        assert_eq!(custody.transfer_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn migrate_fails_closed_when_receipts_land_on_the_wrong_identifier() {
+        // The exact case per-identifier verification exists for: the recipient
+        // ends up with the right total but each amount against the wrong
+        // receipt. A totals-only check would call this a success.
+        let mut custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        custody.swap_on_settle = true;
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        let failure = post_condition_failure(&refusal);
+        assert_eq!(
+            failure.recipient_gained, failure.expected,
+            "the totals must match — this is exactly the case per-identifier \
+             verification exists to catch"
+        );
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::Custody(ref boxed)
+                    if matches!(**boxed,
+                        ReceiptCustodyError::PostConditionFailed(_))
+            ),
+            "matching totals must not rescue a per-identifier mismatch, got \
+             {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_migration_to_a_recipient_holding_a_balance_still_reruns_cleanly()
+    {
+        // The forward path allows a recipient that already holds some of these
+        // identifiers. If the already-migrated check demanded the recipient
+        // hold *exactly* the tracked amount, that migration could never be
+        // re-run: the recipient would hold pre-existing + migrated.
+        let custody = FakeCustody::with_balances(&[
+            (OUTGOING, 1, 100),
+            (INCOMING, 1, 70),
+        ]);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        migrate_vault_custody(&custody, &holdings, INCOMING).await.unwrap();
+
+        let rerun = reconcile(&custody, &tracked).await.unwrap();
+
+        assert_eq!(
+            rerun,
+            SourceCustody::AlreadyMigrated { receipts: 1 },
+            "a completed migration must re-run as a no-op even when the \
+             recipient held a balance beforehand"
+        );
+        assert_eq!(custody.transfer_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn a_short_recipient_response_is_not_read_as_already_migrated() {
+        // Source empty, so the already-migrated path runs — but the recipient
+        // read comes back short. Zip-style iteration would silently compare
+        // fewer identifiers and declare the migration complete.
+        let mut custody = FakeCustody::with_balances(&[
+            (OUTGOING, 1, 0),
+            (OUTGOING, 2, 0),
+            (INCOMING, 1, 100),
+            (INCOMING, 2, 250),
+        ]);
+        custody.truncate_for = Some(INCOMING);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::BalanceCountMismatch {
+                    requested, returned, ..
+                } if requested == 2 && returned == 1
+            ),
+            "a short recipient response must halt, got {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_empty_source_reports_the_recipient_balance_it_queried() {
+        let custody =
+            FakeCustody::with_balances(&[(OUTGOING, 1, 0), (INCOMING, 1, 5)]);
+        let tracked = [FakeCustody::holding(1, 100)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::RecipientBalanceMismatch {
+                    tracked, at_recipient, ..
+                } if tracked == Shares::new(U256::from(100))
+                    && at_recipient == Shares::new(U256::from(5))
+            ),
+            "the refusal must name the recipient balance it actually read, \
+             got {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_permit_for_another_vault_cannot_move_these_holdings() {
+        let custody = FakeCustody::at_source(&[(1, 100)]);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        let other_vault = address!("00000000000000000000000000000000000000dd");
+        let permit = TransferPermit::granted(other_vault, OUTGOING, INCOMING);
+
+        let error = ensure_permit_covers(&permit, &holdings).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                ReceiptCustodyError::WrongVault { expected, requested }
+                    if expected == other_vault && requested == VAULT
+            ),
+            "a permit for another vault must not authorise this transfer, got \
+             {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_permit_for_another_sender_cannot_move_these_holdings() {
+        let custody = FakeCustody::at_source(&[(1, 100)]);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        let stranger = address!("00000000000000000000000000000000000000dd");
+        let permit = TransferPermit::granted(VAULT, stranger, INCOMING);
+
+        let error = ensure_permit_covers(&permit, &holdings).unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                ReceiptCustodyError::PermitHolderMismatch { permitted, holdings }
+                    if permitted == stranger && holdings == OUTGOING
+            ),
+            "a permit naming another sender must not authorise this transfer, \
+             got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_matching_permit_covers_its_holdings() {
+        let custody = FakeCustody::at_source(&[(1, 100)]);
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        let permit = TransferPermit::granted(VAULT, OUTGOING, INCOMING);
+
+        assert!(ensure_permit_covers(&permit, &holdings).is_ok());
+    }
+
+    #[tokio::test]
+    async fn a_recipient_balance_that_falls_is_reported_not_capped() {
+        // The recipient holds 70 before the transfer and 0 after. Capping the
+        // delta at zero would report a plain post-condition failure and hide
+        // that the observation itself is impossible.
+        let mut custody = FakeCustody::with_balances(&[
+            (OUTGOING, 1, 100),
+            (INCOMING, 1, 70),
+        ]);
+        custody.shrink_recipient_on_settle = true;
+        let tracked = [FakeCustody::holding(1, 100)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::Custody(ref boxed)
+                    if matches!(**boxed,
+                        ReceiptCustodyError::RecipientBalanceDecreased(ref decrease)
+                            if decrease.before == Shares::new(U256::from(70))
+                                && decrease.after == Shares::ZERO)
+            ),
+            "a falling recipient balance must be surfaced with the values \
+             observed, got {refusal:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn migrate_fails_closed_when_custody_does_not_actually_move() {
+        let mut custody = FakeCustody::at_source(&[(1, 100), (2, 250)]);
+        custody.settle_transfer = false;
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::Custody(ref boxed)
+                    if matches!(**boxed,
+                        ReceiptCustodyError::PostConditionFailed(_))
+            ),
+            "a transaction that did not move custody must not report success, \
+             got {refusal:?}"
+        );
+    }
+
+    /// An ERC-1155 transfer to a wrong address is final: no counterparty, no
+    /// recovery, and the receipts back tokens that are still outstanding. These
+    /// cover the last gate before the transfer, the only one that consults
+    /// something other than what the operator typed.
+    mod recipient_corroboration {
+        use alloy::providers::ProviderBuilder;
+
+        use super::*;
+        use crate::test_utils::LocalEvm;
+
+        #[tokio::test]
+        async fn an_address_the_chain_has_never_seen_is_refused() {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+            let typo = Address::random();
+            let error = CorroboratedRecipient::verify(&provider, typo)
+                .await
+                .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(MigrationRefusal::RecipientUnknownToChain {
+                        recipient,
+                        ..
+                    }) if *recipient == typo
+                ),
+                "an unfunded, never-used address is what a typo looks like and \
+                 must not be accepted, got: {error:?}"
+            );
+        }
+
+        #[tokio::test]
+        async fn the_zero_address_is_refused() {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+            let error = CorroboratedRecipient::verify(&provider, Address::ZERO)
+                .await
+                .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(MigrationRefusal::RecipientIsZeroAddress { .. })
+                ),
+                "got: {error:?}"
+            );
+        }
+
+        /// The legitimate destination in both directions clears the gate: the
+        /// incoming wallet must be funded for gas before it can run the
+        /// service, and the wallet a rollback returns custody to has been
+        /// signing all along.
+        #[tokio::test]
+        async fn a_funded_wallet_is_corroborated() {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+            let corroborated =
+                CorroboratedRecipient::verify(&provider, evm.wallet_address)
+                    .await
+                    .unwrap();
+
+            assert_eq!(corroborated.address(), evm.wallet_address);
+        }
+    }
+}

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod backfill;
 pub(crate) mod burn_tracking;
 mod cmd;
 mod event;
+pub mod migration;
 pub(crate) mod reconcile;
 mod vault_key;
 pub(crate) mod view;
@@ -632,6 +633,20 @@ pub(crate) struct ReceiptInventory {
 }
 
 impl ReceiptInventory {
+    /// Receipts with shares reserved against an in-flight redemption burn.
+    ///
+    /// Freezing an underlying rejects new mints but lets in-flight redemptions
+    /// complete, so a freeze alone does not prove the wallet is quiescent. Any
+    /// reservation means a burn may still land against these receipts, which is
+    /// what makes moving their custody unsafe.
+    pub(crate) fn reserved_receipts(&self) -> Vec<ReceiptId> {
+        self.receipts
+            .iter()
+            .filter(|(_, metadata)| !metadata.reserved_total().is_zero())
+            .map(|(receipt_id, _)| *receipt_id)
+            .collect()
+    }
+
     pub(crate) fn receipts_with_balance(&self) -> Vec<ReceiptWithBalance> {
         self.receipts
             .iter()
@@ -1429,6 +1444,63 @@ mod tests {
             receipts[0].receipt_info,
             Some(receipt_info),
             "receipt_info should be preserved through command -> event -> state"
+        );
+    }
+
+    /// `reserved_receipts` is the receipt-custody migration's guard against
+    /// moving receipts out from under an in-flight redemption burn, so it has
+    /// to name exactly the reserved ones and nothing else.
+    #[tokio::test]
+    async fn reserved_receipts_names_only_receipts_with_a_live_reservation() {
+        let store = setup_store().await;
+        let vault = address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let key = ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault);
+        let reserved_id = ReceiptId::from(U256::from(1));
+        let untouched_id = ReceiptId::from(U256::from(2));
+        let balance = Shares::new(U256::from(100));
+
+        for receipt_id in [reserved_id, untouched_id] {
+            store
+                .send(
+                    &key,
+                    discover_receipt_cmd(
+                        receipt_id,
+                        balance,
+                        1,
+                        TxHash::repeat_byte(9),
+                    ),
+                )
+                .await
+                .unwrap();
+        }
+
+        let idle =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
+        assert!(
+            idle.reserved_receipts().is_empty(),
+            "an idle vault has nothing reserved, so a migration may proceed"
+        );
+
+        store
+            .send(
+                &key,
+                ReceiptInventoryCommand::ReserveBurn {
+                    redemption_issuer_request_id: planning_redemption(),
+                    burns: vec![BurnRecord {
+                        receipt_id: reserved_id.inner(),
+                        shares_burned: U256::from(40),
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+
+        let reserved =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
+        assert_eq!(
+            reserved.reserved_receipts(),
+            vec![reserved_id],
+            "only the receipt with an in-flight burn may block the migration"
         );
     }
 

--- a/src/redemption/view.rs
+++ b/src/redemption/view.rs
@@ -119,6 +119,23 @@ pub(crate) enum RedemptionView {
 }
 
 impl RedemptionView {
+    /// The asset this redemption is for, when the state still carries it.
+    ///
+    /// `Failed` (and the other terminal shapes) drop the asset; callers that
+    /// need it there must recover it from the aggregate's `Detected` event.
+    pub(crate) const fn underlying(&self) -> Option<&UnderlyingSymbol> {
+        match self {
+            Self::Detected { underlying, .. }
+            | Self::AlpacaCalled { underlying, .. }
+            | Self::Burning { underlying, .. }
+            | Self::BurnFailed { underlying, .. } => Some(underlying),
+            Self::Unavailable
+            | Self::Completed { .. }
+            | Self::Failed { .. }
+            | Self::Closed { .. } => None,
+        }
+    }
+
     fn update_alpaca_called(
         self,
         issuer_request_id: IssuerRedemptionRequestId,

--- a/tests/turnkey_cutover.rs
+++ b/tests/turnkey_cutover.rs
@@ -1,0 +1,881 @@
+#![allow(clippy::unwrap_used)]
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::Provider;
+use alloy::providers::ext::AnvilApi;
+use alloy::signers::local::PrivateKeySigner;
+use alloy::sol_types::SolEvent;
+use httpmock::Mock;
+use httpmock::prelude::*;
+use rocket::local::asynchronous::Client;
+use sqlx::sqlite::SqlitePoolOptions;
+use st0x_issuance::bindings::OffchainAssetReceiptVault::{
+    self, OffchainAssetReceiptVaultInstance,
+};
+use st0x_issuance::bindings::Receipt::ReceiptInstance;
+use st0x_issuance::receipt_inventory::migration::{
+    CorroboratedRecipient, MigrationOutcome, VaultIdentity,
+    migrate_vault_receipts,
+};
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::underlying::UnderlyingSymbol;
+use st0x_issuance::{Config, SignerConfig, initialize_rocket};
+use std::path::{Path, PathBuf};
+
+use crate::harness::create_provider;
+
+/// The single asset every cutover scenario seeds and migrates. The migration
+/// identity must name the seeded listing: quiescence is scoped by underlying,
+/// so a mismatched symbol resolves against an asset absent from the database
+/// and gates nothing.
+const CUTOVER_UNDERLYING: &str = "AAPL";
+const CUTOVER_TOKEN: &str = "tAAPL";
+
+struct CutoverDatabases {
+    fireblocks_url: String,
+    turnkey_path: PathBuf,
+    turnkey_url: String,
+}
+
+struct PreCutoverMint {
+    client_id: String,
+    shares: U256,
+}
+
+impl CutoverDatabases {
+    fn in_directory(directory: &Path) -> Self {
+        let fireblocks_path = directory.join("fireblocks-cutover-source.db");
+        let turnkey_path = directory.join("turnkey-cutover.db");
+
+        Self {
+            fireblocks_url: format!(
+                "sqlite:{}?mode=rwc",
+                fireblocks_path.display()
+            ),
+            turnkey_url: format!("sqlite:{}?mode=rwc", turnkey_path.display()),
+            turnkey_path,
+        }
+    }
+}
+
+/// Waits until the running service has recorded the vault's receipt inventory.
+///
+/// The migration refuses outright on an empty inventory, so without this the
+/// test would race the backfiller and fail for a reason unrelated to what it is
+/// proving.
+async fn wait_for_receipt_in_inventory(
+    database_url: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(database_url)
+        .await?;
+
+    for _ in 0..100 {
+        // Deliberately not filtered by aggregate id: reproducing the
+        // `{chain_id}:{vault}` key here would couple this wait to an encoding
+        // that has already been re-keyed once by migration. This scenario uses
+        // a single vault, so the aggregate type alone is an unambiguous signal.
+        let recorded: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'ReceiptInventory'
+            ",
+        )
+        .fetch_one(&pool)
+        .await?;
+
+        if recorded > 0 {
+            pool.close().await;
+            return Ok(());
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    pool.close().await;
+    Err("no receipt ever entered the inventory".into())
+}
+
+async fn snapshot_database(
+    source_database_url: &str,
+    destination_path: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(source_database_url)
+        .await?;
+
+    sqlx::query("VACUUM INTO ?")
+        .bind(destination_path.to_string_lossy().as_ref())
+        .execute(&pool)
+        .await?;
+    pool.close().await;
+
+    Ok(())
+}
+
+async fn mint_before_cutover(
+    client: &Client,
+    evm: &LocalEvm,
+    user_signer: &PrivateKeySigner,
+    user_wallet: Address,
+    mint_callback_mock: &Mock<'_>,
+) -> Result<PreCutoverMint, Box<dyn std::error::Error>> {
+    let account = harness::setup_account(client, user_wallet).await;
+    harness::perform_mint_and_confirm(
+        client,
+        user_wallet,
+        &account.client_id.to_string(),
+        "turnkey-cutover-mint",
+        "50.0",
+    )
+    .await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer.clone()))
+        .connect(&evm.endpoint)
+        .await?;
+    let user_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let minted_shares =
+        harness::wait_for_shares(&user_vault, user_wallet).await?;
+    harness::wait_for_mock_hits(mint_callback_mock, 1).await?;
+
+    Ok(PreCutoverMint {
+        client_id: account.client_id.to_string(),
+        shares: minted_shares,
+    })
+}
+
+async fn mint_after_cutover(
+    client: &Client,
+    user_wallet: Address,
+    client_id: &str,
+    mint_callback_mock: &Mock<'_>,
+) -> Result<U256, Box<dyn std::error::Error>> {
+    harness::perform_mint_and_confirm(
+        client,
+        user_wallet,
+        client_id,
+        "turnkey-cutover-canary",
+        "25.0",
+    )
+    .await?;
+    harness::wait_for_mock_hits(mint_callback_mock, 2).await?;
+
+    Ok(U256::from(25) * U256::from(10).pow(U256::from(18)))
+}
+
+struct PostCutoverCanaries<'context, 'server> {
+    client: &'context Client,
+    evm: &'context LocalEvm,
+    user_signer: &'context PrivateKeySigner,
+    user_wallet: Address,
+    turnkey_wallet: Address,
+    pre_cutover_mint: &'context PreCutoverMint,
+    mint_callback_mock: &'context Mock<'server>,
+    redeem_mock: &'context Mock<'server>,
+    poll_mock: &'context Mock<'server>,
+}
+
+impl PostCutoverCanaries<'_, '_> {
+    async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
+        let user_provider = create_provider()
+            .wallet(EthereumWallet::from(self.user_signer.clone()))
+            .connect(&self.evm.endpoint)
+            .await?;
+        let user_vault = OffchainAssetReceiptVaultInstance::new(
+            self.evm.vault_address,
+            &user_provider,
+        );
+        let canary_shares = mint_after_cutover(
+            self.client,
+            self.user_wallet,
+            &self.pre_cutover_mint.client_id,
+            self.mint_callback_mock,
+        )
+        .await?;
+        assert_eq!(
+            user_vault.balanceOf(self.user_wallet).call().await?,
+            self.pre_cutover_mint.shares + canary_shares,
+            "the new wallet must complete exactly one canary mint"
+        );
+
+        user_vault
+            .transfer(self.turnkey_wallet, self.pre_cutover_mint.shares)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        harness::wait_for_mock_hits(self.redeem_mock, 1).await?;
+        harness::wait_for_mock_hit(self.poll_mock).await?;
+        harness::wait_for_burn(&user_vault, self.turnkey_wallet).await?;
+        assert_eq!(
+            user_vault.balanceOf(self.user_wallet).call().await?,
+            canary_shares,
+            "only the post-cutover canary shares must remain after redemption"
+        );
+
+        Ok(())
+    }
+}
+
+/// Migrates custody against the outgoing service's database — driving the
+/// migration engine the operator's tooling runs, exercised as an operator
+/// would.
+///
+/// Note what this does and does not cover. The database snapshot handed to the
+/// replacement service is taken *before* this runs, so the migration here acts
+/// on the retiring store. That is deliberate and mirrors production: the
+/// outgoing service is already stopped (see the module-level requirement in
+/// `src/receipt_inventory/migration.rs`), and the quiescence gate checks real
+/// persisted state — reservations and in-flight work — not service liveness.
+///
+/// The migration is run twice: the second run stands in for the operator losing
+/// the terminal between the transaction confirming and success being recorded,
+/// and must be a no-op rather than a second transfer or a divergence failure.
+async fn run_operator_migration(
+    database_url: &str,
+    provider: &impl Provider,
+    chain_id: u64,
+    vault: Address,
+    outgoing: Address,
+    incoming: Address,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let underlying = UnderlyingSymbol::new("AAPL")?;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(database_url)
+        .await?;
+
+    let identity = VaultIdentity { chain_id, vault, underlying: &underlying };
+    let recipient = CorroboratedRecipient::verify(&provider, incoming).await?;
+
+    let outcome =
+        migrate_vault_receipts(&pool, provider, identity, outgoing, recipient)
+            .await?;
+    assert!(
+        matches!(outcome, MigrationOutcome::Migrated { receipts, .. } if receipts > 0),
+        "the migration must report moving receipts, got {outcome:?}"
+    );
+
+    let rerun =
+        migrate_vault_receipts(&pool, provider, identity, outgoing, recipient)
+            .await?;
+    assert!(
+        matches!(rerun, MigrationOutcome::AlreadyMigrated { receipts } if receipts > 0),
+        "re-running a completed migration must be a no-op, got {rerun:?}"
+    );
+
+    pool.close().await;
+
+    Ok(())
+}
+
+async fn start_service(
+    config: Config,
+) -> Result<Client, Box<dyn std::error::Error>> {
+    let rocket = initialize_rocket(config).await?;
+    Ok(Client::tracked(rocket).await?)
+}
+
+async fn assert_additional_chains_disabled(client: &Client) {
+    let response = client
+        .post("/tokenized-assets")
+        .header(rocket::http::ContentType::JSON)
+        .header(rocket::http::Header::new(
+            "X-API-KEY",
+            "test-key-12345678901234567890123456",
+        ))
+        .remote("127.0.0.1:8000".parse().unwrap())
+        .body(
+            serde_json::json!({
+                "underlying": "TSLA",
+                "token": "tTSLA",
+                "network": "ethereum",
+                "vault": Address::random()
+            })
+            .to_string(),
+        )
+        .dispatch()
+        .await;
+
+    assert_eq!(response.status(), rocket::http::Status::UnprocessableEntity);
+}
+
+async fn setup_cutover_roles(
+    evm: &LocalEvm,
+    user_wallet: Address,
+    fireblocks_wallet: Address,
+    turnkey_wallet: Address,
+) -> Result<(), Box<dyn std::error::Error>> {
+    evm.grant_deposit_role(user_wallet).await?;
+    evm.grant_deposit_role(turnkey_wallet).await?;
+    evm.grant_withdraw_role(fireblocks_wallet).await?;
+    evm.grant_withdraw_role(turnkey_wallet).await?;
+    evm.grant_certify_role(fireblocks_wallet).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    Ok(())
+}
+
+async fn single_deposit_for_owner(
+    provider: &impl Provider,
+    vault_address: Address,
+    owner: Address,
+) -> Result<(U256, U256, Bytes), Box<dyn std::error::Error>> {
+    let vault = OffchainAssetReceiptVaultInstance::new(vault_address, provider);
+    let deposit_logs =
+        provider.get_logs(&vault.Deposit_filter().from_block(0).filter).await?;
+    let deposits = deposit_logs
+        .iter()
+        .filter_map(|log| {
+            OffchainAssetReceiptVault::Deposit::decode_log(&log.inner).ok()
+        })
+        .filter(|deposit| deposit.owner == owner)
+        .collect::<Vec<_>>();
+
+    assert_eq!(deposits.len(), 1, "the wallet must own exactly one deposit");
+
+    Ok((
+        deposits[0].id,
+        deposits[0].shares,
+        deposits[0].receiptInformation.clone(),
+    ))
+}
+
+/// Proves the Base-only wallet-rotation sequence with multichain code present
+/// but additional chains disabled, driving the operator's real command: migrate
+/// receipt custody over a stopped, quiescent deployment.
+///
+/// The local signers model the old Fireblocks-controlled address and the new
+/// Turnkey-controlled address; the custodian's own credential and policy
+/// checks remain staging gates outside this test's scope. This scenario proves
+/// the application-owned custody, persistence, restart, checkpoint, and
+/// transaction-idempotency invariants.
+#[tokio::test]
+async fn test_wallet_cutover_redeems_pre_cutover_receipt_after_restart()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let fireblocks_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::random();
+    let user_wallet = user_signer.address();
+    let turnkey_signer = PrivateKeySigner::random();
+    let turnkey_private_key: B256 = turnkey_signer.to_bytes();
+    let turnkey_wallet = turnkey_signer.address();
+    assert_ne!(
+        fireblocks_wallet, turnkey_wallet,
+        "the cutover must model migration to a new Turnkey address"
+    );
+    let fireblocks_provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+    let test_gas_balance = U256::from(10) * U256::from(10).pow(U256::from(18));
+    fireblocks_provider
+        .anvil_set_balance(user_wallet, test_gas_balance)
+        .await?;
+    fireblocks_provider
+        .anvil_set_balance(turnkey_wallet, test_gas_balance)
+        .await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (redeem_mock, poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CutoverDatabases::in_directory(temp_dir.path());
+
+    harness::preseed_tokenized_asset(
+        &databases.fireblocks_url,
+        evm.vault_address,
+        CUTOVER_UNDERLYING,
+        CUTOVER_TOKEN,
+    )
+    .await?;
+
+    setup_cutover_roles(&evm, user_wallet, fireblocks_wallet, turnkey_wallet)
+        .await?;
+
+    let (fireblocks_config, _fireblocks_subgraph) =
+        harness::create_config_with_db(
+            &databases.fireblocks_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    let fireblocks_client = start_service(fireblocks_config).await?;
+
+    let pre_cutover_mint = mint_before_cutover(
+        &fireblocks_client,
+        &evm,
+        &user_signer,
+        user_wallet,
+        &mint_callback_mock,
+    )
+    .await?;
+
+    let fireblocks_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &fireblocks_provider,
+    );
+    let (minted_receipt_id, minted_receipt_shares, _) =
+        single_deposit_for_owner(
+            &fireblocks_provider,
+            evm.vault_address,
+            fireblocks_wallet,
+        )
+        .await?;
+
+    let receipt_contract_address =
+        fireblocks_vault.receipt().call().await?.0.into();
+    let fireblocks_receipt =
+        ReceiptInstance::new(receipt_contract_address, &fireblocks_provider);
+    assert_eq!(
+        fireblocks_receipt
+            .balanceOf(fireblocks_wallet, minted_receipt_id)
+            .call()
+            .await?,
+        minted_receipt_shares,
+        "the old wallet must custody the historical mint receipt before cutover"
+    );
+
+    fireblocks_client.terminate().await;
+    // Process exit kills the old service's detached workers in production. A
+    // consistent snapshot gives the replacement service the same persisted
+    // state without leaving those in-process test workers attached to its DB.
+    snapshot_database(&databases.fireblocks_url, &databases.turnkey_path)
+        .await?;
+
+    run_operator_migration(
+        &databases.fireblocks_url,
+        &fireblocks_provider,
+        evm.chain_id,
+        evm.vault_address,
+        fireblocks_wallet,
+        turnkey_wallet,
+    )
+    .await?;
+
+    assert_eq!(
+        fireblocks_receipt
+            .balanceOf(fireblocks_wallet, minted_receipt_id)
+            .call()
+            .await?,
+        U256::ZERO,
+        "the old wallet must not retain migrated receipt custody"
+    );
+    assert_eq!(
+        fireblocks_receipt
+            .balanceOf(turnkey_wallet, minted_receipt_id)
+            .call()
+            .await?,
+        minted_receipt_shares,
+        "the new wallet must receive the historical receipt before startup"
+    );
+
+    let (mut turnkey_config, _turnkey_subgraph) =
+        harness::create_config_with_db(
+            &databases.turnkey_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    turnkey_config.signer = SignerConfig::Local(turnkey_private_key);
+    let turnkey_client = start_service(turnkey_config).await?;
+    assert_additional_chains_disabled(&turnkey_client).await;
+
+    PostCutoverCanaries {
+        client: &turnkey_client,
+        evm: &evm,
+        user_signer: &user_signer,
+        user_wallet,
+        turnkey_wallet,
+        pre_cutover_mint: &pre_cutover_mint,
+        mint_callback_mock: &mint_callback_mock,
+        redeem_mock: &redeem_mock,
+        poll_mock: &poll_mock,
+    }
+    .run()
+    .await?;
+    assert_eq!(
+        fireblocks_receipt
+            .balanceOf(turnkey_wallet, minted_receipt_id)
+            .call()
+            .await?,
+        U256::ZERO,
+        "the historical receipt must be consumed by the new wallet"
+    );
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        2,
+        "restart plus one canary must produce exactly two mint callbacks"
+    );
+    assert_eq!(
+        redeem_mock.calls_async().await,
+        1,
+        "cutover must create exactly one redemption"
+    );
+
+    let _turnkey_canary_receipt = single_deposit_for_owner(
+        &fireblocks_provider,
+        evm.vault_address,
+        turnkey_wallet,
+    )
+    .await?;
+    let withdraw_logs = fireblocks_provider
+        .get_logs(&fireblocks_vault.Withdraw_filter().from_block(0).filter)
+        .await?;
+    let turnkey_withdrawals = withdraw_logs
+        .iter()
+        .filter_map(|log| {
+            OffchainAssetReceiptVault::Withdraw::decode_log(&log.inner).ok()
+        })
+        .filter(|withdrawal| withdrawal.owner == turnkey_wallet)
+        .count();
+
+    assert_eq!(
+        turnkey_withdrawals, 1,
+        "the new wallet must submit exactly one historical-receipt burn"
+    );
+    assert_eq!(
+        fireblocks_provider.get_transaction_count(turnkey_wallet).await?,
+        2,
+        "the new wallet must sign exactly one canary mint and one historical-receipt burn"
+    );
+
+    turnkey_client.terminate().await;
+
+    Ok(())
+}
+
+/// Proves receipt custody can be moved back after a completed migration, so an
+/// aborted cutover is recoverable.
+///
+/// This matters because the two directions are authorized by different systems:
+/// the outbound leg is signed by the retiring custodian, the inbound leg by the
+/// replacement. If the reverse were not permitted on-chain, an aborted cutover
+/// would strand custody with no way back. The vault's
+/// `authorizeReceiptTransfer3` requires no role in either direction, only live
+/// certification and no blocking owner freeze — this asserts that symmetry
+/// against a real vault rather than trusting the reading.
+///
+/// No migration-specific code is exercised in reverse: the same
+/// `migrate_vault_receipts` runs with the wallets swapped, which is the point.
+#[tokio::test]
+async fn test_receipt_custody_can_be_rolled_back_to_the_outgoing_wallet()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CutoverDatabases::in_directory(temp_dir.path());
+    let fireblocks_wallet = evm.wallet_address;
+    let turnkey_signer = PrivateKeySigner::random();
+    let turnkey_wallet = turnkey_signer.address();
+    assert_ne!(fireblocks_wallet, turnkey_wallet);
+
+    let fireblocks_provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+    let gas = U256::from(10) * U256::from(10).pow(U256::from(18));
+    fireblocks_provider.anvil_set_balance(turnkey_wallet, gas).await?;
+
+    harness::preseed_tokenized_asset(
+        &databases.fireblocks_url,
+        evm.vault_address,
+        CUTOVER_UNDERLYING,
+        CUTOVER_TOKEN,
+    )
+    .await?;
+    evm.grant_deposit_role(fireblocks_wallet).await?;
+    evm.grant_certify_role(fireblocks_wallet).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Run the service only long enough to discover the receipt into inventory,
+    // which the migration cross-checks against the chain.
+    let (config, _subgraph) = harness::create_config_with_db(
+        &databases.fireblocks_url,
+        &mock_alpaca,
+        &evm,
+    )?;
+    let client = start_service(config).await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &fireblocks_provider,
+    );
+    let receipt_shares = U256::from(40) * U256::from(10).pow(U256::from(18));
+    let share_ratio = U256::from(10).pow(U256::from(18));
+    let deposit = vault
+        .deposit(receipt_shares, fireblocks_wallet, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let receipt_id = deposit
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            OffchainAssetReceiptVault::Deposit::decode_log(&log.inner).ok()
+        })
+        .ok_or("deposit must emit a Deposit event")?
+        .id;
+    let receipt_contract: Address = vault.receipt().call().await?.0.into();
+    let receipt = ReceiptInstance::new(receipt_contract, &fireblocks_provider);
+    wait_for_receipt_in_inventory(&databases.fireblocks_url).await?;
+    client.terminate().await;
+
+    let underlying = UnderlyingSymbol::new("AAPL")?;
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(&databases.fireblocks_url)
+        .await?;
+
+    let identity = VaultIdentity {
+        chain_id: evm.chain_id,
+        vault: evm.vault_address,
+        underlying: &underlying,
+    };
+    let incoming =
+        CorroboratedRecipient::verify(&fireblocks_provider, turnkey_wallet)
+            .await?;
+    let forward = migrate_vault_receipts(
+        &pool,
+        &fireblocks_provider,
+        identity,
+        fireblocks_wallet,
+        incoming,
+    )
+    .await?;
+    assert!(
+        matches!(forward, MigrationOutcome::Migrated { receipts, .. } if receipts > 0),
+        "the forward migration must move receipts, got {forward:?}"
+    );
+    assert_eq!(
+        receipt.balanceOf(turnkey_wallet, receipt_id).call().await?,
+        receipt_shares,
+        "the incoming wallet must hold the receipt after the forward move"
+    );
+
+    // The rollback: same command, signer and recipient swapped.
+    let turnkey_provider = create_provider()
+        .wallet(EthereumWallet::from(turnkey_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let rollback_destination =
+        CorroboratedRecipient::verify(&turnkey_provider, fireblocks_wallet)
+            .await?;
+    let rolled_back = migrate_vault_receipts(
+        &pool,
+        &turnkey_provider,
+        identity,
+        turnkey_wallet,
+        rollback_destination,
+    )
+    .await?;
+
+    assert!(
+        matches!(rolled_back, MigrationOutcome::Migrated { receipts, .. } if receipts > 0),
+        "the rollback must move receipts back, got {rolled_back:?}"
+    );
+    assert_eq!(
+        receipt.balanceOf(fireblocks_wallet, receipt_id).call().await?,
+        receipt_shares,
+        "custody must return to the outgoing wallet after rollback"
+    );
+    assert_eq!(
+        receipt.balanceOf(turnkey_wallet, receipt_id).call().await?,
+        U256::ZERO,
+        "the incoming wallet must retain nothing after rollback"
+    );
+
+    pool.close().await;
+
+    Ok(())
+}
+
+/// Proves what the running service does when the custody step is skipped, which
+/// is the failure this whole cutover is sequenced to avoid.
+///
+/// The service is started against the un-migrated state and driven through the
+/// public path, rather than the burn being called directly: a direct call would
+/// only demonstrate that the vault reverts without a receipt, which is a
+/// property of the vault contract and not of this codebase.
+///
+/// What it pins down is worse than a revert. The redemption flow calls Alpaca
+/// before it burns, so the participant's shares are journaled back while the
+/// tokens remain outstanding and unbacked, and `BurnFailed` recovery will not
+/// auto-fail the redemption because the on-chain *share* balance is present —
+/// it is the *receipt* that is missing. Nothing here recovers on its own. The
+/// operator sequence, not the code, is what prevents this: pause the authorized
+/// participant's redemptions and stop the service for the window.
+#[tokio::test]
+async fn test_cutover_without_receipt_transfer_cannot_burn_historical_shares()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (redeem_mock, _poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CutoverDatabases::in_directory(temp_dir.path());
+    let fireblocks_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::random();
+    let user_wallet = user_signer.address();
+    let turnkey_signer = PrivateKeySigner::random();
+    let turnkey_wallet = turnkey_signer.address();
+    assert_ne!(fireblocks_wallet, turnkey_wallet);
+
+    let fireblocks_provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+    let test_gas_balance = U256::from(10) * U256::from(10).pow(U256::from(18));
+    fireblocks_provider
+        .anvil_set_balance(user_wallet, test_gas_balance)
+        .await?;
+    fireblocks_provider
+        .anvil_set_balance(turnkey_wallet, test_gas_balance)
+        .await?;
+
+    harness::preseed_tokenized_asset(
+        &databases.fireblocks_url,
+        evm.vault_address,
+        CUTOVER_UNDERLYING,
+        CUTOVER_TOKEN,
+    )
+    .await?;
+    setup_cutover_roles(&evm, user_wallet, fireblocks_wallet, turnkey_wallet)
+        .await?;
+    let (fireblocks_config, _fireblocks_subgraph) =
+        harness::create_config_with_db(
+            &databases.fireblocks_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    let fireblocks_client = start_service(fireblocks_config).await?;
+    let pre_cutover_mint = mint_before_cutover(
+        &fireblocks_client,
+        &evm,
+        &user_signer,
+        user_wallet,
+        &mint_callback_mock,
+    )
+    .await?;
+    let (receipt_id, receipt_shares, _receipt_information) =
+        single_deposit_for_owner(
+            &fireblocks_provider,
+            evm.vault_address,
+            fireblocks_wallet,
+        )
+        .await?;
+    fireblocks_client.terminate().await;
+    snapshot_database(&databases.fireblocks_url, &databases.turnkey_path)
+        .await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let user_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    user_vault
+        .transfer(turnkey_wallet, pre_cutover_mint.shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    // Bring up the replacement service against the un-migrated state, exactly
+    // as an operator who skipped the custody step would.
+    let (mut turnkey_config, _turnkey_subgraph) =
+        harness::create_config_with_db(
+            &databases.turnkey_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    turnkey_config.signer =
+        SignerConfig::Local(B256::from(turnkey_signer.to_bytes()));
+    let turnkey_client = start_service(turnkey_config).await?;
+
+    let turnkey_provider = create_provider()
+        .wallet(EthereumWallet::from(turnkey_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let turnkey_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &turnkey_provider,
+    );
+
+    // The service detects the transfer and calls Alpaca before it can burn, so
+    // the redeem callback firing is the point of no return: shares are journaled
+    // back to the participant while the tokens are still outstanding.
+    harness::wait_for_mock_hits(&redeem_mock, 1).await?;
+
+    // Give the burn every chance to land before asserting it did not. Without
+    // the receipt it reverts, and `BurnFailed` recovery retries against an
+    // on-chain share balance that is present, so it never auto-fails either.
+    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+    let withdraw_logs = turnkey_provider
+        .get_logs(&turnkey_vault.Withdraw_filter().from_block(0).filter)
+        .await?;
+    let turnkey_withdrawals = withdraw_logs
+        .iter()
+        .filter_map(|log| {
+            OffchainAssetReceiptVault::Withdraw::decode_log(&log.inner).ok()
+        })
+        .filter(|withdrawal| withdrawal.owner == turnkey_wallet)
+        .count();
+    assert_eq!(
+        turnkey_withdrawals, 0,
+        "no burn may succeed without receipt custody"
+    );
+
+    assert_eq!(
+        turnkey_vault.balanceOf(turnkey_wallet).call().await?,
+        pre_cutover_mint.shares,
+        "the shares must remain outstanding and unburned"
+    );
+
+    let receipt_contract_address =
+        turnkey_vault.receipt().call().await?.0.into();
+    let receipt =
+        ReceiptInstance::new(receipt_contract_address, &turnkey_provider);
+    assert_eq!(
+        receipt.balanceOf(fireblocks_wallet, receipt_id).call().await?,
+        receipt_shares,
+        "the historical receipt must remain in old-wallet custody"
+    );
+    assert_eq!(
+        receipt.balanceOf(turnkey_wallet, receipt_id).call().await?,
+        U256::ZERO,
+        "the new wallet must still lack the historical receipt"
+    );
+
+    turnkey_client.terminate().await;
+
+    Ok(())
+}


### PR DESCRIPTION
## Motivation

Rotating the issuer's signing backend (Fireblocks -> Turnkey) strands every
vault's ERC-1155 deposit receipts at the old wallet: the issuer burns against
receipts held by its own signing address, so the receipts must follow the
signer or every outstanding token becomes unredeemable.

**This PR performs no migration and ships no operator command.** It is the
engine layer only: the invariants and refusal gates that every execution path
must run through. The executable capability lands upstack — #294 resurrects
the narrow Fireblocks client (the retiring custodian that signs the real
forward transfer), and #295 ships the `issuer migrate-receipts` command that
drives this engine through both custodians end to end. If you want the
end-to-end story first, read #294 and #295 before this; review this PR as the
answer to "what can never go wrong, no matter which path executes the move".

Splitting the engine from its executors is deliberate: an ERC-1155 transfer is
final, with no counterparty and no recovery, so the safety argument gets
reviewed once, here, and the upstack PRs only add submission mechanisms behind
the same seam.

## Solution

- `migrate_vault_receipts` moves one vault's receipts end to end behind a
  `ReceiptCustody` seam: quiescence gates, exact tracked-vs-on-chain balance
  agreement, certification and owner-freeze checks re-read immediately before
  submission, per-identifier post-condition verification afterwards, and
  idempotent `AlreadyMigrated` reporting on re-runs.
- Quiescence is per-asset in-flight work, not a freeze: the engine refuses
  while a burn is reserved against the vault's receipts or while any mint or
  redemption of the migrating asset sits between initiation and a terminal
  state (it would resume against the wrong wallet after a custody move). Work
  that cannot be attributed to an asset counts against every vault. The
  corporate-action freeze keeps its own lifecycle — a migration neither
  requires declaring one nor ends one that is real.
- The recipient must clear `CorroboratedRecipient` — an on-chain existence
  witness (transaction history or native balance) encoded as a type the
  transfer cannot be reached without.
- The owner-freeze exemption preflight mirrors the vault's
  `ownerFreezeCheckTransaction` semantics: the always-allowed values are
  timestamps, exempting a pair only while current, never mere flags.
- `docs/fireblocks-migration-authorization.md`: what the Fireblocks workspace
  must authorize (whitelisting, TAP rule, approval quorums), for whoever
  administers it.
- The cutover e2e proves the engine against a real vault with local signers
  standing in for both custodians: cutover with the replacement service
  redeeming a pre-cutover receipt after restart, custody rollback to the
  outgoing wallet (same engine, wallets swapped), the re-run no-op, and the
  negative case — skipping the custody step leaves historical shares
  unburnable.

Advances [RAI-1549](https://linear.app/makeitrain/issue/RAI-1549).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

