### PR TITLE
feat: refuse custody moves and depletions that cannot be proven safe

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -170,15 +170,14 @@ Command -> Aggregate.handle() -> Validate & Produce Events -> Persist Events
 **Critical Methods:**
 
 - `handle(command) -> Result<Vec<Event>, Error>`: Business logic. Validates the
-  command against current state and returns 0+ events (e.g. `ConfirmJournal` may
+  command against current state, returns 0+ events (e.g. `ConfirmJournal` may
   produce both `JournalConfirmed` and `MintingStarted`).
-- `apply(event)`: Deterministically updates state from events. Pure, never fails
-  - events are historical facts that already occurred.
+- `apply(event)`: Deterministically updates state from events. Pure, never
+  fails - events are historical facts.
 
 **Benefits:** complete audit trail; time-travel debugging (replay to any point);
 testability via Given-When-Then; rebuild/add views by replaying events; multiple
-projections from the same events; event store is the single source of truth, all
-else derived.
+projections from the same events; the event store is the single source of truth.
 
 **CRITICAL: Events Are Permanent:**
 
@@ -195,8 +194,8 @@ else derived.
 well-designed service trait:
 
 - **Models domain capabilities**: Methods describe what the system can DO in
-  domain terms, not how it's implemented. "Domain" is context-dependent - here,
-  burning tokens is domain because 1:1 backing is the value proposition.
+  domain terms, not how it's implemented. "Domain" is context-dependent (see
+  "Domain context" below).
 - **Plugs into command handlers**: When a command says "do X", the service
   provides the capability to do X; events are produced from what the service
   did.
@@ -242,8 +241,7 @@ naming.
 
 - **Aggregates**: entity state reconstructed by replaying events (O(n)); enforce
   business rules and invariants; naming reflects **entity lifecycle**
-  (`NotLinked`/`Linked`, `NotAdded`/`Added`) - where the entity is in its
-  lifecycle.
+  (`NotLinked`/`Linked`, `NotAdded`/`Added`).
 - **Views**: materialized projections optimized for reads, filtered access, and
   cross-entity queries; naming is **query-oriented** (`Unavailable` instead of
   `NotAdded`/`Removed`).
@@ -308,37 +306,38 @@ SQLite for event store and views, with an async runtime for coordination.
 IDs, ERC-20 shares representing vault ownership; `deposit()` mints, `withdraw()`
 burns.
 
-- **Contract Documentation**: Rain contracts are thoroughly documented with
-  inline comments on parameters, behavior, and rationale. Always consult the
-  Solidity source for authoritative behavior, parameter meanings, and formulas
-  (contracts use 18-decimal fixed-point arithmetic for share ratios):
+- **Contract Documentation**: Rain contracts carry thorough inline comments on
+  parameters, behavior, and rationale. Always consult the Solidity source for
+  authoritative behavior, parameter meanings, and formulas (contracts use
+  18-decimal fixed-point arithmetic for share ratios):
   - Primary: `lib/ethgild/src/concrete/vault/OffchainAssetReceiptVault.sol`
   - Base: `lib/ethgild/src/abstract/ReceiptVault.sol`
 
-**Redemption Wallet:** on-chain address where APs send tokens to redeem; we
-monitor it for incoming transfers.
+**Redemption Wallet:** on-chain address where APs send tokens to redeem;
+monitored for incoming transfers.
 
-**MonitorService:** watches the redemption wallet via a WebSocket subscription;
-methods `watch_transfers()`, `get_transfer_details()`.
+**MonitorService:** watches the redemption wallet via WebSocket; methods
+`watch_transfers()`, `get_transfer_details()`.
 
 **Signing Backends (`src/wallet/`):** two mutually exclusive backends, both
-resolving into a `ResolvedSigner` holding an `EthereumWallet`. `config.rs` then
-wraps that wallet into a signing `Provider` via `ProviderBuilder` and passes it
-to `RealBlockchainService`:
+resolving into a `ResolvedSigner` holding an `EthereumWallet`, which `config.rs`
+wraps into a signing `Provider` for `RealBlockchainService`:
 
 - **Local**: `EVM_PRIVATE_KEY` → raw private key signer (dev/test)
 - **Turnkey**: `TURNKEY_ORG_ID` + `TURNKEY_API_PRIVATE_KEY` + `TURNKEY_ADDRESS`
   → remote signing via Turnkey's AWS Nitro secure enclaves;
-  `TURNKEY_API_PRIVATE_KEY` is a P-256 key used to authenticate requests to
-  Turnkey, not the wallet signing key (prod)
+  `TURNKEY_API_PRIVATE_KEY` is a P-256 key authenticating requests to Turnkey,
+  not the wallet signing key (prod)
 
 Key files: `wallet/mod.rs` (SignerConfig, ResolvedSigner), `wallet/local.rs`,
 `wallet/turnkey.rs`, `config.rs` (backend selection, Provider construction)
 
 **Receipt custody migration (`receipt_inventory/migration.rs`, temporary):**
 rotating the signer strands the vault's receipts at the old address. **Stop the
-service before moving custody** — startup reconciliation depletes receipts the
-old signer no longer holds.
+service before moving custody.** No wallet address is ever an argument to the
+migration engine; destinations are derived and gated by the
+`CorroboratedRecipient` witness. Custody is aggregate state, so a rotated
+wallet reading zero is refused, not depleted.
 
 ### Core Flows
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -739,25 +739,35 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
   work; the engine and its gates are specified here because every execution path
   must run through them unchanged.
 
-The transfer is signed by the holding wallet itself: ERC-1155 lets a balance be
-moved only by its holder or by an operator the holder has approved via
+**No wallet address is ever an argument.** An ERC-1155 transfer to a wrong
+address is final — no counterparty, no recovery, and the receipts back tokens
+that are still outstanding — so every address the migration uses is derived
+from configuration the system already holds rather than typed. The outgoing
+wallet is whatever the signing configuration resolves: whatever signs is
+necessarily what custody leaves. The destination is derived by the execution
+path from the same environment, never named by an operator, and must clear an
+on-chain corroboration witness: an address with no transaction history and no
+native balance has no on-chain existence, which is what a corrupted config
+value looks like. The corroboration is a witness type, so the transfer cannot
+be reached without it.
+
+The transfer is signed by the holding wallet itself: ERC-1155 lets a balance
+be moved only by its holder or by an operator the holder has approved via
 `setApprovalForAll`, and the migration relies on the holder case rather than
 granting any operator approval — ERC-1155 approval is all-or-nothing across
 every token the holder owns, so granting it for a one-shot transfer would be a
-far wider authorization than the operation needs. The recipient must clear an
-on-chain corroboration witness (an address the chain has never seen is refused),
-since an ERC-1155 transfer is final, with no counterparty and no recovery. The
-engine refuses while any burn is reserved against the vault's receipts, refuses
-while any mint or redemption of the migrating asset sits between initiation and
-a terminal state (in-flight work resumes against the wrong wallet after a
-custody move; work that cannot be attributed to an asset counts against every
-vault), and refuses when the vault has no tracked receipts rather than reporting
-an unverified no-op. Quiescence is deliberately not a freeze check: the
-corporate-action freeze has its own lifecycle, and a migration neither requires
-declaring one nor ends one that is real. The tracked inventory is cross-checked
-against on-chain balances, the vault's certification and owner-freeze gates are
-re-read immediately before submission, and post-conditions are verified per
-receipt identifier afterwards. Re-running after a successful move reports
+far wider authorization than the operation needs. The engine refuses while any
+burn is reserved against the vault's receipts, refuses while any mint or
+redemption of the migrating asset sits between initiation and a terminal state
+(in-flight work resumes against the wrong wallet after a custody move; work
+that cannot be attributed to an asset counts against every vault), and refuses
+when the vault has no tracked receipts rather than reporting an unverified
+no-op. Quiescence is deliberately not a freeze check: the corporate-action
+freeze has its own lifecycle, and a migration neither requires declaring one
+nor ends one that is real. The tracked inventory is cross-checked against
+on-chain balances, the vault's certification and owner-freeze gates are re-read
+immediately before submission, and post-conditions are verified per receipt
+identifier afterwards. Re-running after a successful move reports
 `AlreadyMigrated` instead of submitting a second transfer.
 
 The operator sequence around the engine is **stop the issuer service** → move
