### PR TITLE
feat: execute the custody migration through Fireblocks and Turnkey end to end

### DIFF
--- a/.env.secrets.example
+++ b/.env.secrets.example
@@ -65,21 +65,60 @@
 # has no registry entry.
 
 RPC_URL=${RPC_URL}
+
+# --- Turnkey signer ---
+#
+# Where each value comes from (UI steps drift; the authoritative walkthrough
+# is https://docs.turnkey.com/getting-started/quickstart):
+#
+# - TURNKEY_ORG_ID: the Organization ID in the dashboard's user dropdown
+#   (top right). A UUID. If the issuance wallet lives in a sub-organization,
+#   use that sub-org's ID, not the parent's.
+# - TURNKEY_API_PRIVATE_KEY: create an API key from your user's profile page.
+#   An API key is a P-256 keypair that authenticates requests AS your user —
+#   it is not the wallet signing key. The private key is shown exactly once
+#   at creation; expect a hex string (no 0x prefix). Rotating means creating
+#   a new API key and deleting the old one; the wallet is untouched.
+#   Signing authority follows the user the key is attached to: root-quorum
+#   membership signs unconditionally (check the quorum threshold — above 1,
+#   a lone API key's activity stalls pending consensus), otherwise a policy
+#   must allow SIGN_TRANSACTION for the user
+#   (https://docs.turnkey.com/concepts/policies/overview).
+# - TURNKEY_ADDRESS: the wallet account's Ethereum address, from the wallet's
+#   accounts list on the Wallets page. Standard 0x-prefixed address.
 TURNKEY_API_PRIVATE_KEY=<hex-encoded-p256-api-private-key>
 TURNKEY_ORG_ID=<turnkey-organization-id>
 TURNKEY_ADDRESS=<0x-ethereum-address-managed-by-turnkey>
+
+# --- Fireblocks (temporary: receipt-custody migration only) ---
+#
+# Read by the migrate-receipts/verify-custodians/confirm-custody CLI, not the
+# service. Leaves together with src/fireblocks once every vault has migrated.
+# The API user id is a UUID from the Fireblocks console's API users page. Do
+# NOT set FIREBLOCKS_SECRET_PATH here — the deploy activation injects the
+# decrypted RSA key's path, and a stale copy in this file would shadow it.
+FIREBLOCKS_API_USER_ID=<fireblocks-api-user-uuid>
+
+# Defaults ("0", "8453:BASECHAIN_ETH", "production") — set only if they differ:
+# FIREBLOCKS_VAULT_ACCOUNT_ID=0
+# FIREBLOCKS_CHAIN_ASSET_IDS=8453:BASECHAIN_ETH
+# FIREBLOCKS_ENVIRONMENT=production
+
 ISSUER_API_KEY=${ISSUER_API_KEY}
 ALPACA_IP_RANGES=${ALPACA_IP_RANGES}
+
 # INTERNAL_IP_RANGES is baked in at encryption time — no substitution happens
 # after decryption. Add any extra trusted CIDRs (e.g. VPN, office) directly
 # in the comma-separated list before running ragenix.
 INTERNAL_IP_RANGES=127.0.0.0/8,::1/128,172.16.0.0/12
+
 ALPACA_API_BASE_URL=${ALPACA_API_BASE_URL}
 ALPACA_ACCOUNT_ID=${ALPACA_ACCOUNT_ID}
 ALPACA_API_KEY=${ALPACA_API_KEY}
 ALPACA_API_SECRET=${ALPACA_API_SECRET}
 HYPERDX_API_KEY=${HYPERDX_API_KEY}
 SUBGRAPH_URL=${SUBGRAPH_URL}
+
 # ENVIRONMENT is injected by the systemd unit (production vs staging) and must
 # NOT be set here. Setting it in this file would override the unit's value
 # because systemd applies EnvironmentFile= after Environment=.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,9 +175,9 @@ Command -> Aggregate.handle() -> Validate & Produce Events -> Persist Events
 - `apply(event)`: Deterministically updates state from events. Pure, never
   fails - events are historical facts.
 
-**Benefits:** complete audit trail; time-travel debugging (replay to any point);
-testability via Given-When-Then; rebuild/add views by replaying events; multiple
-projections from the same events; the event store is the single source of truth.
+**Benefits:** complete audit trail; time-travel debugging; Given-When-Then
+testability; rebuild/add views by replaying events; multiple projections from
+the same events; the event store is the single source of truth.
 
 **CRITICAL: Events Are Permanent:**
 
@@ -332,12 +332,16 @@ wraps into a signing `Provider` for `RealBlockchainService`:
 Key files: `wallet/mod.rs` (SignerConfig, ResolvedSigner), `wallet/local.rs`,
 `wallet/turnkey.rs`, `config.rs` (backend selection, Provider construction)
 
-**Receipt custody migration (`receipt_inventory/migration.rs`, temporary):**
-rotating the signer strands the vault's receipts at the old address. **Stop the
-service before moving custody.** No wallet address is ever an argument to the
-migration engine; destinations are derived and gated by the
-`CorroboratedRecipient` witness. Custody is aggregate state, so a rotated
-wallet reading zero is refused, not depleted.
+**Receipt custody migration (`receipt_inventory/migration.rs` +
+`src/fireblocks/`, temporary):** rotating the signer strands the vault's
+receipts at the old address. **Stop the service before `migrate-receipts`.** No
+wallet address is an argument: Fireblocks wallet from its API, Turnkey wallet
+from `TURNKEY_ADDRESS`, direction from recorded custody; forward submits via the
+restored narrow Fireblocks client, rollback signs with Turnkey. Ownership
+verification (exact balances before, per-identifier gain after) is the check.
+Custody is aggregate state: a rotated wallet reading zero is refused, not
+depleted. Quiescence gates on in-flight mints/redemptions, never on freeze
+(freeze = corporate action). See `docs/turnkey-receipt-migration-plan.md`.
 
 ### Core Flows
 
@@ -847,13 +851,11 @@ artifacts).
 // minting without backing shares.
 let confirmed = wait_for_journal_confirmation(&mint_id).await?;
 
-// Bad: Restates WHAT (obvious from code)
-// Execute mint command
+// Bad: Restates WHAT // Execute mint command
 execute_mint_command(mint);
 ```
 
-Use `///` doc comments for public APIs. Keep comments focused on "why" not
-"what".
+Use `///` doc comments for public APIs; comments explain "why" not "what".
 
 ## Code Style
 
@@ -892,24 +894,11 @@ can't be mixed up in function arguments.
 ### Avoid deep nesting
 
 Use early returns and `let-else` for flat code instead of nested `if let` / `if`
-pyramids:
-
-```rust
-fn validate(d: Option<&Data>) -> Res<()> {
-    let d = d.ok_or(Error::NoData)?;
-    if d.qty <= 0 { return Err(Error::Qty); }
-    if !d.sym.ok() { return Err(Error::Sym); }
-    Ok(())
-}
-```
+pyramids: guard clauses first (`let value = input.ok_or(Error::NoData)?;`,
+`if bad { return Err(...); }`), then the happy path unindented.
 
 ### Struct field access
 
-Prefer direct field access over unnecessary constructors/getters:
-
-```rust
-let req = MintRequest { qty: 100.into(), underlying: "AAPL".into(), .. };
-println!("{}", req.qty); // direct access; don't add getters like
-// `fn qty(&self) -> Decimal { self.qty }` that just forward to fields
-}
-```
+Prefer direct field access over unnecessary constructors/getters: use struct
+literal syntax and read fields directly; never add getters like
+`fn qty(&self) -> Decimal { self.qty }` that just forward to fields.

--- a/SPEC.md
+++ b/SPEC.md
@@ -191,44 +191,49 @@ initial request through journal confirmation to on-chain minting and callback.
   `MintingStarted`. Intent is persisted before the network call so that a crash
   during submission leaves the aggregate in a recoverable `Minting` state rather
   than `JournalConfirmed` (which would lose track of the submission)
-- `RecordTxIntended { issuer_request_id, prepared_tx }` - Persist the exact
-  signed transaction prepared by `SubmitMintJob` before broadcast. Pure,
-  requires `Minting`, emits `MintTxIntended`
-- `RecordTxSubmitted { issuer_request_id, external_tx_id, signer_tx_id }` -
-  Records a successful on-chain submission performed by `SubmitMintJob`. Pure,
-  requires `Minting`, emits `MintTxSubmitted`
-- `RecordTokensMinted { issuer_request_id, signer_tx_id, tx_hash, receipt_id, shares_minted, gas_used, block_number }` -
-  Records a confirmed mint performed by `ConfirmMintJob`. Pure, requires
-  `TxSubmitted`, emits `TokensMinted`
-- `RecordCallbackSent { issuer_request_id }` - Records the Alpaca completion
-  callback performed by `SendCallbackJob`. Pure, requires `CallbackPending`,
-  emits `MintCompleted`
-- `RecordMintFailed { issuer_request_id, error }` - Records a side-effect
-  failure reported by a job. Pure, emits `MintingFailed`
-- `RecordExistingMint { issuer_request_id, tx_hash, receipt_id, shares_minted, block_number }` -
-  Records a mint whose on-chain transaction already succeeded (a receipt
-  exists), reported by `SubmitMintJob` before it re-submits. Pure double-mint
-  guard; emits `ExistingMintRecovered` and advances to `CallbackPending`
-- `RetryMint { issuer_request_id }` - Transitions `MintingFailed` -> `Minting`,
-  advancing the automatic-retry attempt counter. Pure, emits `MintRetryStarted`.
-  Recovery sends this before re-enqueuing a `SubmitMintJob`
-- `CloseMint { issuer_request_id, reason }` - Admin-closes a mint that cannot be
-  automatically recovered. Valid from any non-terminal state; emits `MintClosed`
-  (terminal)
-
-The external mint side effects run in **durable apalis jobs**, not in the
-command handlers — closing the crash window between a signer submission and the
-event commit (ADR-0001). The handlers above are pure: each job performs one
-external call and reports the outcome via the matching `Record…` command. The
-job chain is `SubmitMintJob` (prepares the transaction, persists
-`MintTxIntended`, then calls `vault.submit_mint`) -> `ConfirmMintJob` (polls
-`vault.confirm_mint`, registers the receipt) -> `SendCallbackJob` (calls
-Alpaca); `process_journal_completion` resolves the vault and enqueues the first
-job. `SubmitMintJob` uses the configured network's Turnkey-backed vault service
-to prepare and submit the signed transaction. A retry with an unresolved
-`MintIntended` predecessor rebroadcasts those exact persisted bytes instead of
-preparing a replacement, and other mint jobs wait while that wallet intent is
-unresolved.
+- `PrepareMint { issuer_request_id }` - Build and sign the exact on-chain
+  deposit transaction. Requires `Minting` state. Produces `MintTxIntended`,
+  which persists the raw transaction, hash, nonce, signing time, and stable
+  external transaction ID before any broadcast
+- `SubmitMint { issuer_request_id }` - Broadcast the exact transaction stored by
+  `MintTxIntended`. Requires `MintIntended` state. Produces `MintTxSubmitted` on
+  success. An uncertain broadcast failure leaves the aggregate in
+  `MintIntended`, so recovery rebroadcasts the same bytes
+- `ConfirmMint { issuer_request_id, tx_id }` - Confirm a previously submitted
+  mint transaction. Re-fetches the on-chain receipt for the stored `tx_id` and
+  produces `TokensMinted` or `MintingFailed`
+- `SendCallback { issuer_request_id }` - Send the callback to Alpaca confirming
+  mint completion
+- `Recover { issuer_request_id, mode }` - Recover a mint stuck in an incomplete
+  state. Startup recovery drives any mint in `JournalConfirmed`, `Minting`,
+  `MintIntended`, `TxSubmitted`, `MintingFailed`, or `CallbackPending` state; at
+  runtime, live retry scheduling is triggered specifically when a mint lands in
+  `MintingFailed` during the journal-confirmation flow. Both paths hand a mint
+  that is waiting on a retry window to a background scheduled-recovery task, so
+  retries fire on schedule without waiting for a restart. Queries the receipt
+  inventory for a receipt matching the `issuer_request_id`. If a matching
+  receipt is found, the mint already succeeded on-chain, so recovery records the
+  existing mint (`ExistingMintRecovered`) and proceeds to callback. If no
+  receipt is found and the previous transaction is terminally failed, automatic
+  recovery submits up to four retry transactions after 1m, 10m, 30m, and 1h
+  delays. Manual admin reprocess uses the same recovery path but bypasses the
+  automatic retry cap so an operator can retry after fixing the underlying
+  cause. This prevents double-minting after crashes while ensuring terminal
+  failures can be retried with new `externalTxId`s
+- `RecoverWalletStep { issuer_request_id, mode }` - Internal recovery variant
+  used only while the wallet lock is held. It performs the same recoverable
+  on-chain steps as `Recover`, but becomes a no-op if a concurrent transition
+  already reached `CallbackPending`; the next recovery iteration then sends the
+  callback without the wallet lock
+- `RecoverFromReceipt { issuer_request_id, tx_hash }` - Recover a mint that
+  failed during the minting step, or whose broadcast outcome was not persisted,
+  when an ITN receipt is discovered on-chain. Triggered by the receipt monitor
+  when it finds a Deposit event with a matching `issuer_request_id`. Accepts
+  `MintIntended`, because the persisted transaction may have been mined before
+  submission recording, and `MintingFailed` when the non-failed predecessor was
+  `Minting`. Rejects `JournalConfirmed` and `Minting` because neither state
+  proves a transaction was signed or submitted. Emits `ExistingMintRecovered`
+  and proceeds to callback
 
 **Events:**
 
@@ -246,7 +251,6 @@ unresolved.
 - `ExistingMintRecovered` - Existing on-chain mint discovered during recovery
   (carries tx details)
 - `MintRetryStarted` - Mint retry started during recovery
-- `MintClosed` - Admin-closed mint that cannot be auto-recovered (terminal)
 
 Newly persisted transaction IDs use an explicitly tagged `hash` or `legacy`
 representation so replay preserves the original `TxId` variant, including a
@@ -265,25 +269,40 @@ dual-format reader or restore the pre-cutover backup.
 
 **Command -> Event Mappings:**
 