@@ -766,6 +776,25 @@ not optional: startup reconciliation reads `balanceOf(bot_wallet)` for every
 tracked receipt, so a service still configured with the outgoing signer that
 restarts after custody has moved reads zero for every one of them, reconciles
 that as depletion, and drops the receipts from the aggregate.
+
+Custody is therefore part of the `ReceiptInventory` aggregate's own state,
+maintained by two events. `CustodyConfirmed { holder }` records the wallet the
+balances were read against, emitted only when custody goes from unobserved to
+known or the holder genuinely changes — the periodic reconciler's re-confirms
+are no-ops, so the log does not grow per pass.
+`CustodyMigrated { from, to,
+tx_hash }` records a completed move; its `from` is
+what a rollback later reads its destination out of. Balances in this aggregate
+are `balanceOf(holder, id)` readings, so the holder is part of what they mean: a
+zero only means "spent" while the holder is unchanged. Once it has rotated, a
+zero means "held elsewhere", and depleting on it would erase inventory whose
+receipts sit untouched at the previous wallet — permanently, since the receipt
+backfiller has already checkpointed past the deposits that created them. A
+reconciliation pass that finds the wallet rotated and holding none of the
+claimed receipts writes nothing, logs at ERROR, and fails, leaving the inventory
+intact. This is what makes a single-asset cutover safe: the vaults that have not
+migrated yet are refused rather than wiped. A pass that cannot read every
+balance confirms nothing, so one flaky call cannot disarm the guard.
 
 Freeze, unfreeze, and status address the `Underlying` aggregate, so they take no
 network argument: one freeze covers every listing of the underlying. The CLI
@@ -938,6 +967,12 @@ Commands:
   reservation after its burn confirmed on-chain: clear the reservation and
   reduce the mirror balance by the reserved amount. Idempotent; emits `Depleted`
   for any receipt the settlement empties
+- `ConfirmCustody { holder }` - Record the wallet the balances were read
+  against, once a reconciliation pass has verified it holds the tracked
+  receipts. No-op when the holder is unchanged, so the periodic reconciler
+  cannot grow the log a pass at a time
+- `RecordCustodyMigration { from, to, tx_hash }` - Record a verified custody
+  move (issued by `migrate-receipts` only after post-conditions hold)
 
 Release and settle are keyed only by redemption; `apply` uses the stored
 `reserved` amounts, so neither carries a `burns` payload.
@@ -959,6 +994,12 @@ Events:
   definitive terminal/reverted failure, restoring availability
 - `BurnSettled { redemption_issuer_request_id }` - Reservation consumed after
   on-chain confirmation; mirror balance reduced by the reserved amount
+- `CustodyConfirmed { holder }` - The wallet these balances belong to, emitted
+  when custody goes from unobserved to known or the holder changes — never per
+  reconciliation pass
+- `CustodyMigrated { from, to, tx_hash }` - Custody of every tracked receipt
+  moved to a replacement wallet; `from` is where a rollback returns it to, read
+  off the aggregate instead of asked for
 
 **Startup reservation recovery** (`recover_stuck_reservations`) runs after
 redemption recovery. For each vault it enumerates the redemptions holding a

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -509,6 +509,7 @@ where
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id: discovery.receipt_id,
                 on_chain_balance: Shares::from(current_balance),
+                observed_wallet: self.bot_wallet,
             },
         )
         .await?;
@@ -545,6 +546,7 @@ where
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id,
                 on_chain_balance: Shares::from(on_chain_balance),
+                observed_wallet: self.bot_wallet,
             },
         )
         .await?;

--- a/src/receipt_inventory/cmd.rs
+++ b/src/receipt_inventory/cmd.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Bytes, TxHash};
+use alloy::primitives::{Address, Bytes, TxHash};
 use serde::{Deserialize, Serialize};
 
 use super::event::ReceiptSource;
@@ -17,9 +17,17 @@ pub(crate) enum ReceiptInventoryCommand {
         receipt_info: Option<Box<ReceiptInformation>>,
         receipt_info_bytes: Option<Bytes>,
     },
+    /// Apply an on-chain `balanceOf(observed_wallet, receipt_id)` reading.
+    ///
+    /// The reading only means anything relative to the wallet it was taken
+    /// against, so the handler refuses it when that wallet is not the recorded
+    /// custody holder — and refuses a destructive zero reading outright while
+    /// custody has never been confirmed. This is the aggregate-level backstop
+    /// no balance reader can bypass; see [`super::Custody`].
     ReconcileBalance {
         receipt_id: ReceiptId,
         on_chain_balance: Shares,
+        observed_wallet: Address,
     },
     ReserveBurn {
         redemption_issuer_request_id: IssuerRedemptionRequestId,
@@ -30,5 +38,19 @@ pub(crate) enum ReceiptInventoryCommand {
     },
     SettleBurn {
         redemption_issuer_request_id: IssuerRedemptionRequestId,
+    },
+    /// Record the wallet these balances were read against, once a
+    /// reconciliation pass has confirmed it holds the tracked receipts.
+    ///
+    /// Idempotent: re-confirming the wallet already held produces no event, so
+    /// the periodic reconciler cannot grow the log a pass at a time.
+    ConfirmCustody {
+        holder: Address,
+    },
+    /// Record that custody of every tracked receipt moved to a new wallet.
+    RecordCustodyMigration {
+        from: Address,
+        to: Address,
+        tx_hash: TxHash,
     },
 }

--- a/src/receipt_inventory/event.rs
+++ b/src/receipt_inventory/event.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Bytes, TxHash};
+use alloy::primitives::{Address, Bytes, TxHash};
 use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
 