-| Command              | Events                  | Notes                                  |
-| -------------------- | ----------------------- | -------------------------------------- |
-| `Initiate`           | `Initiated`             | Mint request created                   |
-| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                      |
-| `RejectJournal`      | `JournalRejected`       | Terminal failure                       |
-| `Deposit`            | `MintingStarted`        | Records intent (no network call)       |
-| `RecordTxSubmitted`  | `MintTxSubmitted`       | `SubmitMintJob` outcome                |
-| `RecordTokensMinted` | `TokensMinted`          | `ConfirmMintJob` outcome               |
-| `RecordCallbackSent` | `MintCompleted`         | `SendCallbackJob` outcome              |
-| `RecordMintFailed`   | `MintingFailed`         | Job-reported side-effect failure       |
-| `RecordExistingMint` | `ExistingMintRecovered` | Double-mint guard (receipt exists)     |
-| `RetryMint`          | `MintRetryStarted`      | `MintingFailed` -> `Minting` for retry |
-| `CloseMint`          | `MintClosed`            | Admin-close (terminal)                 |
+| Command              | Events                  | Notes                                          |
+| -------------------- | ----------------------- | ---------------------------------------------- |
+| `Initiate`           | `Initiated`             | Mint request created                           |
+| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                              |
+| `RejectJournal`      | `JournalRejected`       | Terminal failure                               |
+| `Deposit`            | `MintingStarted`        | Records intent (no network call)               |
+| `PrepareMint`        | `MintTxIntended`        | Persists exact signed tx before broadcast      |
+| `SubmitMint`         | `MintTxSubmitted`       | Broadcasts the persisted transaction           |
+| `ConfirmMint`        | See below               | Confirms submitted tx                          |
+| `SendCallback`       | `MintCompleted`         | Calls Alpaca callback                          |
+| `Recover`            | See below               | Checks receipt inventory                       |
+| `RecoverWalletStep`  | See below               | Never sends callbacks while wallet-locked      |
+| `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt recovery from intended or failed state |
 
-`Deposit` emits only `MintingStarted` (intent). The actual submission is handled
-by `SubmitMintJob`, whose outcome command emits either `MintTxSubmitted`
-(success) or `MintingFailed` (failure). This two-step design persists intent
-before the network call, so a crash during submission leaves the aggregate in
-`Minting` state (recoverable) rather than `JournalConfirmed`.
+`Deposit` emits only `MintingStarted` (business intent). `PrepareMint` builds
+and signs the transaction, then persists the exact bytes and hash in
+`MintTxIntended`. Only `SubmitMint` may broadcast those persisted bytes. A crash
+before `MintTxIntended` cannot have broadcast anything; a crash after it causes
+recovery to rebroadcast or poll that same transaction, never prepare a second
+one. A crash after broadcast but before `MintTxSubmitted` therefore remains safe
+because rebroadcasting identical signed bytes is idempotent. Preparing,
+persisting, and initially broadcasting a mint transaction share one wallet
+critical section. Startup mint recovery processes its persisted intents in nonce
+order before mint states that may prepare a new transaction. Mint and redemption
+recovery run concurrently so persisted transactions from either domain can fill
+lower nonce gaps while higher transactions await confirmation. Live mint and
+burn preparation query the authoritative event log and are blocked while any
+other wallet intent remains unresolved; this safety check does not depend on a
+fallible read-model projection. Together these rules prevent two aggregate
+commands from signing the same wallet nonce without relying on in-memory nonce
+state that would be lost on restart. Each live burn attempt waits at most 30
+seconds behind an earlier unresolved wallet intent. On timeout it prepares and
+broadcasts nothing, leaves the redemption recoverable, and defers the burn to
+recovery rather than occupying the live flow indefinitely.
 
 The issuer is a single-writer service: exactly one process may own a given
 SQLite event store and signing wallet at a time. Horizontal replicas sharing a
@@ -291,26 +310,36 @@ wallet are unsupported because the wallet critical section is process-local.
 Deployments must terminate the old process before the replacement begins serving
 or recovering work.
 
-**Recovery.** A durable `MintRecoveryJob` re-drives a stuck or failed mint. Its
-budget loop (driven by `automatic_retry_decision`) enqueues the per-state job
-for the mint's current state — `SubmitMintJob` from `Minting`, `ConfirmMintJob`
-from `TxSubmitted`, `SendCallbackJob` from `CallbackPending` — or issues the
-pure transition that precedes it (`Deposit` from `JournalConfirmed`, `RetryMint`
-from `MintingFailed`). The startup re-scan, the periodic reconciler, the receipt
-monitor (on ITN-receipt discovery), and the admin reprocess endpoint all route
-through the same enqueue path.
+`ConfirmMint` re-fetches the on-chain receipt for the submitted `tx_id` and
+emits either `TokensMinted` (success) or `MintingFailed` (failure).
 
-Re-submission is double-mint-safe: before submitting, `SubmitMintJob` checks the
-receipt inventory and, if the mint already succeeded on-chain, sends
-`RecordExistingMint` (emitting `ExistingMintRecovered`) instead of submitting
-again; the deterministic `external_tx_id` (`mint-{issuer_request_id}`) lets a
-deduplicating signing backend drop repeats. The retry-delay/exhaustion schedule
-is driven by a `MintingFailed` attempt counter (retries due after 1m, 10m, 30m,
-1h, then exhausted). A discovered receipt bypasses the backoff so a mint that
-actually succeeded is recorded immediately rather than waiting out the retry
-window. A pre-existing `MintIntended` state is recovered by submitting its
-persisted signed transaction, preserving the Turnkey migration's rebroadcast
-behavior.
+`Recover` checks the receipt inventory for a receipt matching the
+`issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
+in `Minting` state, prepares and persists `MintTxIntended`. If in
+`MintIntended`, rebroadcasts the persisted raw transaction. If in `TxSubmitted`
+(or `MintingFailed` with a known prior transaction), calls `ConfirmMint` with
+the stored `tx_id` to re-fetch the on-chain receipt. `TxSubmitted` means the
+persisted transaction was broadcast; it does not mean the transaction succeeded
+on-chain. `ConfirmMint` waits for the receipt and emits `TokensMinted` for a
+successful transaction or `MintingFailed` for a reverted or otherwise failed
+transaction. Retry transactions use `mint-{issuer_request_id}-retry-{n}` where
+automatic retries use n = 1..4 and the delay schedule is 1m, 10m, 30m, then 1h.
+
+The retry-delay/exhaustion schedule is driven by a `MintingFailed` attempt
+counter. A transaction-preparation failure records `MintingFailed`; an uncertain
+broadcast failure instead preserves `MintIntended` and recovery rebroadcasts the
+exact same signed bytes without advancing the attempt. A running service keeps
+driving deferred retries via a background scheduled-recovery task (also spawned
+at startup and after a manual reprocess), rather than waiting for the next
+restart.
+
+`RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
+receipt for a mint in `MintIntended`, or in `MintingFailed` where the
+predecessor was `Minting`. It emits `ExistingMintRecovered`, transitions to
+`CallbackPending`, then continues through the existing `SendCallback` ->
+`MintCompleted` flow without rebroadcasting. Automated recovery persists the
+`CallbackPending` boundary before delivering the callback, so receipt polling
+and Alpaca requests do not hold the wallet transaction lock.
 
 ### Redemption Aggregate
 
@@ -731,70 +760,112 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
 - `issuer freeze <UNDERLYING>` — dispatch the `Freeze` command.
 - `issuer unfreeze <UNDERLYING>` — dispatch the `Unfreeze` command.
 - `issuer status <UNDERLYING>` — print the underlying's current freeze status.
-  The receipt-custody **migration engine**
-  (`receipt_inventory::migration::migrate_vault_receipts`) moves a vault's
-  ERC-1155 deposit receipts from their holding wallet to a replacement wallet.
-  Temporary, for the Turnkey signing-backend cutover; removed once every vault
-  has migrated. The operator command that executes it ships with the execution
-  work; the engine and its gates are specified here because every execution path
-  must run through them unchanged.
+- `issuer migrate-receipts <UNDERLYING>` — move a vault's ERC-1155 deposit
+  receipts between the Fireblocks and Turnkey wallets. Temporary, for the
+  Turnkey signing-backend cutover; removed once every vault has migrated.
+- `issuer confirm-custody <UNDERLYING>` — record which wallet holds a vault's
+  receipts, after verifying on-chain that it holds exactly every tracked
+  balance. The bootstrap that arms the reconciliation displacement guard for
+  history predating custody tracking. Temporary, like `migrate-receipts`.
+- `issuer verify-custodians <UNDERLYING>` — prove both custodian connections
+  before anything moves: authenticate against Fireblocks and resolve the
+  whitelisted Receipt contract, and sign the exact rollback-shaped transaction
+  with Turnkey without broadcasting it. `--smoke` additionally submits a
+  zero-amount transfer through the full Fireblocks path. Temporary, like
+  `migrate-receipts`.
+
+The custody subcommands are listing-scoped and therefore take `--network`, plus
+`--rpc-url` (the service's own `RPC_URL`) and `--chain-id` (cross-checked
+against the chain that endpoint reports). `migrate-receipts` and
+`verify-custodians` require both custodians' configurations — the `TURNKEY_*`
+group and the `FIREBLOCKS_*` group the retired integration used — all from the
+service's own environment.
 
 **No wallet address is ever an argument.** An ERC-1155 transfer to a wrong
 address is final — no counterparty, no recovery, and the receipts back tokens
-that are still outstanding — so every address the migration uses is derived
-from configuration the system already holds rather than typed. The outgoing
-wallet is whatever the signing configuration resolves: whatever signs is
-necessarily what custody leaves. The destination is derived by the execution
-path from the same environment, never named by an operator, and must clear an
-on-chain corroboration witness: an address with no transaction history and no
-native balance has no on-chain existence, which is what a corrupted config
-value looks like. The corroboration is a witness type, so the transfer cannot
-be reached without it.
+that are still outstanding — so every address is derived, never typed: the
+Fireblocks wallet from the Fireblocks API (`fetch_vault_address`), the Turnkey
+wallet from `TURNKEY_ADDRESS` (the exact value the service runs with after the
+cutover), and the direction from the inventory's recorded custody. Custody at
+the Fireblocks wallet → forward transfer, submitted through the Fireblocks API
+as a `CONTRACT_CALL` via the whitelisted Receipt contract with a deterministic
+`externalTxId` (a retried run resumes the original transaction instead of
+double-submitting), polled to a terminal status. Custody at the Turnkey wallet →
+rollback, signed by Turnkey back to the API-derived Fireblocks wallet.
+Unobserved custody → refuse and demand `confirm-custody`.
 
-The transfer is signed by the holding wallet itself: ERC-1155 lets a balance
-be moved only by its holder or by an operator the holder has approved via
-`setApprovalForAll`, and the migration relies on the holder case rather than
-granting any operator approval — ERC-1155 approval is all-or-nothing across
-every token the holder owns, so granting it for a one-shot transfer would be a
-far wider authorization than the operation needs. The engine refuses while any
-burn is reserved against the vault's receipts, refuses while any mint or
-redemption of the migrating asset sits between initiation and a terminal state
-(in-flight work resumes against the wrong wallet after a custody move; work
-that cannot be attributed to an asset counts against every vault), and refuses
-when the vault has no tracked receipts rather than reporting an unverified
-no-op. Quiescence is deliberately not a freeze check: the corporate-action
-freeze has its own lifecycle, and a migration neither requires declaring one
-nor ends one that is real. The tracked inventory is cross-checked against
-on-chain balances, the vault's certification and owner-freeze gates are re-read
-immediately before submission, and post-conditions are verified per receipt
-identifier afterwards. Re-running after a successful move reports
-`AlreadyMigrated` instead of submitting a second transfer.
+**Ownership verification is the check, not address comparison.** The engine
+requires the holder to hold exactly every tracked balance on-chain before
+submitting (a wrong Fireblocks workspace holds nothing tracked and is refused),
+and verifies the recipient's per-identifier gain afterwards. The derived
+destination is additionally refused if it is the zero address or the sender
+itself, and must be corroborated by the chain (an address with no transaction
+history and no native balance is what a corrupted config value looks like) via a
+witness type the transfer cannot be reached without.
 
-The operator sequence around the engine is **stop the issuer service** → move
-custody → swap the signer configuration → start the service. Stopping first is
-not optional: startup reconciliation reads `balanceOf(bot_wallet)` for every
-tracked receipt, so a service still configured with the outgoing signer that
-restarts after custody has moved reads zero for every one of them, reconciles
-that as depletion, and drops the receipts from the aggregate.
+ERC-1155 lets a balance be moved only by its holder or by an operator the holder
+has approved via `setApprovalForAll`, and the migration relies on the holder
+case rather than granting any operator approval — ERC-1155 approval is
+all-or-nothing across every token the holder owns, so granting it for a one-shot
+transfer would be a far wider authorization than the operation needs.
+
+Quiescence is deliberately **not** a freeze check: the `Underlying` freeze means
+"corporate action in progress", and a custody migration must neither require
+declaring one nor end one that is real. The migration refuses when any of the
+following holds, read from the same store the recovery paths read:
+
+- a burn is reserved against the vault's receipts;
+- a redemption **for the migrating asset** is between detection and a terminal
+  state;
+- a mint **for the migrating asset** is between initiation and a terminal state;
+- the vault has no tracked receipts with balance (an empty or fully-spent vault
+  has nothing to move, and treating it as migratable would let a move "verify"
+  on two zero readings).
+
+The in-flight gates are scoped to the asset because stuck work only ever resumes
+against its own vault; work that cannot be attributed to an asset counts against
+every vault instead of none. Beyond quiescence: the tracked inventory is
+cross-checked against on-chain balances, the vault's certification and
+owner-freeze gates are re-read immediately before submission, and a completed
+move observed again is recorded (idempotently) instead of re-transferred,
+reported as `AlreadyMigrated`.
+
+The operator sequence is **pause liquidity rebalancing → stop the issuer service
+→ `migrate-receipts` → start the replacement service**. Stopping first keeps the
+window clean: startup reads `balanceOf(bot_wallet)` for every tracked receipt
+(the backfiller first, then startup reconciliation), and a service still
+configured with the outgoing signer reads zero for every one of them after
+custody moves. Applying that as depletion is what the custody guard exists to
+refuse — the readings are refused at the aggregate, per vault, at ERROR.
 
 Custody is therefore part of the `ReceiptInventory` aggregate's own state,
 maintained by two events. `CustodyConfirmed { holder }` records the wallet the
 balances were read against, emitted only when custody goes from unobserved to
 known or the holder genuinely changes — the periodic reconciler's re-confirms
 are no-ops, so the log does not grow per pass.
-`CustodyMigrated { from, to,
-tx_hash }` records a completed move; its `from` is
-what a rollback later reads its destination out of. Balances in this aggregate
-are `balanceOf(holder, id)` readings, so the holder is part of what they mean: a
+`CustodyMigrated { from, to, tx_hash }` records a completed move (`tx_hash` is
+`None` when the move was verified from balances after the fact rather than
+submitted by this binary). Balances in this aggregate are
+`balanceOf(holder, id)` readings, so the holder is part of what they mean: a
 zero only means "spent" while the holder is unchanged. Once it has rotated, a
 zero means "held elsewhere", and depleting on it would erase inventory whose
 receipts sit untouched at the previous wallet — permanently, since the receipt
-backfiller has already checkpointed past the deposits that created them. A
-reconciliation pass that finds the wallet rotated and holding none of the
-claimed receipts writes nothing, logs at ERROR, and fails, leaving the inventory
-intact. This is what makes a single-asset cutover safe: the vaults that have not
-migrated yet are refused rather than wiped. A pass that cannot read every
-balance confirms nothing, so one flaky call cannot disarm the guard.
+backfiller has already checkpointed past the deposits that created them.
+
+The guard is enforced in the aggregate's `ReconcileBalance` handler itself:
+every balance reading carries the wallet it was taken against, and the handler
+refuses readings from any wallet other than the recorded holder — and refuses a
+destructive zero reading outright while no holder has ever been confirmed
+(`issuer confirm-custody` is the bootstrap). Every reader — the startup
+backfiller, startup and periodic reconciliation, and any future caller — goes
+through this one handler, so no code path can apply a wrong-wallet reading. The
+refusal is per vault and writes nothing: the service keeps serving vaults whose
+custody matches while a displaced vault fails loudly at ERROR. This is what
+makes a single-asset cutover safe — vaults that have not migrated yet are
+refused rather than wiped — and it is also what lets the service operate
+normally after a bulk cutover while a straggler vault awaits its own migration.
+A pass that cannot read every balance confirms nothing, so one flaky call cannot
+disarm the guard.
 
 Freeze, unfreeze, and status address the `Underlying` aggregate, so they take no
 network argument: one freeze covers every listing of the underlying. The CLI
@@ -814,39 +885,6 @@ CLI. Listing-scoped subcommands (asset addition and any future per-listing
 action) resolve by `{underlying}:{network}` and take a required
 `--network <NETWORK>` flag (wire value) — there is deliberately no default
 network so an operator can never target the wrong chain's listing by omission.
-
-**Scheduled freeze windows.** For a corporate action known in advance (an
-ex-date), the freeze/unfreeze pair can be armed ahead of time instead of fired
-by hand at the exact instants. `POST /admin/freeze-schedules` (internal
-API-key + IP-allowlist auth, like all admin endpoints) takes an underlying and a
-`freeze_at`/`unfreeze_at` window and enqueues two durable apalis jobs — a
-`Freeze` at `freeze_at` and an `Unfreeze` at `unfreeze_at`. The worker
-dispatches the exact same `Underlying` commands the CLI does; only the trigger
-differs. Scheduled transitions survive restarts (apalis persists the due time),
-and re-posting an identical window is an idempotent no-op while its jobs are
-pending or running (jobs are keyed by underlying + the full scheduled instant,
-including subseconds); a window whose job reached a terminal state (done,
-killed, or out of retries) releases its key on re-arm, so an infrastructure
-failure never permanently blocks a window. At startup, orphaned `Running` rows
-reset to `Pending` and terminal rows are vacuumed, mirroring the mint jobs;
-transitions that died without applying (killed or out of retries) are surfaced
-at ERROR before their rows are removed. Command idempotency makes a _repeated_
-transition landing on an already-transitioned asset harmless, but the two jobs
-of a window are independent with no cross-ordering guarantee, so the binary
-Freeze/Unfreeze model is **not** safe against overlap or reordering: an Unfreeze
-for one schedule can release another still-active window, and a freeze job that
-only succeeds after its paired unfreeze already ran leaves the asset frozen
-until an operator unfreezes it by hand. Operators must not arm overlapping
-windows for the same underlying. An underlying with no listing is rejected with
-404 (the `Underlying` commands would succeed for any symbol, so an unchecked
-typo would arm a freeze that gates nothing while reporting success; the check
-lives in the scheduler itself so every schedule source inherits it); an inverted
-or sub-second window is rejected with 422 (apalis schedules at second
-granularity, so a sub-second window has no defined execution order); a fully
-elapsed window is rejected rather than flapping the asset; a `freeze_at` already
-in the past with `unfreeze_at` still ahead (window in progress) freezes
-immediately. This is the schedule mechanism the automated corporate-actions
-sourcing feeds; until then an operator arms windows manually.
 
 ## Services
 
@@ -1391,11 +1429,11 @@ sequenceDiagram
     Alpaca->>Us: POST /inkind/issuance/confirm<br/>{status: "completed"}
     Note right of Us: ConfirmJournal command<br/>Event: JournalConfirmed
     Note right of Us: Deposit command<br/>Event: MintingStarted
-    Note right of Us: Enqueue SubmitMintJob
+    Note right of Us: PrepareMint command<br/>Event: MintTxIntended<br/>(signed transaction persisted)
 
     rect rgb(200, 220, 250)
         Note over Us,Blockchain: Single Atomic Transaction (multicall)
-        Us->>Blockchain: SubmitMintJob: prepare and submit transaction
+        Us->>Blockchain: SubmitMint: broadcast persisted transaction
         Note right of Us: Event: MintTxSubmitted
         Note right of Blockchain: 1. deposit(10 AAPL, bot_wallet)
         Note right of Blockchain: Bot receives shares + receipts
@@ -1403,10 +1441,10 @@ sequenceDiagram
         Note right of Blockchain: Bot transfers shares to AP<br/>(keeps receipts)
     end
     Blockchain->>Us: Transaction confirmed (both steps succeeded)
-    Note right of Us: Deposit + durable submit/confirm jobs<br/>Events: MintingStarted,<br/>MintTxSubmitted, TokensMinted
+    Note right of Us: ConfirmMint command<br/>Event: TokensMinted
 
     Us->>Alpaca: POST /tokenization/callback/mint<br/>{tx_hash, wallet_address}
-    Note right of Us: SendCallbackJob -> RecordCallbackSent<br/>Event: MintCompleted<br/>Status: completed
+    Note right of Us: SendCallback command<br/>Event: MintCompleted<br/>Status: completed
 
     Alpaca->>AP: Mint completed ✓
     Note left of AP: AP now has 10 AAPL0x<br/>share tokens in their wallet<br/>(Bot holds receipts)
@@ -1673,25 +1711,19 @@ stateDiagram-v2
     PendingJournal --> JournalConfirmed: ConfirmJournal
     PendingJournal --> JournalRejected: RejectJournal
     JournalConfirmed --> Minting: Deposit (MintingStarted)
-    Minting --> TxSubmitted: RecordTxSubmitted (MintTxSubmitted)
-    Minting --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
-    Minting --> MintingFailed: RecordMintFailed (MintingFailed)
-    MintIntended --> TxSubmitted: SubmitMintJob (legacy persisted intent)
-    MintIntended --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
-    TxSubmitted --> CallbackPending: RecordTokensMinted (TokensMinted)
-    TxSubmitted --> MintingFailed: RecordMintFailed (MintingFailed)
-    MintingFailed --> Minting: RetryMint (MintRetryStarted)
-    MintingFailed --> CallbackPending: RecordExistingMint (ExistingMintRecovered)
-    CallbackPending --> Completed: RecordCallbackSent (MintCompleted)
-    JournalConfirmed --> Closed: CloseMint (MintClosed)
-    Minting --> Closed: CloseMint (MintClosed)
-    MintIntended --> Closed: CloseMint (MintClosed)
-    TxSubmitted --> Closed: CloseMint (MintClosed)
-    CallbackPending --> Closed: CloseMint (MintClosed)
-    MintingFailed --> Closed: CloseMint (MintClosed)
+    Minting --> MintIntended: PrepareMint (MintTxIntended)
+    Minting --> MintingFailed: PrepareMint (MintingFailed)
+    MintIntended --> TxSubmitted: SubmitMint (MintTxSubmitted)
+    MintIntended --> MintIntended: SubmitMint uncertain failure (no event)
+    MintIntended --> CallbackPending: Recover or RecoverFromReceipt (ExistingMintRecovered)
+    TxSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
+    TxSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
+    MintingFailed --> MintIntended: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + MintTxIntended)
+    MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
+    MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
+    CallbackPending --> Completed: SendCallback
     JournalRejected --> [*]
     Completed --> [*]
-    Closed --> [*]
 ```
 
 **Data Structures:**
@@ -2516,13 +2548,10 @@ Auto-detects the right recovery path from the event history:
 
 **Mint:** `POST /admin/reprocess/mint/<aggregate_id>`
 
-Enqueues a durable `MintRecoveryJob` — the same path the startup re-scan, the
-periodic reconciler, and the receipt monitor use — which re-drives the mint
-through the per-state jobs from whatever incomplete state it is in
-(`JournalConfirmed`, `Minting`, `TxSubmitted`, `MintingFailed`,
-`CallbackPending`). The recovery budget loop honours the automatic-retry
-schedule, so a mint whose automatic retries are already exhausted is not retried
-again by a manual reprocess; close it with `/admin/close/mint` instead.
+Dispatches the manual `Recover` command which handles `JournalConfirmed`,
+`Minting`, `MintIntended`, `TxSubmitted`, `MintingFailed`, and `CallbackPending`
+states. Manual reprocess can submit the next deterministic retry even after
+automatic retries have exhausted.
 
 **Post-Alpaca with existing on-chain burn:** If a `BurningFailed` event carries
 a tx ID, the endpoint scans on-chain for the transaction. If the tx completed

--- a/deploy.nix
+++ b/deploy.nix
@@ -42,7 +42,14 @@ let
   #   2. Decrypt and install the env-file secrets (chmod 0640 group st0x).
   #   3. Chown any existing data files so the st0x user can access them.
   #   4. Record the deployed git revision for ops tooling.
-  #   5. Touch the marker (ConditionPathExists in the unit) and restart.
+  #   5. Touch the marker (ConditionPathExists in the unit) and restart —
+  #      unless the operator hold file (/run/st0x/<name>.hold) exists, in
+  #      which case the binary and secrets are installed and validated but the
+  #      service is left stopped. The hold protects a custody-migration
+  #      window: while it is present, NO deploy — intentional or stray — can
+  #      start a service against custody that has not finished moving. /run is
+  #      tmpfs, so a reboot clears the hold along with the marker; re-create
+  #      it before any deploy if the window is still open.
   #
   # If any step fails, deploy-rs exits non-zero and rolls back automatically.
   mkIssuanceProfile =
@@ -98,8 +105,16 @@ let
         "(chown -R st0x:st0x /mnt/data/logs 2>/dev/null || true)"
 
         "echo '${gitRev}' > /run/st0x/${name}.git-rev"
-        "touch ${cfg.markerFile}"
-        "systemctl restart ${name}"
+        ''
+          if [ -f /run/st0x/${name}.hold ]; then
+            echo 'hold file /run/st0x/${name}.hold present:' \
+              '${name} installed and validated but left stopped'
+            rm -f ${cfg.markerFile}
+          else
+            touch ${cfg.markerFile}
+            systemctl restart ${name}
+          fi
+        ''
       ]
     );
 

--- a/docs/turnkey-receipt-migration-plan.md
+++ b/docs/turnkey-receipt-migration-plan.md
@@ -1,0 +1,544 @@
+# Plan: migrating deposit receipts to the Turnkey wallet
+
+Status: the migration CLI executes the live move end to end. The narrow
+Fireblocks client was restored (submit `CONTRACT_CALL`, poll to terminal,
+whitelist resolution, vault-address lookup), so `issuer migrate-receipts`
+submits the forward transfer through the Fireblocks API itself and signs the
+rollback with Turnkey. Every wallet address is derived — from the Fireblocks
+API, the Turnkey configuration, or on-chain state — never typed. What remains
+before the window is the Fireblocks-side authorization (whitelisting + TAP rule,
+RAI-1546/RAI-1544) and the preflights below.
+
+## What this unblocks
+
+The Turnkey signing backend is merged but undeployed. It cannot ship until the
+ERC-1155 deposit receipts held by the Fireblocks signing address are moved to
+the Turnkey signing address.
+
+The receipt inventory is keyed to the bot's own signing address: the backfiller
+and reconciler both read `balanceOf(bot_wallet, receipt_id)`
+(`src/receipt_inventory/backfill.rs:470`,
+`src/receipt_inventory/reconcile.rs:148`). Switching backends changes that
+address. Receipts left behind are invisible to the bot, which would then be
+unable to burn against real backing.
+
+This proposes an automated, idempotent, per-asset migration we can run
+ourselves, starting with AMAT alone, rather than a manual transfer synchronised
+against a service cutover.
+
+## On-chain authorisation
+
+A receipt transfer clears the vault's authorisation path:
+
+1. `safeTransferFrom` / `safeBatchTransferFrom` on the Receipt contract, both
+   inherited from `ERC1155Upgradeable`.
+2. `Receipt._update` calls
+   `manager.authorizeReceiptTransfer3(operator, from, to, ids, amounts)`.
+3. `ReceiptVault.authorizeReceiptTransfer3` enforces only that the caller is the
+   Receipt contract, reverting `UnmanagedReceiptTransfer()`. No other
+   restriction.
+4. `OffchainAssetReceiptVault.authorizeReceiptTransfer3` runs
+   `ownerFreezeCheckTransaction(from, to)`, then delegates to
+   `authorizer.authorize(operator, TRANSFER_RECEIPT, abi.encode(TransferReceiptStateChange{from, to, ids, amounts, isCertificationExpired: isCertificationExpired()}))`.
+5. The authorizer's `TRANSFER_RECEIPT` branch reverts
+   `CertificationExpired(from, to)` if certification has expired, absent a
+   privileged exemption. Otherwise it executes a bare `return`.
+
+**No role is required.** Not `TRANSFER_RECEIPT`, not a handler role, nothing
+granted to either address. Two runtime conditions must hold when the transaction
+lands:
+
+- **Certification is not expired**, or the transfer reverts.
+- **The owner freeze does not block the pair.** `ownerFreezeCheckTransaction`
+  reverts when `block.timestamp <= ownerFrozenUntil` and the sender is absent
+  from `alwaysAllowedFroms` and the recipient absent from `alwaysAllowedTos`. An
+  unset freeze leaves `ownerFrozenUntil` at zero and blocks nothing.
+
+Both are read-only checkable against the live vaults before scheduling anything.
+
+Sourced from `main` on gildlab/ethgild; confirm against deployed bytecode. The
+receiving Turnkey address is an externally owned account, so the ERC-1155
+receiver callback does not apply.
+
+### The operator
+
+`Receipt._update` takes the operator from `_consumeOperator()`: a single-use
+operator if `withOperator` set one, otherwise `_msgSender()`.
+
+- **Direct transfer:** operator is `_msgSender()`, the Fireblocks address, equal
+  to `from`.
+- **Manager-initiated transfer:** `managerTransferFrom(sender, ...)` runs under
+  `onlyManager` and `withOperator(sender)`, so the operator is the `sender` the
+  vault passes, not the holder.
+
+The authorizer checks no roles on the non-expired path, so operator identity
+does not affect an ordinary transfer. It matters only on the
+certification-expired path, where the privileged exemptions are keyed to it.
+
+### Certification is externally controlled
+
+The bot never calls `certify()` in production; the only certification code here
+is the Anvil test harness (`grant_certify_role`, `certify_vault` in
+`src/test_utils.rs`). Certification is maintained by whoever holds `CERTIFY` on
+the live vault.
+
+The migration window therefore depends on a property we neither own nor monitor.
+Certification could lapse between pre-flight check and transaction landing, and
+every remaining asset would begin reverting mid-migration. The automation must
+read `isCertificationExpired()` immediately before each submission and abort
+cleanly rather than retry into a wall.
+
+## Custodian authorisation: the Fireblocks policy changes
+
+The full Fireblocks integration was deleted with the Turnkey switch; the narrow
+client restored for this migration (`src/fireblocks/`) submits `CONTRACT_CALL`
+operations to an `ExternalWallet` destination resolved from the whitelisted
+contract wallet list, and `resolve_contract_wallet` rejects any address not
+already whitelisted. The vault was the only call target historically; the
+Receipt contract was never one. That is the gap the authorization work closes.
+
+### Step 1: whitelist each Receipt contract
+
+For every vault in scope, whitelist its Receipt contract as a contract wallet in
+the Fireblocks workspace.
+
+The Receipt address is not the vault address. Obtain it per vault by calling the
+vault's `receipt()` view function; that is the same address the vault itself
+checks against in `ReceiptVault.authorizeReceiptTransfer3`. These addresses
+should be read off-chain and confirmed before whitelisting, not transcribed from
+any other source.
+
+AMAT's Receipt contract is the only one strictly required for the first run.
+Whitelisting the rest can follow once AMAT proves the path.
+
+### Step 2: add a TAP rule permitting the call
+
+A rule of this shape, in Fireblocks policy JSON, allows a given vault account to
+make contract calls to whitelisted contract destinations:
+
+```json
+{
+  "type": "TRANSFER",
+  "action": "ALLOW",
+  "transactionType": "CONTRACT_CALL",
+  "dstAddressType": "WHITELISTED",
+  "src": { "ids": [["<VAULT_ACCOUNT_ID>", "VAULT", "*"]] },
+  "dst": { "ids": [["<CONTRACT_WALLET_ID>", "UNMANAGED", "CONTRACT"]] },
+  "asset": "BASECHAIN_ETH",
+  "amount": 0,
+  "amountScope": "SINGLE_TX",
+  "amountCurrency": "USD",
+  "periodSec": 0,
+  "operators": { "usersGroups": ["<GROUP_ID>"] }
+}
+```
+
+Field notes for whoever applies this:
+
+- `src` is the bot's vault account. The deleted integration defaulted
+  `FIREBLOCKS_VAULT_ACCOUNT_ID` to `"0"`; confirm the account actually in use
+  rather than assuming the default.
+- `asset` should be the Fireblocks asset identifier for the chain, which was
+  `BASECHAIN_ETH` for Base (chain 8453) in the deleted configuration's default
+  `FIREBLOCKS_CHAIN_ASSET_IDS` mapping.
+- `amount` is 0 because the call transfers no native value, matching what
+  `build_contract_call_request` submitted.
+- `dst` names the specific whitelisted Receipt contract's wallet id in the
+  workspace (confirm the id format in the workspace if it differs). The
+  Fireblocks documentation shows a wildcard `[["*", "UNMANAGED", "CONTRACT"]]`
+  here; the narrowed form above is the safer configuration and is worth
+  insisting on given this is a one-shot migration.
+- `operators` must name the group or users permitted to initiate, which for an
+  automated run is the API user the bot authenticates as.
+
+### What this rule does and does not constrain
+
+The rule matches on transaction type and destination contract. There is no
+function-selector field in this rule shape, so whitelisting the Receipt contract
+grants the vault account the ability to call **any** method on it, including
+`setApprovalForAll`, not just the batch transfer we need.
+
+That is a wider grant than the operation requires. Three mitigations worth
+considering, in order of preference: scope `dst` to the single Receipt contract
+rather than the wildcard; confirm with Fireblocks whether method-level
+restriction is available in this workspace tier, which the public rule schema
+does not appear to express; and remove the rule and the whitelisting once the
+migration completes, since this grant has no ongoing purpose after cutover.
+
+### The shortcut worth asking about first
+
+If the workspace policy still permits RAW operations for that vault account, the
+transfer can be signed without whitelisting the Receipt contract or adding any
+rule. The workspace was originally configured for RAW signing. Establishing
+whether that permission survives is a single question to the workspace
+administrator and, if the answer is yes, removes both steps above from the
+critical path.
+
+## Which receipts to move
+
+A receipt is an ERC-1155 identifier scoped to one vault, modelled as
+`ReceiptId(U256)` (`src/receipt_inventory/mod.rs:62-73`) and tracked in an
+inventory aggregate keyed `{chain_id}:{vault}`
+(`src/receipt_inventory/vault_key.rs`).
+
+The set to move, per asset, is every identifier in that vault's inventory
+holding a non-zero balance at the Fireblocks address. Enumerate it twice:
+
+- **From our state:** the inventory aggregate, maintained by the backfiller and
+  reconciler from on-chain transfer events and `balanceOf`.
+- **From the chain:** `balanceOfBatch` against the Fireblocks address, which is
+  authoritative.
+
+Divergence between the two is a stop condition, not something to reconcile in
+flight: it means we do not know what we hold. Our inventory can be stale; the
+chain query needs a candidate set that only the inventory supplies cheaply.
+
+One `safeBatchTransferFrom` carries parallel `ids` and `amounts` and moves a
+vault's receipts atomically, subject to gas. Batch per vault: one authorisation
+event, one outcome, no partially migrated vault.
+
+## How the CLI executes the move
+
+The forward transfer is signed by the retiring custodian: ERC-1155 only lets the
+holder move its own balance, and the holder is the Fireblocks wallet. The narrow
+Fireblocks client restored for this purpose submits the batch as a
+`CONTRACT_CALL` through the whitelisted Receipt contract (so TAP policy
+applies), with a deterministic `externalTxId` so a crashed or retried run
+resumes the original transaction instead of double-submitting, and polls it to a
+terminal status — waiting through any console approvals. The rollback is signed
+by Turnkey directly.
+
+`issuer migrate-receipts <UNDERLYING> --network base --direction <forward|rollback>
+--chain-id 8453`
+requires both custodians' configurations and decides direction from the
+inventory's recorded custody; the stated `--direction` must agree with that
+resolution, so a re-run after a recorded forward move refuses instead of
+silently rolling back:
+
+- **Custody at the Fireblocks wallet** → forward: every gate runs in-binary
+  (quiescence, exact inventory/chain agreement, certification and owner-freeze
+  re-read, per-identifier post-condition deltas measured as the recipient's
+  gain), and the transfer is submitted via Fireblocks. The engine's holder is
+  the wallet the Fireblocks API says this configuration controls — a wrong
+  workspace or vault account holds none of the tracked receipts and the
+  exact-balance check refuses before anything is submitted. Ownership
+  verification is the check; no addresses are compared, and none are typed.
+- **Custody at the Turnkey wallet** → rollback: Turnkey signs the same batch
+  back to the Fireblocks wallet, fetched from the Fireblocks API. Same gates.
+- A move already completed (e.g. executed manually in the Fireblocks console, or
+  a re-run after a lost terminal) is detected — source empty, recipient holding
+  every tracked balance — and recorded instead of transferred again.
+
+Configuration comes entirely from the service's own environment: `RPC_URL`,
+`DATABASE_URL`, the `TURNKEY_*` group, and the `FIREBLOCKS_*` group the old
+service already uses. The production secret file carries **both** custodians'
+variable sets; each binary reads only its own, so which binary runs is the only
+signer selector and no env edit happens mid-window.
+
+Quiescence is enforced in-binary and is deliberately **not** a freeze check: the
+`Underlying` freeze means "corporate action in progress" — a different fact with
+its own lifecycle — and the migration neither requires declaring one nor ends
+one that is real (one is real right now). The migration refuses while any burn
+is reserved against the vault, or any redemption or mint **for the migrating
+asset** is between initiation and terminal. The in-flight gates are scoped to
+the asset because stuck work only ever resumes against its own vault — a
+permanently stuck legacy redemption on one asset (awaiting its own recovery
+feature) must not hold every other vault's migration hostage. Work that cannot
+be attributed to an asset counts against every vault instead of none.
+
+## The service must be stopped first
+
+The issuer must be **completely stopped** before custody moves, and this is not
+optional. Reconciliation reads `balanceOf(bot_wallet, receipt_id)` for every
+tracked receipt; a service still configured with the outgoing signer after
+custody moved would read zero. Custody is tracked on the inventory aggregate
+(`CustodyConfirmed` / `CustodyMigrated` events), and a reconciliation pass that
+finds the wallet rotated while holding none of the claimed receipts fails at
+ERROR without writing — the displacement guard. But that guard only arms once
+custody is recorded, and the drain gates only see persisted state: stopping the
+service is what actually serialises against it.
+
+Window control is operational: **pause rebalancing on st0x.liquidity** (the only
+Authorized Participant is our own liquidity bot, so this stops new redemptions
+arriving) and **stop the issuer service** (no mints are processed). The
+per-asset rebalancing flag gates new automatic triggers only — already
+dispatched jobs run to completion, which is what the drain step waits out — and
+the paused config must be confirmed against the **actually deployed** liquidity
+revision, never inferred from the repository. If anything moves under the
+migration regardless, its exact-balance divergence check refuses rather than
+proceeds.
+
+A vault that refuses (stuck work, balance mismatch) stays safely on Fireblocks
+while every other vault migrates; it catches up in a later pass. The Fireblocks
+whitelisting and TAP rule must therefore stay in place until the **last** vault
+has migrated — not merely until cutover day.
+
+## Preflights — run at the start of the window, before the forward move
+
+In execution order these slot into the cutover sequence between its steps 3
+(drain, stop, hold armed) and 4 (backup + export) — they are listed first only
+because they gate everything after them.
+
+0. **Install the artifact that contains these commands.** The on-host `issuer`
+   wrapper executes whatever the deployed per-service profile holds, and the
+   subcommands below only exist in this stack's artifact — running them against
+   the currently-deployed profile fails with an unknown-subcommand error.
+
+   Deploys run through CI, never from an operator machine (the host is
+   x86_64-linux; the workflow builds on its runner and pushes with deploy-rs).
+   Arm the hold first so installing does not restart the service, then tag the
+   merged main and dispatch the production workflow:
+
+   ```
+   ssh <host> touch /run/st0x/st0x-issuance.hold
+   git tag v<next> && git push origin v<next>       # on main, post-merge
+   gh workflow run deploy-prod.yaml -f tag=v<next>
+   ```
+
+   Wait for the workflow run to finish before continuing (it verifies the tag is
+   on main, builds, and deploys every profile). Under the hold, the deploy stops
+   the service, installs the new binary and secrets, runs `validate-config`, and
+   leaves the service stopped. Because the service goes down here, run this at
+   the start of the window — after rebalancing is paused and the drain is clean
+   — not days ahead. Remove the hold only at the runbook step that starts the
+   replacement service.
+1. **`issuer confirm-custody <UNDERLYING> --network base --chain-id 8453`**,
+   once per vault. Fetches the Fireblocks wallet from the Fireblocks API,
+   verifies on-chain that it holds exactly every tracked balance, and records it
+   as the inventory's custody holder. This arms the displacement guard for every
+   vault — production history predates custody tracking, and an unarmed guard
+   treats a zero balance as "spent". Run it for **all** vaults before any
+   service starts against a rotated wallet, not just the rehearsal asset.
+2. **`issuer verify-custodians <UNDERLYING> --network base --chain-id 8453`**.
+   Proves both custodian connections before the forward move can become a
+   one-way door: authenticates against Fireblocks and resolves the whitelisted
+   Receipt contract (the authorization work, proven present), and signs the
+   exact rollback-shaped transaction with Turnkey **without broadcasting it**
+   (credentials, organization, address, and signing policy, proven against the
+   real transaction shape). Also reports both wallets' gas and refuses if the
+   Turnkey wallet holds none.
+3. **`--smoke`** on `verify-custodians` additionally submits a zero-amount
+   transfer of one receipt id through the full Fireblocks path — whitelisting,
+   TAP rule, signing, the vault's authorization gates — while moving nothing. A
+   zero-amount transfer cannot create the inventory divergence a real dust
+   transfer would (the migration refuses whenever tracked and on-chain balances
+   disagree, so **never** smoke-test with a non-zero amount). This is the
+   strongest Fireblocks-side proof available before the real batch.
+
+## Two passes, not one
+
+The cutover runs twice: once as a rehearsal on a single asset, and once for
+real. The rehearsal buys the thing no amount of testing against Anvil can — a
+demonstration that the production Fireblocks authorization, Turnkey policies,
+and approvals actually work, taken while the exposure is one asset.
+
+**Pass 1 — single-asset rehearsal (AMAT), rollback mandatory.** Run the full
+sequence below for AMAT alone, exercise both directions of the flow against the
+new custody — one canary **redemption first** (it burns a just-migrated
+pre-cutover receipt, which is the actual proof custody moved and reconciled; a
+mint only proves the new signer can sign fresh work), then one canary mint — and
+then **roll back. Rollback is not a decision point in the rehearsal**: two
+service instances never run in parallel, and the rehearsal's purpose is proving
+the full round trip including the way back. Operation continues on Fireblocks
+until the real pass.
+
+The rehearsal's rollback carries the database forward rather than restoring the
+pre-window backup: the replacement service performed real writes (a redemption
+and a mint), and only custody and the running binary reverse. The complete cycle
+— forward migration, redemption-first canaries, rollback including the canary
+mint's newly created receipt, and the resumed original service redeeming that
+canary — is exercised end to end against a real vault by
+`test_single_asset_rehearsal_operates_reverses_and_resumes` in
+`tests/turnkey_cutover.rs`.
+
+One consequence to expect, not fear: the rehearsal writes custody events into
+AMAT's inventory stream, and the still-deployed old binary does not know those
+event types, so **AMAT receipt tracking and burns are degraded on the old binary
+between the rehearsal's rollback and the real cutover**. Every other asset is
+untouched (aggregates are per-vault, and startup reconciliation tolerates a
+failing vault). Keep AMAT's rebalancing paused for that day.
+
+**Between the passes — remaining authorization.** Fireblocks authorization for
+every other receipt token (RAI-1544), one authorization type at a time across
+all tokens if that is how it goes fastest. This is a prerequisite for the real
+pass, not a cutover pass of its own.
+
+**Pass 2 — the real cutover.** After **regular market close** — not after
+extended hours — run the sequence for every asset, no planned rollback. Regular
+close is the boundary because Alpaca journaling and the liquidity bot's hedging
+both follow the regular session; starting while extended-hours trading is live
+means racing flows that cannot be retracted once dispatched.
+
+## Cutover sequence
+
+Applies to both the rehearsal and the real pass; the rehearsal scopes every step
+to AMAT and ends with the mandatory rollback.
+
+1. **Pause rebalancing on st0x.liquidity.** The sole AP is our own bot, so this
+   stops new redemptions arriving at the redemption wallet. No freeze is
+   involved anywhere in this sequence; the live corporate-action freeze stays
+   exactly as it is.
+2. **Confirm liquidity is quiescent.** No equity or USDC flow in progress;
+   anything already dispatched settles first.
+3. **Drain and stop the issuer service, and arm the deploy hold.**
+   `/admin/stuck` clear, every pending transaction terminal, then stop the
+   service completely and create the hold file:
+
+   ```
+   systemctl stop st0x-issuance
+   touch /run/st0x/st0x-issuance.hold
+   ```
+
+   While the hold exists, any deploy — including the intentional one that ships
+   the Turnkey artifact in step 7, and any stray CI deploy — installs the binary
+   and secrets and runs `validate-config`, but leaves the service stopped. This
+   closes the gap where a deploy would otherwise auto-restart a service against
+   custody that has not finished moving. `/run` is tmpfs: a reboot clears the
+   hold (and the start marker), so re-create it before any deploy if the window
+   is still open. The migration independently refuses while any mint or
+   redemption is non-terminal, but the drain is what makes that gate pass.
+4. **Record pre-cutover state.** Application revision, block height, wallet
+   nonces, checkpoints, then on the host:
+
+   The filenames are per-pass on purpose — `VACUUM INTO` refuses an existing
+   destination, and the rehearsal's evidence must survive the real pass:
+   substitute a date-stamped name per run (e.g.
+   `pre-cutover-issuance-20260728T2100.db` and the matching `.json`).
+
+   ```
+   sqlite3 /mnt/data/issuance.db \
+     "VACUUM INTO '/mnt/data/pre-cutover-issuance.db'"
+   sqlite3 -json /mnt/data/pre-cutover-issuance.db \
+     "SELECT aggregate_id,
+             json_extract(payload, '$.Discovered.receipt_id') AS receipt_id
+      FROM events
+      WHERE aggregate_type = 'ReceiptInventory'
+        AND event_type = 'ReceiptInventoryEvent::Discovered'" \
+     > /mnt/data/pre-cutover-receipt-ids.json
+   ```
+
+   The `VACUUM INTO` backup is the full-fidelity export; the second query lists
+   every receipt identifier the inventory has ever tracked, keyed by
+   `{chain_id}:{vault}`. The `cast` readings run from the operator machine (the
+   repo dev shell provides `cast`; the host does not) against any Base RPC with
+   `--rpc-url`. Resolve the receipt contract once
+   (`cast call <vault> 'receipt()(address)'`), then for each identifier record
+   both wallets' balances
+   (`cast call <receipt-contract> 'balanceOf(address,uint256)(uint256)'
+   <wallet> <receipt_id>`)
+   — step 6 compares against exactly these readings.
+5. **Move custody.**
+   `issuer migrate-receipts <UNDERLYING> --network base --direction forward
+   --chain-id 8453`
+   with the service environment loaded. The transfer submits through Fireblocks
+   and may wait on console approvals; the command polls it to completion and
+   verifies per-identifier post-conditions (the recipient's **gain**, not its
+   absolute balance) before reporting success.
+6. **Verify custody against the export.** Re-run the step-4 `cast call`
+   readings: the Fireblocks wallet holds none of the migrated receipts; the
+   Turnkey wallet's gain matches the step-4 readings exactly.
+7. **Start the replacement service** — the pinned Turnkey + multichain artifact,
+   Base-only configuration, on the same database. Deploy it (the hold leaves it
+   installed and validated but stopped), then release the hold and start:
+
+   ```
+   rm /run/st0x/st0x-issuance.hold
+   touch /run/st0x/st0x-issuance.ready
+   systemctl start st0x-issuance
+   ```
+
+   (The artifact was already installed by the step-0 deploy, so no new deploy is
+   needed here; re-dispatching the CI workflow after removing the hold would
+   also start the unit, but the three commands above are the direct path.)
+   Confirm startup resolves the Turnkey address and chain 8453.
+8. **Canary redemption, then canary mint.** Redemption first: it burns a
+   just-migrated receipt, proving custody and inventory reconciliation. The
+   redemption is driven manually from st0x.liquidity while rebalancing stays
+   paused.
+9. **Rehearsal: roll back now** — stop the service and **re-arm the hold**
+   (`systemctl stop st0x-issuance && touch /run/st0x/st0x-issuance.hold`; the
+   window is open again, so the stray-deploy gap from step 3 must stay closed),
+   then run the same `migrate-receipts` with `--direction rollback` (custody is
+   at Turnkey, so it rolls back to the recorded Fireblocks origin, cross-checked
+   against the Fireblocks API), and verify custody returned with the step-4
+   `cast call` readings.
+
+   **Restoring the old Fireblocks service is a CI re-deploy, not a restart**:
+   the step-0 deploy replaced the per-service profile, so the old binary is no
+   longer on the host — dispatch the deploy workflow with the **previous
+   released tag** (`gh workflow run deploy-prod.yaml -f tag=<previous-tag>`),
+   which installs it under the re-armed hold, then release the hold and start as
+   in step 7. Every asset except the rehearsed one resumes normal operation,
+   while the rehearsed asset stays degraded on the old binary (its inventory
+   stream now carries custody events the old binary cannot read — see Pass 1
+   above), so its rebalancing stays paused until the real cutover. The
+   canary-redeemable-after-rollback proof is exercised by the rehearsal e2e with
+   the current binary running as the outgoing wallet; it is not a live step on
+   the old binary. **Real pass: continue** — production verification, then
+   re-enable rebalancing.
+
+## Rolling back
+
+Rollback is the same command: with custody recorded at the Turnkey wallet, the
+CLI signs the batch with Turnkey back to the recorded migration origin, which
+must equal the wallet the configured Fireblocks workspace resolves — a wrong
+workspace is refused before anything is signed. No address is typed; ownership
+verification before (Turnkey holds exactly every tracked balance) and after (the
+Fireblocks wallet's gain matches) is the check. The rollback moves **everything
+tracked**, including receipts the Turnkey service minted during its window.
+
+The asymmetry is in the custodian: the inbound leg needs a **Turnkey policy
+permitting the reverse transfer** (RAI-1545, in place) — and `verify-custodians`
+proves it against the real transaction shape before the window, so an aborted
+cutover can never strand custody behind an emergency policy change.
+
+Roll back if: custody verification in step 6 does not reconcile, the canary
+redemption fails or produces an unexpected on-chain result, or the restarted
+service cannot see the migrated receipts. Hard boundary for the real pass: after
+the first new Turnkey-backed write, do not restore the old database or restart
+the Fireblocks service — stop traffic, preserve evidence, and roll forward with
+Turnkey.
+
+## If something goes wrong
+
+Every failure below leaves a recoverable state; custody is only ever at one of
+two custodian-controlled wallets, and whichever wallet holds the receipts
+determines which service may run.
+
+- **Fireblocks rejects the transfer (policy, whitelisting, approvals).** Nothing
+  moved. Fix with Alastair and retry. If the wait is long enough to warrant
+  resuming service, restoring the Fireblocks-era binary is a CI re-deploy of the
+  previous released tag (see step 9) — the new artifact is what is installed on
+  the host.
+- **The transfer reverts on-chain** (certification expired, owner freeze on the
+  vault). Nothing moved; the command names the gate. Certification renewal is
+  with whoever holds `CERTIFY`.
+- **The operator loses the terminal mid-transfer.** Re-run the same command: the
+  deterministic `externalTxId` makes Fireblocks return the original transaction
+  instead of accepting a second one, and a completed move is detected and
+  recorded rather than re-transferred.
+- **The canary redemption or mint fails on Turnkey.** Roll back and resume
+  Fireblocks **on the same database**. Never restore the pre-window backup once
+  a Turnkey-backed write exists.
+- **The rollback itself is refused** (Turnkey policy gap that the preflight
+  somehow missed). Custody is safe at Turnkey and the Turnkey service is
+  operational — keep running on Turnkey while the policy is fixed; there is no
+  emergency.
+- **A service starts against the wrong wallet mid-window.** Every balance reader
+  — the startup backfiller included — applies readings through the aggregate's
+  custody guard, which refuses wrong-wallet readings per vault at ERROR without
+  writing anything; stop that service. No inventory is lost.
+- **Anything else that does not reconcile.** Stop, keep both services down, and
+  compare the step-4 export against `balanceOfBatch` at both wallets. The
+  receipts cannot leave those two addresses without a signed transfer, so that
+  fully determines the state.
+
+## Open questions, ordered by what they block
+
+1. Is each vault's certification valid, and when does it expire? A read-only
+   `isCertificationExpired()` check answers it before the window.
+2. Is an owner freeze set on any vault, and do the always-allowed lists cover
+   the pair? Also read-only.
+3. Fireblocks approval quorum mechanics for the whitelisting and TAP rule —
+   tracked in RAI-1546/RAI-1544, answered by the first batch clearing the
+   process.

--- a/src/fireblocks/mod.rs
+++ b/src/fireblocks/mod.rs
@@ -16,6 +16,8 @@
 mod config;
 pub mod vault_service;
 
+use clap::Args;
+
 pub use config::{
     ChainAssetIds, Environment, FireblocksConfig, FireblocksConfigError,
     parse_chain_asset_ids,
@@ -23,3 +25,88 @@ pub use config::{
 pub use vault_service::{
     FireblocksVaultError, FireblocksVaultService, fetch_vault_address,
 };
+
+/// Fireblocks credentials and settings for the migration CLI, using the same
+/// environment variable names the retired integration used. The host wiring
+/// supplies `FIREBLOCKS_SECRET_PATH` (the deploy activation installs the key
+/// and exports the path); the remaining values come from the service
+/// environment file.
+#[derive(Args, Debug, Clone)]
+pub(crate) struct FireblocksEnv {
+    /// Fireblocks API User ID.
+    #[clap(
+        id = "fireblocks_api_user_id",
+        long = "fireblocks-api-user-id",
+        env = "FIREBLOCKS_API_USER_ID"
+    )]
+    api_user_id: Option<String>,
+
+    /// Path to the RSA private key file for Fireblocks API authentication.
+    #[clap(
+        id = "fireblocks_secret_path",
+        long = "fireblocks-secret-path",
+        env = "FIREBLOCKS_SECRET_PATH"
+    )]
+    secret_path: Option<std::path::PathBuf>,
+
+    /// Fireblocks vault account ID containing the signing key.
+    #[clap(
+        id = "fireblocks_vault_account_id",
+        long = "fireblocks-vault-account-id",
+        env = "FIREBLOCKS_VAULT_ACCOUNT_ID",
+        default_value = "0"
+    )]
+    vault_account_id: String,
+
+    /// Mapping of chain ID to Fireblocks asset ID, e.g.
+    /// "1:ETH,8453:BASECHAIN_ETH".
+    #[clap(
+        id = "fireblocks_chain_asset_ids",
+        long = "fireblocks-chain-asset-ids",
+        env = "FIREBLOCKS_CHAIN_ASSET_IDS",
+        default_value = "8453:BASECHAIN_ETH",
+        value_parser = parse_chain_asset_ids
+    )]
+    chain_asset_ids: ChainAssetIds,
+
+    /// Fireblocks environment (production or sandbox).
+    #[clap(
+        id = "fireblocks_environment",
+        long = "fireblocks-environment",
+        env = "FIREBLOCKS_ENVIRONMENT",
+        default_value = "production",
+        value_enum
+    )]
+    environment: Environment,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum FireblocksEnvError {
+    #[error("FIREBLOCKS_API_USER_ID is required to sign the forward transfer")]
+    MissingApiUserId,
+    #[error(
+        "FIREBLOCKS_SECRET_PATH is required when FIREBLOCKS_API_USER_ID is set"
+    )]
+    MissingSecretPath,
+    #[error(transparent)]
+    Config(#[from] FireblocksConfigError),
+}
+
+impl FireblocksEnv {
+    pub(crate) fn into_config(
+        self,
+    ) -> Result<FireblocksConfig, FireblocksEnvError> {
+        let api_user_id =
+            self.api_user_id.ok_or(FireblocksEnvError::MissingApiUserId)?;
+        let secret_path =
+            self.secret_path.ok_or(FireblocksEnvError::MissingSecretPath)?;
+
+        Ok(FireblocksConfig::new(
+            api_user_id.into(),
+            &secret_path,
+            self.vault_account_id.into(),
+            self.chain_asset_ids,
+            self.environment,
+        )?)
+    }
+}