@@ -58,6 +58,28 @@ pub(crate) enum ReceiptInventoryEvent {
     BurnSettled {
         redemption_issuer_request_id: IssuerRedemptionRequestId,
     },
+    /// The wallet these balances belong to, recorded the first time a
+    /// reconciliation pass confirms it holds the tracked receipts.
+    ///
+    /// Balances here are `balanceOf(holder, receipt_id)` readings, so the holder
+    /// is part of what they mean. Recording it is what lets a later signer
+    /// rotation be recognised as a rotation instead of read as every receipt
+    /// having been spent at once. Emitted when the verified holder differs
+    /// from the recorded one — the first confirmation, or a wallet verified to
+    /// hold every tracked receipt after a rotation. Re-confirming the wallet
+    /// already on record is a no-op, never an event per pass.
+    CustodyConfirmed {
+        holder: Address,
+    },
+    /// Custody of every tracked receipt moved to a replacement wallet.
+    ///
+    /// `from` is retained because it is where a rollback returns custody to, so
+    /// reversing a migration needs no address from an operator.
+    CustodyMigrated {
+        from: Address,
+        to: Address,
+        tx_hash: TxHash,
+    },
 }
 
 impl DomainEvent for ReceiptInventoryEvent {
@@ -80,6 +102,12 @@ impl DomainEvent for ReceiptInventoryEvent {
             }
             Self::BurnSettled { .. } => {
                 "ReceiptInventoryEvent::BurnSettled".to_string()
+            }
+            Self::CustodyConfirmed { .. } => {
+                "ReceiptInventoryEvent::CustodyConfirmed".to_string()
+            }
+            Self::CustodyMigrated { .. } => {
+                "ReceiptInventoryEvent::CustodyMigrated".to_string()
             }
         }
     }

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -30,7 +30,8 @@ use std::time::Duration;
 use tracing::{debug, info};
 
 use super::{
-    ReceiptId, ReceiptInventory, Shares, SharesOverflow, load_inventory,
+    ReceiptId, ReceiptInventory, ReceiptInventoryCommand, Shares,
+    SharesOverflow, load_inventory, send_receipt_inventory_command,
 };
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::mint::find_stuck as find_stuck_mints;
@@ -637,7 +638,28 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
             Ok(MigrationOutcome::AlreadyMigrated { receipts })
         }
         SourceCustody::Holds(holdings) => {
-            Ok(migrate_vault_custody(&custody, &holdings, recipient).await?)
+            let outcome =
+                migrate_vault_custody(&custody, &holdings, recipient).await?;
+
+            // Recorded only after the move is verified, so the inventory's
+            // custody history never claims a transfer that did not land. This
+            // is what a later rollback reads its destination from, instead of
+            // being handed an address.
+            if let MigrationOutcome::Migrated { transaction, .. } = &outcome {
+                send_receipt_inventory_command(
+                    &store,
+                    chain_id,
+                    &vault,
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: holder,
+                        to: recipient,
+                        tx_hash: *transaction,
+                    },
+                )
+                .await?;
+            }
+
+            Ok(outcome)
         }
     }
 }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -356,6 +356,10 @@ const fn receipt_inventory_operation(
         ReceiptInventoryCommand::ReserveBurn { .. } => "reserve_burn",
         ReceiptInventoryCommand::ReleaseBurn { .. } => "release_burn",
         ReceiptInventoryCommand::SettleBurn { .. } => "settle_burn",
+        ReceiptInventoryCommand::ConfirmCustody { .. } => "confirm_custody",
+        ReceiptInventoryCommand::RecordCustodyMigration { .. } => {
+            "record_custody_migration"
+        }
     }
 }
 
@@ -630,9 +634,53 @@ pub(crate) struct ReceiptInventory {
     /// Maps issuer_request_id to receipt_id for ITN mints.
     /// Used by mint recovery to check if a mint succeeded on-chain.
     itn_receipts: HashMap<IssuerMintRequestId, ReceiptId>,
+    /// The wallet these balances are held by, and the wallet each moved away
+    /// from. Absent on inventories that predate custody being recorded.
+    #[serde(default)]
+    custody: Custody,
+}
+
+/// Which wallet holds this vault's receipts.
+///
+/// Balances in this aggregate are `balanceOf(holder, receipt_id)` readings, so
+/// they only mean anything relative to a holder. Leaving that holder implicit is
+/// what allows a zero reading taken against the wrong wallet to be applied as a
+/// depletion.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum Custody {
+    /// No custody has been observed yet. Inventories built before custody was
+    /// recorded start here.
+    #[default]
+    Unobserved,
+    /// `holder` is confirmed to hold the tracked receipts. `moved_from` is the
+    /// wallet custody was migrated away from, which is where a rollback returns
+    /// it to.
+    Held { holder: Address, moved_from: Option<Address> },
+}
+
+impl Custody {
+    pub(crate) const fn holder(&self) -> Option<Address> {
+        match self {
+            Self::Unobserved => None,
+            Self::Held { holder, .. } => Some(*holder),
+        }
+    }
+
+    /// The wallet custody was last migrated away from — a rollback's
+    /// destination, known without anyone having to name an address.
+    pub(crate) const fn moved_from(&self) -> Option<Address> {
+        match self {
+            Self::Unobserved => None,
+            Self::Held { moved_from, .. } => *moved_from,
+        }
+    }
 }
 
 impl ReceiptInventory {
+    pub(crate) const fn custody(&self) -> &Custody {
+        &self.custody
+    }
+
     /// Receipts with shares reserved against an in-flight redemption burn.
     ///
     /// Freezing an underlying rejects new mints but lets in-flight redemptions
@@ -825,6 +873,24 @@ pub(crate) enum ReceiptInventoryError {
         available: Shares,
         required: Shares,
     },
+    #[error(
+        "Refusing balance reading for receipt {receipt_id} taken against \
+         wallet {observed_wallet}: recorded custody holder is {holder}. \
+         Point the service at the holder or migrate custody with \
+         `issuer migrate-receipts`."
+    )]
+    CustodyDisplaced {
+        receipt_id: ReceiptId,
+        holder: Address,
+        observed_wallet: Address,
+    },
+    #[error(
+        "Refusing to deplete receipt {receipt_id} from a zero reading at \
+         wallet {observed_wallet}: no custody holder has ever been \
+         confirmed for this vault, so the reading cannot be distinguished \
+         from a wallet rotation. Run `issuer confirm-custody` first."
+    )]
+    CustodyUnconfirmed { receipt_id: ReceiptId, observed_wallet: Address },
 }
 
 impl ReceiptInventory {
@@ -860,10 +926,39 @@ impl ReceiptInventory {
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id,
                 on_chain_balance,
+                observed_wallet,
             } => {
                 let Some(metadata) = self.receipts.get(&receipt_id) else {
                     return Ok(vec![]);
                 };
+
+                // A reading only means anything relative to the wallet it was
+                // taken against. Refuse readings from a wallet other than the
+                // recorded holder, and refuse a destructive zero reading while
+                // custody has never been confirmed — a rotated wallet reading
+                // zero is indistinguishable from a spent receipt, and applying
+                // it would erase inventory the backfill checkpoint can never
+                // rediscover.
+                match self.custody.holder() {
+                    Some(holder) if holder != observed_wallet => {
+                        return Err(ReceiptInventoryError::CustodyDisplaced {
+                            receipt_id,
+                            holder,
+                            observed_wallet,
+                        });
+                    }
+                    None if on_chain_balance.is_zero()
+                        && !metadata.balance.is_zero() =>
+                    {
+                        return Err(
+                            ReceiptInventoryError::CustodyUnconfirmed {
+                                receipt_id,
+                                observed_wallet,
+                            },
+                        );
+                    }
+                    _ => {}
+                }
 
                 let mirror = metadata.balance;
                 let available = metadata.available();
@@ -980,6 +1075,29 @@ impl ReceiptInventory {
                 .chain(depletions)
                 .collect())
             }
+
+            // Idempotent by design: the reconciler issues this on every clean
+            // pass, and an event per pass is what drove the RAI-617 OOM.
+            // Confirming the wallet already on record is a no-op; a different
+            // wallet — verified by the caller to hold every tracked receipt —
+            // records the change.
+            ReceiptInventoryCommand::ConfirmCustody { holder } => {
+                if self.custody.holder() == Some(holder) {
+                    return Ok(vec![]);
+                }
+
+                Ok(vec![ReceiptInventoryEvent::CustodyConfirmed { holder }])
+            }
+
+            ReceiptInventoryCommand::RecordCustodyMigration {
+                from,
+                to,
+                tx_hash,
+            } => Ok(vec![ReceiptInventoryEvent::CustodyMigrated {
+                from,
+                to,
+                tx_hash,
+            }]),
         }
     }
 
@@ -1129,6 +1247,20 @@ impl ReceiptInventory {
                     metadata.balance = new_balance;
                 }
             }