--- a/src/fireblocks/vault_service.rs
+++ b/src/fireblocks/vault_service.rs
@@ -39,6 +39,14 @@ pub enum FireblocksVaultError {
     )]
     TransactionFailed { tx_id: String, status: TransactionStatus },
     #[error(
+        "Fireblocks transaction {tx_id} is still {status:?} after the polling \
+         window — it may yet complete (console approval can take longer). \
+         Approve or reject it in the Fireblocks console, then re-run this \
+         command: the deterministic externalTxId resumes the same transaction \
+         instead of submitting a second one."
+    )]
+    PollTimedOut { tx_id: String, status: TransactionStatus },
+    #[error(
         "Fireblocks transaction {tx_id} did not include a transaction hash"
     )]
     MissingTxHash { tx_id: String },
@@ -72,14 +80,6 @@ pub enum FireblocksVaultError {
          Fireblocks console before retrying"
     )]
     RetryAttemptsExhausted { base_external_tx_id: String, attempts: u32 },
-    #[error(
-        "Fireblocks transaction {tx_id} is still {status:?} after the polling \
-         window — it may yet complete (console approval can take longer). \
-         Approve or reject it in the Fireblocks console, then re-run this \
-         command: the deterministic externalTxId resumes the same transaction \
-         instead of submitting a second one."
-    )]
-    PollTimedOut { tx_id: String, status: TransactionStatus },
 }
 
 /// How [`FireblocksVaultService::submit_contract_call`] obtained its
@@ -524,6 +524,28 @@ impl<P: Provider + Clone> FireblocksVaultService<P> {
         })?;
 
         parse_tx_hash(&tx_hash_str)
+    }
+
+    /// The read-only provider this service fetches receipts through.
+    pub const fn read_provider(&self) -> &P {
+        &self.read_provider
+    }
+
+    /// Test constructor injecting a client pointed at a mock server.
+    #[cfg(test)]
+    pub(crate) fn for_tests(
+        client: Client,
+        read_provider: P,
+        chain_id: u64,
+        chain_asset_ids: ChainAssetIds,
+    ) -> Self {
+        Self {
+            client,
+            vault_account_id: "0".to_string(),
+            chain_asset_ids,
+            read_provider,
+            chain_id,
+        }
     }
 
     /// Fetches a transaction receipt from the RPC provider.

--- a/src/receipt_inventory/cmd.rs
+++ b/src/receipt_inventory/cmd.rs
@@ -48,9 +48,14 @@ pub(crate) enum ReceiptInventoryCommand {
         holder: Address,
     },
     /// Record that custody of every tracked receipt moved to a new wallet.
+    ///
+    /// `tx_hash` is `None` when the transfer was signed outside this binary
+    /// and verified against on-chain balances after the fact. Idempotent and
+    /// keyed on the destination alone: a move whose `to` is already the
+    /// recorded holder produces no event, whatever `from` it claims.
     RecordCustodyMigration {
         from: Address,
         to: Address,
-        tx_hash: TxHash,
+        tx_hash: Option<TxHash>,
     },
 }

--- a/src/receipt_inventory/event.rs
+++ b/src/receipt_inventory/event.rs
@@ -74,11 +74,14 @@ pub(crate) enum ReceiptInventoryEvent {
     /// Custody of every tracked receipt moved to a replacement wallet.
     ///
     /// `from` is retained because it is where a rollback returns custody to, so
-    /// reversing a migration needs no address from an operator.
+    /// reversing a migration needs no address from an operator. `tx_hash` is
+    /// absent when the transfer was signed outside this binary (the production
+    /// forward leg is signed by the retiring custodian) and the move was
+    /// verified against on-chain balances after the fact.
     CustodyMigrated {
         from: Address,
         to: Address,
-        tx_hash: TxHash,
+        tx_hash: Option<TxHash>,
     },
 }
 

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -20,8 +20,12 @@
 //! migrate, swap the signer configuration, start again.
 
 use alloy::eips::BlockId;
+use alloy::network::{
+    Ethereum, EthereumWallet, NetworkWallet, TransactionBuilder,
+};
 use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::{PendingTransactionError, Provider};
+use alloy::rpc::types::TransactionRequest;
 use async_trait::async_trait;
 use event_sorcery::StoreBuilder;
 use itertools::izip;
@@ -34,6 +38,9 @@ use super::{
     SharesOverflow, load_inventory, send_receipt_inventory_command,
 };
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
+use crate::fireblocks::{
+    FireblocksConfig, FireblocksVaultError, FireblocksVaultService,
+};
 use crate::mint::find_stuck as find_stuck_mints;
 use crate::redemption::view::find_stuck as find_stuck_redemptions;
 use crate::redemption::{IssuerRedemptionRequestId, RedemptionEvent};
@@ -201,6 +208,10 @@ pub(crate) struct MigratableHoldings {
     vault: Address,
     holder: Address,
     holdings: Vec<ReceiptHolding>,
+    /// How many custody migrations the vault had recorded when these holdings
+    /// were reconciled — the salt that gives a deliberate re-migration a
+    /// fresh transfer identity while a retry keeps the original.
+    migration_ordinal: u32,
 }
 
 /// A single receipt identifier and the balance held against it.
@@ -226,6 +237,10 @@ pub(crate) enum SourceCustody {
 impl MigratableHoldings {
     pub(crate) const fn chain_id(&self) -> u64 {
         self.chain_id
+    }
+
+    pub(crate) const fn migration_ordinal(&self) -> u32 {
+        self.migration_ordinal
     }
 
     pub(crate) const fn vault(&self) -> Address {
@@ -283,6 +298,9 @@ pub(crate) enum MigrationRefusal {
          move. Drain them to terminal (see /admin/stuck) before migrating"
     )]
     MintsInFlight { count: usize },
+
+    #[error(transparent)]
+    HolderMismatch(Box<HolderMismatch>),
 
     #[error(
         "vault {vault} has {receipts} receipt(s) reserved for an in-flight \
@@ -401,6 +419,12 @@ pub(crate) enum ReceiptCustodyError {
 
     #[error(transparent)]
     PostConditionFailed(Box<PostConditionFailure>),
+
+    #[error(transparent)]
+    Fireblocks(#[from] Box<FireblocksVaultError>),
+
+    #[error("custody transfer {tx_hash} has no receipt after confirmation")]
+    MissingReceipt { tx_hash: B256 },
 }
 
 /// A recipient balance that fell over a transfer that should only have raised
@@ -453,6 +477,31 @@ pub(crate) struct PostConditionFailure {
 impl From<PostConditionFailure> for ReceiptCustodyError {
     fn from(failure: PostConditionFailure) -> Self {
         Self::PostConditionFailed(Box::new(failure))
+    }
+}
+
+/// A wallet whose on-chain balances do not match the tracked inventory, so it
+/// cannot be confirmed as the custody holder.
+///
+/// Boxed inside [`MigrationRefusal`] because five inline fields push every
+/// `Result` in this module over clippy's large-error threshold.
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "wallet {holder} does not hold vault {vault}'s tracked receipts (receipt \
+     {receipt_id}: tracked {tracked}, held {held}); custody cannot be \
+     confirmed against a wallet the chain says holds something else"
+)]
+pub(crate) struct HolderMismatch {
+    pub(crate) vault: Address,
+    pub(crate) holder: Address,
+    pub(crate) receipt_id: ReceiptId,
+    pub(crate) tracked: Shares,
+    pub(crate) held: Shares,
+}
+
+impl From<HolderMismatch> for MigrationRefusal {
+    fn from(mismatch: HolderMismatch) -> Self {
+        Self::HolderMismatch(Box::new(mismatch))
     }
 }
 
@@ -564,16 +613,6 @@ impl std::fmt::Display for CorroboratedRecipient {
     }
 }
 
-/// The vault a custody operation addresses: its chain, its address, and the
-/// asset it belongs to. The asset scopes the in-flight quiescence gates —
-/// stuck work only ever resumes against its own vault.
-#[derive(Debug, Clone, Copy)]
-pub struct VaultIdentity<'a> {
-    pub chain_id: u64,
-    pub vault: Address,
-    pub underlying: &'a UnderlyingSymbol,
-}
-
 /// Migrates one vault's receipt custody to `recipient`, end to end.
 ///
 /// Public so the operator CLI and the cutover end-to-end test drive the same
@@ -606,6 +645,63 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
     holder: Address,
     recipient: CorroboratedRecipient,
 ) -> anyhow::Result<MigrationOutcome> {
+    let custody =
+        OnchainReceiptCustody::resolve(provider, identity.vault).await?;
+
+    execute_migration(pool, &custody, identity, holder, recipient).await
+}
+
+/// The vault a custody operation addresses: its chain, its address, and the
+/// asset it belongs to. The asset scopes the in-flight quiescence gates —
+/// stuck work only ever resumes against its own vault.
+#[derive(Debug, Clone, Copy)]
+pub struct VaultIdentity<'a> {
+    pub chain_id: u64,
+    pub vault: Address,
+    pub underlying: &'a UnderlyingSymbol,
+}
+
+/// [`migrate_vault_receipts`] with the transfer submitted through the
+/// Fireblocks API instead of a locally held key — the production forward leg.
+///
+/// Every gate is identical to the in-binary path: same quiescence checks, same
+/// inventory/chain agreement, same certification and owner-freeze re-read,
+/// same per-identifier post-condition deltas. Only the submission mechanism
+/// differs, behind the same [`ReceiptCustody`] seam the tests exercise.
+///
+/// # Errors
+///
+/// As [`migrate_vault_receipts`], plus Fireblocks-side failures: authentication,
+/// a non-whitelisted Receipt contract, TAP policy rejection, or a transaction
+/// that reaches a terminal non-completed status.
+pub async fn migrate_vault_receipts_via_fireblocks<
+    P: Provider + Clone + Send + Sync,
+>(
+    pool: &Pool<Sqlite>,
+    provider: P,
+    fireblocks: &FireblocksConfig,
+    identity: VaultIdentity<'_>,
+    holder: Address,
+    recipient: CorroboratedRecipient,
+) -> anyhow::Result<MigrationOutcome> {
+    let custody = FireblocksReceiptCustody::resolve(
+        provider,
+        fireblocks,
+        identity.chain_id,
+        identity.vault,
+    )
+    .await?;
+
+    execute_migration(pool, &custody, identity, holder, recipient).await
+}
+
+async fn execute_migration(
+    pool: &Pool<Sqlite>,
+    custody: &(impl ReceiptCustody + Sync),
+    identity: VaultIdentity<'_>,
+    holder: Address,
+    recipient: CorroboratedRecipient,
+) -> anyhow::Result<MigrationOutcome> {
     let VaultIdentity { chain_id, vault, underlying } = identity;
     let recipient = recipient.address();
 
@@ -618,10 +714,14 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
     )
     .await?;
 
-    let custody = OnchainReceiptCustody::resolve(provider, vault).await?;
-
     match reconcile_holdings(
-        &custody, chain_id, vault, holder, recipient, &tracked,
+        custody,
+        chain_id,
+        vault,
+        holder,
+        recipient,
+        &tracked,
+        inventory.migrations_recorded(),
     )
     .await?
     {
@@ -635,11 +735,28 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
                 receipts,
                 "Receipt custody already migrated"
             );
+
+            // An already-completed move is still recorded (idempotently): the
+            // production forward transfer is signed by the custodian itself,
+            // outside this binary, so this observation is the only way the
+            // event a rollback derives its destination from ever lands.
+            send_receipt_inventory_command(
+                &store,
+                chain_id,
+                &vault,
+                ReceiptInventoryCommand::RecordCustodyMigration {
+                    from: holder,
+                    to: recipient,
+                    tx_hash: None,
+                },
+            )
+            .await?;
+
             Ok(MigrationOutcome::AlreadyMigrated { receipts })
         }
         SourceCustody::Holds(holdings) => {
             let outcome =
-                migrate_vault_custody(&custody, &holdings, recipient).await?;
+                migrate_vault_custody(custody, &holdings, recipient).await?;
 
             // Recorded only after the move is verified, so the inventory's
             // custody history never claims a transfer that did not land. This
@@ -653,7 +770,7 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
                     ReceiptInventoryCommand::RecordCustodyMigration {
                         from: holder,
                         to: recipient,
-                        tx_hash: *transaction,
+                        tx_hash: Some(*transaction),
                     },
                 )
                 .await?;
@@ -662,6 +779,267 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
             Ok(outcome)
         }
     }
+}
+
+/// Confirms on-chain that `holder` holds exactly every tracked balance for
+/// this vault, then records it as the inventory's custody holder.
+///
+/// This is the bootstrap for deployments whose events predate custody
+/// tracking: the displacement guard treats unobserved custody as "a zero
+/// balance means spent", so every vault's holder must be on record before any
+/// service starts against a rotated wallet. The address is operator-supplied,
+/// but it cannot be recorded wrongly: a mistyped wallet holds none of the
+/// tracked receipts and is refused with the first mismatch.
+///
+/// Requires quiescence like the migration itself — recording custody while
+/// work is in flight would capture a moving target.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened, work is in flight, the
+/// vault has no tracked receipts, or `holder`'s on-chain balances do not match
+/// the tracked inventory exactly.
+pub async fn confirm_custody_holder<P: Provider + Clone + Send + Sync>(
+    pool: &Pool<Sqlite>,
+    provider: P,
+    identity: VaultIdentity<'_>,
+    holder: Address,
+) -> anyhow::Result<usize> {
+    let VaultIdentity { chain_id, vault, underlying } = identity;
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+    let tracked = quiescent_tracked_holdings(
+        pool, &inventory, chain_id, vault, underlying,
+    )
+    .await?;
+
+    let custody = OnchainReceiptCustody::resolve(provider, vault).await?;
+    let receipt_ids: Vec<ReceiptId> =
+        tracked.iter().map(|held| held.receipt_id).collect();
+    let held = custody.held_balances(vault, holder, &receipt_ids).await?;
+
+    if held.len() != receipt_ids.len() {
+        return Err(MigrationRefusal::BalanceCountMismatch {
+            vault,
+            requested: receipt_ids.len(),
+            returned: held.len(),
+        }
+        .into());
+    }
+
+    for (holding, onchain) in izip!(&tracked, &held) {
+        if holding.balance != *onchain {
+            return Err(MigrationRefusal::from(HolderMismatch {
+                vault,
+                holder,
+                receipt_id: holding.receipt_id,
+                tracked: holding.balance,
+                held: *onchain,
+            })
+            .into());
+        }
+    }
+
+    send_receipt_inventory_command(
+        &store,
+        chain_id,
+        &vault,
+        ReceiptInventoryCommand::ConfirmCustody { holder },
+    )
+    .await?;
+
+    Ok(tracked.len())
+}
+
+/// Proof that the Turnkey connection can sign the rollback, produced before
+/// anything moves.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RollbackSigningProof {
+    /// Where the signed (never broadcast) rollback would send custody.
+    pub destination: Address,
+    /// How many tracked receipts the rollback transaction covers.
+    pub receipts: usize,
+    /// Native balance of the Turnkey wallet — it needs gas to actually
+    /// broadcast a rollback and to operate the service afterwards.
+    pub turnkey_gas: U256,
+    /// Native balance of the wallet custody currently sits with.
+    pub holder_gas: U256,
+}
+
+/// Signs the exact rollback-shaped transaction with Turnkey — **without
+/// broadcasting it** — proving the connection end to end.
+///
+/// The transaction is a `safeBatchTransferFrom` of every tracked receipt from
+/// the Turnkey wallet back to the current holder, the real shape a rollback
+/// would submit.
+///
+/// This is the gate that keeps the forward move from being a one-way door: the
+/// custodian signs the forward transfer outside this binary, and if the
+/// Turnkey credentials, organization, address, or signing policy turn out
+/// broken only *after* custody has moved, there is no way back and no service
+/// that can run. A successful sign here proves the API credentials, the
+/// organization, the address, and the policy against the real transaction
+/// shape; the signer itself verifies the recovered signature matches the
+/// Turnkey address before returning.
+///
+/// Gas and fee fields are fixed rather than estimated: estimating a transfer
+/// of receipts the Turnkey wallet does not hold yet would revert, and the
+/// signature's validity does not depend on them.
+///
+/// `destination` is the Fireblocks wallet the rollback would return custody
+/// to, derived by the caller from the Fireblocks API — never typed.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened, the vault has no tracked
+/// receipts, or Turnkey refuses or mis-signs the transaction.
+pub async fn verify_rollback_signing<P: Provider>(
+    pool: &Pool<Sqlite>,
+    provider: P,
+    wallet: &EthereumWallet,
+    identity: VaultIdentity<'_>,
+    destination: Address,
+) -> anyhow::Result<RollbackSigningProof> {
+    let turnkey = NetworkWallet::<Ethereum>::default_signer_address(wallet);
+    let VaultIdentity { chain_id, vault, underlying } = identity;
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+
+    // The same loader the migration itself uses: the signed shape is only
+    // "exact" if it covers the identical holdings a real rollback would move,
+    // gated by the identical quiescence checks.
+    let tracked = quiescent_tracked_holdings(
+        pool, &inventory, chain_id, vault, underlying,
+    )
+    .await?;
+
+    let vault_contract = OffchainAssetReceiptVault::new(vault, &provider);
+    let receipt_contract = Address::from(
+        vault_contract
+            .receipt()
+            .call()
+            .await
+            .map_err(|error| ReceiptCustodyError::Contract(Box::new(error)))?
+            .0,
+    );
+
+    let receipt = Receipt::new(receipt_contract, &provider);
+    let ids: Vec<U256> =
+        tracked.iter().map(|held| held.receipt_id.inner()).collect();
+    let amounts: Vec<U256> =
+        tracked.iter().map(|held| held.balance.inner()).collect();
+    let calldata = receipt
+        .safeBatchTransferFrom(turnkey, destination, ids, amounts, Bytes::new())
+        .calldata()
+        .clone();
+
+    let nonce = provider
+        .get_transaction_count(turnkey)
+        .await
+        .map_err(ReceiptCustodyError::from)?;
+
+    let request = TransactionRequest::default()
+        .with_from(turnkey)
+        .with_to(receipt_contract)
+        .with_input(calldata)
+        .with_chain_id(chain_id)
+        .with_nonce(nonce)
+        .with_gas_limit(ROLLBACK_PROOF_GAS_LIMIT)
+        .with_max_fee_per_gas(ROLLBACK_PROOF_MAX_FEE_PER_GAS)
+        .with_max_priority_fee_per_gas(ROLLBACK_PROOF_MAX_PRIORITY_FEE);
+
+    // Signing only: the transaction is built and signed but never submitted.
+    // The Turnkey signer verifies the recovered signature matches its address
+    // before returning, so success is proof of control, not just of an HTTP
+    // 200.
+    request.build(wallet).await?;
+
+    let turnkey_gas = provider
+        .get_balance(turnkey)
+        .await
+        .map_err(ReceiptCustodyError::from)?;
+    let holder_gas = provider
+        .get_balance(destination)
+        .await
+        .map_err(ReceiptCustodyError::from)?;
+
+    Ok(RollbackSigningProof {
+        destination,
+        receipts: tracked.len(),
+        turnkey_gas,
+        holder_gas,
+    })
+}
+
+/// Deliberately generous: the signature's validity does not depend on these,
+/// and the transaction is never broadcast.
+const ROLLBACK_PROOF_GAS_LIMIT: u64 = 1_000_000;
+const ROLLBACK_PROOF_MAX_FEE_PER_GAS: u128 = 100_000_000_000;
+const ROLLBACK_PROOF_MAX_PRIORITY_FEE: u128 = 1_000_000_000;
+
+/// The minimum native balance the Turnkey wallet must hold before a forward
+/// move becomes acceptable.
+///
+/// A bare non-zero check lets one wei pass while leaving a real rollback
+/// unbroadcastable — a one-way door discovered only when the way back is
+/// needed. Sized as the proof's gas limit at its priority fee (0.001 ether):
+/// enough to broadcast a worst-case rollback batch under congested Base fees
+/// with a wide margin, without demanding the proof's deliberately absurd
+/// `max_fee` ceiling, which is two orders of magnitude above any real
+/// broadcast cost.
+pub(crate) fn rollback_gas_reserve() -> U256 {
+    U256::from(ROLLBACK_PROOF_GAS_LIMIT)
+        * U256::from(ROLLBACK_PROOF_MAX_PRIORITY_FEE)
+}
+
+/// The wallet a rollback returns custody to, read from the recorded migration.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened or no custody migration was
+/// ever recorded for this vault.
+pub async fn recorded_migration_origin(
+    pool: &Pool<Sqlite>,
+    chain_id: u64,
+    vault: Address,
+) -> anyhow::Result<Address> {
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+
+    inventory.custody().moved_from().ok_or_else(|| {
+        anyhow::anyhow!(
+            "vault {vault} on chain {chain_id} has no recorded custody \
+             migration to roll back; record the forward move first (re-run \
+             migrate-receipts once custody has actually moved)"
+        )
+    })
+}
+
+/// The recorded custody holder for this vault, if any.
+///
+/// The migrate CLI uses this to decide direction when the incoming wallet's
+/// credentials are what is configured: a recorded holder that is not the
+/// incoming wallet means the forward move happened (or must be verified)
+/// out-of-band; a recorded holder that *is* the incoming wallet means the only
+/// move left is a rollback.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened.
+pub async fn recorded_custody_holder(
+    pool: &Pool<Sqlite>,
+    chain_id: u64,
+    vault: Address,
+) -> anyhow::Result<Option<Address>> {
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+
+    Ok(inventory.custody().holder())
 }
 
 /// Loads the tracked holdings after proving the deployment is quiescent.
@@ -802,6 +1180,7 @@ pub(crate) async fn reconcile_holdings(
     holder: Address,
     recipient: Address,
     tracked: &[ReceiptHolding],
+    migration_ordinal: u32,
 ) -> Result<SourceCustody, MigrationRefusal> {
     let receipt_ids: Vec<ReceiptId> =
         tracked.iter().map(|held| held.receipt_id).collect();
@@ -860,6 +1239,7 @@ pub(crate) async fn reconcile_holdings(
         vault,
         holder,
         holdings,
+        migration_ordinal,
     }))
 }
 
@@ -1267,6 +1647,188 @@ impl<P: Provider + Clone + Send + Sync> ReceiptCustody
     }
 }
 
+/// Receipt custody whose transfer is submitted through the Fireblocks API —
+/// the production forward leg, where the holder's key lives with the custodian
+/// and this binary signs nothing.
+///
+/// Balance reads and the permission gates delegate to the on-chain
+/// implementation; only [`ReceiptCustody::transfer_custody`] differs. The
+/// `externalTxId` is deterministic over the batch content and the number of
+/// custody migrations already recorded for the vault, so a crashed or retried
+/// run resumes the original Fireblocks transaction instead of submitting a
+/// second transfer, while a deliberate later re-migration (after a rollback)
+/// carries a new ordinal and gets a fresh identity.
+pub(crate) struct FireblocksReceiptCustody<P> {
+    onchain: OnchainReceiptCustody<P>,
+    client: FireblocksVaultService<P>,
+    receipt_contract: Address,
+    chain_id: u64,
+}
+
+impl<P: Provider + Clone> FireblocksReceiptCustody<P> {
+    pub(crate) async fn resolve(
+        provider: P,
+        config: &FireblocksConfig,
+        chain_id: u64,
+        vault: Address,
+    ) -> Result<Self, ReceiptCustodyError> {
+        let receipt_contract = OffchainAssetReceiptVault::new(vault, &provider)
+            .receipt()
+            .call()
+            .await?;
+
+        let client =
+            FireblocksVaultService::new(config, provider.clone(), chain_id)
+                .map_err(Box::new)?;
+
+        Ok(Self {
+            onchain: OnchainReceiptCustody::new(
+                provider,
+                vault,
+                receipt_contract,
+            ),
+            client,
+            receipt_contract,
+            chain_id,
+        })
+    }
+}
+
+#[async_trait]
+impl<P: Provider + Clone + Send + Sync> ReceiptCustody
+    for FireblocksReceiptCustody<P>
+{
+    async fn held_balances(
+        &self,
+        vault: Address,
+        holder: Address,
+        receipt_ids: &[ReceiptId],
+    ) -> Result<Vec<Shares>, ReceiptCustodyError> {
+        self.onchain.held_balances(vault, holder, receipt_ids).await
+    }
+
+    async fn transfer_permission(
+        &self,
+        vault: Address,
+        from: Address,
+        to: Address,
+    ) -> Result<TransferPermission, ReceiptCustodyError> {
+        self.onchain.transfer_permission(vault, from, to).await
+    }
+
+    async fn transfer_custody(
+        &self,
+        permit: &TransferPermit,
+        holdings: &MigratableHoldings,
+    ) -> Result<B256, ReceiptCustodyError> {
+        self.onchain.check_vault(permit.vault())?;
+        ensure_permit_covers(permit, holdings)?;
+
+        let receipt =
+            Receipt::new(self.receipt_contract, &self.onchain.provider);
+        let (ids, amounts) = holdings.batch_arguments();
+        let external_tx_id = migration_external_tx_id(
+            self.chain_id,
+            permit.vault(),
+            permit.to(),
+            &ids,
+            &amounts,
+            holdings.migration_ordinal(),
+        );
+        let calldata = receipt
+            .safeBatchTransferFrom(
+                permit.from(),
+                permit.to(),
+                ids,
+                amounts,
+                Bytes::new(),
+            )
+            .calldata()
+            .clone();
+        let note = format!(
+            "receipt custody migration: vault {} -> {}",
+            permit.vault(),
+            permit.to()
+        );
+
+        // Submission walks to a fresh `-retry-N` id when a previous attempt's
+        // transaction failed terminally: Fireblocks spends an externalTxId
+        // forever, so fix-and-retry after a TAP rejection or an expired
+        // certification must not resume the corpse.
+        //
+        // Logged before the await: completion can block through console
+        // approvals for minutes, and if this process dies or times out the
+        // operator needs the id to look the transaction up.
+        info!(target: "receipt_inventory",
+            vault = %permit.vault(),
+            receipt_contract = %self.receipt_contract,
+            %external_tx_id,
+            "submitting custody transfer to Fireblocks"
+        );
+        let tx_hash = self
+            .client
+            .submit_contract_call_to_completion(
+                self.receipt_contract,
+                &calldata,
+                &note,
+                &external_tx_id,
+            )
+            .await
+            .map_err(Box::new)?;
+
+        // Fireblocks can report `Completed` while the EVM transaction itself
+        // reverted; a reverted transfer moved nothing, so it is a definitive
+        // failure rather than a hash to report as success.
+        let confirmed = self
+            .onchain
+            .provider
+            .get_transaction_receipt(tx_hash)
+            .await?
+            .ok_or(ReceiptCustodyError::MissingReceipt { tx_hash })?;
+
+        if !confirmed.status() {
+            return Err(ReceiptCustodyError::Reverted {
+                vault: permit.vault(),
+                tx_hash,
+            });
+        }
+
+        Ok(tx_hash)
+    }
+}
+
+/// Deterministic `externalTxId` for a custody migration batch.
+///
+/// Stable over the batch content — chain, vault, destination, identifiers,
+/// amounts — so a retry of the same attempt deduplicates against the original
+/// Fireblocks transaction (across restarts, crashes, and midnight), and
+/// salted with the vault's migration ordinal so a deliberate re-migration
+/// (the rehearsal's forward leg happens again at the real cutover, after the
+/// rollback restored identical balances and recorded another migration) is a
+/// new transaction rather than a stale dedup hit.
+fn migration_external_tx_id(
+    chain_id: u64,
+    vault: Address,
+    to: Address,
+    ids: &[U256],
+    amounts: &[U256],
+    migration_ordinal: u32,
+) -> String {
+    let mut preimage = Vec::with_capacity(8 + 44 + (ids.len() * 64));
+    preimage.extend_from_slice(&chain_id.to_be_bytes());
+    preimage.extend_from_slice(vault.as_slice());
+    preimage.extend_from_slice(to.as_slice());
+    preimage.extend_from_slice(&migration_ordinal.to_be_bytes());
+    for (id, amount) in izip!(ids, amounts) {
+        preimage.extend_from_slice(&id.to_be_bytes::<32>());
+        preimage.extend_from_slice(&amount.to_be_bytes::<32>());
+    }
+
+    let digest = alloy::primitives::keccak256(&preimage);
+
+    format!("receipt-migration-{}", alloy::hex::encode(&digest[..16]))
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::primitives::address;
@@ -1460,7 +2022,7 @@ mod tests {
         tracked: &[ReceiptHolding],
     ) -> Result<SourceCustody, MigrationRefusal> {
         reconcile_holdings(
-            custody, CHAIN_ID, VAULT, OUTGOING, INCOMING, tracked,
+            custody, CHAIN_ID, VAULT, OUTGOING, INCOMING, tracked, 0,
         )
         .await
     }
@@ -2043,6 +2605,701 @@ mod tests {
                     .unwrap();
 
             assert_eq!(corroborated.address(), evm.wallet_address);
+        }
+    }
+
+    /// The idempotency identity for a Fireblocks-submitted migration must be
+    /// stable over the batch content (so an in-flight retry deduplicates) and
+    /// sensitive to it (so a different batch is a different transaction).
+    mod migration_external_id {
+        use super::*;
+
+        #[test]
+        fn identical_batches_share_an_identity() {
+            let ids = vec![U256::from(1), U256::from(2)];
+            let amounts = vec![U256::from(10), U256::from(20)];
+
+            assert_eq!(
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 0),
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 0),
+            );
+        }
+
+        #[test]
+        fn different_batches_get_different_identities() {
+            let ids = vec![U256::from(1)];
+            let amounts = vec![U256::from(10)];
+            let other_amounts = vec![U256::from(11)];
+
+            assert_ne!(
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 0),
+                migration_external_tx_id(
+                    1,
+                    VAULT,
+                    INCOMING,
+                    &ids,
+                    &other_amounts,
+                    0
+                ),
+                "a changed batch must not deduplicate against the old one"
+            );
+            assert_ne!(
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 0),
+                migration_external_tx_id(1, VAULT, OUTGOING, &ids, &amounts, 0),
+                "a changed destination must not deduplicate either"
+            );
+        }
+
+        /// The rehearsal's exact hazard: rollback restores identical balances,
+        /// so the real cutover re-submits an identical batch — possibly the
+        /// same day. The migration ordinal is what makes it a new Fireblocks
+        /// transaction instead of a stale dedup hit, while a retry of the
+        /// same attempt (same ordinal) still deduplicates.
+        #[test]
+        fn a_re_migration_after_rollback_gets_a_fresh_identity() {
+            let ids = vec![U256::from(1)];
+            let amounts = vec![U256::from(10)];
+
+            assert_ne!(
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 0),
+                migration_external_tx_id(1, VAULT, INCOMING, &ids, &amounts, 2),
+                "an identical batch at a later migration ordinal must be a \
+                 new transaction identity"
+            );
+        }
+    }
+
+    /// The two operator gates that bootstrap and protect custody state:
+    /// `confirm_custody_holder` (the only writer of trusted custody before a
+    /// migration) and `verify_rollback_signing` (the proof that keeps the
+    /// forward move from being a one-way door).
+    mod custody_bootstrap {
+        use alloy::network::EthereumWallet;
+        use alloy::primitives::TxHash;
+        use alloy::providers::ProviderBuilder;
+        use alloy::signers::local::PrivateKeySigner;
+        use alloy::sol_types::SolEvent;
+        use sqlx::sqlite::SqlitePoolOptions;
+
+        use super::*;
+        use crate::test_utils::{ANVIL_CHAIN_ID, LocalEvm};
+
+        async fn pool_with_migrations() -> Pool<Sqlite> {
+            let pool = SqlitePoolOptions::new()
+                .max_connections(5)
+                .connect(":memory:")
+                .await
+                .unwrap();
+            sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+            pool
+        }
+
+        /// Deposits one receipt at the EVM wallet and mirrors it into the
+        /// inventory, returning the signing provider and the receipt's id and
+        /// share balance.
+        async fn seeded_vault(
+            evm: &LocalEvm,
+            pool: &Pool<Sqlite>,
+        ) -> (impl Provider + Clone + use<>, U256, U256) {
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let provider = ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &provider,
+            );
+            let shares = U256::from(25) * U256::from(10).pow(U256::from(18));
+            let deposited = vault
+                .deposit(
+                    shares,
+                    evm.wallet_address,
+                    U256::from(10).pow(U256::from(18)),
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            let receipt_id = deposited
+                .inner
+                .logs()
+                .iter()
+                .find_map(|log| {
+                    crate::bindings::OffchainAssetReceiptVault::Deposit::decode_log(
+                        &log.inner,
+                    )
+                    .ok()
+                })
+                .expect("deposit must emit a Deposit event")
+                .id;
+
+            let store = StoreBuilder::<ReceiptInventory>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+            send_receipt_inventory_command(
+                &store,
+                ANVIL_CHAIN_ID,
+                &evm.vault_address,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(receipt_id),
+                    balance: Shares::from(shares),
+                    block_number: 1,
+                    tx_hash: TxHash::ZERO,
+                    source: crate::receipt_inventory::ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
+
+            (provider, receipt_id, shares)
+        }
+
+        async fn recorded_holder(
+            pool: &Pool<Sqlite>,
+            vault: Address,
+        ) -> Option<Address> {
+            let store = StoreBuilder::<ReceiptInventory>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault)
+                .await
+                .unwrap()
+                .custody()
+                .holder()
+        }
+
+        /// The bootstrap only records a holder whose on-chain balances match
+        /// the tracked inventory exactly.
+        #[tokio::test]
+        async fn a_holder_with_matching_balances_is_confirmed() {
+            let evm = LocalEvm::new().await.unwrap();
+            let pool = pool_with_migrations().await;
+            let (provider, _, _) = seeded_vault(&evm, &pool).await;
+            let underlying: UnderlyingSymbol = "TSLA".parse().unwrap();
+
+            let receipts = confirm_custody_holder(
+                &pool,
+                provider,
+                VaultIdentity {
+                    chain_id: ANVIL_CHAIN_ID,
+                    vault: evm.vault_address,
+                    underlying: &underlying,
+                },
+                evm.wallet_address,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(receipts, 1);
+            assert_eq!(
+                recorded_holder(&pool, evm.vault_address).await,
+                Some(evm.wallet_address),
+                "the verified holder must be on record"
+            );
+        }
+
+        /// A wallet that does not hold the tracked receipts is refused and
+        /// nothing is recorded — a mistyped or wrong-workspace wallet cannot
+        /// become the trusted custody holder.
+        #[tokio::test]
+        async fn a_holder_without_the_receipts_is_refused() {
+            let evm = LocalEvm::new().await.unwrap();
+            let pool = pool_with_migrations().await;
+            let (provider, _, _) = seeded_vault(&evm, &pool).await;
+            let underlying: UnderlyingSymbol = "TSLA".parse().unwrap();
+
+            let error = confirm_custody_holder(
+                &pool,
+                provider,
+                VaultIdentity {
+                    chain_id: ANVIL_CHAIN_ID,
+                    vault: evm.vault_address,
+                    underlying: &underlying,
+                },
+                Address::random(),
+            )
+            .await
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(MigrationRefusal::HolderMismatch(_))
+                ),
+                "the refusal must be a holder mismatch, got: {error}"
+            );
+            assert_eq!(
+                recorded_holder(&pool, evm.vault_address).await,
+                None,
+                "no custody may be recorded from a failed verification"
+            );
+        }
+
+        /// The rollback proof signs the exact tracked batch without
+        /// broadcasting: the proof covers every tracked receipt, names the
+        /// derived destination, and reports gas for both wallets.
+        #[tokio::test]
+        async fn rollback_signing_proof_covers_the_tracked_batch() {
+            let evm = LocalEvm::new().await.unwrap();
+            let pool = pool_with_migrations().await;
+            let (provider, receipt_id, _) = seeded_vault(&evm, &pool).await;
+            let underlying: UnderlyingSymbol = "TSLA".parse().unwrap();
+
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let wallet = EthereumWallet::from(signer);
+            let destination = Address::random();
+
+            let proof = verify_rollback_signing(
+                &pool,
+                &provider,
+                &wallet,
+                VaultIdentity {
+                    chain_id: ANVIL_CHAIN_ID,
+                    vault: evm.vault_address,
+                    underlying: &underlying,
+                },
+                destination,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(proof.receipts, 1);
+            assert_eq!(proof.destination, destination);
+            assert!(
+                !proof.turnkey_gas.is_zero(),
+                "the signing wallet is funded on the local chain"
+            );
+            assert!(
+                proof.holder_gas.is_zero(),
+                "a random destination holds no gas yet"
+            );
+
+            // Signing proved control without moving anything: the receipt
+            // still sits with its holder.
+            let vault_contract =
+                crate::bindings::OffchainAssetReceiptVault::new(
+                    evm.vault_address,
+                    &provider,
+                );
+            let receipt_contract =
+                Address::from(vault_contract.receipt().call().await.unwrap().0);
+            let receipt = Receipt::new(receipt_contract, &provider);
+            assert!(
+                !receipt
+                    .balanceOf(evm.wallet_address, receipt_id)
+                    .call()
+                    .await
+                    .unwrap()
+                    .is_zero(),
+                "the proof must not move custody"
+            );
+        }
+    }
+
+    /// The Fireblocks-submitted transfer path, end to end against a real vault
+    /// with the Fireblocks API mocked: the custody impl builds the batch
+    /// calldata, submits it as a `CONTRACT_CALL`, polls to completion, and
+    /// verifies the returned transaction actually landed and did not revert.
+    mod fireblocks_transfer {
+        use alloy::network::EthereumWallet;
+        use alloy::providers::ProviderBuilder;
+        use alloy::signers::local::PrivateKeySigner;
+        use alloy::sol_types::SolEvent;
+        use fireblocks_sdk::{Client, ClientBuilder};
+        use httpmock::MockServer;
+        use rsa::RsaPrivateKey;
+        use rsa::pkcs8::EncodePrivateKey;
+        use std::sync::LazyLock;
+
+        use super::*;
+        use crate::fireblocks::parse_chain_asset_ids;
+        use crate::test_utils::{ANVIL_CHAIN_ID, LocalEvm};
+
+        static TEST_RSA_PEM: LazyLock<Vec<u8>> = LazyLock::new(|| {
+            let mut rng = rand::thread_rng();
+            let key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+            key.to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+                .unwrap()
+                .as_bytes()
+                .to_vec()
+        });
+
+        fn mock_client(server: &MockServer) -> Client {
+            ClientBuilder::new("test-api-user", &TEST_RSA_PEM)
+                .with_url(&server.base_url())
+                .build()
+                .unwrap()
+        }
+
+        #[tokio::test]
+        async fn transfer_custody_returns_the_hash_of_a_landed_transfer() {
+            let evm = LocalEvm::new().await.unwrap();
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let holder = evm.wallet_address;
+            let recipient = Address::random();
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let provider = ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &provider,
+            );
+            let shares = U256::from(40) * U256::from(10).pow(U256::from(18));
+            let deposited = vault
+                .deposit(
+                    shares,
+                    holder,
+                    U256::from(10).pow(U256::from(18)),
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            let receipt_id = deposited
+                .inner
+                .logs()
+                .iter()
+                .find_map(|log| {
+                    crate::bindings::OffchainAssetReceiptVault::Deposit::decode_log(
+                        &log.inner,
+                    )
+                    .ok()
+                })
+                .expect("deposit must emit a Deposit event")
+                .id;
+            let receipt_contract =
+                Address::from(vault.receipt().call().await.unwrap().0);
+
+            // Holdings and permit are established while the holder still owns
+            // the receipts, exactly as the engine does before submitting.
+            let onchain = OnchainReceiptCustody::resolve(
+                provider.clone(),
+                evm.vault_address,
+            )
+            .await
+            .unwrap();
+            let tracked = [ReceiptHolding {
+                receipt_id: ReceiptId::from(receipt_id),
+                balance: Shares::from(shares),
+            }];
+            let SourceCustody::Holds(holdings) = reconcile_holdings(
+                &onchain,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                holder,
+                recipient,
+                &tracked,
+                0,
+            )
+            .await
+            .unwrap() else {
+                panic!("the holder must still own the receipts")
+            };
+            let TransferPermission::Permitted(permit) = onchain
+                .transfer_permission(evm.vault_address, holder, recipient)
+                .await
+                .unwrap()
+            else {
+                panic!("a certified vault must permit the transfer")
+            };
+
+            // The "custodian" executes the batch on-chain; the mocked
+            // Fireblocks API then reports that transaction as the completed
+            // CONTRACT_CALL, exactly as production does once approvals clear.
+            let receipt_instance = Receipt::new(receipt_contract, &provider);
+            let landed = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_id],
+                    vec![shares],
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            let landed_hash = landed.transaction_hash;
+
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method("GET").path("/contracts");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!([
+                        {
+                            "id": "contract-wallet-123",
+                            "name": "Receipt",
+                            "assets": [
+                                {
+                                    "id": "TESTCHAIN_ETH",
+                                    "address": receipt_contract
+                                        .to_string()
+                                        .to_lowercase()
+                                }
+                            ]
+                        }
+                    ]));
+            });
+            let create_mock = server.mock(|when, then| {
+                when.method("POST").path("/transactions");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({ "id": "fb-tx-1" }));
+            });
+            server.mock(|when, then| {
+                when.method("GET").path("/transactions/fb-tx-1");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({
+                        "id": "fb-tx-1",
+                        "status": "COMPLETED",
+                        "txHash": format!("{landed_hash:#x}"),
+                    }));
+            });
+
+            let custody = FireblocksReceiptCustody {
+                onchain,
+                client: FireblocksVaultService::for_tests(
+                    mock_client(&server),
+                    provider.clone(),
+                    ANVIL_CHAIN_ID,
+                    parse_chain_asset_ids(&format!(
+                        "{ANVIL_CHAIN_ID}:TESTCHAIN_ETH"
+                    ))
+                    .unwrap(),
+                ),
+                receipt_contract,
+                chain_id: ANVIL_CHAIN_ID,
+            };
+
+            let returned =
+                custody.transfer_custody(&permit, &holdings).await.unwrap();
+
+            assert_eq!(
+                returned, landed_hash,
+                "the custody impl must report the hash of the transfer that \
+                 actually landed"
+            );
+            assert_eq!(
+                create_mock.calls_async().await,
+                1,
+                "exactly one CONTRACT_CALL must be submitted"
+            );
+        }
+
+        /// Fireblocks `Completed` is not proof the EVM transaction succeeded:
+        /// a reverted transfer moved nothing and must fail closed rather than
+        /// report the hash as a success.
+        #[tokio::test]
+        async fn transfer_custody_fails_closed_on_a_reverted_transfer() {
+            let evm = LocalEvm::new().await.unwrap();
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let holder = evm.wallet_address;
+            let recipient = Address::random();
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let provider = ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &provider,
+            );
+            let shares = U256::from(40) * U256::from(10).pow(U256::from(18));
+            let deposited = vault
+                .deposit(
+                    shares,
+                    holder,
+                    U256::from(10).pow(U256::from(18)),
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            let receipt_id = deposited
+                .inner
+                .logs()
+                .iter()
+                .find_map(|log| {
+                    crate::bindings::OffchainAssetReceiptVault::Deposit::decode_log(
+                        &log.inner,
+                    )
+                    .ok()
+                })
+                .expect("deposit must emit a Deposit event")
+                .id;
+            let receipt_contract =
+                Address::from(vault.receipt().call().await.unwrap().0);
+
+            let onchain = OnchainReceiptCustody::resolve(
+                provider.clone(),
+                evm.vault_address,
+            )
+            .await
+            .unwrap();
+            let tracked = [ReceiptHolding {
+                receipt_id: ReceiptId::from(receipt_id),
+                balance: Shares::from(shares),
+            }];
+            let SourceCustody::Holds(holdings) = reconcile_holdings(
+                &onchain,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                holder,
+                recipient,
+                &tracked,
+                0,
+            )
+            .await
+            .unwrap() else {
+                panic!("the holder must still own the receipts")
+            };
+            let TransferPermission::Permitted(permit) = onchain
+                .transfer_permission(evm.vault_address, holder, recipient)
+                .await
+                .unwrap()
+            else {
+                panic!("a certified vault must permit the transfer")
+            };
+
+            // A transfer of more than the tracked balance lands but reverts;
+            // the explicit gas limit skips estimation, which would otherwise
+            // refuse to broadcast it. The mocked Fireblocks API then reports
+            // exactly this reverted transaction as `Completed`.
+            let receipt_instance = Receipt::new(receipt_contract, &provider);
+            let reverted = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_id],
+                    vec![shares + U256::from(1)],
+                    Bytes::new(),
+                )
+                .gas(1_000_000)
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            assert!(
+                !reverted.status(),
+                "the oversized transfer must land reverted"
+            );
+            let reverted_hash = reverted.transaction_hash;
+
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method("GET").path("/contracts");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!([
+                        {
+                            "id": "contract-wallet-123",
+                            "name": "Receipt",
+                            "assets": [
+                                {
+                                    "id": "TESTCHAIN_ETH",
+                                    "address": receipt_contract
+                                        .to_string()
+                                        .to_lowercase()
+                                }
+                            ]
+                        }
+                    ]));
+            });
+            server.mock(|when, then| {
+                when.method("POST").path("/transactions");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({ "id": "fb-tx-1" }));
+            });
+            server.mock(|when, then| {
+                when.method("GET").path("/transactions/fb-tx-1");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!({
+                        "id": "fb-tx-1",
+                        "status": "COMPLETED",
+                        "txHash": format!("{reverted_hash:#x}"),
+                    }));
+            });
+
+            let custody = FireblocksReceiptCustody {
+                onchain,
+                client: FireblocksVaultService::for_tests(
+                    mock_client(&server),
+                    provider.clone(),
+                    ANVIL_CHAIN_ID,
+                    parse_chain_asset_ids(&format!(
+                        "{ANVIL_CHAIN_ID}:TESTCHAIN_ETH"
+                    ))
+                    .unwrap(),
+                ),
+                receipt_contract,
+                chain_id: ANVIL_CHAIN_ID,
+            };
+
+            let error =
+                custody.transfer_custody(&permit, &holdings).await.unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    ReceiptCustodyError::Reverted { tx_hash, .. }
+                        if tx_hash == reverted_hash
+                ),
+                "a reverted transfer must fail closed naming the reverted \
+                 hash, got: {error}"
+            );
+            assert_eq!(
+                receipt_instance
+                    .balanceOf(holder, receipt_id)
+                    .call()
+                    .await
+                    .unwrap(),
+                shares,
+                "the reverted transfer must have moved nothing"
+            );
         }
     }
 }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -638,6 +638,12 @@ pub(crate) struct ReceiptInventory {
     /// from. Absent on inventories that predate custody being recorded.
     #[serde(default)]
     custody: Custody,
+    /// How many custody migrations this vault has recorded. Gives each
+    /// deliberate re-migration (forward after a rollback, or vice versa) a
+    /// distinct transfer identity while retries of the same attempt keep the
+    /// original one.
+    #[serde(default)]
+    migrations_recorded: u32,
 }
 
 /// Which wallet holds this vault's receipts.