+
+            // Confirming custody establishes the holder without disturbing a
+            // migration already recorded against it.
+            ReceiptInventoryEvent::CustodyConfirmed { holder } => {
+                let moved_from = self.custody.moved_from();
+                self.custody = Custody::Held { holder, moved_from };
+            }
+
+            // A migration both moves the holder and records where it came from,
+            // which is where a rollback returns it to.
+            ReceiptInventoryEvent::CustodyMigrated { from, to, .. } => {
+                self.custody =
+                    Custody::Held { holder: to, moved_from: Some(from) };
+            }
         }
     }
 }
@@ -1251,6 +1383,10 @@ mod tests {
 
     const TEST_OA_SCHEMA: &str =
         "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
+
+    /// The wallet balance readings are taken against in these tests.
+    const OBSERVER: Address =
+        address!("00000000000000000000000000000000000000ab");
 
     fn make_receipt_id(n: u64) -> ReceiptId {
         ReceiptId::from(U256::from(n))
@@ -2399,6 +2535,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(100),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -2448,6 +2585,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(40),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -2486,6 +2624,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(50),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -2538,6 +2677,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(0),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -2562,6 +2702,9 @@ mod tests {
     #[tokio::test]
     async fn test_reconcile_zero_drain_preserves_reservation() {
         let mut aggregate = ReceiptInventory::default();
+        aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
+            holder: OBSERVER,
+        });
         drive(
             &mut aggregate,
             discover_receipt_cmd(
@@ -2587,6 +2730,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(0),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -2714,6 +2858,9 @@ mod tests {
         let redemption_id: IssuerRedemptionRequestId =
             "red-00000001".parse().unwrap();
         let mut aggregate = ReceiptInventory::default();
+        aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
+            holder: OBSERVER,
+        });
         drive(
             &mut aggregate,
             discover_receipt_cmd(
@@ -2739,6 +2886,7 @@ mod tests {
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id: make_receipt_id(1),
                 on_chain_balance: make_shares(0),
+                observed_wallet: OBSERVER,
             },
         )
         .await;
@@ -3169,6 +3317,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(100),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -3210,6 +3359,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(50),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -3233,6 +3383,9 @@ mod tests {
     async fn test_reconcile_zero_balance_emits_balance_reconciled_and_depleted()
     {
         let mut aggregate = ReceiptInventory::default();
+        aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
+            holder: OBSERVER,
+        });
         let tx_hash = b256!(
             "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
@@ -3259,6 +3412,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(0),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -3288,6 +3442,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(99),
                     on_chain_balance: make_shares(0),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -3329,6 +3484,7 @@ mod tests {
                 ReceiptInventoryCommand::ReconcileBalance {
                     receipt_id: make_receipt_id(42),
                     on_chain_balance: make_shares(100),
+                    observed_wallet: OBSERVER,
                 },
                 &(),
             )
@@ -3811,6 +3967,224 @@ mod tests {
                 untouched, unexpected_id,
                 "aborted migration must leave the row untouched"
             );
+        }
+    }
+
+    mod custody {
+        use super::*;
+
+        const HOLDER: Address =
+            address!("00000000000000000000000000000000000000aa");
+        const REPLACEMENT: Address =
+            address!("00000000000000000000000000000000000000bb");
+
+        /// The aggregate-level backstop: a reading taken against a wallet
+        /// other than the recorded holder is refused outright — through this
+        /// handler there is no reader (reconciler, backfiller, or future
+        /// caller) that can apply a wrong-wallet reading.
+        #[tokio::test]
+        async fn a_reading_from_a_wallet_other_than_the_holder_is_refused() {
+            let mut aggregate = ReceiptInventory::default();
+            aggregate.apply_event(ReceiptInventoryEvent::Discovered {
+                receipt_id: make_receipt_id(1),
+                balance: make_shares(100),
+                block_number: 1,
+                tx_hash: TxHash::ZERO,
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            });
+            aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
+                holder: HOLDER,
+            });
+
+            let refusal = aggregate
+                .transition(
+                    ReceiptInventoryCommand::ReconcileBalance {
+                        receipt_id: make_receipt_id(1),
+                        on_chain_balance: make_shares(0),
+                        observed_wallet: REPLACEMENT,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                refusal,
+                ReceiptInventoryError::CustodyDisplaced {
+                    holder,
+                    observed_wallet,
+                    ..
+                } if holder == HOLDER && observed_wallet == REPLACEMENT
+            ));
+        }
+
+        /// A destructive zero reading while custody has never been confirmed
+        /// is refused: a rotated wallet reading zero is indistinguishable
+        /// from a spent receipt, so the operator must bootstrap custody with
+        /// `issuer confirm-custody` before any depletion can apply.
+        #[tokio::test]
+        async fn a_zero_reading_without_confirmed_custody_is_refused() {
+            let mut aggregate = ReceiptInventory::default();
+            aggregate.apply_event(ReceiptInventoryEvent::Discovered {
+                receipt_id: make_receipt_id(1),
+                balance: make_shares(100),
+                block_number: 1,
+                tx_hash: TxHash::ZERO,
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            });
+
+            let refusal = aggregate
+                .transition(
+                    ReceiptInventoryCommand::ReconcileBalance {
+                        receipt_id: make_receipt_id(1),
+                        on_chain_balance: make_shares(0),
+                        observed_wallet: REPLACEMENT,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap_err();
+
+            assert!(matches!(
+                refusal,
+                ReceiptInventoryError::CustodyUnconfirmed {
+                    observed_wallet,
+                    ..
+                } if observed_wallet == REPLACEMENT
+            ));
+        }
+
+        /// A non-zero reading under unconfirmed custody stays allowed — the
+        /// discovery-era backfill reconciles balances upward before custody
+        /// is ever recorded, and a non-zero reading cannot destroy inventory.
+        #[tokio::test]
+        async fn a_nonzero_reading_without_confirmed_custody_is_applied() {
+            let mut aggregate = ReceiptInventory::default();
+            aggregate.apply_event(ReceiptInventoryEvent::Discovered {
+                receipt_id: make_receipt_id(1),
+                balance: make_shares(100),
+                block_number: 1,
+                tx_hash: TxHash::ZERO,
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            });
+
+            let events = aggregate
+                .transition(
+                    ReceiptInventoryCommand::ReconcileBalance {
+                        receipt_id: make_receipt_id(1),
+                        on_chain_balance: make_shares(60),
+                        observed_wallet: REPLACEMENT,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+
+            assert!(matches!(
+                events.as_slice(),
+                [ReceiptInventoryEvent::BalanceReconciled {
+                    on_chain_balance,
+                    ..
+                }] if *on_chain_balance == make_shares(60)
+            ));
+        }
+
+        /// The periodic reconciler confirms custody every pass. Only the first
+        /// confirmation is a fact worth recording; repeating it would grow the
+        /// event log a pass at a time, which is the RAI-617 failure shape.
+        #[tokio::test]
+        async fn confirming_the_same_holder_twice_emits_one_event() {
+            let mut aggregate = ReceiptInventory::default();
+
+            let events = aggregate
+                .transition(
+                    ReceiptInventoryCommand::ConfirmCustody { holder: HOLDER },
+                    &(),
+                )
+                .await
+                .unwrap();
+            assert!(matches!(
+                events.as_slice(),
+                [ReceiptInventoryEvent::CustodyConfirmed { holder }]
+                    if *holder == HOLDER
+            ));
+            for event in events {
+                aggregate.apply_event(event);
+            }
+
+            let repeat = aggregate
+                .transition(
+                    ReceiptInventoryCommand::ConfirmCustody { holder: HOLDER },
+                    &(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                repeat.is_empty(),
+                "re-confirming an unchanged holder must be a no-op, got \
+                 {repeat:?}"
+            );
+        }
+
+        /// A migration is where a rollback's destination comes from: the event
+        /// keeps the outgoing wallet, so reversing the move needs no address
+        /// from anyone.
+        #[tokio::test]
+        async fn a_migration_records_where_custody_came_from() {
+            let mut aggregate = ReceiptInventory::default();
+            let tx_hash = b256!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            );
+
+            let events = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            for event in events {
+                aggregate.apply_event(event);
+            }
+
+            assert_eq!(aggregate.custody().holder(), Some(REPLACEMENT));
+            assert_eq!(
+                aggregate.custody().moved_from(),
+                Some(HOLDER),
+                "the rollback destination must be readable off the aggregate"
+            );
+        }
+
+        /// Reconciliation passes after a migration keep confirming the new
+        /// holder; that must not erase where custody came from, or a rollback
+        /// after the first post-cutover pass would have nowhere to go.
+        #[tokio::test]
+        async fn confirming_after_a_migration_keeps_the_origin() {
+            let mut aggregate = ReceiptInventory::default();
+            let tx_hash = b256!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            );
+
+            aggregate.apply_event(ReceiptInventoryEvent::CustodyMigrated {
+                from: HOLDER,
+                to: REPLACEMENT,
+                tx_hash,
+            });
+            aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
+                holder: REPLACEMENT,
+            });
+
+            assert_eq!(aggregate.custody().moved_from(), Some(HOLDER));
         }
     }
 }

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -4,10 +4,10 @@ use cqrs_es::AggregateError;
 use event_sorcery::Store;
 use futures::{StreamExt, stream};
 use std::sync::Arc;
-use tracing::{debug, info, trace};
+use tracing::{debug, error, info, trace};
 
 use super::{
-    ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
+    Custody, ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
     ReceiptInventoryError, Shares, load_inventory,
     send_receipt_inventory_command,
 };
@@ -32,6 +32,14 @@ pub(crate) enum ReconcileError {
     // no separate persistence error path.
     #[error("CQRS error: {0}")]
     Aggregate(#[from] AggregateError<ReceiptInventoryError>),
+    #[error(
+        "Wallet {wallet} holds none of the {receipt_count} receipts the \
+         inventory claims for vault {vault}; refusing to deplete them. The \
+         receipts are most likely still held by the previous signing wallet — \
+         point the service at the wallet that holds them, or migrate custody \
+         with `issuer migrate-receipts`."
+    )]
+    CustodyDisplaced { vault: Address, wallet: Address, receipt_count: usize },
 }
 
 pub(crate) struct ReceiptReconciler<Node> {
@@ -66,6 +74,12 @@ where
     /// actual on-chain balance for each, and executes ReconcileBalance commands
     /// for any mismatches (emitting BalanceReconciled, and Depleted when the
     /// on-chain balance is zero).
+    ///
+    /// A zero on-chain balance only means "spent" while the signing wallet is
+    /// the one the inventory was built against. Every balance is therefore read
+    /// before anything is written, so a wallet rotation can be recognised for
+    /// what it is instead of being applied as mass depletion — see
+    /// [`super::Custody`].
     pub(crate) async fn reconcile(
         &self,
     ) -> Result<ReconcileResult, ReconcileError> {
@@ -78,6 +92,9 @@ where
             .map(|receipt| (receipt.receipt_id, receipt.available_balance))
             .collect();
 
+        // An empty inventory proves nothing about which wallet holds
+        // anything, so no custody is confirmed here — recording a holder on
+        // no evidence would arm the guard around the wrong wallet.
         if receipts.is_empty() {
             return Ok(ReconcileResult {
                 checked: 0,
@@ -91,29 +108,39 @@ where
             "Reconciling receipt balances with on-chain state"
         );
 
-        let results: Vec<_> = stream::iter(receipts)
-            .map(|(receipt_id, aggregate_balance)| {
-                self.check_single_receipt(receipt_id, aggregate_balance)
+        let readings: Vec<_> = stream::iter(receipts)
+            .map(|(receipt_id, aggregate_balance)| async move {
+                (
+                    receipt_id,
+                    aggregate_balance,
+                    self.read_on_chain_balance(receipt_id).await,
+                )
             })
             .buffer_unordered(MAX_CONCURRENT_BALANCE_CHECKS)
             .collect()
             .await;
 
+        self.refuse_if_displaced(inventory.custody(), &readings)?;
+
         let mut checked = 0usize;
         let mut mismatches = 0usize;
         let mut errors = 0usize;
 
-        for result in results {
-            match result {
-                Ok(true) => {
+        for (receipt_id, aggregate_balance, reading) in readings {
+            match reading {
+                Ok(on_chain_balance) => {
                     checked += 1;
-                    mismatches += 1;
-                }
-                Ok(false) => {
-                    checked += 1;
-                }
-                Err(error @ ReconcileError::Aggregate(_)) => {
-                    return Err(error);
+
+                    if self
+                        .apply_reading(
+                            receipt_id,
+                            aggregate_balance,
+                            on_chain_balance,
+                        )
+                        .await?
+                    {
+                        mismatches += 1;
+                    }
                 }
                 Err(err) => {
                     debug!(target: "receipt", vault = %self.vault,
@@ -123,6 +150,13 @@ where
                     errors += 1;
                 }
             }
+        }
+
+        // A pass that could not read every balance has not proven the wallet
+        // holds this vault's receipts, so custody stays as it was and the next
+        // pass re-checks.
+        if errors == 0 {
+            self.confirm_custody().await?;
         }
 
         info!(target: "receipt", checked,
@@ -135,12 +169,56 @@ where
         Ok(ReconcileResult { checked, mismatches, errors })
     }
 
-    /// Returns true if a mismatch was detected and corrected.
-    async fn check_single_receipt(
+    /// Fails the pass without writing anything when the signing wallet changed
+    /// and does not hold receipts the inventory still claims.
+    ///
+    /// Those receipts are almost certainly sitting at the previous wallet:
+    /// depleting them would erase inventory backed by real on-chain receipts,
+    /// and the backfiller's checkpoint is already past the deposits that
+    /// created them, so nothing would ever rediscover them.
+    fn refuse_if_displaced(
+        &self,
+        custody: &Custody,
+        readings: &[(ReceiptId, Shares, Result<Shares, ReconcileError>)],
+    ) -> Result<(), ReconcileError> {
+        // Unobserved custody is the pre-cutover baseline, and an unchanged
+        // holder means a zero reading really is a spent receipt. Only a holder
+        // that has moved makes the reading ambiguous.
+        let Some(previous) =
+            custody.holder().filter(|holder| *holder != self.bot_wallet)
+        else {
+            return Ok(());
+        };
+
+        let displaced = readings
+            .iter()
+            .filter(|(_, _, reading)| {
+                matches!(reading, Ok(balance) if balance.is_zero())
+            })
+            .count();
+
+        if displaced == 0 {
+            return Ok(());
+        }
+
+        error!(target: "receipt", vault = %self.vault,
+            wallet = %self.bot_wallet,
+            previous_wallet = %previous,
+            receipt_count = displaced,
+            "Refusing to deplete receipts the signing wallet does not hold"
+        );
+
+        Err(ReconcileError::CustodyDisplaced {
+            vault: self.vault,
+            wallet: self.bot_wallet,
+            receipt_count: displaced,
+        })
+    }
+
+    async fn read_on_chain_balance(
         &self,
         receipt_id: ReceiptId,
-        aggregate_balance: Shares,
-    ) -> Result<bool, ReconcileError> {
+    ) -> Result<Shares, ReconcileError> {
         let receipt_contract =
             Receipt::new(self.receipt_contract, &self.provider);
 
@@ -149,9 +227,17 @@ where
             .call()
             .await?;
 
-        let on_chain_shares = Shares::from(on_chain_balance);
+        Ok(Shares::from(on_chain_balance))
+    }
 
-        if on_chain_shares == aggregate_balance {
+    /// Returns true if a mismatch was detected and corrected.
+    async fn apply_reading(
+        &self,
+        receipt_id: ReceiptId,
+        aggregate_balance: Shares,
+        on_chain_balance: Shares,
+    ) -> Result<bool, ReconcileError> {
+        if on_chain_balance == aggregate_balance {
             trace!(target: "receipt", receipt_id = %receipt_id,
                 balance = %aggregate_balance,
                 "Receipt balance matches on-chain"
@@ -161,7 +247,7 @@ where
 
         trace!(target: "receipt", receipt_id = %receipt_id,
             aggregate_balance = %aggregate_balance,
-            on_chain_balance = %on_chain_shares,
+            on_chain_balance = %on_chain_balance,
             "Balance mismatch detected"
         );
 
@@ -171,12 +257,29 @@ where
             &self.vault,
             ReceiptInventoryCommand::ReconcileBalance {
                 receipt_id,
-                on_chain_balance: on_chain_shares,
+                on_chain_balance,
+                observed_wallet: self.bot_wallet,
             },
         )
         .await?;
 
         Ok(true)
+    }
+
+    /// Records the wallet these balances were read against.
+    ///
+    /// The command is a no-op when custody is already this wallet, so the
+    /// periodic reconciler does not append an event per pass.
+    async fn confirm_custody(&self) -> Result<(), ReconcileError> {
+        send_receipt_inventory_command(
+            &self.store,
+            self.chain_id,
+            &self.vault,
+            ReceiptInventoryCommand::ConfirmCustody { holder: self.bot_wallet },
+        )
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -306,6 +409,22 @@ mod tests {
             .unwrap();
     }
 
+    /// Mirrors the `issuer confirm-custody` bootstrap: depletion from a zero
+    /// reading only applies once the holder is on record.
+    async fn seed_custody(
+        store: &Arc<Store<ReceiptInventory>>,
+        vault: Address,
+        holder: Address,
+    ) {
+        store
+            .send(
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault),
+                ReceiptInventoryCommand::ConfirmCustody { holder },
+            )
+            .await
+            .unwrap();
+    }
+
     #[tokio::test]
     async fn test_reconcile_empty_aggregate_returns_zero_counts() {
         let evm = LocalEvm::new().await.unwrap();
@@ -326,7 +445,7 @@ mod tests {
             evm.wallet_address,
             ANVIL_CHAIN_ID,
             evm.vault_address,
-            store,
+            store.clone(),
         );
 
         let result = reconciler.reconcile().await.unwrap();
@@ -334,6 +453,14 @@ mod tests {
         assert_eq!(result.checked, 0);
         assert_eq!(result.mismatches, 0);
         assert_eq!(result.errors, 0);
+
+        // An empty inventory proves nothing about who holds anything, so the
+        // pass must not record a holder.
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &evm.vault_address)
+                .await
+                .unwrap();
+        assert_eq!(*inventory.custody(), Custody::Unobserved);
     }
 
     #[traced_test]
@@ -406,6 +533,7 @@ mod tests {
             U256::from(100) * U256::from(10).pow(U256::from(18)),
         )
         .await;
+        seed_custody(&store, evm.vault_address, evm.wallet_address).await;
 
         // Second vault: its receipt contract address has no contract deployed,
         // so the balance check errors -> one per-receipt error, which must be
@@ -479,6 +607,7 @@ mod tests {
             stale_balance,
         )
         .await;
+        seed_custody(&store, evm.vault_address, evm.wallet_address).await;
 
         let reconciler = ReceiptReconciler::new(
             provider,
@@ -593,5 +722,304 @@ mod tests {
             result.mismatches, 0,
             "Balance matches, no mismatch expected"
         );
+    }
+
+    mod custody_displacement {
+        use super::*;
+        use crate::receipt_inventory::Custody;
+
+        /// Establishes custody the way the service does — through the
+        /// aggregate — so the guard is tested against real recorded state.
+        async fn seed_custody(
+            store: &Arc<Store<ReceiptInventory>>,
+            vault: Address,
+            holder: Address,
+        ) {
+            send_receipt_inventory_command(
+                store,
+                ANVIL_CHAIN_ID,
+                &vault,
+                ReceiptInventoryCommand::ConfirmCustody { holder },
+            )
+            .await
+            .unwrap();
+        }
+
+        async fn custody_of(
+            store: &Arc<Store<ReceiptInventory>>,
+            vault: Address,
+        ) -> Custody {
+            load_inventory(store, ANVIL_CHAIN_ID, &vault)
+                .await
+                .unwrap()
+                .custody()
+                .clone()
+        }
+
+        /// The cutover hazard. The service restarts on the incoming signing
+        /// wallet before that wallet holds the receipts, so every balance reads
+        /// zero. Depleting on that reading would erase inventory whose receipts
+        /// are sitting untouched at the outgoing wallet — and the backfiller
+        /// has already checkpointed past the deposits that created them, so
+        /// nothing would ever rediscover them.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_rotated_wallet_holding_nothing_is_refused_not_depleted() {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let vault_contract =
+                crate::bindings::OffchainAssetReceiptVault::new(
+                    evm.vault_address,
+                    &provider,
+                );
+            let receipt_contract =
+                Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+            let balance = U256::from(100) * U256::from(10).pow(U256::from(18));
+            seed_receipt(&store, evm.vault_address, uint!(0xaa_U256), balance)
+                .await;
+            seed_receipt(&store, evm.vault_address, uint!(0xbb_U256), balance)
+                .await;
+
+            let outgoing = Address::random();
+            seed_custody(&store, evm.vault_address, outgoing).await;
+
+            let reconciler = ReceiptReconciler::new(
+                provider,
+                receipt_contract,
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let error = reconciler.reconcile().await.unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    ReconcileError::CustodyDisplaced { receipt_count: 2, .. }
+                ),
+                "expected both receipts reported as displaced, got: {error:?}"
+            );
+
+            let inventory =
+                load_inventory(&store, ANVIL_CHAIN_ID, &evm.vault_address)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                inventory.receipts_with_balance().len(),
+                2,
+                "a displaced inventory must survive the pass intact"
+            );
+            assert!(logs_contain_at!(
+                tracing::Level::ERROR,
+                &[
+                    "Refusing to deplete receipts the signing wallet does not \
+                     hold",
+                    "receipt_count=2"
+                ]
+            ));
+        }
+
+        /// Only the depletion is refused, not the whole cutover: once custody
+        /// has actually moved, the incoming wallet holds every receipt, the
+        /// pass succeeds, and the newly recorded holder makes subsequent
+        /// passes ordinary again.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_rotated_wallet_that_holds_the_receipts_is_accepted() {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let (bot_provider, receipt_contract, receipt_id, minted_shares) =
+                deposit_one_receipt(&evm).await;
+
+            seed_receipt(&store, evm.vault_address, receipt_id, minted_shares)
+                .await;
+
+            seed_custody(&store, evm.vault_address, Address::random()).await;
+
+            let reconciler = ReceiptReconciler::new(
+                bot_provider,
+                receipt_contract,
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let result = reconciler.reconcile().await.unwrap();
+
+            assert_eq!(result.checked, 1);
+            assert_eq!(result.mismatches, 0);
+
+            assert_eq!(
+                custody_of(&store, evm.vault_address).await.holder(),
+                Some(evm.wallet_address),
+                "a verified wallet must be recorded so later passes reconcile \
+                 normally"
+            );
+            assert!(logs_contain_at!(
+                tracing::Level::INFO,
+                &["Receipt reconciliation complete", "errors=0"]
+            ));
+        }
+
+        /// The guard must not cost us ordinary cleanup: with the wallet
+        /// unchanged, a receipt that really was spent still gets depleted.
+        #[traced_test]
+        #[tokio::test]
+        async fn an_unchanged_wallet_still_depletes_a_spent_receipt() {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let vault_contract =
+                crate::bindings::OffchainAssetReceiptVault::new(
+                    evm.vault_address,
+                    &provider,
+                );
+            let receipt_contract =
+                Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+            seed_receipt(
+                &store,
+                evm.vault_address,
+                uint!(0xff_U256),
+                U256::from(100) * U256::from(10).pow(U256::from(18)),
+            )
+            .await;
+
+            seed_custody(&store, evm.vault_address, evm.wallet_address).await;
+
+            let reconciler = ReceiptReconciler::new(
+                provider,
+                receipt_contract,
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let result = reconciler.reconcile().await.unwrap();
+
+            assert_eq!(result.mismatches, 1);
+
+            let inventory =
+                load_inventory(&store, ANVIL_CHAIN_ID, &evm.vault_address)
+                    .await
+                    .unwrap();
+            assert!(
+                inventory.receipts_with_balance().is_empty(),
+                "an unchanged wallet reading zero means the receipt was spent"
+            );
+            assert!(logs_contain_at!(
+                tracing::Level::INFO,
+                &["Receipt reconciliation complete", "mismatches=1"]
+            ));
+        }
+
+        /// A pass that could not read every balance has proven nothing about
+        /// where custody sits, so it must not record the wallet as verified —
+        /// otherwise one flaky RPC call during the cutover window would
+        /// silently disarm the guard for every later pass.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_pass_with_unreadable_balances_records_no_holder() {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+            seed_receipt(
+                &store,
+                evm.vault_address,
+                uint!(0xff_U256),
+                U256::from(100) * U256::from(10).pow(U256::from(18)),
+            )
+            .await;
+
+            let reconciler = ReceiptReconciler::new(
+                provider,
+                Address::random(),
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let result = reconciler.reconcile().await.unwrap();
+            assert_eq!(result.errors, 1);
+
+            assert_eq!(
+                custody_of(&store, evm.vault_address).await,
+                Custody::Unobserved,
+                "no holder may be recorded from an unverified pass"
+            );
+            assert!(logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["Failed to reconcile receipt"]
+            ));
+        }
+
+        async fn deposit_one_receipt(
+            evm: &LocalEvm,
+        ) -> (impl Provider + Clone, Address, U256, U256) {
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let signer = alloy::signers::local::PrivateKeySigner::from_bytes(
+                &evm.private_key,
+            )
+            .unwrap();
+            let wallet = alloy::network::EthereumWallet::from(signer);
+            let bot_provider = ProviderBuilder::new()
+                .wallet(wallet)
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &bot_provider,
+            );
+            let receipt_contract =
+                Address::from(vault.receipt().call().await.unwrap().0);
+
+            let deposit_receipt = vault
+                .deposit(
+                    uint!(50_000000000000000000_U256),
+                    evm.wallet_address,
+                    U256::ZERO,
+                    alloy::primitives::Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+
+            let deposit_log = deposit_receipt
+                .inner
+                .logs()
+                .iter()
+                .find_map(|log| {
+                    crate::bindings::OffchainAssetReceiptVault::Deposit::decode_log(
+                        &log.inner,
+                    )
+                    .ok()
+                })
+                .expect("Should find Deposit event");
+
+            (bot_provider, receipt_contract, deposit_log.id, deposit_log.shares)
+        }
     }
 }

--- a/src/wallet/mod.rs
+++ b/src/wallet/mod.rs
@@ -111,27 +111,30 @@ impl SignerEnv {
             (Some(_), Some(_)) => Err(SignerConfigError::BothConfigured),
             (None, None) => Err(SignerConfigError::NeitherConfigured),
             (Some(key), None) => Ok(SignerConfig::Local(key)),
-            (None, Some(org_id)) => {
-                let api_private_key = TurnkeyApiPrivateKey::new(
-                    self.turnkey
-                        .api_private_key
-                        .ok_or(SignerConfigError::MissingApiPrivateKey)?,
-                );
-                let address = self
-                    .turnkey
-                    .address
-                    .ok_or(SignerConfigError::MissingAddress)?;
-
-                let config = TurnkeyConfig::new(
-                    TurnkeyOrganizationId::new(org_id),
-                    api_private_key,
-                    address,
-                );
-
-                Ok(SignerConfig::Turnkey(config))
-            }
+            (None, Some(org_id)) => signer_config_from_turnkey(
+                org_id,
+                self.turnkey.api_private_key,
+                self.turnkey.address,
+            ),
         }
     }
+}
+
+fn signer_config_from_turnkey(
+    org_id: String,
+    api_private_key: Option<String>,
+    address: Option<Address>,
+) -> Result<SignerConfig, SignerConfigError> {
+    let api_private_key = TurnkeyApiPrivateKey::new(
+        api_private_key.ok_or(SignerConfigError::MissingApiPrivateKey)?,
+    );
+    let address = address.ok_or(SignerConfigError::MissingAddress)?;
+
+    Ok(SignerConfig::Turnkey(TurnkeyConfig::new(
+        TurnkeyOrganizationId::new(org_id),
+        api_private_key,
+        address,
+    )))
 }
 
 impl SignerConfig {

--- a/tests/turnkey_cutover.rs
+++ b/tests/turnkey_cutover.rs
@@ -78,12 +78,16 @@ async fn wait_for_receipt_in_inventory(
         // Deliberately not filtered by aggregate id: reproducing the
         // `{chain_id}:{vault}` key here would couple this wait to an encoding
         // that has already been re-keyed once by migration. This scenario uses
-        // a single vault, so the aggregate type alone is an unambiguous signal.
+        // a single vault, so the aggregate type alone identifies it — but the
+        // event type matters: startup reconciliation records custody as soon
+        // as the service boots, so "any inventory event" fires long before the
+        // deposit this wait is actually for has been discovered.
         let recorded: i64 = sqlx::query_scalar(
             "
             SELECT COUNT(*)
             FROM events
             WHERE aggregate_type = 'ReceiptInventory'
+              AND event_type = 'ReceiptInventoryEvent::Discovered'
             ",
         )
         .fetch_one(&pool)
@@ -707,6 +711,222 @@ async fn test_receipt_custody_can_be_rolled_back_to_the_outgoing_wallet()
     );
 
     pool.close().await;
+
+    Ok(())
+}
+
+/// Proves the complete single-asset rehearsal, end to end, in the order the
+/// operator will run it: cutover, operate, reverse, resume.
+///
+/// 1. The outgoing service mints a receipt (pre-cutover custody).
+/// 2. Stop; custody migrates forward; the replacement service starts.
+/// 3. The replacement service performs one canary redemption of the
+///    pre-cutover receipt and one canary mint — the two directions of the flow
+///    against the new custody.
+/// 4. Stop; custody rolls back — including the canary mint's receipt, which
+///    only exists because of step 3 and which the resumed service could not
+///    burn against if it were left behind.
+/// 5. The original service resumes on the same event history and redeems the
+///    canary, proving the rehearsal ends with a fully operational deployment
+///    on the outgoing wallet, not merely with balances returned.
+///
+/// The rollback deliberately carries the database forward rather than
+/// restoring the pre-cutover backup: the replacement service performed real
+/// writes (a redemption and a mint), and discarding them would fork history.
+/// Only custody and the signer configuration reverse.
+#[tokio::test]
+async fn test_single_asset_rehearsal_operates_reverses_and_resumes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let (redeem_mock, poll_mock) =
+        harness::alpaca_mocks::setup_redemption_mocks(&mock_alpaca);
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CutoverDatabases::in_directory(temp_dir.path());
+    let resumed_path = temp_dir.path().join("fireblocks-resumed.db");
+    let resumed_url = format!("sqlite:{}?mode=rwc", resumed_path.display());
+
+    let fireblocks_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::random();
+    let user_wallet = user_signer.address();
+    let turnkey_signer = PrivateKeySigner::random();
+    let turnkey_private_key: B256 = turnkey_signer.to_bytes();
+    let turnkey_wallet = turnkey_signer.address();
+    assert_ne!(fireblocks_wallet, turnkey_wallet);
+
+    let fireblocks_provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+    let test_gas_balance = U256::from(10) * U256::from(10).pow(U256::from(18));
+    fireblocks_provider
+        .anvil_set_balance(user_wallet, test_gas_balance)
+        .await?;
+    fireblocks_provider
+        .anvil_set_balance(turnkey_wallet, test_gas_balance)
+        .await?;
+
+    harness::preseed_tokenized_asset(
+        &databases.fireblocks_url,
+        evm.vault_address,
+        CUTOVER_UNDERLYING,
+        CUTOVER_TOKEN,
+    )
+    .await?;
+    setup_cutover_roles(&evm, user_wallet, fireblocks_wallet, turnkey_wallet)
+        .await?;
+
+    let (fireblocks_config, _fireblocks_subgraph) =
+        harness::create_config_with_db(
+            &databases.fireblocks_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    let fireblocks_client = start_service(fireblocks_config).await?;
+    let pre_cutover_mint = mint_before_cutover(
+        &fireblocks_client,
+        &evm,
+        &user_signer,
+        user_wallet,
+        &mint_callback_mock,
+    )
+    .await?;
+    fireblocks_client.terminate().await;
+
+    // Forward cutover. The migration runs against the same database the
+    // replacement service will use, as it does in production, so the custody
+    // events are part of the history the service starts from.
+    snapshot_database(&databases.fireblocks_url, &databases.turnkey_path)
+        .await?;
+    run_operator_migration(
+        &databases.turnkey_url,
+        &fireblocks_provider,
+        evm.chain_id,
+        evm.vault_address,
+        fireblocks_wallet,
+        turnkey_wallet,
+    )
+    .await?;
+
+    let (mut turnkey_config, _turnkey_subgraph) =
+        harness::create_config_with_db(
+            &databases.turnkey_url,
+            &mock_alpaca,
+            &evm,
+        )?;
+    turnkey_config.signer = SignerConfig::Local(turnkey_private_key);
+    let turnkey_client = start_service(turnkey_config).await?;
+
+    PostCutoverCanaries {
+        client: &turnkey_client,
+        evm: &evm,
+        user_signer: &user_signer,
+        user_wallet,
+        turnkey_wallet,
+        pre_cutover_mint: &pre_cutover_mint,
+        mint_callback_mock: &mint_callback_mock,
+        redeem_mock: &redeem_mock,
+        poll_mock: &poll_mock,
+    }
+    .run()
+    .await?;
+    turnkey_client.terminate().await;
+
+    // The reversal. The canary mint left its receipt with the incoming wallet,
+    // so the rollback has real, newly created custody to return — not just the
+    // original receipts.
+    snapshot_database(&databases.turnkey_url, &resumed_path).await?;
+    run_operator_migration(
+        &resumed_url,
+        &create_provider()
+            .wallet(EthereumWallet::from(turnkey_signer))
+            .connect(&evm.endpoint)
+            .await?,
+        evm.chain_id,
+        evm.vault_address,
+        turnkey_wallet,
+        fireblocks_wallet,
+    )
+    .await?;
+
+    resume_on_outgoing_wallet_and_redeem_canary(
+        &resumed_url,
+        &evm,
+        &mock_alpaca,
+        &user_signer,
+        fireblocks_wallet,
+        &redeem_mock,
+        &poll_mock,
+    )
+    .await?;
+
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        2,
+        "the rehearsal must produce exactly two mints: pre-cutover and canary"
+    );
+    assert_eq!(
+        redeem_mock.calls_async().await,
+        2,
+        "the rehearsal must produce exactly two redemptions: canary and \
+         post-rollback"
+    );
+
+    Ok(())
+}
+
+/// The rehearsal's final act: the outgoing wallet's service resumes on the
+/// rolled-back state and redeems the canary receipt minted by the replacement,
+/// proving the reversal restored an operational deployment.
+async fn resume_on_outgoing_wallet_and_redeem_canary(
+    database_url: &str,
+    evm: &LocalEvm,
+    mock_alpaca: &MockServer,
+    user_signer: &PrivateKeySigner,
+    fireblocks_wallet: Address,
+    redeem_mock: &Mock<'_>,
+    poll_mock: &Mock<'_>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let (resumed_config, _resumed_subgraph) =
+        harness::create_config_with_db(database_url, mock_alpaca, evm)?;
+    let resumed_client = start_service(resumed_config).await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer.clone()))
+        .connect(&evm.endpoint)
+        .await?;
+    let user_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let canary_shares =
+        user_vault.balanceOf(user_signer.address()).call().await?;
+    assert!(
+        canary_shares > U256::ZERO,
+        "the user must still hold the canary shares minted on the replacement"
+    );
+
+    user_vault
+        .transfer(fireblocks_wallet, canary_shares)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    harness::wait_for_mock_hits(redeem_mock, 2).await?;
+    harness::wait_for_mock_hits(poll_mock, 2).await?;
+    harness::wait_for_burn(&user_vault, fireblocks_wallet).await?;
+    assert_eq!(
+        user_vault.balanceOf(user_signer.address()).call().await?,
+        U256::ZERO,
+        "the resumed service must redeem the canary shares in full"
+    );
+
+    resumed_client.terminate().await;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

A partial cutover must not wipe the inventory it did not migrate.
Reconciliation treats a zero `balanceOf(bot_wallet, receipt_id)` as proof the
receipt was spent — which only holds while the wallet is unchanged. A service
started against the incoming wallet before every vault migrated reads zero for
every non-migrated vault at once, and each one would be reconciled as a
depletion. The receipt backfiller has already checkpointed past the deposits
that created them, so nothing rediscovers them: the loss is permanent and
survives a rollback. This is exactly the state the single-asset rehearsal
(AMAT first, then roll back and keep operating on Fireblocks) deliberately
creates, so it blocked rehearsing the cutover at all.

## Solution

Custody becomes domain state on the `ReceiptInventory` aggregate, and the
guard lives in the one place no balance reader can bypass:

- `CustodyConfirmed { holder }` records the wallet balances were read against;
  re-confirming the recorded holder is a no-op. `CustodyMigrated { from, to,
  tx_hash }` records a completed move.
- Every `ReconcileBalance` now carries the wallet the reading was taken
  against, and the **aggregate handler itself** refuses readings from any
  wallet other than the recorded holder — and refuses a destructive zero
  reading outright while no holder has ever been confirmed. The startup
  backfiller, startup and periodic reconciliation, and any future reader all
  go through this one handler.
- Refusals are per vault and write nothing: the service keeps serving vaults
  whose custody matches while a displaced vault fails loudly at ERROR — which
  is also what lets the service operate normally after a bulk cutover while a
  straggler vault awaits its own migration pass.
- An empty inventory no longer confirms custody (recording a holder on no
  evidence would arm the guard around the wrong wallet); a pass that cannot
  read every balance confirms nothing.
- The chain-scanning background loops (periodic receipt backfill, transfer
  poller) now stop on server shutdown: a poller outliving its server is
  precisely the wrong-service-still-running hazard the guard exists to
  refuse.

Advances [RAI-1550](https://linear.app/makeitrain/issue/RAI-1550).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