@@ -679,6 +685,12 @@ impl Custody {
 impl ReceiptInventory {
     pub(crate) const fn custody(&self) -> &Custody {
         &self.custody
+    }
+
+    /// How many custody migrations this vault has recorded — the ordinal that
+    /// gives each deliberate re-migration a fresh transfer identity.
+    pub(crate) const fn migrations_recorded(&self) -> u32 {
+        self.migrations_recorded
     }
 
     /// Receipts with shares reserved against an in-flight redemption burn.
@@ -1089,15 +1101,27 @@ impl ReceiptInventory {
                 Ok(vec![ReceiptInventoryEvent::CustodyConfirmed { holder }])
             }
 
+            // Idempotent for the verify-and-record flow: the same completed
+            // move observed again (a re-run after a lost terminal, or a
+            // rollback preflight) must not append a second event. Keyed on the
+            // destination alone — once custody is recorded at `to`, a repeat
+            // observation must not rewrite `moved_from` history, whatever
+            // wallet the repeat claims it came from.
             ReceiptInventoryCommand::RecordCustodyMigration {
                 from,
                 to,
                 tx_hash,
-            } => Ok(vec![ReceiptInventoryEvent::CustodyMigrated {
-                from,
-                to,
-                tx_hash,
-            }]),
+            } => {
+                if self.custody.holder() == Some(to) {
+                    return Ok(vec![]);
+                }
+
+                Ok(vec![ReceiptInventoryEvent::CustodyMigrated {
+                    from,
+                    to,
+                    tx_hash,
+                }])
+            }
         }
     }
 
@@ -1260,6 +1284,8 @@ impl ReceiptInventory {
             ReceiptInventoryEvent::CustodyMigrated { from, to, .. } => {
                 self.custody =
                     Custody::Held { holder: to, moved_from: Some(from) };
+                self.migrations_recorded =
+                    self.migrations_recorded.saturating_add(1);
             }
         }
     }
@@ -4147,7 +4173,7 @@ mod tests {
                     ReceiptInventoryCommand::RecordCustodyMigration {
                         from: HOLDER,
                         to: REPLACEMENT,
-                        tx_hash,
+                        tx_hash: Some(tx_hash),
                     },
                     &(),
                 )
@@ -4165,6 +4191,163 @@ mod tests {
             );
         }
 
+        /// The same completed move observed again — a re-run after a lost
+        /// terminal, or a rollback preflight — must not append a second event.
+        #[tokio::test]
+        async fn recording_the_same_migration_twice_emits_one_event() {
+            let mut aggregate = ReceiptInventory::default();
+
+            let events = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(events.len(), 1);
+            for event in events {
+                aggregate.apply_event(event);
+            }
+
+            let repeat = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            assert!(
+                repeat.is_empty(),
+                "re-recording an identical move must be a no-op, got \
+                 {repeat:?}"
+            );
+        }
+
+        /// The repeat is keyed on the destination alone: a re-observation
+        /// claiming a different origin must also be a no-op, and must not
+        /// rewrite where a rollback returns custody to.
+        #[tokio::test]
+        async fn a_repeat_claiming_another_origin_cannot_rewrite_the_rollback_target()
+         {
+            let mut aggregate = ReceiptInventory::default();
+            let stranger =
+                address!("0x00000000000000000000000000000000000000cc");
+
+            let events = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            for event in events {
+                aggregate.apply_event(event);
+            }
+
+            let repeat = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: stranger,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+
+            assert!(
+                repeat.is_empty(),
+                "a repeat naming another origin must be a no-op, got \
+                 {repeat:?}"
+            );
+            assert_eq!(
+                aggregate.custody().moved_from(),
+                Some(HOLDER),
+                "the recorded rollback target must survive the repeat"
+            );
+        }
+
+        /// The migration ordinal salts the forward transfer's `externalTxId`:
+        /// it must advance on every real move (a re-migration after rollback
+        /// gets a fresh id) and must not advance on the deduplicated repeat
+        /// (an in-flight retry resumes the same Fireblocks transaction).
+        #[tokio::test]
+        async fn the_migration_ordinal_advances_on_moves_and_not_on_repeats() {
+            let mut aggregate = ReceiptInventory::default();
+            assert_eq!(aggregate.migrations_recorded(), 0);
+
+            let forward = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            for event in forward {
+                aggregate.apply_event(event);
+            }
+            assert_eq!(
+                aggregate.migrations_recorded(),
+                1,
+                "a real move must advance the ordinal"
+            );
+
+            let repeat = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: HOLDER,
+                        to: REPLACEMENT,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            assert!(repeat.is_empty());
+            assert_eq!(
+                aggregate.migrations_recorded(),
+                1,
+                "the deduplicated repeat must not advance the ordinal"
+            );
+
+            let rollback = aggregate
+                .transition(
+                    ReceiptInventoryCommand::RecordCustodyMigration {
+                        from: REPLACEMENT,
+                        to: HOLDER,
+                        tx_hash: None,
+                    },
+                    &(),
+                )
+                .await
+                .unwrap();
+            for event in rollback {
+                aggregate.apply_event(event);
+            }
+            assert_eq!(
+                aggregate.migrations_recorded(),
+                2,
+                "the rollback is a real move and must advance the ordinal"
+            );
+        }
+
         /// Reconciliation passes after a migration keep confirming the new
         /// holder; that must not erase where custody came from, or a rollback
         /// after the first post-cutover pass would have nowhere to go.
@@ -4178,7 +4361,7 @@ mod tests {
             aggregate.apply_event(ReceiptInventoryEvent::CustodyMigrated {
                 from: HOLDER,
                 to: REPLACEMENT,
-                tx_hash,
+                tx_hash: Some(tx_hash),
             });
             aggregate.apply_event(ReceiptInventoryEvent::CustodyConfirmed {
                 holder: REPLACEMENT,

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -1,3 +1,5 @@
+use alloy::primitives::{Address, Bytes, U256};
+use alloy::providers::{Provider, ProviderBuilder};
 use clap::{Args, Parser, Subcommand};
 use event_sorcery::{
     AggregateError, LifecycleError, ReconcileError, Store, StoreBuilder,
@@ -8,17 +10,34 @@ use std::io::{self, Write};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
+use url::Url;
 
 use super::UnderlyingSymbol;
-use super::view::{TokenizedAssetViewError, underlying_has_listing};
+use super::view::{
+    TokenizedAssetViewError, find_vault, underlying_has_listing,
+};
+use crate::Network;
+use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::config::{
     DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, LogLevel,
     setup_tracing,
 };
+use crate::fireblocks::{
+    FireblocksEnv, FireblocksVaultService, fetch_vault_address,
+};
+use crate::receipt_inventory::migration::{
+    CorroboratedRecipient, MigrationOutcome, VaultIdentity,
+    confirm_custody_holder, migrate_vault_receipts,
+    migrate_vault_receipts_via_fireblocks, recorded_custody_holder,
+    recorded_migration_origin, rollback_gas_reserve, verify_rollback_signing,
+};
+use crate::receipt_inventory::{ReceiptInventory, load_inventory};
 use crate::underlying::{
     AssetStatus, Underlying, UnderlyingCommand, UnderlyingViewError,
     load_freeze_status,
 };
+use crate::wallet::turnkey::{TurnkeyConfig, resolve_turnkey_signer};
+use crate::wallet::{SignerConfig, SignerEnv};
 
 /// Parses and runs the issuer-host CLI end to end. The `issuer` binary is a thin
 /// wrapper over this entry point.
@@ -56,6 +75,201 @@ enum IssuerCommand {
     Unfreeze(AssetArgs),
     /// Print an underlying's current freeze status.
     Status(AssetArgs),
+    /// Move a vault's deposit receipts between the Fireblocks wallet and the
+    /// Turnkey wallet, with the direction resolved from recorded custody.
+    ///
+    /// Custody at the Fireblocks wallet runs the forward leg, submitted
+    /// through the Fireblocks API (console approval may be required); custody
+    /// at the Turnkey wallet runs the rollback, signed by Turnkey back to the
+    /// API-derived Fireblocks wallet. Both custodians' configurations are
+    /// required and no wallet address is ever typed.
+    ///
+    /// Temporary, for the Turnkey cutover: the issuer burns against receipts
+    /// held by its own signing address, so rotating the signing backend strands
+    /// them until custody follows. Remove once every vault has migrated.
+    ///
+    /// Unlike the freeze subcommands this is network-scoped, because receipts
+    /// live in a single vault on a single chain.
+    MigrateReceipts(Box<MigrateReceiptsArgs>),
+    /// Record which wallet holds a vault's receipts, after verifying on-chain
+    /// that it holds exactly every tracked balance.
+    ///
+    /// The bootstrap for deployments whose history predates custody tracking:
+    /// the reconciliation guard treats unobserved custody as "a zero balance
+    /// means spent", so every vault's holder must be on record before any
+    /// service starts against a rotated wallet. The holder is fetched from the
+    /// Fireblocks API — never typed — and recorded only if it holds every
+    /// tracked balance exactly. Submits no transaction.
+    ConfirmCustody(Box<ConfirmCustodyArgs>),
+    /// Prove both custodian connections, before anything moves.
+    ///
+    /// Fireblocks: authenticates, derives the wallet, and resolves the
+    /// whitelisted Receipt contract — proving credentials and authorization
+    /// without submitting anything. Turnkey: signs the exact rollback-shaped
+    /// transaction — every tracked receipt back from the Turnkey wallet to
+    /// the current holder — WITHOUT broadcasting it, exercising the
+    /// credentials, organization, address, and signing policy end to end. The
+    /// custodian signs the forward transfer outside this binary, so a broken
+    /// Turnkey setup discovered after the move would strand custody with no
+    /// way back; this makes that undiscoverable state impossible to enter.
+    /// Also reports both wallets' gas balances. With `--smoke`, additionally
+    /// submits a zero-amount transfer through the full Fireblocks path — the
+    /// only live-transaction step, and the full proof of the custodian's own
+    /// signing path.
+    VerifyCustodians(Box<VerifyCustodiansArgs>),
+}
+
+/// Which way the operator intends custody to move. Stated explicitly and
+/// checked against the direction the recorded custody state resolves to, so a
+/// re-run after a recorded forward move cannot silently become a rollback.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+enum MigrationDirection {
+    /// Fireblocks -> Turnkey.
+    Forward,
+    /// Turnkey -> the recorded Fireblocks origin.
+    Rollback,
+}
+
+impl std::fmt::Display for MigrationDirection {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(match self {
+            Self::Forward => "forward",
+            Self::Rollback => "rollback",
+        })
+    }
+}
+
+#[derive(Args)]
+struct MigrateReceiptsArgs {
+    /// Underlying symbol, e.g. AMAT. Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// Network whose vault to migrate.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// The direction this run is meant to move custody; refused if the
+    /// recorded custody state resolves to the other one.
+    #[arg(long, value_enum)]
+    direction: MigrationDirection,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain the migration must run against, cross-checked against the chain
+    /// the RPC reports. Stated explicitly because the same vault address can
+    /// exist on more than one chain, so reaching the contract does not prove
+    /// the endpoint is the intended one.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[clap(flatten)]
+    fireblocks: FireblocksEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
+struct VerifyCustodiansArgs {
+    /// Underlying symbol, e.g. AMAT. Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// Network whose vault to verify against.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    /// Additionally submit a zero-amount transfer through the full Fireblocks
+    /// path — whitelisting, TAP rule, signing, and the vault's authorization
+    /// gates — moving nothing. The strongest possible Fireblocks-side proof.
+    #[arg(long)]
+    smoke: bool,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[clap(flatten)]
+    fireblocks: FireblocksEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
+struct ConfirmCustodyArgs {
+    /// Underlying symbol, e.g. AMAT. Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// Network whose vault to confirm.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    fireblocks: FireblocksEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
 }
 
 #[derive(Args)]
@@ -93,7 +307,680 @@ impl IssuerCli {
             IssuerCommand::Status(args) => {
                 run_asset_command(AssetAction::Status, &args).await
             }
+            IssuerCommand::MigrateReceipts(args) => {
+                run_migrate_receipts(*args, prompt_confirm).await
+            }
+            IssuerCommand::ConfirmCustody(args) => {
+                run_confirm_custody(*args, prompt_confirm).await
+            }
+            IssuerCommand::VerifyCustodians(args) => {
+                run_verify_custodians(*args, prompt_confirm).await
+            }
         }
+    }
+}
+
+/// Verifies and records a vault's custody holder. No transaction; the holder
+/// is fetched from the Fireblocks API, its on-chain balances compared against
+/// the tracked inventory, and only an exact match is recorded.
+async fn run_confirm_custody(
+    args: ConfirmCustodyArgs,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    println!("Using database: {}", args.database_url);
+
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    let fireblocks_config = args.fireblocks.into_config()?;
+    let holder = fetch_vault_address(&fireblocks_config).await?;
+
+    if !confirm(&format!(
+        "Verify on-chain that the Fireblocks wallet {holder} holds every \
+         tracked receipt of {} vault {vault} and record it as the custody \
+         holder?",
+        args.underlying
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+    let receipts = confirm_custody_holder(
+        &admin.pool,
+        provider,
+        VaultIdentity { chain_id, vault, underlying: &args.underlying },
+        holder,
+    )
+    .await?;
+
+    println!(
+        "Confirmed: {holder} holds all {receipts} tracked receipt(s) for \
+         vault {vault}."
+    );
+
+    Ok(())
+}
+
+/// Proves both custodian connections before anything moves. Signs the exact
+/// rollback-shaped transaction with Turnkey without broadcasting it,
+/// authenticates against Fireblocks and resolves the whitelisted Receipt
+/// contract, and reports gas balances. With `--smoke`, additionally submits a
+/// zero-amount transfer through the full Fireblocks path.
+async fn run_verify_custodians(
+    args: VerifyCustodiansArgs,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    println!("Using database: {}", args.database_url);
+
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    let SignerConfig::Turnkey(turnkey_config) =
+        args.signer.clone().into_config()?
+    else {
+        anyhow::bail!(
+            "verify-custodians requires the Turnkey signer configuration"
+        );
+    };
+    let turnkey = turnkey_config.settings.address;
+    let fireblocks_config = args.fireblocks.clone().into_config()?;
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+
+    // Fireblocks: authenticating and resolving the wallet proves the
+    // credentials; resolving the whitelisted Receipt contract proves the
+    // authorization work is in place before the window opens.
+    let fireblocks_wallet = fetch_vault_address(&fireblocks_config).await?;
+    println!("Fireblocks: authenticated; wallet {fireblocks_wallet}");
+
+    let receipt_contract = OffchainAssetReceiptVault::new(vault, &provider)
+        .receipt()
+        .call()
+        .await?
+        .0
+        .into();
+    let fireblocks_service = FireblocksVaultService::new(
+        &fireblocks_config,
+        provider.clone(),
+        chain_id,
+    )?;
+    fireblocks_service.resolve_contract_wallet(receipt_contract).await?;
+    println!("Fireblocks: Receipt contract {receipt_contract} is whitelisted");
+
+    // Turnkey: signing the exact rollback-shaped transaction (never
+    // broadcast) proves the credentials, the organization, the address, and
+    // the signing policy — before the forward move can become a one-way door.
+    let resolved = resolve_turnkey_signer(&turnkey_config, chain_id)?;
+    let proof = verify_rollback_signing(
+        &admin.pool,
+        &provider,
+        &resolved.wallet,
+        VaultIdentity { chain_id, vault, underlying: &args.underlying },
+        fireblocks_wallet,
+    )
+    .await?;
+    println!(
+        "Turnkey: signed the rollback of {} receipt(s) to {} without \
+         broadcasting",
+        proof.receipts, proof.destination
+    );
+    println!(
+        "Gas: turnkey {turnkey} holds {} wei; holder {} holds {} wei",
+        proof.turnkey_gas, proof.destination, proof.holder_gas
+    );
+    require_rollback_gas(proof.turnkey_gas, turnkey)?;
+
+    if args.smoke {
+        // The one live transaction in the preflight: zero-amount, but still
+        // submitted through the real custodian path and possibly waiting on
+        // console approval — the operator opts in explicitly.
+        if !confirm(&format!(
+            "Submit a zero-amount smoke transfer of a {} receipt through the \
+             full Fireblocks path (console approval may be required)?",
+            args.underlying
+        ))? {
+            anyhow::bail!("aborted by operator");
+        }
+
+        run_fireblocks_smoke(
+            &admin.pool,
+            &fireblocks_service,
+            chain_id,
+            SmokeTarget { vault, receipt_contract, fireblocks_wallet, turnkey },
+        )
+        .await?;
+    }
+
+    println!("Both custodian connections verified.");
+
+    Ok(())
+}
+
+/// The four distinct addresses the smoke transfer touches, under named
+/// fields: they are all bare `Address`es, so as positional parameters a
+/// transposed pair would compile silently and smoke-test the wrong transfer.
+struct SmokeTarget {
+    vault: Address,
+    receipt_contract: Address,
+    fireblocks_wallet: Address,
+    turnkey: Address,
+}
+
+/// Submits a zero-amount `safeTransferFrom` of the first tracked receipt
+/// through the full Fireblocks path. Exercises whitelisting, the TAP rule,
+/// signing, and the vault's authorization gates while moving nothing — a
+/// zero-amount transfer cannot create the inventory divergence a real dust
+/// transfer would.
+async fn run_fireblocks_smoke<P: Provider + Clone>(
+    pool: &Pool<Sqlite>,
+    fireblocks_service: &FireblocksVaultService<P>,
+    chain_id: u64,
+    target: SmokeTarget,
+) -> anyhow::Result<()> {
+    let SmokeTarget { vault, receipt_contract, fireblocks_wallet, turnkey } =
+        target;
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+    let receipt_id = inventory
+        .receipts_with_balance()
+        .first()
+        .map(|receipt| receipt.receipt_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "vault {vault} has no tracked receipts to smoke-test with"
+            )
+        })?;
+
+    let calldata =
+        Receipt::new(receipt_contract, fireblocks_service.read_provider())
+            .safeTransferFrom(
+                fireblocks_wallet,
+                turnkey,
+                receipt_id.inner(),
+                U256::ZERO,
+                Bytes::new(),
+            )
+            .calldata()
+            .clone();
+
+    // The same fresh-retry walk the migration transfer uses: a smoke run that
+    // failed terminally (e.g. a TAP rule fixed minutes later) must not brick
+    // the same-day smoke id.
+    let date = chrono::Utc::now().format("%Y-%m-%d");
+    let tx_hash = fireblocks_service
+        .submit_contract_call_to_completion(
+            receipt_contract,
+            &calldata,
+            "zero-amount custody-path smoke test",
+            &format!("custody-smoke-{chain_id}-{vault:#x}-{date}"),
+        )
+        .await?;
+
+    // Fireblocks can report `Completed` while the EVM transaction reverted —
+    // the same discrepancy the migration's transfer path treats as failure. A
+    // reverted smoke test proves the path is broken, so it must not print
+    // success.
+    let receipt = fireblocks_service
+        .read_provider()
+        .get_transaction_receipt(tx_hash)
+        .await?
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "smoke transfer {tx_hash} has no receipt on-chain despite \
+                 Fireblocks reporting completion"
+            )
+        })?;
+
+    if !receipt.status() {
+        anyhow::bail!(
+            "smoke transfer {tx_hash} REVERTED on-chain despite Fireblocks \
+             reporting completion — the custody path is not working"
+        );
+    }
+
+    println!("Fireblocks smoke transfer completed (moved nothing): {tx_hash}");
+
+    Ok(())
+}
+
+/// Moves one vault's receipt custody to a replacement wallet.
+///
+/// The wallet whose custody moves is whoever this command signs as, not a
+/// separate argument: the two can then never disagree, and ERC-1155 only lets
+/// the holder move its own balance anyway.
+async fn run_migrate_receipts(
+    args: MigrateReceiptsArgs,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    // Checked first, before any database or network work: a network paired with
+    // a chain it does not name is answerable from the arguments alone, and
+    // every later step — vault resolution, the inventory key, the prompt the
+    // operator confirms — would otherwise be derived from a premise already
+    // known to be wrong.
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    println!("Using database: {}", args.database_url);
+
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    // No wallet is an argument. Both custodians' configurations are required:
+    // the forward transfer is signed by Fireblocks through its API, the
+    // rollback by Turnkey, and which one runs is resolved from the inventory's
+    // recorded custody — never from the operator's intent alone.
+    let signer = args.signer.clone().into_config()?;
+    let SignerConfig::Turnkey(turnkey_config) = signer else {
+        anyhow::bail!(
+            "migrate-receipts requires the Turnkey signer configuration: the \
+             destination of the forward transfer and the signer of the \
+             rollback both come from it."
+        );
+    };
+    let turnkey = turnkey_config.settings.address;
+
+    let recorded =
+        recorded_custody_holder(&admin.pool, args.chain_id, vault).await?;
+
+    match recorded {
+        None => anyhow::bail!(
+            "vault {vault} on chain {} has no recorded custody holder; run \
+             `issuer confirm-custody` first",
+            args.chain_id
+        ),
+        Some(holder) if holder == turnkey => {
+            require_direction(args.direction, MigrationDirection::Rollback)?;
+            run_rollback_transfer(
+                &args,
+                &admin,
+                vault,
+                &turnkey_config,
+                confirm,
+            )
+            .await
+        }
+        Some(holder) => {
+            require_direction(args.direction, MigrationDirection::Forward)?;
+            run_forward_via_fireblocks(
+                &args,
+                &admin,
+                vault,
+                holder,
+                &turnkey_config,
+                confirm,
+            )
+            .await
+        }
+    }
+}
+
+/// Refuses when the operator's stated direction disagrees with the direction
+/// the recorded custody state resolves to.
+///
+/// The command is state-driven and therefore reversible: once a forward move
+/// is recorded, custody sits at Turnkey and a mechanical re-run of the same
+/// command would resolve to a rollback. Requiring the direction to be stated
+/// turns that surprise into a refusal before any prompt or network work.
+fn require_direction(
+    stated: MigrationDirection,
+    resolved: MigrationDirection,
+) -> anyhow::Result<()> {
+    if stated != resolved {
+        anyhow::bail!(
+            "recorded custody state resolves this command to a {resolved} \
+             transfer, but --direction says {stated}; if a previous run \
+             already moved custody, a re-run is a {resolved} — state the \
+             direction you actually intend"
+        );
+    }
+
+    Ok(())
+}
+
+/// The rollback: Turnkey signs custody back to the Fireblocks wallet, fetched
+/// from the Fireblocks API — the same derivation the forward leg uses — and
+/// cross-checked against the origin recorded by the forward move, so a wrong
+/// Fireblocks workspace cannot redirect the rollback. No address is typed
+/// anywhere, and the migration engine's ownership checks are the
+/// verification: the source must hold exactly every tracked balance before,
+/// and the recipient's gain must match exactly after.
+async fn run_rollback_transfer(
+    args: &MigrateReceiptsArgs,
+    admin: &AssetAdmin,
+    vault: Address,
+    turnkey_config: &TurnkeyConfig,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    let turnkey = turnkey_config.settings.address;
+    let fireblocks_config = args.fireblocks.clone().into_config()?;
+    let fireblocks_wallet = fetch_vault_address(&fireblocks_config).await?;
+    let recorded_origin =
+        recorded_migration_origin(&admin.pool, args.chain_id, vault).await?;
+    let recipient =
+        Recipient::for_rollback(recorded_origin, fireblocks_wallet, turnkey)?;
+
+    println!(
+        "{} on {} (chain {}) vault {vault}: rolling receipt custody back from \
+         {turnkey} to the recorded Fireblocks origin {recipient}",
+        args.underlying, args.network, args.chain_id
+    );
+
+    if !confirm(&format!(
+        "The issuer service MUST be stopped before this runs. Roll {} receipt \
+         custody back from {turnkey} to {recipient}?",
+        args.underlying
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let resolved = resolve_turnkey_signer(turnkey_config, chain_id)?;
+    let provider = ProviderBuilder::new()
+        .with_chain_id(chain_id)
+        .wallet(resolved.wallet)
+        .connect(args.rpc_url.as_str())
+        .await?;
+
+    let recipient =
+        CorroboratedRecipient::verify(&provider, recipient.address()).await?;
+
+    let outcome = migrate_vault_receipts(
+        &admin.pool,
+        provider,
+        VaultIdentity { chain_id, vault, underlying: &args.underlying },
+        turnkey,
+        recipient,
+    )
+    .await?;
+    report_outcome(&outcome, recipient.address(), vault);
+
+    Ok(())
+}
+
+/// The forward leg: the transfer is signed by the retiring custodian, so it is
+/// submitted through the Fireblocks API and may wait on approvals in the
+/// Fireblocks console. Every migration gate still runs in this binary; only
+/// the signing happens at the custodian.
+///
+/// Re-running after a completed move records it instead of transferring again,
+/// which is also how a transfer executed manually in the console gets onto the
+/// record a rollback later depends on.
+async fn run_forward_via_fireblocks(
+    args: &MigrateReceiptsArgs,
+    admin: &AssetAdmin,
+    vault: Address,
+    holder: Address,
+    turnkey_config: &TurnkeyConfig,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    let turnkey = turnkey_config.settings.address;
+    let fireblocks_config = args.fireblocks.clone().into_config()?;
+    let recipient = Recipient::for_holder(turnkey, holder)?;
+
+    println!(
+        "{} on {} (chain {}) vault {vault}: moving receipt custody from \
+         {holder} to {recipient} via Fireblocks",
+        args.underlying, args.network, args.chain_id
+    );
+
+    // The operator is warned here because this is the last point of no return
+    // and it is the one precondition nothing downstream can detect: an issuer
+    // service still running with the outgoing signer reconciles the moved
+    // receipts as depletions and drops them from the aggregate. The prompt
+    // deliberately runs before any network call, so declining costs nothing.
+    if !confirm(&format!(
+        "The issuer service MUST be stopped before this runs. Submit the \
+         transfer through Fireblocks (console approval may be required) and \
+         move {} receipt custody from {holder} to {recipient}?",
+        args.underlying
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+
+    // The wallet the configured Fireblocks workspace actually controls. The
+    // recorded holder must be that wallet: anything else means the
+    // configuration points at a different workspace or vault account than
+    // the one holding custody, and the transfer this command would submit
+    // could never move the recorded holder's receipts. Checked before any
+    // submission, so a mismatch is a clean refusal.
+    let fireblocks_wallet = fetch_vault_address(&fireblocks_config).await?;
+
+    if holder != fireblocks_wallet {
+        anyhow::bail!(
+            "recorded custody holder {holder} is not the wallet the \
+             configured Fireblocks workspace controls ({fireblocks_wallet}); \
+             refusing to submit a transfer that cannot move the recorded \
+             holder's receipts. Check FIREBLOCKS_* configuration."
+        );
+    }
+
+    // The forward transfer is a one-way door unless Turnkey can sign the way
+    // back. Re-proven here, immediately before the irreversible submission,
+    // rather than trusted from an earlier `verify-custodians` run that may be
+    // stale or skipped: the exact rollback-shaped transaction — every tracked
+    // receipt back from the Turnkey wallet to the current holder — is signed
+    // without being broadcast, and the Turnkey wallet must hold the rollback
+    // gas reserve.
+    let resolved = resolve_turnkey_signer(turnkey_config, chain_id)?;
+    let proof = verify_rollback_signing(
+        &admin.pool,
+        &provider,
+        &resolved.wallet,
+        VaultIdentity { chain_id, vault, underlying: &args.underlying },
+        fireblocks_wallet,
+    )
+    .await?;
+    println!(
+        "Turnkey rollback re-proven: signed the return of {} receipt(s) to \
+         {} without broadcasting",
+        proof.receipts, proof.destination
+    );
+    require_rollback_gas(proof.turnkey_gas, turnkey)?;
+
+    let recipient =
+        CorroboratedRecipient::verify(&provider, recipient.address()).await?;
+
+    let outcome = migrate_vault_receipts_via_fireblocks(
+        &admin.pool,
+        provider,
+        &fireblocks_config,
+        VaultIdentity { chain_id, vault, underlying: &args.underlying },
+        fireblocks_wallet,
+        recipient,
+    )
+    .await?;
+    report_outcome(&outcome, recipient.address(), vault);
+
+    Ok(())
+}
+
+/// Requires the Turnkey wallet to hold the rollback gas reserve.
+///
+/// One wei passes a bare non-zero check while leaving a real rollback
+/// unbroadcastable, which would turn the forward move into a one-way door
+/// discovered only when the way back is needed.
+fn require_rollback_gas(
+    turnkey_gas: U256,
+    turnkey: Address,
+) -> anyhow::Result<()> {
+    let reserve = rollback_gas_reserve();
+    if turnkey_gas < reserve {
+        anyhow::bail!(
+            "the Turnkey wallet {turnkey} holds {turnkey_gas} wei but the \
+             rollback gas reserve is {reserve} wei; fund it before the \
+             window — it cannot broadcast a rollback or operate the service \
+             without gas"
+        );
+    }
+
+    Ok(())
+}
+
+/// Connects to the RPC and cross-checks the chain it reports against
+/// `--chain-id`.
+///
+/// Reached only once the operator has confirmed intent, so an `--rpc-url` typo
+/// cannot surface before they have decided. The RPC is the authority on which
+/// chain the transfer lands on, but only the operator knows which one they
+/// meant; disagreement means the vault address, the inventory key, or the
+/// endpoint is wrong — and a deterministic deployment can put the same vault
+/// address on both chains, so reaching the contract proves nothing.
+async fn verified_chain_id(
+    rpc_url: &Url,
+    expected_chain_id: u64,
+) -> anyhow::Result<u64> {
+    let chain_id = ProviderBuilder::new()
+        .connect(rpc_url.as_str())
+        .await?
+        .get_chain_id()
+        .await?;
+
+    if chain_id != expected_chain_id {
+        anyhow::bail!(
+            "--chain-id is {expected_chain_id} but {rpc_url} reports chain \
+             {chain_id}"
+        );
+    }
+
+    Ok(chain_id)
+}
+
+fn report_outcome(
+    outcome: &MigrationOutcome,
+    recipient: Address,
+    vault: Address,
+) {
+    match outcome {
+        MigrationOutcome::Migrated { transaction, receipts } => {
+            println!(
+                "Moved {receipts} receipt(s) to {recipient} in {transaction}."
+            );
+        }
+        MigrationOutcome::AlreadyMigrated { receipts } => {
+            println!(
+                "Already migrated: {recipient} holds all {receipts} \
+                 receipt(s) for vault {vault}."
+            );
+        }
+    }
+}
+
+/// A destination that is safe to move custody to.
+///
+/// Existence implies validity: both constructors funnel through
+/// [`Recipient::for_holder`]'s checks ([`Recipient::for_rollback`] adds the
+/// recorded-origin cross-check on top), so a caller cannot hold one without
+/// having rejected the two destinations that make an irreversible move
+/// unrecoverable or pointless.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct Recipient(Address);
+
+impl Recipient {
+    /// Rejects the zero address, which would burn the receipts, and the
+    /// signing wallet itself, which would submit a transaction that moves
+    /// nothing.
+    fn for_holder(recipient: Address, holder: Address) -> anyhow::Result<Self> {
+        if recipient.is_zero() {
+            anyhow::bail!(
+                "recipient is the zero address; custody would be lost"
+            );
+        }
+
+        if recipient == holder {
+            anyhow::bail!(
+                "recipient {recipient} is already the signing wallet; nothing \
+                 would move"
+            );
+        }
+
+        Ok(Self(recipient))
+    }
+
+    /// The rollback destination: the recorded migration origin, cross-checked
+    /// against the wallet the configured Fireblocks workspace resolves. The
+    /// two are derived independently — one from the inventory's custody
+    /// history, one from the custodian's API — and a mismatch means the
+    /// operator is running against the wrong Fireblocks workspace: rolling
+    /// back there would move custody to a wallet this vault's receipts never
+    /// came from.
+    fn for_rollback(
+        recorded_origin: Address,
+        fireblocks_wallet: Address,
+        holder: Address,
+    ) -> anyhow::Result<Self> {
+        if fireblocks_wallet != recorded_origin {
+            anyhow::bail!(
+                "the configured Fireblocks workspace resolves wallet \
+                 {fireblocks_wallet}, but custody was recorded as moved from \
+                 {recorded_origin}; refusing to roll back to a wallet this \
+                 vault's custody never came from — check the FIREBLOCKS_* \
+                 configuration"
+            );
+        }
+
+        Self::for_holder(recorded_origin, holder)
+    }
+
+    const fn address(self) -> Address {
+        self.0
+    }
+}
+
+impl std::fmt::Display for Recipient {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}", self.0)
     }
 }
 
@@ -393,6 +1280,16 @@ mod tests {
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
     };
 
+    const TEST_SIGNER_KEY: &str =
+        "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    /// The one vault every CLI test seeds. `seed_custody_at` keys the
+    /// aggregate with this same vault (and Base's chain id), so the seeded
+    /// custody can never silently desynchronise from the listing the CLI
+    /// resolves.
+    const TEST_VAULT: Address =
+        address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
     /// Seeds one listing per given network for `underlying`, then hands back an
     /// admin over the same pool — mirroring an issuer host where the server
     /// maintains the listing view and the CLI acts on the freeze store.
@@ -427,9 +1324,7 @@ mod tests {
                         underlying: underlying.clone(),
                         token: TokenSymbol::new(format!("t{underlying}")),
                         network: *network,
-                        vault: address!(
-                            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-                        ),
+                        vault: TEST_VAULT,
                     },
                 )
                 .await
@@ -697,6 +1592,418 @@ mod tests {
             ])
             .is_err(),
             "non-sqlite database URL must be rejected at parse time"
+        );
+    }
+
+    /// Seeds a listing into a file-backed store, since `run_migrate_receipts`
+    /// opens its own pool from the URL and so cannot share an in-memory one.
+    async fn seed_listing_at(database_url: &str, underlying: &str) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(database_url)
+            .await
+            .expect("Failed to open database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        let (listing_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .expect("Failed to build tokenized asset store");
+
+        let underlying = UnderlyingSymbol::new(underlying).unwrap();
+        listing_store
+            .send(
+                &AssetKey::new(underlying.clone(), Network::Base),
+                TokenizedAssetCommand::Add {
+                    underlying: underlying.clone(),
+                    token: TokenSymbol::new(format!("t{underlying}")),
+                    network: Network::Base,
+                    vault: TEST_VAULT,
+                },
+            )
+            .await
+            .expect("Failed to add asset");
+        pool.close().await;
+    }
+
+    /// Seeds a recorded custody holder the way the service does — through the
+    /// aggregate — so direction dispatch is tested against real state.
+    async fn seed_custody_at(database_url: &str, holder: Address) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(database_url)
+            .await
+            .expect("Failed to open database");
+        let store = StoreBuilder::<ReceiptInventory>::new(pool)
+            .build(())
+            .await
+            .expect("Failed to build receipt inventory store");
+
+        store
+            .send(
+                &crate::receipt_inventory::ReceiptVaultKey::new(
+                    Network::Base.chain_id(),
+                    TEST_VAULT,
+                ),
+                crate::receipt_inventory::ReceiptInventoryCommand::ConfirmCustody {
+                    holder,
+                },
+            )
+            .await
+            .expect("Failed to seed custody");
+    }
+
+    fn turnkey_migrate_args(
+        direction: &str,
+        chain_id: &str,
+        database_url: &str,
+        secret_path: &str,
+    ) -> MigrateReceiptsArgs {
+        let cli = IssuerCli::try_parse_from([
+            "issuer",
+            "migrate-receipts",
+            "AMAT",
+            "--network",
+            "base",
+            "--direction",
+            direction,
+            "--chain-id",
+            chain_id,
+            "--turnkey-org-id",
+            "org-id",
+            "--turnkey-api-private-key",
+            "api-key",
+            "--turnkey-address",
+            "0x00000000000000000000000000000000000000cc",
+            "--fireblocks-api-user-id",
+            "fb-user",
+            "--fireblocks-secret-path",
+            secret_path,
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            database_url,
+        ])
+        .expect("arguments parse");
+
+        let IssuerCommand::MigrateReceipts(args) = cli.command else {
+            panic!("expected the migrate-receipts subcommand")
+        };
+
+        *args
+    }
+
+    /// A declined confirmation must abort before any network call. The
+    /// unreachable `--rpc-url` is the assertion: if the prompt were bypassed,
+    /// or the chain-id round-trip still ran first, this would fail on the
+    /// endpoint rather than on the operator's decision.
+    #[tokio::test]
+    async fn migrate_receipts_aborts_without_touching_the_chain_when_declined()
+    {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("decline.db").display()
+        );
+        seed_listing_at(&database_url, "AMAT").await;
+        // Custody sits with a wallet that is not Turnkey, so dispatch chooses
+        // the forward (Fireblocks) leg — the one whose prompt is under test.
+        seed_custody_at(
+            &database_url,
+            address!("00000000000000000000000000000000000000bb"),
+        )
+        .await;
+        let secret = directory.path().join("fb-secret.pem");
+        std::fs::write(&secret, b"test-secret").unwrap();
+
+        let args = turnkey_migrate_args(
+            "forward",
+            "8453",
+            &database_url,
+            secret.to_str().unwrap(),
+        );
+
+        let error =
+            run_migrate_receipts(args, |_| Ok(false)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("aborted by operator"),
+            "a declined confirmation must abort before any RPC, got {error}"
+        );
+    }
+
+    /// The forward transfer is signed by the custodian through its API and the
+    /// rollback by Turnkey; a local key can do neither, so the command refuses
+    /// it outright instead of offering a transfer path production never has.
+    #[tokio::test]
+    async fn migrate_receipts_refuses_a_non_turnkey_signer() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("local.db").display()
+        );
+        seed_listing_at(&database_url, "AMAT").await;
+
+        let cli = IssuerCli::try_parse_from([
+            "issuer",
+            "migrate-receipts",
+            "AMAT",
+            "--network",
+            "base",
+            "--direction",
+            "forward",
+            "--chain-id",
+            "8453",
+            "--evm-private-key",
+            TEST_SIGNER_KEY,
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            &database_url,
+        ])
+        .expect("arguments parse");
+
+        let IssuerCommand::MigrateReceipts(args) = cli.command else {
+            panic!("expected the migrate-receipts subcommand")
+        };
+
+        let error =
+            run_migrate_receipts(*args, |_| Ok(true)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("Turnkey signer configuration"),
+            "a local key must be refused, got {error}"
+        );
+    }
+
+    /// With no recorded custody holder there is nothing to resolve a direction
+    /// from, and the command must demand the bootstrap rather than guess.
+    #[tokio::test]
+    async fn migrate_receipts_without_recorded_custody_demands_the_bootstrap() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("unobserved.db").display()
+        );
+        seed_listing_at(&database_url, "AMAT").await;
+        let secret = directory.path().join("fb-secret.pem");
+        std::fs::write(&secret, b"test-secret").unwrap();
+
+        let args = turnkey_migrate_args(
+            "forward",
+            "8453",
+            &database_url,
+            secret.to_str().unwrap(),
+        );
+
+        let error = run_migrate_receipts(args, |_| Ok(true)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("no recorded custody holder"),
+            "unobserved custody must demand confirm-custody, got {error}"
+        );
+    }
+
+    /// The rollback's destination comes from the Fireblocks API, so a broken
+    /// Fireblocks configuration must stop the rollback before anything is
+    /// derived or signed — never fall back to a guess.
+    #[tokio::test]
+    async fn a_rollback_with_a_broken_fireblocks_config_is_refused() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("rollback.db").display()
+        );
+        seed_listing_at(&database_url, "AMAT").await;
+        // The recorded holder IS the Turnkey wallet, so dispatch chooses the
+        // rollback leg — whose destination derivation must fail closed on an
+        // unusable Fireblocks credential.
+        seed_custody_at(
+            &database_url,
+            address!("00000000000000000000000000000000000000cc"),
+        )
+        .await;
+        let secret = directory.path().join("fb-secret.pem");
+        std::fs::write(&secret, b"not-an-rsa-key").unwrap();
+
+        let args = turnkey_migrate_args(
+            "rollback",
+            "8453",
+            &database_url,
+            secret.to_str().unwrap(),
+        );
+
+        let error = run_migrate_receipts(args, |_| Ok(true)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("Fireblocks"),
+            "a rollback without a working Fireblocks configuration must \
+             refuse, got {error}"
+        );
+    }
+
+    /// The command is state-driven: once a forward move is recorded, custody
+    /// sits at Turnkey and a mechanical re-run resolves to a rollback. The
+    /// stated direction must catch that before any prompt or network work.
+    #[tokio::test]
+    async fn a_rerun_after_a_recorded_forward_move_is_refused_as_a_rollback() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("rerun.db").display()
+        );
+        seed_listing_at(&database_url, "AMAT").await;
+        // Custody recorded at the Turnkey wallet: the state a completed
+        // forward move leaves behind.
+        seed_custody_at(
+            &database_url,
+            address!("0x00000000000000000000000000000000000000cc"),
+        )
+        .await;
+        let secret = directory.path().join("fb-secret.pem");
+        std::fs::write(&secret, b"test-secret").unwrap();
+
+        let args = turnkey_migrate_args(
+            "forward",
+            "8453",
+            &database_url,
+            secret.to_str().unwrap(),
+        );
+
+        let error = run_migrate_receipts(args, |_| Ok(true)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("resolves this command to a rollback"),
+            "a forward-stated re-run over rolled custody must refuse, got \
+             {error}"
+        );
+    }
+
+    /// A network paired with the wrong chain must be rejected from the
+    /// arguments alone, before any database or RPC work, so nothing downstream
+    /// is derived from a premise already known to be wrong.
+    #[tokio::test]
+    async fn migrate_receipts_rejects_a_network_bound_to_the_wrong_chain() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("mismatch.db").display()
+        );
+        let secret = directory.path().join("fb-secret.pem");
+        std::fs::write(&secret, b"test-secret").unwrap();
+
+        // The database is never seeded and the RPC is unreachable: reaching
+        // either would mean the mismatch was not caught up front.
+        let args = turnkey_migrate_args(
+            "forward",
+            "84532",
+            &database_url,
+            secret.to_str().unwrap(),
+        );
+
+        let error = run_migrate_receipts(args, |_| Ok(true)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("84532")
+                && error.to_string().contains("8453"),
+            "the rejection must name both chains, got {error}"
+        );
+    }
+
+    #[test]
+    fn recipient_may_not_be_the_zero_address() {
+        let holder = address!("00000000000000000000000000000000000000bb");
+
+        let error = Recipient::for_holder(Address::ZERO, holder).unwrap_err();
+
+        assert!(
+            error.to_string().contains("zero address"),
+            "burning the receipts is unrecoverable, got {error}"
+        );
+    }
+
+    #[test]
+    fn recipient_may_not_be_the_signing_wallet() {
+        let holder = address!("00000000000000000000000000000000000000bb");
+
+        let error = Recipient::for_holder(holder, holder).unwrap_err();
+
+        assert!(
+            error.to_string().contains("already the signing wallet"),
+            "a self-transfer would submit a pointless transaction, got {error}"
+        );
+    }
+
+    /// A wrong Fireblocks workspace resolves a wallet that is not the
+    /// recorded migration origin; the rollback must refuse before anything is
+    /// signed rather than move custody to a wallet this vault's receipts
+    /// never came from.
+    #[test]
+    fn rollback_refuses_a_workspace_that_is_not_the_recorded_origin() {
+        let recorded = address!("0x00000000000000000000000000000000000000aa");
+        let configured = address!("0x00000000000000000000000000000000000000bb");
+        let holder = address!("0x00000000000000000000000000000000000000cc");
+
+        let error =
+            Recipient::for_rollback(recorded, configured, holder).unwrap_err();
+
+        assert!(
+            error.to_string().contains("recorded as moved from"),
+            "a workspace mismatch must name both derived wallets, got {error}"
+        );
+    }
+
+    #[test]
+    fn rollback_destination_is_the_recorded_origin_when_workspaces_agree() {
+        let recorded = address!("0x00000000000000000000000000000000000000aa");
+        let holder = address!("0x00000000000000000000000000000000000000cc");
+
+        let recipient =
+            Recipient::for_rollback(recorded, recorded, holder).unwrap();
+
+        assert_eq!(recipient.address(), recorded);
+    }
+
+    #[test]
+    fn recipient_accepts_a_distinct_address() {
+        let holder = address!("00000000000000000000000000000000000000bb");
+        let recipient = address!("00000000000000000000000000000000000000cc");
+
+        assert_eq!(
+            Recipient::for_holder(recipient, holder).unwrap().address(),
+            recipient,
+            "a valid recipient must carry the address it was built from"
+        );
+    }
+
+    #[test]
+    fn migrate_receipts_requires_an_explicit_chain_id() {
+        let Err(error) = IssuerCli::try_parse_from([
+            "issuer",
+            "migrate-receipts",
+            "RKLB",
+            "--network",
+            "base",
+            "--direction",
+            "forward",
+            "--rpc-url",
+            "http://localhost:8545",
+            "--evm-private-key",
+            TEST_SIGNER_KEY,
+        ]) else {
+            panic!(
+                "omitting --chain-id must fail at parse time rather than \
+                 trusting whatever chain the RPC happens to be"
+            )
+        };
+
+        assert!(
+            error.to_string().contains("--chain-id"),
+            "the parse failure must name the missing --chain-id, got {error}"
         );
     }
 }

--- a/tests/turnkey_cutover.rs
+++ b/tests/turnkey_cutover.rs
@@ -18,10 +18,10 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::{
 use st0x_issuance::bindings::Receipt::ReceiptInstance;
 use st0x_issuance::receipt_inventory::migration::{
     CorroboratedRecipient, MigrationOutcome, VaultIdentity,
-    migrate_vault_receipts,
+    migrate_vault_receipts, recorded_migration_origin,
 };
 use st0x_issuance::test_utils::LocalEvm;
-use st0x_issuance::underlying::UnderlyingSymbol;
+use st0x_issuance::tokenized_asset::UnderlyingSymbol;
 use st0x_issuance::{Config, SignerConfig, initialize_rocket};
 use std::path::{Path, PathBuf};
 
@@ -227,6 +227,10 @@ struct PostCutoverCanaries<'context, 'server> {
 }
 
 impl PostCutoverCanaries<'_, '_> {
+    /// The canary redemption runs FIRST: it burns against a just-migrated
+    /// pre-cutover receipt, which is the actual proof that custody moved and
+    /// the inventory reconciled against the new holder. The canary mint only
+    /// proves the new signer can sign fresh work, so it runs second.
     async fn run(&self) -> Result<(), Box<dyn std::error::Error>> {
         let user_provider = create_provider()
             .wallet(EthereumWallet::from(self.user_signer.clone()))
@@ -235,18 +239,6 @@ impl PostCutoverCanaries<'_, '_> {
         let user_vault = OffchainAssetReceiptVaultInstance::new(
             self.evm.vault_address,
             &user_provider,
-        );
-        let canary_shares = mint_after_cutover(
-            self.client,
-            self.user_wallet,
-            &self.pre_cutover_mint.client_id,
-            self.mint_callback_mock,
-        )
-        .await?;
-        assert_eq!(
-            user_vault.balanceOf(self.user_wallet).call().await?,
-            self.pre_cutover_mint.shares + canary_shares,
-            "the new wallet must complete exactly one canary mint"
         );
 
         user_vault
@@ -261,24 +253,32 @@ impl PostCutoverCanaries<'_, '_> {
         harness::wait_for_burn(&user_vault, self.turnkey_wallet).await?;
         assert_eq!(
             user_vault.balanceOf(self.user_wallet).call().await?,
+            U256::ZERO,
+            "the canary redemption must consume every pre-cutover share"
+        );
+
+        let canary_shares = mint_after_cutover(
+            self.client,
+            self.user_wallet,
+            &self.pre_cutover_mint.client_id,
+            self.mint_callback_mock,
+        )
+        .await?;
+        assert_eq!(
+            user_vault.balanceOf(self.user_wallet).call().await?,
             canary_shares,
-            "only the post-cutover canary shares must remain after redemption"
+            "the new wallet must complete exactly one canary mint"
         );
 
         Ok(())
     }
 }
 
-/// Migrates custody against the outgoing service's database — driving the
-/// migration engine the operator's tooling runs, exercised as an operator
-/// would.
-///
-/// Note what this does and does not cover. The database snapshot handed to the
-/// replacement service is taken *before* this runs, so the migration here acts
-/// on the retiring store. That is deliberate and mirrors production: the
-/// outgoing service is already stopped (see the module-level requirement in
-/// `src/receipt_inventory/migration.rs`), and the quiescence gate checks real
-/// persisted state — reservations and in-flight work — not service liveness.
+/// Migrates custody against the given database — the same engine `issuer
+/// migrate-receipts` runs, exercised in the same order an operator would. The
+/// migration deliberately touches no freeze state: freezing means "corporate
+/// action in progress", and the window is controlled operationally (liquidity
+/// rebalancing paused, service stopped) instead.
 ///
 /// The migration is run twice: the second run stands in for the operator losing
 /// the terminal between the transaction confirming and success being recorded,
@@ -291,18 +291,17 @@ async fn run_operator_migration(
     outgoing: Address,
     incoming: Address,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let underlying = UnderlyingSymbol::new("AAPL")?;
-
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
         .connect(database_url)
         .await?;
 
-    let identity = VaultIdentity { chain_id, vault, underlying: &underlying };
-    let recipient = CorroboratedRecipient::verify(&provider, incoming).await?;
+    let underlying: UnderlyingSymbol = CUTOVER_UNDERLYING.parse()?;
+    let incoming = CorroboratedRecipient::verify(provider, incoming).await?;
 
+    let identity = VaultIdentity { chain_id, vault, underlying: &underlying };
     let outcome =
-        migrate_vault_receipts(&pool, provider, identity, outgoing, recipient)
+        migrate_vault_receipts(&pool, provider, identity, outgoing, incoming)
             .await?;
     assert!(
         matches!(outcome, MigrationOutcome::Migrated { receipts, .. } if receipts > 0),
@@ -310,7 +309,7 @@ async fn run_operator_migration(
     );
 
     let rerun =
-        migrate_vault_receipts(&pool, provider, identity, outgoing, recipient)
+        migrate_vault_receipts(&pool, provider, identity, outgoing, incoming)
             .await?;
     assert!(
         matches!(rerun, MigrationOutcome::AlreadyMigrated { receipts } if receipts > 0),
@@ -395,14 +394,14 @@ async fn single_deposit_for_owner(
 }
 
 /// Proves the Base-only wallet-rotation sequence with multichain code present
-/// but additional chains disabled, driving the operator's real command: migrate
-/// receipt custody over a stopped, quiescent deployment.
+/// but additional chains disabled, driving the operator's real sequence:
+/// stop the service, migrate receipt custody, start the replacement.
 ///
 /// The local signers model the old Fireblocks-controlled address and the new
-/// Turnkey-controlled address; the custodian's own credential and policy
-/// checks remain staging gates outside this test's scope. This scenario proves
-/// the application-owned custody, persistence, restart, checkpoint, and
-/// transaction-idempotency invariants.
+/// Turnkey-controlled address; the custodian's own credential and policy checks
+/// remain staging gates, described in `docs/turnkey-receipt-migration-plan.md`.
+/// This scenario proves the application-owned custody, persistence, restart,
+/// checkpoint, and transaction-idempotency invariants.
 #[tokio::test]
 async fn test_wallet_cutover_redeems_pre_cutover_receipt_after_restart()
 -> Result<(), Box<dyn std::error::Error>> {
@@ -683,26 +682,24 @@ async fn test_receipt_custody_can_be_rolled_back_to_the_outgoing_wallet()
     wait_for_receipt_in_inventory(&databases.fireblocks_url).await?;
     client.terminate().await;
 
-    let underlying = UnderlyingSymbol::new("AAPL")?;
     let pool = SqlitePoolOptions::new()
         .max_connections(5)
         .connect(&databases.fireblocks_url)
         .await?;
 
+    let underlying: UnderlyingSymbol = CUTOVER_UNDERLYING.parse()?;
     let identity = VaultIdentity {
         chain_id: evm.chain_id,
         vault: evm.vault_address,
         underlying: &underlying,
     };
-    let incoming =
-        CorroboratedRecipient::verify(&fireblocks_provider, turnkey_wallet)
-            .await?;
     let forward = migrate_vault_receipts(
         &pool,
         &fireblocks_provider,
         identity,
         fireblocks_wallet,
-        incoming,
+        CorroboratedRecipient::verify(&fireblocks_provider, turnkey_wallet)
+            .await?,
     )
     .await?;
     assert!(
@@ -715,20 +712,28 @@ async fn test_receipt_custody_can_be_rolled_back_to_the_outgoing_wallet()
         "the incoming wallet must hold the receipt after the forward move"
     );
 
-    // The rollback: same command, signer and recipient swapped.
+    // The rollback: same command with the wallets swapped, and its destination
+    // derived from the recorded forward migration rather than named — exactly
+    // what the CLI reads in production.
+    let derived_destination =
+        recorded_migration_origin(&pool, evm.chain_id, evm.vault_address)
+            .await?;
+    assert_eq!(
+        derived_destination, fireblocks_wallet,
+        "the rollback destination must derive from the recorded migration"
+    );
+
     let turnkey_provider = create_provider()
         .wallet(EthereumWallet::from(turnkey_signer))
         .connect(&evm.endpoint)
         .await?;
-    let rollback_destination =
-        CorroboratedRecipient::verify(&turnkey_provider, fireblocks_wallet)
-            .await?;
     let rolled_back = migrate_vault_receipts(
         &pool,
         &turnkey_provider,
         identity,
         turnkey_wallet,
-        rollback_destination,
+        CorroboratedRecipient::verify(&turnkey_provider, derived_destination)
+            .await?,
     )
     .await?;
 
@@ -982,8 +987,9 @@ async fn resume_on_outgoing_wallet_and_redeem_canary(
 /// tokens remain outstanding and unbacked, and `BurnFailed` recovery will not
 /// auto-fail the redemption because the on-chain *share* balance is present —
 /// it is the *receipt* that is missing. Nothing here recovers on its own. The
-/// operator sequence, not the code, is what prevents this: pause the authorized
-/// participant's redemptions and stop the service for the window.
+/// operator sequence, not the code, is what prevents this: pause rebalancing
+/// so no redemption arrives (the sole participant is our own bot), and stop
+/// the service for the window.
 #[tokio::test]
 async fn test_cutover_without_receipt_transfer_cannot_burn_historical_shares()
 -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Motivation

Today's rehearsal (AMAT) and tomorrow's full cutover need the migration CLI to
perform the entire operation itself — forward transfer signed by Fireblocks,
rollback signed by Turnkey — with zero typed wallet addresses, without touching
the freeze mechanism (the `Underlying` freeze means "corporate action in
progress", and a real one is live), and with both custodian connections proven
before the forward move can become a one-way door.

## Solution

- `migrate-receipts` requires both custodians' configurations (the service's
  own `FIREBLOCKS_*` + `TURNKEY_*` env) and resolves direction from recorded
  custody: custody at Fireblocks → forward, submitted through the Fireblocks
  API via the restored client (`FireblocksReceiptCustody`, same
  `ReceiptCustody` seam and identical gates as the in-binary path); custody at
  Turnkey → rollback, signed by Turnkey back to the API-derived Fireblocks
  wallet. Ownership verification is the check: exact tracked balances at the
  holder before, per-identifier recipient gain after. A completed move observed
  again is recorded idempotently, not re-transferred.
- Deterministic migration `externalTxId` (batch-content hash + UTC date):
  in-flight retries resume the original Fireblocks transaction; a deliberate
  later re-migration gets a fresh identity.
- `confirm-custody`: bootstrap that fetches the Fireblocks wallet from its API,
  verifies it holds exactly every tracked balance, and records it — arming the
  reconciliation displacement guard for history predating custody tracking.
- The rollback destination is bound to the recorded migration origin: the
  wallet the configured Fireblocks workspace resolves must equal the origin
  the forward move recorded on the inventory, so a wrong workspace
  configuration is refused before anything is signed.
- The forward leg re-proves the Turnkey rollback immediately before the
  irreversible Fireblocks submission — the exact rollback-shaped transaction
  is signed (never broadcast) and the Turnkey wallet must hold the rollback
  gas reserve (0.001 ether, not merely nonzero) — so a stale or skipped
  `verify-custodians` run cannot turn the forward move into a one-way door.
- `verify-custodians`: preflight proving both connections — Fireblocks auth +
  whitelisted Receipt-contract resolution, and the exact rollback-shaped
  transaction signed by Turnkey **without broadcasting**; reports gas;
  `--smoke` submits a zero-amount transfer through the full Fireblocks path.
- Freeze decoupled: `require_quiescent` gates on reserved burns and in-flight
  (non-terminal) mints/redemptions instead — the states whose recovery would
  resume against the wrong wallet after a move.
- `CustodyMigrated.tx_hash` is optional (`None` = verified from balances after
  the fact); recording is idempotent at the aggregate.
- All custody subcommands read `RPC_URL`/`DATABASE_URL` from the service env
  (scheme-agnostic connect; prod `RPC_URL` may be `wss://`).
- Rehearsal e2e reshaped: canary **redemption first** (burns a just-migrated
  receipt — the custody proof), then mint; mandatory rollback carries the
  database forward and the resumed service redeems the canary.
- Deploy hold for the window: with `/run/st0x/<name>.hold` present, the
  per-service activation installs the binary and secrets and runs
  `validate-config` but leaves the unit stopped — no deploy, intentional or
  stray, can start a service against custody mid-move.
- Runbook concretized: exact drain/hold commands, `VACUUM INTO` backup plus a
  receipt-identifier export with per-wallet `cast call` readings that step 6
  reconciles against, and the hold-release start sequence.

Advances [RAI-1552](https://linear.app/makeitrain/issue/RAI-1552).

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added operator CLI tools to migrate ERC-1155 deposit receipts between Fireblocks and Turnkey (forward transfer, rollback, custody confirmation, and custodian verification), including optional smoke testing.
  - Updated mint recovery workflow with new mint-stage commands and deterministic retry/recovery behavior.
- **Operational Changes**
  - Added an operator-controlled deployment hold window to install/validate without auto-starting services.
- **Documentation**
  - Expanded the receipt-custody migration runbook, updated spec/state diagrams, and refreshed the secrets example.
- **Bug Fixes**
  - Receipt custody migration now supports optional transaction hashes for externally signed transfers and improves destination idempotency.
- **Tests**
  - Updated cutover and migration test sequencing to match the new flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
