### PR TITLE
feat: orchestrator mint preparation, confirmation, and authorization validation

### DIFF
--- a/nix/st0x-deploy.nix
+++ b/nix/st0x-deploy.nix
@@ -23,5 +23,6 @@ in
     ST0X_STOX_RECEIPT_ABI = "${abi}/out/StoxReceipt.sol/StoxReceipt.json";
     ST0X_STOX_RECEIPT_VAULT_ABI = "${abi}/out/StoxReceiptVault.sol/StoxReceiptVault.json";
     ST0X_STOX_OARV_BEACON_SET_DEPLOYER_ABI = "${abi}/out/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol/StoxOffchainAssetReceiptVaultBeaconSetDeployer.json";
+    IERC1271_ABI = "${abi}/out/IERC1271.sol/IERC1271.json";
   };
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -42,3 +42,10 @@ sol!(
     ST0xOrchestrator,
     env!("ST0X_ORCHESTRATOR_ABI")
 );
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IERC1271,
+    env!("IERC1271_ABI")
+);

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -1054,6 +1054,11 @@ const fn is_uncertain_broadcast_error(error: &VaultError) -> bool {
         | VaultError::BurnReplacementDestinationMismatch { .. }
         | VaultError::BurnReplacementValueMismatch { .. }
         | VaultError::BurnReplacementInputMismatch { .. }
+        | VaultError::MintAuthSignerMismatch { .. }
+        | VaultError::MintAuthNonceUsed { .. }
+        | VaultError::MintAuthRejectedByContract { .. }
+        | VaultError::MintAuthEmptySignatureForEoa { .. }
+        | VaultError::Signature(_)
         | VaultError::SignerRecovery(_)
         | VaultError::Eip2718(_)
         | VaultError::Contract(_)
@@ -1094,6 +1099,11 @@ const fn is_uncertain_confirm_observation(error: &VaultError) -> bool {
         | VaultError::BurnReplacementDestinationMismatch { .. }
         | VaultError::BurnReplacementValueMismatch { .. }
         | VaultError::BurnReplacementInputMismatch { .. }
+        | VaultError::MintAuthSignerMismatch { .. }
+        | VaultError::MintAuthNonceUsed { .. }
+        | VaultError::MintAuthRejectedByContract { .. }
+        | VaultError::MintAuthEmptySignatureForEoa { .. }
+        | VaultError::Signature(_)
         | VaultError::SignerRecovery(_)
         | VaultError::Eip2718(_)
         | VaultError::Contract(_)

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -409,7 +409,13 @@ const fn burn_failure_classification(
             OrchestratorRevertReason::ReceiptLogicMismatch => {
                 BurnFailureClassification::ReceiptLogicMismatch
             }
-            OrchestratorRevertReason::Unknown => {
+            // Mint-side reverts can never arise from a burn transaction;
+            // if one somehow surfaces here it stays unclassified.
+            OrchestratorRevertReason::NonceReplayed { .. }
+            | OrchestratorRevertReason::BadRecipientSignature
+            | OrchestratorRevertReason::RecipientCallbackRejected { .. }
+            | OrchestratorRevertReason::VaultAmountMismatch { .. }
+            | OrchestratorRevertReason::Unknown => {
                 BurnFailureClassification::Unclassified
             }
         },

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -16,14 +16,18 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
 
 use super::{
-    BurnRange, BurnTxStatus, BurnVerification, MintResult, MintTxStatus,
-    MultiBurnParams, MultiBurnResult, MultiBurnResultEntry,
-    OrchestratorBurnParams, OrchestratorBurnReadiness, OrchestratorBurnResult,
-    PreparedMintTx, ReceiptInformation, SubmittedTx, VaultError, VaultService,
-    WalletNonceGuard,
+    BurnRange, BurnTxStatus, BurnVerification, MintAuthorization, MintResult,
+    MintTxStatus, MintedLogQuery, MintedLogScan, MultiBurnParams,
+    MultiBurnResult, MultiBurnResultEntry, OrchestratorBurnParams,
+    OrchestratorBurnReadiness, OrchestratorBurnResult, OrchestratorMintParams,
+    OrchestratorMintResult, PreparedMintTx, ReceiptInformation, SubmittedTx,
+    VaultError, VaultService, WalletNonceGuard,
 };
 #[cfg(test)]
-use super::{OrchestratorRevertReason, VerifiedBurn, VerifiedShareTransfer};
+use super::{
+    OrchestratorMintedLog, OrchestratorRevertReason, VerifiedBurn,
+    VerifiedShareTransfer,
+};
 use crate::redemption::BurnExternalTxId;
 use crate::vault::orchestrator::BurnProofKind;
 use crate::vault::{SendableTxWithHash, TxId};
@@ -78,6 +82,11 @@ enum MockBehavior {
     /// where signed-tx preparation fails before the tx is stored in the event.
     #[cfg(test)]
     PrepareTxFails,
+    /// Mint preparation returns a syntactically complete envelope whose
+    /// persisted hash does not match its bytes, testing the
+    /// `PreparedMintTx::validate` rejection path.
+    #[cfg(test)]
+    InvalidPreparedMint,
 }
 
 /// Configured outcome for `verify_burn_tx` in tests.
@@ -178,6 +187,45 @@ struct OrchestratorMockState {
     next_burn_receipt_id_should_error: Mutex<bool>,
     #[cfg(test)]
     vault_logic_call_count: AtomicUsize,
+    /// Cached result from `prepare_orchestrator_mint_tx` for retrieval in
+    /// `confirm_orchestrator_mint`.
+    pending_mint_result: Mutex<Option<OrchestratorMintResult>>,
+    /// When set, `confirm_orchestrator_mint` fails with
+    /// `VaultError::OrchestratorReverted` carrying this reason.
+    #[cfg(test)]
+    mint_confirm_revert: Mutex<Option<OrchestratorRevertReason>>,
+    /// Landed mint returned by `find_orchestrator_minted_log`; `None` means
+    /// no full match on-chain.
+    #[cfg(test)]
+    minted_log: Mutex<Option<OrchestratorMintedLog>>,
+    /// Optional `(orchestrator, to, token)` binding for the configured
+    /// `minted_log`: when set, a query naming a different orchestrator,
+    /// recipient, or token does NOT match — mirroring the address half of
+    /// the real lookup's four-field full-match, which the log's own fields
+    /// (`nonce`, `shares_minted`) cannot express.
+    #[cfg(test)]
+    minted_log_binding: Mutex<Option<(Address, Address, Address)>>,
+    /// When set, `validate_mint_authorization` fails with this outcome.
+    #[cfg(test)]
+    mint_auth_failure: Mutex<Option<MockMintAuthFailure>>,
+    #[cfg(test)]
+    last_mint_params: Mutex<Option<OrchestratorMintParams>>,
+    #[cfg(test)]
+    mint_preparation_call_count: AtomicUsize,
+    #[cfg(test)]
+    mint_auth_validation_call_count: AtomicUsize,
+    #[cfg(test)]
+    find_minted_log_call_count: AtomicUsize,
+}
+
+/// Configurable failure outcomes for the mock's
+/// `validate_mint_authorization`, mirroring the typed `VaultError` variants
+/// the endpoint maps to actionable responses.
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MockMintAuthFailure {
+    SignerMismatch,
+    NonceUsed,
 }
 
 /// Mock blockchain service for testing.
@@ -400,6 +448,13 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
+    pub(crate) fn new_invalid_prepared_mint() -> Self {
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::InvalidPreparedMint;
+        service
+    }
+
+    #[cfg(test)]
     pub(crate) fn new_prepare_tx_failure() -> Self {
         let mut service = Self::new_success();
         service.behavior = MockBehavior::PrepareTxFails;
@@ -498,6 +553,21 @@ impl MockVaultService {
         *self.orchestrator.next_burn_receipt_id_should_error.lock().unwrap() =
             false;
         self.orchestrator.vault_logic_call_count.store(0, Ordering::Relaxed);
+        *self.orchestrator.pending_mint_result.lock().unwrap() = None;
+        *self.orchestrator.mint_confirm_revert.lock().unwrap() = None;
+        *self.orchestrator.minted_log.lock().unwrap() = None;
+        *self.orchestrator.minted_log_binding.lock().unwrap() = None;
+        *self.orchestrator.mint_auth_failure.lock().unwrap() = None;
+        *self.orchestrator.last_mint_params.lock().unwrap() = None;
+        self.orchestrator
+            .mint_preparation_call_count
+            .store(0, Ordering::Relaxed);
+        self.orchestrator
+            .mint_auth_validation_call_count
+            .store(0, Ordering::Relaxed);
+        self.orchestrator
+            .find_minted_log_call_count
+            .store(0, Ordering::Relaxed);
         *self.last_burn_proof_kind.lock().unwrap() = None;
     }
 
@@ -788,6 +858,93 @@ impl MockVaultService {
         *self.orchestrator.readiness.lock().unwrap() = Some(readiness);
     }
 
+    /// Configures `confirm_orchestrator_mint` to fail with
+    /// `VaultError::OrchestratorReverted` carrying the given typed reason.
+    #[cfg(test)]
+    pub(crate) fn with_orchestrator_mint_confirm_revert(
+        self,
+        reason: OrchestratorRevertReason,
+    ) -> Self {
+        *self.orchestrator.mint_confirm_revert.lock().unwrap() = Some(reason);
+        self
+    }
+
+    /// Overrides the result `confirm_orchestrator_mint` returns.
+    #[cfg(test)]
+    pub(crate) fn with_orchestrator_mint_result(
+        self,
+        result: OrchestratorMintResult,
+    ) -> Self {
+        *self.orchestrator.pending_mint_result.lock().unwrap() = Some(result);
+        self
+    }
+
+    /// Configures the landed mint `find_orchestrator_minted_log` can find.
+    /// Like the real implementation, the lookup only reports it when the
+    /// query full-matches — on the fields the log carries: its `nonce` and
+    /// `shares_minted` (amount) must equal the queried ones. A log configured
+    /// with a different nonce or amount exercises the
+    /// "nonce consumed by a different mint" path. Pair with
+    /// [`Self::with_minted_log_binding`] to also pin the query's address
+    /// fields (`orchestrator`, `to`, `token`), which the log itself cannot
+    /// express.
+    #[cfg(test)]
+    pub(crate) fn with_minted_log(self, log: OrchestratorMintedLog) -> Self {
+        *self.orchestrator.minted_log.lock().unwrap() = Some(log);
+        self
+    }
+
+    /// Binds the configured `minted_log` to an exact
+    /// `(orchestrator, to, token)`: a lookup passing any other address must
+    /// miss (or mismatch, for `token`), mirroring the address half of the
+    /// real scan's four-field full-match.
+    #[cfg(test)]
+    pub(crate) fn with_minted_log_binding(
+        self,
+        orchestrator: Address,
+        to: Address,
+        token: Address,
+    ) -> Self {
+        *self.orchestrator.minted_log_binding.lock().unwrap() =
+            Some((orchestrator, to, token));
+        self
+    }
+
+    /// Configures `validate_mint_authorization` to fail with the given typed
+    /// outcome.
+    #[cfg(test)]
+    pub(crate) fn with_mint_auth_failure(
+        self,
+        failure: MockMintAuthFailure,
+    ) -> Self {
+        *self.orchestrator.mint_auth_failure.lock().unwrap() = Some(failure);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn get_last_orchestrator_mint_params(
+        &self,
+    ) -> Option<OrchestratorMintParams> {
+        self.orchestrator.last_mint_params.lock().unwrap().clone()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn orchestrator_mint_preparation_call_count(&self) -> usize {
+        self.orchestrator.mint_preparation_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mint_auth_validation_call_count(&self) -> usize {
+        self.orchestrator
+            .mint_auth_validation_call_count
+            .load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn find_minted_log_call_count(&self) -> usize {
+        self.orchestrator.find_minted_log_call_count.load(Ordering::Relaxed)
+    }
+
     #[cfg(test)]
     pub(crate) fn last_orchestrator_burn_params(
         &self,
@@ -834,6 +991,16 @@ fn default_orchestrator_burn_result() -> OrchestratorBurnResult {
             first_receipt_id: U256::from(1u8),
             next_burn_receipt_id_after: U256::from(2u8),
         },
+        gas_used: 50000,
+        block_number: 5000,
+    }
+}
+
+fn default_orchestrator_mint_result() -> OrchestratorMintResult {
+    OrchestratorMintResult {
+        tx_hash: MOCK_MINT_TX_HASH,
+        nonce: B256::with_last_byte(1),
+        shares_minted: U256::from(100_000_000_000_000_000_000u128),
         gas_used: 50000,
         block_number: 5000,
     }
@@ -1034,7 +1201,10 @@ impl VaultService for MockVaultService {
             #[cfg(test)]
             MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails => Err(VaultError::InvalidReceipt),
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
+                Err(VaultError::InvalidReceipt)
+            }
         }
     }
 
@@ -1189,7 +1359,8 @@ impl VaultService for MockVaultService {
             #[cfg(test)]
             MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails => {
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
                 let result = self
                     .pending_burn_result
                     .lock()
@@ -1513,7 +1684,8 @@ impl VaultService for MockVaultService {
             MockBehavior::SubmitFailure
             | MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::SubmitRevert
-            | MockBehavior::PrepareTxFails => {
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
                 let result = self
                     .orchestrator
                     .pending_result
@@ -1574,23 +1746,247 @@ impl VaultService for MockVaultService {
         #[cfg(not(test))]
         Ok(U256::ZERO)
     }
+
+    async fn prepare_orchestrator_mint_tx(
+        &self,
+        params: &OrchestratorMintParams,
+    ) -> Result<PreparedMintTx, VaultError> {
+        #[cfg(test)]
+        {
+            self.orchestrator
+                .mint_preparation_call_count
+                .fetch_add(1, Ordering::Relaxed);
+            if matches!(self.behavior, MockBehavior::PrepareTxFails) {
+                return Err(VaultError::InvalidReceipt);
+            }
+            *self.orchestrator.last_mint_params.lock().unwrap() =
+                Some(params.clone());
+        }
+
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce: 1,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(params.orchestrator),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let envelope = TxEnvelope::from(transaction.into_signed(signature));
+        let tx_hash = *envelope.tx_hash();
+
+        // Fill the pending result only when a test has not already configured
+        // an override, so `with_orchestrator_mint_result` survives prepare.
+        {
+            let mut pending = self
+                .orchestrator
+                .pending_mint_result
+                .lock()
+                .expect("pending_mint_result mutex poisoned");
+            if pending.is_none() {
+                *pending = Some(OrchestratorMintResult {
+                    tx_hash,
+                    nonce: params.authorization.nonce,
+                    shares_minted: params.amount,
+                    gas_used: 21000,
+                    block_number: 1000,
+                });
+            }
+        }
+
+        #[cfg(test)]
+        let persisted_hash =
+            if matches!(self.behavior, MockBehavior::InvalidPreparedMint) {
+                B256::ZERO
+            } else {
+                tx_hash
+            };
+        #[cfg(not(test))]
+        let persisted_hash = tx_hash;
+
+        Ok(PreparedMintTx {
+            tx: envelope.encoded_2718(),
+            hash: persisted_hash,
+            nonce: envelope.nonce(),
+            signed_at: chrono::Utc::now(),
+            external_tx_id: params.external_tx_id.clone().unwrap_or_else(
+                || format!("mint-{}", params.receipt_info.issuer_request_id),
+            ),
+        })
+    }
+
+    async fn confirm_orchestrator_mint(
+        &self,
+        _tx_id: &TxId,
+    ) -> Result<OrchestratorMintResult, VaultError> {
+        #[cfg(test)]
+        {
+            let reason_opt =
+                *self.orchestrator.mint_confirm_revert.lock().unwrap();
+            if let Some(reason) = reason_opt {
+                return Err(VaultError::OrchestratorReverted {
+                    tx_hash: MOCK_MINT_TX_HASH,
+                    reason,
+                });
+            }
+        }
+
+        match &self.behavior {
+            MockBehavior::Success => {
+                let result = self
+                    .orchestrator
+                    .pending_mint_result
+                    .lock()
+                    .expect("pending_mint_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(default_orchestrator_mint_result);
+
+                Ok(result)
+            }
+            #[cfg(test)]
+            MockBehavior::Failure => Err(VaultError::InvalidReceipt),
+            #[cfg(test)]
+            MockBehavior::ConfirmRevert => {
+                Err(VaultError::Reverted { tx_hash: MOCK_MINT_TX_HASH })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPending => {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPendingBlocked { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                Err(VaultError::ConfirmationPending {
+                    tx_id: _tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::SubmitFailure
+            | MockBehavior::WalletLockBlocked { .. }
+            | MockBehavior::SubmitRevert
+            | MockBehavior::PrepareTxFails
+            | MockBehavior::InvalidPreparedMint => {
+                let result = self
+                    .orchestrator
+                    .pending_mint_result
+                    .lock()
+                    .expect("pending_mint_result mutex poisoned")
+                    .take()
+                    .unwrap_or_else(default_orchestrator_mint_result);
+                Ok(result)
+            }
+        }
+    }
+
+    async fn find_orchestrator_minted_log(
+        &self,
+        query: MintedLogQuery,
+    ) -> Result<MintedLogScan, VaultError> {
+        let MintedLogQuery { nonce, amount, .. } = query;
+        #[cfg(test)]
+        {
+            self.orchestrator
+                .find_minted_log_call_count
+                .fetch_add(1, Ordering::Relaxed);
+            // Mirror the real scan's three-way verdict. The stored log
+            // carries `nonce`/`shares_minted`; the optional
+            // `(orchestrator, to, token)` binding stands in for the address
+            // fields it lacks. A query naming a different orchestrator or
+            // recipient finds no log at ITS `(to, nonce)` pair —
+            // `NotFound` — while the right pair with a differing `token`
+            // or `amount` is the pair's one landing disagreeing on the
+            // signed facts: the proven `Mismatch`. A missing or
+            // different-nonce log means nothing was found at the pair.
+            let binding = *self.orchestrator.minted_log_binding.lock().unwrap();
+            let stored = self.orchestrator.minted_log.lock().unwrap().clone();
+            return Ok(match stored {
+                Some(log) if log.nonce == nonce => {
+                    let pair_matches =
+                        binding.is_none_or(|(orchestrator, to, _)| {
+                            query.orchestrator == orchestrator && query.to == to
+                        });
+                    if !pair_matches {
+                        MintedLogScan::NotFound
+                    } else if binding
+                        .is_none_or(|(_, _, token)| query.token == token)
+                        && log.shares_minted == amount
+                    {
+                        MintedLogScan::FullMatch(log)
+                    } else {
+                        MintedLogScan::Mismatch
+                    }
+                }
+                _ => MintedLogScan::NotFound,
+            });
+        }
+
+        #[cfg(not(test))]
+        {
+            let _ = (nonce, amount);
+            Ok(MintedLogScan::NotFound)
+        }
+    }
+
+    async fn validate_mint_authorization(
+        &self,
+        query: MintedLogQuery,
+        authorization: &MintAuthorization,
+    ) -> Result<(), VaultError> {
+        #[cfg(test)]
+        {
+            self.orchestrator
+                .mint_auth_validation_call_count
+                .fetch_add(1, Ordering::Relaxed);
+            let failure_opt =
+                *self.orchestrator.mint_auth_failure.lock().unwrap();
+            match failure_opt {
+                Some(MockMintAuthFailure::SignerMismatch) => {
+                    return Err(VaultError::MintAuthSignerMismatch {
+                        expected: query.to,
+                        recovered: Address::ZERO,
+                    });
+                }
+                Some(MockMintAuthFailure::NonceUsed) => {
+                    return Err(VaultError::MintAuthNonceUsed {
+                        to: query.to,
+                        nonce: query.nonce,
+                    });
+                }
+                None => {}
+            }
+        }
+
+        let _ = (query, authorization);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{Address, B256, U256, address, b256};
+    use alloy::primitives::{Address, B256, Bytes, U256, address, b256};
     use chrono::Utc;
     use rust_decimal::Decimal;
 
-    use super::MockVaultService;
+    use super::{
+        MockMintAuthFailure, MockVaultService, default_orchestrator_mint_result,
+    };
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::redemption::IssuerRedemptionRequestId;
     use crate::vault::orchestrator::BurnProofKind;
     use crate::vault::{
-        BurnRequestOrigin, MultiBurnEntry, MultiBurnParams, ReceiptInformation,
-        SendableTxWithHash, VaultError, VaultService,
+        BurnRequestOrigin, MintAuthorization, MintedLogQuery, MintedLogScan,
+        MultiBurnEntry, MultiBurnParams, OrchestratorMintParams,
+        OrchestratorMintResult, OrchestratorMintedLog,
+        OrchestratorRevertReason, ReceiptInformation, SendableTxWithHash, TxId,
+        VaultError, VaultService,
     };
 
     fn test_sendable_tx() -> SendableTxWithHash {
@@ -2030,6 +2426,288 @@ mod tests {
             U256::from(17u64),
             burns,
             transfers,
+        );
+    }
+
+    /// The signed-tuple query derived from [`test_orchestrator_mint_params`],
+    /// with `nonce` taken from the authorization as the callers do.
+    fn params_query(params: &OrchestratorMintParams) -> MintedLogQuery {
+        MintedLogQuery {
+            orchestrator: params.orchestrator,
+            to: params.to,
+            nonce: params.authorization.nonce,
+            token: params.token,
+            amount: params.amount,
+            lookback_blocks: None,
+        }
+    }
+
+    fn test_orchestrator_mint_params() -> OrchestratorMintParams {
+        OrchestratorMintParams {
+            orchestrator: address!(
+                "0x00000000000000000000000000000000000000aa"
+            ),
+            token: test_vault(),
+            to: test_receiver(),
+            amount: U256::from(1_000_000u64),
+            authorization: MintAuthorization {
+                nonce: B256::repeat_byte(0x07),
+                signature: Bytes::from_static(&[0xaa; 65]),
+            },
+            receipt_info: test_receipt_info(),
+            external_tx_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrator_mint_mock_round_trip_records_and_confirms() {
+        let mock = MockVaultService::new_success();
+        let params = test_orchestrator_mint_params();
+
+        assert_eq!(mock.orchestrator_mint_preparation_call_count(), 0);
+        assert!(mock.get_last_orchestrator_mint_params().is_none());
+
+        let prepared = mock
+            .prepare_orchestrator_mint_tx(&params)
+            .await
+            .expect("mock prepare must succeed");
+        assert_eq!(
+            prepared.external_tx_id,
+            format!("mint-{}", params.receipt_info.issuer_request_id)
+        );
+        assert_eq!(mock.orchestrator_mint_preparation_call_count(), 1);
+        let recorded = mock
+            .get_last_orchestrator_mint_params()
+            .expect("prepare must record its params");
+        assert_eq!(recorded.to, params.to);
+        assert_eq!(recorded.amount, params.amount);
+        assert_eq!(recorded.authorization, params.authorization);
+
+        let result = mock
+            .confirm_orchestrator_mint(&TxId::Hash(prepared.hash))
+            .await
+            .expect("mock confirm must succeed");
+        assert_eq!(result.tx_hash, prepared.hash);
+        assert_eq!(result.nonce, params.authorization.nonce);
+        assert_eq!(result.shares_minted, params.amount);
+    }
+
+    /// `InvalidPreparedMint` must corrupt the orchestrator preparation —
+    /// persisting a hash that does not match the envelope's bytes — so
+    /// callers can exercise the `PreparedMintTx::validate` rejection path in
+    /// orchestrator mode.
+    #[tokio::test]
+    async fn orchestrator_mint_mock_honors_invalid_prepared_mint() {
+        let mock = MockVaultService::new_invalid_prepared_mint();
+
+        let prepared = mock
+            .prepare_orchestrator_mint_tx(&test_orchestrator_mint_params())
+            .await
+            .expect("mock prepare must succeed");
+
+        assert!(
+            prepared.validate().is_err(),
+            "InvalidPreparedMint must produce an envelope that fails \
+             validation"
+        );
+    }
+
+    #[tokio::test]
+    async fn orchestrator_mint_mock_result_override_survives_prepare() {
+        let override_result = OrchestratorMintResult {
+            tx_hash: b256!(
+                "0x1212121212121212121212121212121212121212121212121212121212121212"
+            ),
+            nonce: B256::repeat_byte(0x33),
+            shares_minted: U256::from(42u64),
+            gas_used: 777,
+            block_number: 4242,
+        };
+        let mock = MockVaultService::new_success()
+            .with_orchestrator_mint_result(override_result.clone());
+
+        mock.prepare_orchestrator_mint_tx(&test_orchestrator_mint_params())
+            .await
+            .expect("mock prepare must succeed");
+
+        let result = mock
+            .confirm_orchestrator_mint(&TxId::Hash(B256::ZERO))
+            .await
+            .expect("mock confirm must succeed");
+        assert_eq!(result, override_result);
+    }
+
+    #[tokio::test]
+    async fn orchestrator_mint_mock_confirm_revert_and_auth_failures() {
+        let mock = MockVaultService::new_success()
+            .with_orchestrator_mint_confirm_revert(
+                OrchestratorRevertReason::NonceReplayed {
+                    to: test_receiver(),
+                    nonce: B256::repeat_byte(0x07),
+                },
+            );
+        let result =
+            mock.confirm_orchestrator_mint(&TxId::Hash(B256::ZERO)).await;
+        assert!(matches!(
+            result,
+            Err(VaultError::OrchestratorReverted {
+                reason: OrchestratorRevertReason::NonceReplayed { .. },
+                ..
+            })
+        ));
+
+        let params = test_orchestrator_mint_params();
+        let mock = MockVaultService::new_success()
+            .with_mint_auth_failure(MockMintAuthFailure::SignerMismatch);
+        let result = mock
+            .validate_mint_authorization(
+                params_query(&params),
+                &params.authorization,
+            )
+            .await;
+        assert!(matches!(
+            result,
+            Err(VaultError::MintAuthSignerMismatch { .. })
+        ));
+        assert_eq!(mock.mint_auth_validation_call_count(), 1);
+
+        let mock = MockVaultService::new_success()
+            .with_mint_auth_failure(MockMintAuthFailure::NonceUsed);
+        let result = mock
+            .validate_mint_authorization(
+                params_query(&params),
+                &params.authorization,
+            )
+            .await;
+        assert!(matches!(result, Err(VaultError::MintAuthNonceUsed { .. })));
+    }
+
+    #[tokio::test]
+    async fn orchestrator_mint_mock_minted_log_and_reset() {
+        let minted = OrchestratorMintedLog {
+            tx_hash: b256!(
+                "0x3434343434343434343434343434343434343434343434343434343434343434"
+            ),
+            nonce: B256::repeat_byte(0x07),
+            shares_minted: U256::from(1_000_000u64),
+            block_number: 4242,
+        };
+        let params = test_orchestrator_mint_params();
+        let mock = MockVaultService::new_success()
+            .with_minted_log(minted.clone())
+            .with_mint_auth_failure(MockMintAuthFailure::NonceUsed);
+
+        let query = params_query(&params);
+        let found = mock
+            .find_orchestrator_minted_log(query)
+            .await
+            .expect("mock lookup must succeed");
+        assert_eq!(found, MintedLogScan::FullMatch(minted.clone()));
+        assert_eq!(mock.find_minted_log_call_count(), 1);
+
+        // The lookup honors the real scan's three-way verdict: an amount
+        // differing from the configured log at the same nonce is the proven
+        // consumed-by-a-different-mint case (`Mismatch`), while a different
+        // nonce means no log exists at the queried pair (`NotFound`) —
+        // never conflated.
+        let wrong_amount = mock
+            .find_orchestrator_minted_log(MintedLogQuery {
+                amount: params.amount + U256::from(1u8),
+                ..query
+            })
+            .await
+            .expect("mock lookup must succeed");
+        assert_eq!(
+            wrong_amount,
+            MintedLogScan::Mismatch,
+            "a differing amount at the same nonce must be the proven \
+             mismatch verdict"
+        );
+        let wrong_nonce = mock
+            .find_orchestrator_minted_log(MintedLogQuery {
+                nonce: B256::repeat_byte(0x08),
+                ..query
+            })
+            .await
+            .expect("mock lookup must succeed");
+        assert_eq!(
+            wrong_nonce,
+            MintedLogScan::NotFound,
+            "a different nonce must find no log at the queried pair"
+        );
+
+        // The optional binding stands in for the address fields the log
+        // lacks, aligning the mock with the real four-field full-match: a
+        // wrong recipient/orchestrator misses (`NotFound`), a wrong token at
+        // the right pair is the proven `Mismatch`, and the exact query still
+        // full-matches.
+        let bound = MockVaultService::new_success()
+            .with_minted_log(minted.clone())
+            .with_minted_log_binding(query.orchestrator, query.to, query.token);
+        assert_eq!(
+            bound
+                .find_orchestrator_minted_log(query)
+                .await
+                .expect("mock lookup must succeed"),
+            MintedLogScan::FullMatch(minted),
+            "the exact bound query must still full-match"
+        );
+        assert_eq!(
+            bound
+                .find_orchestrator_minted_log(MintedLogQuery {
+                    to: Address::repeat_byte(0x99),
+                    ..query
+                })
+                .await
+                .expect("mock lookup must succeed"),
+            MintedLogScan::NotFound,
+            "a wrong recipient must find no log at ITS pair"
+        );
+        assert_eq!(
+            bound
+                .find_orchestrator_minted_log(MintedLogQuery {
+                    token: Address::repeat_byte(0x99),
+                    ..query
+                })
+                .await
+                .expect("mock lookup must succeed"),
+            MintedLogScan::Mismatch,
+            "a wrong token at the right pair must be the proven mismatch"
+        );
+
+        mock.prepare_orchestrator_mint_tx(&params)
+            .await
+            .expect("mock prepare must succeed");
+
+        mock.reset();
+
+        assert_eq!(mock.orchestrator_mint_preparation_call_count(), 0);
+        assert_eq!(mock.find_minted_log_call_count(), 0);
+        assert_eq!(mock.mint_auth_validation_call_count(), 0);
+        assert!(mock.get_last_orchestrator_mint_params().is_none());
+        let found = mock
+            .find_orchestrator_minted_log(query)
+            .await
+            .expect("mock lookup must succeed");
+        assert_eq!(
+            found,
+            MintedLogScan::NotFound,
+            "reset must clear the configured minted log"
+        );
+        mock.validate_mint_authorization(
+            params_query(&params),
+            &params.authorization,
+        )
+        .await
+        .expect("reset must clear the configured auth failure");
+        let result = mock
+            .confirm_orchestrator_mint(&TxId::Hash(B256::ZERO))
+            .await
+            .expect("mock confirm must succeed");
+        assert_eq!(
+            result,
+            default_orchestrator_mint_result(),
+            "reset must clear the pending mint result"
         );
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -38,8 +38,10 @@ pub(crate) use network_services::{
 };
 
 pub(crate) use orchestrator::{
-    BurnRange, OrchestratorBurnParams, OrchestratorBurnReadiness,
-    OrchestratorBurnResult, OrchestratorRevertReason,
+    BurnRange, MintAuthorization, MintedLogQuery, MintedLogScan,
+    OrchestratorBurnParams, OrchestratorBurnReadiness, OrchestratorBurnResult,
+    OrchestratorMintParams, OrchestratorMintResult, OrchestratorMintedLog,
+    OrchestratorRevertReason,
 };
 
 /// Service abstraction for vault operations.
@@ -281,6 +283,75 @@ pub(crate) trait VaultService: Send + Sync {
         _orchestrator: Address,
         _token: Address,
     ) -> Result<U256, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Builds and signs the `ST0xOrchestrator.mint()` transaction without
+    /// broadcasting it. The returned bytes must be persisted (via
+    /// `MintTxIntended`) before [`VaultService::submit_mint`], which
+    /// rebroadcasts them mode-agnostically. No `previewDeposit`, no
+    /// multicall — the orchestrator asserts 1:1 on-chain and forwards shares
+    /// to the recipient. The call uses exactly the signed
+    /// `(token, to, amount, nonce)` from the authorization.
+    ///
+    /// Production callers land with the orchestrator mint aggregate arms
+    /// (mirroring how `check_orchestrator_burn_readiness` above awaited its
+    /// caller); the allow is removed then.
+    #[allow(dead_code)]
+    async fn prepare_orchestrator_mint_tx(
+        &self,
+        _params: &OrchestratorMintParams,
+    ) -> Result<PreparedMintTx, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Confirms a previously submitted orchestrator mint, parsing the
+    /// orchestrator's `Minted` event. A mined-but-reverted mint fails with
+    /// [`VaultError::OrchestratorReverted`] carrying the decoded typed reason
+    /// (`NonceReplayed`, `VaultLogicMismatch`, ...).
+    #[allow(dead_code)]
+    async fn confirm_orchestrator_mint(
+        &self,
+        _tx_id: &TxId,
+    ) -> Result<OrchestratorMintResult, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Looks up a landed orchestrator mint by its `Minted` log and reports a
+    /// three-way [`MintedLogScan`] verdict: `FullMatch` when a log at
+    /// `(to, nonce)` also matches `token`/`amount` (this mint's landing),
+    /// `Mismatch` when a log at `(to, nonce)` disagrees on either (a
+    /// different mint provably consumed the pair), and `NotFound` when the
+    /// scanned window holds no log at the pair at all — which, with the
+    /// nonce consumed, is an inconclusive chain view, never proof. Callers
+    /// must never conflate the last two (SPEC "Recipient Authorization" ->
+    /// "Nonce").
+    #[allow(dead_code)]
+    async fn find_orchestrator_minted_log(
+        &self,
+        _query: MintedLogQuery,
+    ) -> Result<MintedLogScan, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
+    /// Validates a delivered recipient authorization before it is stored:
+    /// the signature must recover to `query.to` over the orchestrator's own
+    /// `mintAuthDigest(token, to, amount, nonce)` (ECDSA, or ERC-1271 when
+    /// `to` is a contract), and `(to, nonce)` must not already be consumed
+    /// on-chain (`nonceUsed`). An EMPTY signature skips signer recovery —
+    /// the future bridge recipient authorizes via the orchestrator's
+    /// `authorizeMint` callback instead — but still checks the nonce.
+    ///
+    /// `query` supplies the signed tuple's addresses and amount; the nonce
+    /// is read from the delivered `authorization` itself (never
+    /// `query.nonce`), so the validated pair is exactly the one the mint
+    /// will consume.
+    #[allow(dead_code)]
+    async fn validate_mint_authorization(
+        &self,
+        _query: MintedLogQuery,
+        _authorization: &MintAuthorization,
+    ) -> Result<(), VaultError> {
         Err(VaultError::InvalidReceipt)
     }
 }
@@ -903,6 +974,33 @@ pub(crate) enum VaultError {
     /// it.
     #[error("Burned event diverges from the mined burn calldata: {tx_hash:?}")]
     BurnedEventMismatch { tx_hash: B256 },
+    /// A delivered mint authorization's signature recovered to a signer other
+    /// than the recipient it must authorize.
+    #[error(
+        "Mint authorization signature recovered {recovered:?}, expected the recipient {expected:?}"
+    )]
+    MintAuthSignerMismatch { expected: Address, recovered: Address },
+    /// A delivered mint authorization's `(to, nonce)` is already consumed
+    /// on-chain — submitting with it could only revert `NonceReplayed`.
+    #[error(
+        "Mint authorization nonce {nonce:?} is already consumed on-chain for recipient {to:?}"
+    )]
+    MintAuthNonceUsed { to: Address, nonce: B256 },
+    /// A contract recipient rejected the mint authorization signature via
+    /// ERC-1271 `isValidSignature`.
+    #[error(
+        "Contract recipient {to:?} rejected the mint authorization signature (ERC-1271)"
+    )]
+    MintAuthRejectedByContract { to: Address },
+    /// An empty-signature authorization names a recipient with no contract
+    /// code. Only a contract can answer the orchestrator's `authorizeMint`
+    /// callback, so this authorization could never be satisfied on-chain.
+    #[error(
+        "Empty-signature mint authorization requires a contract recipient; {to:?} has no code"
+    )]
+    MintAuthEmptySignatureForEoa { to: Address },
+    #[error(transparent)]
+    Signature(#[from] alloy::primitives::SignatureError),
     #[error(
         "Node returned transaction hash {returned:?} for persisted transaction {expected:?}"
     )]

--- a/src/vault/orchestrator.rs
+++ b/src/vault/orchestrator.rs
@@ -1,8 +1,140 @@
-use alloy::primitives::{Address, B256, U256};
+use alloy::primitives::{Address, B256, Bytes, U256};
 use serde::{Deserialize, Serialize};
 
 use crate::VaultMode;
+use crate::bindings::IST0xOrchestratorV1;
 use crate::redemption::{BurnExternalTxId, IssuerRedemptionRequestId};
+use crate::vault::ReceiptInformation;
+
+/// A recipient-produced `MintAuthV1` authorizing one orchestrator mint.
+///
+/// The liquidity bot (the AP controlling the recipient wallet) picks a random
+/// nonce and signs the EIP-712 `MintAuthV1` over `(token, to, amount, nonce)`
+/// with the recipient wallet's key, then delivers it via the internal
+/// mint-authorization call. Persisted verbatim on
+/// `MintAuthorizationReceived`, so this serde shape is permanent.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct MintAuthorization {
+    /// Recipient-chosen random nonce; `(to, nonce)` is single-use on-chain.
+    pub(crate) nonce: B256,
+    /// Opaque recipient signature over the `MintAuthV1` digest. EMPTY is a
+    /// valid input: the future Atomic Bridge recipient authorizes via the
+    /// orchestrator's `authorizeMint` callback instead of a signature, so
+    /// validation skips signer recovery for empty bytes (SPEC Decision 1).
+    pub(crate) signature: Bytes,
+}
+
+impl MintAuthorization {
+    pub(crate) fn to_binding(&self) -> IST0xOrchestratorV1::MintAuthV1 {
+        IST0xOrchestratorV1::MintAuthV1 {
+            nonce: self.nonce,
+            signature: self.signature.clone(),
+        }
+    }
+}
+
+/// Parameters for a single `ST0xOrchestrator.mint()` call.
+///
+/// Unlike the vault-direct deposit multicall there is no `previewDeposit` and
+/// no share transfer: the orchestrator asserts 1:1 on-chain
+/// (`VaultAmountMismatch` otherwise), keeps the receipt, and forwards the
+/// ERC-20 shares to `to`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct OrchestratorMintParams {
+    /// `ST0xOrchestrator` contract address, taken from the mint's persisted
+    /// `mint_mode` anchor — never from live config.
+    pub(crate) orchestrator: Address,
+    /// The vault contract, which is also the ERC-20 share token being minted.
+    pub(crate) token: Address,
+    /// Recipient wallet — the exact `to` the authorization was signed over.
+    pub(crate) to: Address,
+    /// Mint amount in 18-decimal share-wei — the exact `amount` the
+    /// authorization was signed over.
+    pub(crate) amount: U256,
+    /// The liquidity bot's `MintAuthV1` for this mint; the on-chain call must
+    /// use exactly the signed `(token, to, amount, nonce)`.
+    pub(crate) authorization: MintAuthorization,
+    /// Off-chain audit payload forwarded verbatim to `vault.mint`, keeping the
+    /// CBOR audit-trail format identical to vault-direct deposits.
+    pub(crate) receipt_info: ReceiptInformation,
+    /// Optional deterministic `externalTxId` override for retry submissions.
+    #[serde(default)]
+    pub(crate) external_tx_id: Option<String>,
+}
+
+/// Result of a confirmed `ST0xOrchestrator.mint()`, parsed from the
+/// orchestrator's `Minted` event. Carries the consumed `nonce` in place of
+/// vault-direct's `receipt_id` — the orchestrator, not the bot, owns receipt
+/// custody.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OrchestratorMintResult {
+    pub(crate) tx_hash: B256,
+    /// `Minted.nonce` — the authorization nonce this mint consumed.
+    pub(crate) nonce: B256,
+    /// `Minted.amount` — shares minted and forwarded to the recipient.
+    pub(crate) shares_minted: U256,
+    pub(crate) gas_used: u64,
+    pub(crate) block_number: u64,
+}
+
+/// Query identifying one specific mint's landing on-chain: the full-match
+/// key `(to, nonce, token, amount)` plus the orchestrator whose `Minted`
+/// logs are scanned. Named fields, because three of these are same-typed
+/// addresses — positional arguments would let a call site transpose them
+/// and compile cleanly while querying the wrong pair.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct MintedLogQuery {
+    pub(crate) orchestrator: Address,
+    /// Recipient wallet the mint was signed over.
+    pub(crate) to: Address,
+    /// The authorization nonce — `(to, nonce)` is the on-chain uniqueness
+    /// key.
+    pub(crate) nonce: B256,
+    /// The vault share token the mint was signed over.
+    pub(crate) token: Address,
+    /// Mint amount in 18-decimal share-wei.
+    pub(crate) amount: U256,
+    /// Override for the scan's backward window in blocks; `None` uses the
+    /// default recovery-timeline window. Reconciliation of an inconclusive
+    /// replay re-queries with a widened window (SPEC "Recipient
+    /// Authorization" -> "Nonce"). Ignored by authorization validation,
+    /// which reads on-chain state and never scans logs.
+    pub(crate) lookback_blocks: Option<u64>,
+}
+
+/// Verdict of a `Minted`-log scan for one mint's landing. The on-chain
+/// uniqueness key is only `(to, nonce)`, so the scan distinguishes THREE
+/// outcomes — a bare hit is not proof the mint landed, and a bare miss is
+/// not proof of absence (SPEC "Recipient Authorization" -> "Nonce": two
+/// outcomes, never conflated).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum MintedLogScan {
+    /// A log at `(to, nonce)` whose `token` and `amount` equal the query's —
+    /// THIS mint's landing.
+    FullMatch(OrchestratorMintedLog),
+    /// A log at `(to, nonce)` exists but its `token` or `amount` disagrees:
+    /// affirmative proof a DIFFERENT mint consumed the pair, so this mint
+    /// can never land.
+    Mismatch,
+    /// No log at `(to, nonce)` anywhere in the scanned window. When
+    /// `nonceUsed` reports the nonce consumed, this is an inconclusive
+    /// chain view (window too narrow, RPC or indexer lag) — an unknown
+    /// outcome, never proof of anything.
+    NotFound,
+}
+
+/// A landed orchestrator mint discovered via a `Minted`-log lookup that
+/// full-matched `(to, nonce, token, amount)`. Unlike
+/// [`OrchestratorMintResult`] this carries no `gas_used` — a bare log does
+/// not expose it, and the recovery event it feeds
+/// (`OrchestratorMintRecovered`) does not record it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct OrchestratorMintedLog {
+    pub(crate) tx_hash: B256,
+    pub(crate) nonce: B256,
+    pub(crate) shares_minted: U256,
+    pub(crate) block_number: u64,
+}
 
 /// Parameters for a single `ST0xOrchestrator.burn()` call.
 ///
@@ -92,7 +224,8 @@ pub(crate) enum OrchestratorBurnReadiness {
     },
 }
 
-/// Typed revert reason decoded from a mined-but-reverted orchestrator burn.
+/// Typed revert reason decoded from a mined-but-reverted orchestrator mint or
+/// burn.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum OrchestratorRevertReason {
     /// `InsufficientReceipts(token, shortfall)` — the on-chain receipt walk
@@ -103,6 +236,28 @@ pub(crate) enum OrchestratorRevertReason {
     },
     VaultLogicMismatch,
     ReceiptLogicMismatch,
+    /// `NonceReplayed(to, nonce)` — the `(to, nonce)` pair was already
+    /// consumed by a successful mint. Recovery must full-match the on-chain
+    /// `Minted` log against this mint's own `(to, nonce, token, amount)`
+    /// before treating the earlier landing as this mint's.
+    NonceReplayed {
+        to: Address,
+        nonce: B256,
+    },
+    /// `BadRecipientSignature()` — the recipient signature did not recover to
+    /// `to`.
+    BadRecipientSignature,
+    /// `RecipientCallbackRejected(recipient)` — an `IMintRecipient` contract
+    /// refused the mint via its `authorizeMint` callback (bridge path).
+    RecipientCallbackRejected {
+        recipient: Address,
+    },
+    /// `VaultAmountMismatch(expected, actual)` — the vault did not mint 1:1
+    /// against the requested amount.
+    VaultAmountMismatch {
+        expected: U256,
+        actual: U256,
+    },
     /// Revert data was unavailable or did not decode to one of the
     /// orchestrator's typed errors.
     Unknown,

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -2,7 +2,7 @@ use alloy::consensus::Transaction;
 use alloy::consensus::transaction::SignerRecoverable;
 use alloy::eips::Encodable2718;
 use alloy::network::{EthereumWallet, TransactionResponse};
-use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::primitives::{Address, B256, Bytes, Signature, U256};
 use alloy::providers::fillers::{
     BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill,
     NonceFiller, SimpleNonceManager, WalletFiller,
@@ -12,28 +12,31 @@ use alloy::providers::{
 };
 use alloy::rpc::json_rpc::ErrorPayload;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
-use alloy::sol_types::SolCall;
-use alloy::sol_types::SolInterface;
+use alloy::sol_types::{SolCall, SolInterface};
 use async_trait::async_trait;
 use chrono::Utc;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Mutex;
-use tracing::debug;
+use tracing::{debug, trace, warn};
 
 use super::rain_meta::OaSchemaCache;
 use super::{
-    BurnRange, BurnTxStatus, BurnVerification, MintResult, MintTxStatus,
-    MultiBurnResult, MultiBurnResultEntry, OrchestratorBurnParams,
-    OrchestratorBurnReadiness, OrchestratorBurnResult,
-    OrchestratorRevertReason, PreparedMintTx, ReceiptInformation,
-    SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
-    WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
+    BurnRange, BurnTxStatus, BurnVerification, MintAuthorization, MintResult,
+    MintTxStatus, MintedLogQuery, MintedLogScan, MultiBurnResult,
+    MultiBurnResultEntry, OrchestratorBurnParams, OrchestratorBurnReadiness,
+    OrchestratorBurnResult, OrchestratorMintParams, OrchestratorRevertReason,
+    PreparedMintTx, ReceiptInformation, SendableTxWithHash, SubmittedTx, TxId,
+    VaultError, VaultService, WalletNonceGuard, classify_checked_receipt,
+    verify_burn_in_receipt,
 };
 use crate::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Errors;
-use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
+use crate::bindings::{
+    IERC1271, IST0xOrchestratorV1, OffchainAssetReceiptVault,
+};
 use crate::redemption::BurnExternalTxId;
 use crate::vault::orchestrator::BurnProofKind;
+use crate::vault::{OrchestratorMintResult, OrchestratorMintedLog};
 
 pub type RealBlockchainServiceProvider = FillProvider<
     JoinFill<
@@ -48,6 +51,29 @@ pub type RealBlockchainServiceProvider = FillProvider<
     >,
     RootProvider,
 >;
+
+/// Total backward window `find_orchestrator_minted_log` scans for a landed
+/// `Minted` log, from the chain head. A consuming transaction can only land
+/// after the mint's authorization was delivered (the delivery endpoint
+/// rejects an already-consumed nonce), so the sought log is at most as old
+/// as the mint's own recovery timeline — this window (~5.8 days on Base's 2s
+/// blocks) covers the automatic retry schedule and same-week manual
+/// re-drives with ample margin.
+const MINTED_LOG_LOOKBACK_BLOCKS: u64 = 250_000;
+
+/// Blocks per `eth_getLogs` call in the `Minted`-log scan, mirroring the
+/// receipt backfiller's `BLOCK_CHUNK_SIZE` (providers typically cap
+/// `eth_getLogs` ranges around this size).
+const MINTED_LOG_CHUNK_BLOCKS: u64 = 2_000;
+
+/// Blocks a `Minted` log must be buried under before the scan treats it as
+/// proof that a mint landed: the scan ceiling is the chain head minus this
+/// depth, so a log from a block that later reorgs out cannot terminalize a
+/// mint whose shares no longer exist. 32 blocks (~64s on Base) comfortably
+/// exceeds observed OP-stack reorg depth; the cost of the lag is one deferred
+/// recovery pass for a landing younger than the window (the lookup's `None`
+/// is retryable).
+const MINTED_LOG_CONFIRMATION_BLOCKS: u64 = 32;
 
 /// Alloy-based blockchain service that interacts with the Rain OffchainAssetReceiptVault
 /// contract.
@@ -130,8 +156,9 @@ impl RealBlockchainService {
             .and_then(|data| IST0xOrchestratorV1Errors::abi_decode(&data).ok())
             .map_or(OrchestratorRevertReason::Unknown, |decoded| {
                 use IST0xOrchestratorV1Errors::{
-                    InsufficientReceipts, ReceiptLogicMismatch,
-                    VaultLogicMismatch,
+                    BadRecipientSignature, InsufficientReceipts, NonceReplayed,
+                    ReceiptLogicMismatch, RecipientCallbackRejected,
+                    VaultAmountMismatch, VaultLogicMismatch,
                 };
                 match decoded {
                     InsufficientReceipts(error) => {
@@ -145,6 +172,26 @@ impl RealBlockchainService {
                     }
                     ReceiptLogicMismatch(_) => {
                         OrchestratorRevertReason::ReceiptLogicMismatch
+                    }
+                    NonceReplayed(error) => {
+                        OrchestratorRevertReason::NonceReplayed {
+                            to: error.to,
+                            nonce: error.nonce,
+                        }
+                    }
+                    BadRecipientSignature(_) => {
+                        OrchestratorRevertReason::BadRecipientSignature
+                    }
+                    RecipientCallbackRejected(error) => {
+                        OrchestratorRevertReason::RecipientCallbackRejected {
+                            recipient: error.recipient,
+                        }
+                    }
+                    VaultAmountMismatch(error) => {
+                        OrchestratorRevertReason::VaultAmountMismatch {
+                            expected: error.expected,
+                            actual: error.actual,
+                        }
                     }
                     _ => OrchestratorRevertReason::Unknown,
                 }
@@ -1043,6 +1090,327 @@ impl VaultService for RealBlockchainService {
         let contract = IST0xOrchestratorV1::new(orchestrator, &self.provider);
         Ok(contract.nextBurnReceiptId(token).call().await?)
     }
+
+    async fn prepare_orchestrator_mint_tx(
+        &self,
+        params: &OrchestratorMintParams,
+    ) -> Result<PreparedMintTx, VaultError> {
+        let external_tx_id =
+            params.external_tx_id.clone().unwrap_or_else(|| {
+                format!("mint-{}", params.receipt_info.issuer_request_id)
+            });
+        let oa_schema = self.oa_schema_cache.get(params.token).await;
+        let receipt_info_bytes =
+            params.receipt_info.encode(oa_schema.as_deref())?;
+
+        let orchestrator_contract =
+            IST0xOrchestratorV1::new(params.orchestrator, &self.provider);
+
+        let tx = orchestrator_contract
+            .mint(
+                params.token,
+                params.to,
+                params.amount,
+                params.authorization.to_binding(),
+                receipt_info_bytes,
+            )
+            .into_transaction_request();
+
+        let envelope = self
+            .provider
+            .fill(tx)
+            .await?
+            .try_into_envelope()
+            .map_err(Box::new)?;
+        let prepared_tx = PreparedMintTx {
+            nonce: envelope.nonce(),
+            hash: *envelope.tx_hash(),
+            tx: envelope.encoded_2718(),
+            signed_at: Utc::now(),
+            external_tx_id,
+        };
+        prepared_tx.validate()?;
+
+        Ok(prepared_tx)
+    }
+
+    async fn confirm_orchestrator_mint(
+        &self,
+        tx_id: &TxId,
+    ) -> Result<OrchestratorMintResult, VaultError> {
+        debug!(target: "vault", tx_hash = %tx_id,
+            "Getting orchestrator mint tx data from chain"
+        );
+
+        let tx_hash = tx_id.to_hash().ok_or(VaultError::InvalidReceipt)?;
+
+        let receipt = PendingTransactionBuilder::new(
+            self.provider.root().clone(),
+            tx_hash,
+        )
+        .with_timeout(Some(Duration::from_secs(120)))
+        .get_receipt()
+        .await
+        .map_err(|error| VaultError::ConfirmationPending {
+            tx_id: TxId::Hash(tx_hash),
+            message: error.to_string(),
+        })?;
+
+        let block_number =
+            receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
+
+        // A mined-but-reverted orchestrator mint is a definitive failure;
+        // decode its typed reason so the aggregate records the right
+        // classification (NonceReplayed routes into the full-match recovery).
+        if !receipt.status() {
+            let reason = self
+                .decode_orchestrator_revert(
+                    tx_hash,
+                    block_number.saturating_sub(1),
+                )
+                .await;
+            return Err(VaultError::OrchestratorReverted { tx_hash, reason });
+        }
+
+        // Bind the decoded event to OUR mint before recording it: emitted by
+        // the orchestrator this persisted transaction targeted
+        // (`receipt.to`), with the transaction's own sender as `caller`. The
+        // mint calls into the recipient contract before completing (ERC-1271
+        // today, `authorizeMint` on the bridge path), so an unbound decode
+        // could pick up a same-topic log the recipient emitted with an
+        // inflated amount. Token, `to`, and amount are then bound
+        // transitively: the orchestrator emits exactly one `Minted` per
+        // `mint()` call, with fields taken from our own persisted calldata.
+        let orchestrator = receipt.to.ok_or(VaultError::InvalidReceipt)?;
+        let minted = receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                if log.address() != orchestrator {
+                    return None;
+                }
+                let decoded =
+                    log.log_decode::<IST0xOrchestratorV1::Minted>().ok()?;
+                (decoded.data().caller == receipt.from).then_some(decoded)
+            })
+            .ok_or(VaultError::EventNotFound { tx_hash })?;
+        let minted = minted.data();
+
+        Ok(OrchestratorMintResult {
+            tx_hash,
+            nonce: minted.nonce,
+            shares_minted: minted.amount,
+            gas_used: receipt.gas_used,
+            block_number,
+        })
+    }
+
+    /// Scans backward from the chain head in bounded chunks (providers cap
+    /// `eth_getLogs` block ranges), stopping at the first log carrying the
+    /// queried `(to, nonce)` pair — the on-chain uniqueness key, consumed at
+    /// most once, so the first such log is the ONLY such log and decides the
+    /// verdict: [`MintedLogScan::FullMatch`] when its `token`/`amount` agree,
+    /// [`MintedLogScan::Mismatch`] when they don't. The sought log is at
+    /// most as old as the mint being recovered, so a hit costs one or two
+    /// calls; only [`MintedLogScan::NotFound`] walks the whole window
+    /// (`lookback_blocks` override, else [`MINTED_LOG_LOOKBACK_BLOCKS`]).
+    ///
+    /// The filter is by `to` (topic3) alone, deliberately NOT by `token`
+    /// (topic2): a topic-filtered token would make a same-`(to, nonce)`
+    /// landing under a different token invisible, turning the provable
+    /// `Mismatch` verdict into an inconclusive `NotFound` — the exact
+    /// conflation the three-way verdict exists to prevent.
+    ///
+    /// A chunk failure aborts the scan and surfaces to the caller
+    /// deliberately, without per-chunk retries: every caller already owns a
+    /// safe retry of the whole lookup (the confirm path records a retryable
+    /// `Unclassified` failure; recovery backs off to its next pass), so an
+    /// inner retry layer would only duplicate that policy.
+    async fn find_orchestrator_minted_log(
+        &self,
+        query: MintedLogQuery,
+    ) -> Result<MintedLogScan, VaultError> {
+        let MintedLogQuery {
+            orchestrator,
+            to,
+            nonce,
+            token,
+            amount,
+            lookback_blocks,
+        } = query;
+        let contract = IST0xOrchestratorV1::new(orchestrator, &self.provider);
+        // The ceiling excludes the newest blocks so a reorged-out log can
+        // never count as proof (see `MINTED_LOG_CONFIRMATION_BLOCKS`).
+        let head = self
+            .provider
+            .get_block_number()
+            .await?
+            .saturating_sub(MINTED_LOG_CONFIRMATION_BLOCKS);
+        let floor = head.saturating_sub(
+            lookback_blocks.unwrap_or(MINTED_LOG_LOOKBACK_BLOCKS),
+        );
+
+        let mut to_block = head;
+        loop {
+            let from_block =
+                to_block.saturating_sub(MINTED_LOG_CHUNK_BLOCKS - 1).max(floor);
+            // `to` is an indexed topic; `nonce`, `amount` live in the data
+            // payload and `token` (topic2) is read from the decoded log
+            // rather than filtered on (see the method comment). Topic
+            // positions follow the ABI's indexed-param order —
+            // `Minted(caller indexed, token indexed, to indexed, amount,
+            // nonce)` — so `to` is topic3 (pinned by
+            // `minted_event_indexes_token_and_to_as_topics_2_and_3` below).
+            trace!(target: "vault",
+                from_block,
+                to_block,
+                to = %to,
+                "Scanning chunk for orchestrator Minted log"
+            );
+            let logs = contract
+                .Minted_filter()
+                .topic3(to)
+                .from_block(from_block)
+                .to_block(to_block)
+                .query()
+                .await?;
+
+            for (minted, log) in logs {
+                if minted.nonce != nonce || minted.to != to {
+                    continue;
+                }
+                if minted.token == token && minted.amount == amount {
+                    return Ok(MintedLogScan::FullMatch(
+                        OrchestratorMintedLog {
+                            tx_hash: log
+                                .transaction_hash
+                                .ok_or(VaultError::InvalidReceipt)?,
+                            nonce,
+                            shares_minted: minted.amount,
+                            block_number: log
+                                .block_number
+                                .ok_or(VaultError::InvalidReceipt)?,
+                        },
+                    ));
+                }
+                // `(to, nonce)` is consumed at most once on-chain, so this
+                // log is the pair's one landing — and it is not this
+                // mint's: affirmative proof of a different mint.
+                warn!(target: "vault",
+                    to = %to,
+                    nonce = %nonce,
+                    expected_token = %token,
+                    landed_token = %minted.token,
+                    expected_amount = %amount,
+                    landed_amount = %minted.amount,
+                    "Minted log at (to, nonce) disagrees on token/amount; a \
+                     different mint consumed the pair"
+                );
+                return Ok(MintedLogScan::Mismatch);
+            }
+
+            if from_block <= floor {
+                // The span a `NotFound` actually looked back over — the
+                // callers' logs carry the mint facts; this records how far
+                // the (inconclusive) absence reading goes.
+                debug!(target: "vault",
+                    head,
+                    floor,
+                    scanned_blocks = head - floor + 1,
+                    to = %to,
+                    nonce = %nonce,
+                    token = %token,
+                    amount = %amount,
+                    "No Minted log at (to, nonce) within the lookback window"
+                );
+                return Ok(MintedLogScan::NotFound);
+            }
+            to_block = from_block - 1;
+        }
+    }
+
+    async fn validate_mint_authorization(
+        &self,
+        query: MintedLogQuery,
+        authorization: &MintAuthorization,
+    ) -> Result<(), VaultError> {
+        let MintedLogQuery { orchestrator, to, token, amount, .. } = query;
+        // Single nonce source: every check reads the delivered
+        // authorization's own nonce — `query.nonce` is deliberately unused,
+        // so a future caller building the query differently can never
+        // validate one nonce while the mint consumes another.
+        let nonce = authorization.nonce;
+        let contract = IST0xOrchestratorV1::new(orchestrator, &self.provider);
+
+        // Consumed-nonce first: definitive regardless of recipient type, and
+        // a submission with a used nonce could only revert NonceReplayed.
+        if contract.nonceUsed(to, nonce).call().await? {
+            return Err(VaultError::MintAuthNonceUsed { to, nonce });
+        }
+
+        // The bridge/`IMintRecipient` recipient authorizes on-chain via the
+        // orchestrator's `authorizeMint` callback — there is no signature to
+        // recover (SPEC Decision 1). Only a CONTRACT can answer that
+        // callback: an EOA with an empty signature could never be satisfied
+        // on-chain, so it is rejected here instead of passing preflight and
+        // reverting at the mint.
+        if authorization.signature.is_empty() {
+            if self.provider.get_code_at(to).await?.is_empty() {
+                return Err(VaultError::MintAuthEmptySignatureForEoa { to });
+            }
+            return Ok(());
+        }
+
+        // The contract's own digest view guarantees the exact EIP-712 domain
+        // and struct hash the orchestrator will verify at mint time.
+        let digest =
+            contract.mintAuthDigest(token, to, amount, nonce).call().await?;
+
+        if self.provider.get_code_at(to).await?.is_empty() {
+            let signature =
+                Signature::from_raw(authorization.signature.as_ref())?;
+            let recovered = signature.recover_address_from_prehash(&digest)?;
+            if recovered != to {
+                return Err(VaultError::MintAuthSignerMismatch {
+                    expected: to,
+                    recovered,
+                });
+            }
+            return Ok(());
+        }
+
+        // Contract recipient: ERC-1271. The magic success value is the
+        // `isValidSignature(bytes32,bytes)` selector itself. Anything short
+        // of it is a rejection, not a transport failure: a revert (a
+        // recipient without `isValidSignature` typically reverts the unknown
+        // call) or a response that fails the `bytes4` decode (a permissive
+        // fallback returning empty data). Only a transport-level failure
+        // propagates as retryable.
+        match IERC1271::new(to, &self.provider)
+            .isValidSignature(digest, authorization.signature.clone())
+            .call()
+            .await
+        {
+            Ok(magic)
+                if magic
+                    == alloy::primitives::FixedBytes(
+                        IERC1271::isValidSignatureCall::SELECTOR,
+                    ) =>
+            {
+                Ok(())
+            }
+            Err(error) if error.as_revert_data().is_some() => {
+                Err(VaultError::MintAuthRejectedByContract { to })
+            }
+            Err(error @ alloy::contract::Error::TransportError(_)) => {
+                Err(error.into())
+            }
+            Ok(_) | Err(_) => {
+                Err(VaultError::MintAuthRejectedByContract { to })
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1066,8 +1434,9 @@ mod tests {
         Block, FeeHistory, Transaction as RpcTransaction, TransactionReceipt,
         TransactionRequest,
     };
+    use alloy::signers::SignerSync;
     use alloy::signers::local::PrivateKeySigner;
-    use alloy::sol_types::{SolCall, SolError};
+    use alloy::sol_types::{SolCall, SolError, SolEvent};
     use chrono::Utc;
     use rust_decimal::Decimal;
     use std::sync::Arc;
@@ -1075,11 +1444,14 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{
-        BurnRange, OrchestratorBurnParams, OrchestratorBurnReadiness,
-        OrchestratorRevertReason, RealBlockchainService,
+        BurnRange, MintAuthorization, MintedLogQuery, OrchestratorBurnParams,
+        OrchestratorBurnReadiness, OrchestratorMintParams,
+        OrchestratorMintedLog, OrchestratorRevertReason, RealBlockchainService,
         RealBlockchainServiceProvider,
     };
-    use crate::bindings::{IST0xOrchestratorV1, OffchainAssetReceiptVault};
+    use crate::bindings::{
+        IERC1271, IST0xOrchestratorV1, OffchainAssetReceiptVault,
+    };
     use crate::mint::{
         IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
     };
@@ -1088,8 +1460,8 @@ mod tests {
     use crate::vault::orchestrator::BurnProofKind;
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
-        BurnRequestOrigin, BurnTxStatus, MintTxStatus, MultiBurnEntry,
-        MultiBurnParams, PreparedMintTx, ReceiptInformation,
+        BurnRequestOrigin, BurnTxStatus, MintTxStatus, MintedLogScan,
+        MultiBurnEntry, MultiBurnParams, PreparedMintTx, ReceiptInformation,
         SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
@@ -3252,5 +3624,1021 @@ mod tests {
                 "a transport failure must not be classified as a readiness outcome"
             );
         }
+    }
+
+    fn test_mint_authorization() -> MintAuthorization {
+        MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from_static(&[0xaa; 65]),
+        }
+    }
+
+    fn test_orchestrator_mint_params(to: Address) -> OrchestratorMintParams {
+        OrchestratorMintParams {
+            orchestrator: test_orchestrator_address(),
+            token: test_vault_address(),
+            to,
+            amount: U256::from(1_000_000u64),
+            authorization: test_mint_authorization(),
+            receipt_info: test_receipt_info(),
+            external_tx_id: None,
+        }
+    }
+
+    /// The signed-tuple query the validation tests hand to
+    /// `validate_mint_authorization`, with `nonce` taken from the delivered
+    /// authorization as the callers do.
+    fn auth_query(recipient: Address, nonce: B256) -> MintedLogQuery {
+        MintedLogQuery {
+            orchestrator: test_orchestrator_address(),
+            to: recipient,
+            nonce,
+            token: test_vault_address(),
+            amount: U256::from(1_000_000u64),
+            lookback_blocks: None,
+        }
+    }
+
+    fn create_minted_receipt(
+        tx_hash: B256,
+        to: Address,
+        amount: U256,
+        nonce: B256,
+        succeeded: bool,
+    ) -> TransactionReceipt {
+        create_minted_receipt_from(
+            tx_hash,
+            to,
+            amount,
+            nonce,
+            succeeded,
+            test_orchestrator_address(),
+        )
+    }
+
+    /// Like [`create_minted_receipt`], with the `Minted` log's emitting
+    /// contract chosen by the caller — for pinning that the confirm path
+    /// binds the event to the orchestrator the transaction targeted.
+    fn create_minted_receipt_from(
+        tx_hash: B256,
+        to: Address,
+        amount: U256,
+        nonce: B256,
+        succeeded: bool,
+        emitter: Address,
+    ) -> TransactionReceipt {
+        let minted_event = IST0xOrchestratorV1::Minted {
+            caller: address!("2222222222222222222222222222222222222222"),
+            token: test_vault_address(),
+            to,
+            amount,
+            nonce,
+        };
+
+        let logs = if succeeded {
+            vec![alloy::rpc::types::Log {
+                inner: alloy::primitives::Log {
+                    address: emitter,
+                    data: minted_event.into_log_data(),
+                },
+                block_hash: Some(b256!(
+                    "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+                )),
+                block_number: Some(0x9c4),
+                block_timestamp: None,
+                transaction_hash: Some(tx_hash),
+                transaction_index: Some(0),
+                log_index: Some(0),
+                removed: false,
+            }]
+        } else {
+            vec![]
+        };
+
+        let consensus_receipt: Receipt<alloy::rpc::types::Log> = Receipt {
+            status: Eip658Value::Eip658(succeeded),
+            cumulative_gas_used: 0x8000,
+            logs,
+        };
+
+        TransactionReceipt {
+            transaction_hash: tx_hash,
+            transaction_index: Some(0),
+            block_hash: Some(fixed_bytes!(
+                "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+            )),
+            block_number: Some(0x9c4),
+            from: address!("2222222222222222222222222222222222222222"),
+            to: Some(test_orchestrator_address()),
+            gas_used: 0x8000,
+            effective_gas_price: 0x3b9a_ca00,
+            contract_address: None,
+            blob_gas_used: None,
+            blob_gas_price: None,
+            inner: ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                consensus_receipt,
+                Bloom::default(),
+            )),
+        }
+    }
+
+    #[tokio::test]
+    async fn orchestrator_mint_prepare_encodes_signed_facts_verbatim() {
+        let asserter = Asserter::new();
+        setup_asserter_for_fill(&asserter, 7);
+        let signer = PrivateKeySigner::random();
+        let service = create_service_with_signer(asserter, signer);
+
+        let recipient = test_receiver();
+        let params = test_orchestrator_mint_params(recipient);
+
+        let prepared = service
+            .prepare_orchestrator_mint_tx(&params)
+            .await
+            .expect("expected PreparedMintTx");
+
+        assert_eq!(prepared.nonce, 7);
+        assert_eq!(
+            prepared.external_tx_id,
+            format!("mint-{}", params.receipt_info.issuer_request_id),
+            "deterministic externalTxId must derive from the issuer request id"
+        );
+        let envelope = TxEnvelope::decode_2718(&mut prepared.tx.as_slice())
+            .expect("prepared orchestrator mint must decode");
+        assert_eq!(*envelope.tx_hash(), prepared.hash);
+        assert_eq!(envelope.to(), Some(test_orchestrator_address()));
+
+        // The calldata must carry exactly the signed (token, to, amount,
+        // nonce) plus the CBOR receipt information — no previewDeposit, no
+        // multicall.
+        let expected_receipt_info = params
+            .receipt_info
+            .encode(Some(TEST_OA_SCHEMA))
+            .expect("receipt info must encode");
+        let expected_calldata = IST0xOrchestratorV1::mintCall {
+            token: params.token,
+            to: params.to,
+            amount: params.amount,
+            auth: params.authorization.to_binding(),
+            receiptInformation: expected_receipt_info,
+        }
+        .abi_encode();
+        assert_eq!(
+            envelope.input().as_ref(),
+            expected_calldata.as_slice(),
+            "calldata must be mint(token, to, amount, auth, receiptInformation)"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_orchestrator_mint_parses_minted_event() {
+        let tx_hash = b256!(
+            "0x8888888888888888888888888888888888888888888888888888888888888888"
+        );
+        let recipient = test_receiver();
+        let nonce = B256::repeat_byte(0x07);
+        let receipt = create_minted_receipt(
+            tx_hash,
+            recipient,
+            U256::from(1_000_000u64),
+            nonce,
+            true,
+        );
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .confirm_orchestrator_mint(&TxId::Hash(tx_hash))
+            .await
+            .expect("expected OrchestratorMintResult");
+
+        assert_eq!(result.tx_hash, tx_hash);
+        assert_eq!(result.nonce, nonce);
+        assert_eq!(result.shares_minted, U256::from(1_000_000u64));
+        assert_eq!(result.gas_used, 0x8000);
+        assert_eq!(result.block_number, 0x9c4);
+    }
+
+    /// The mint calls into the recipient contract before completing, so a
+    /// same-signature `Minted` event emitted by anything other than the
+    /// orchestrator the transaction targeted must never be recorded: the
+    /// confirm path binds the log to `receipt.to` and reads anything else as
+    /// `EventNotFound`.
+    #[tokio::test]
+    async fn confirm_orchestrator_mint_ignores_foreign_minted_logs() {
+        let tx_hash = b256!(
+            "0x6666666666666666666666666666666666666666666666666666666666666666"
+        );
+        let recipient = test_receiver();
+        let receipt = create_minted_receipt_from(
+            tx_hash,
+            recipient,
+            U256::from(1_000_000u64),
+            B256::repeat_byte(0x07),
+            true,
+            // The spoof vector: the RECIPIENT emitting an inflated Minted.
+            recipient,
+        );
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result =
+            service.confirm_orchestrator_mint(&TxId::Hash(tx_hash)).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(VaultError::EventNotFound { tx_hash: hash })
+                    if hash == tx_hash
+            ),
+            "a foreign contract's Minted log must not confirm the mint, \
+             got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn confirm_orchestrator_mint_without_minted_event_is_not_found() {
+        let tx_hash = b256!(
+            "0x8888888888888888888888888888888888888888888888888888888888888888"
+        );
+        let receipt = create_minted_receipt(
+            tx_hash,
+            test_receiver(),
+            U256::from(1u8),
+            B256::ZERO,
+            true,
+        );
+        let mut receipt = receipt;
+        receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+            Receipt {
+                status: Eip658Value::Eip658(true),
+                cumulative_gas_used: 0x8000,
+                logs: vec![],
+            },
+            Bloom::default(),
+        ));
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result =
+            service.confirm_orchestrator_mint(&TxId::Hash(tx_hash)).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::EventNotFound { tx_hash: hash }) if hash == tx_hash
+        ));
+    }
+
+    /// A mined-but-reverted orchestrator mint replays the transaction as an
+    /// `eth_call` at its mined block and decodes the mint-side typed revert
+    /// reasons.
+    #[tokio::test]
+    async fn confirm_orchestrator_mint_decodes_typed_revert_reasons() {
+        let recipient = test_receiver();
+        let nonce = B256::repeat_byte(0x07);
+        let cases = [
+            (
+                Bytes::from(
+                    IST0xOrchestratorV1::NonceReplayed { to: recipient, nonce }
+                        .abi_encode(),
+                ),
+                OrchestratorRevertReason::NonceReplayed {
+                    to: recipient,
+                    nonce,
+                },
+            ),
+            (
+                Bytes::from(
+                    IST0xOrchestratorV1::VaultAmountMismatch {
+                        expected: U256::from(10u8),
+                        actual: U256::from(9u8),
+                    }
+                    .abi_encode(),
+                ),
+                OrchestratorRevertReason::VaultAmountMismatch {
+                    expected: U256::from(10u8),
+                    actual: U256::from(9u8),
+                },
+            ),
+            (
+                Bytes::from(
+                    IST0xOrchestratorV1::BadRecipientSignature {}.abi_encode(),
+                ),
+                OrchestratorRevertReason::BadRecipientSignature,
+            ),
+            (
+                Bytes::from(
+                    IST0xOrchestratorV1::RecipientCallbackRejected {
+                        recipient,
+                    }
+                    .abi_encode(),
+                ),
+                OrchestratorRevertReason::RecipientCallbackRejected {
+                    recipient,
+                },
+            ),
+        ];
+
+        for (revert_data, expected_reason) in cases {
+            let persisted = SendableTxWithHash::valid_for_test(
+                17,
+                test_orchestrator_address(),
+                Bytes::from_static(&[0xde, 0xad]),
+            );
+            let owner = persisted.signer_for_test();
+            let receipt = create_minted_receipt(
+                persisted.hash,
+                owner,
+                U256::ZERO,
+                B256::ZERO,
+                false,
+            );
+            let transaction = rpc_transaction(&persisted.tx, owner);
+
+            let asserter = Asserter::new();
+            asserter.push_success(&receipt); // eth_getTransactionReceipt
+            asserter.push_success(&receipt); // eth_getTransactionReceipt (polling)
+            asserter.push_success(&transaction); // eth_getTransactionByHash
+            asserter.push_failure(ErrorPayload {
+                code: 3,
+                message: "execution reverted".into(),
+                data: Some(
+                    serde_json::value::to_raw_value(&format!("{revert_data}"))
+                        .expect("revert data must serialize"),
+                ),
+            }); // eth_call replay
+            let service = create_service_with_asserter(asserter);
+
+            let result = service
+                .confirm_orchestrator_mint(&TxId::Hash(persisted.hash))
+                .await;
+
+            assert!(
+                matches!(
+                    &result,
+                    Err(VaultError::OrchestratorReverted { tx_hash, reason })
+                        if *tx_hash == persisted.hash
+                            && *reason == expected_reason
+                ),
+                "expected {expected_reason:?}, got {result:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn validate_mint_authorization_accepts_recipient_signature() {
+        let signer = PrivateKeySigner::random();
+        let recipient = signer.address();
+        let digest = B256::repeat_byte(0x42);
+        let signature = signer
+            .sign_hash_sync(&digest)
+            .expect("test signer must sign the digest");
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from(signature.as_bytes().to_vec()),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&format!("{digest}")); // mintAuthDigest
+        asserter.push_success(&Bytes::new()); // eth_getCode: EOA
+        let service = create_service_with_asserter(asserter);
+
+        service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await
+            .expect("a recipient-signed authorization must validate");
+    }
+
+    #[tokio::test]
+    async fn validate_mint_authorization_rejects_wrong_signer() {
+        let recipient = test_receiver();
+        let other_signer = PrivateKeySigner::random();
+        let digest = B256::repeat_byte(0x42);
+        let signature = other_signer
+            .sign_hash_sync(&digest)
+            .expect("test signer must sign the digest");
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from(signature.as_bytes().to_vec()),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&format!("{digest}")); // mintAuthDigest
+        asserter.push_success(&Bytes::new()); // eth_getCode: EOA
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthSignerMismatch {
+                    expected,
+                    recovered,
+                }) if *expected == recipient
+                    && *recovered == other_signer.address()
+            ),
+            "expected MintAuthSignerMismatch, got {result:?}"
+        );
+    }
+
+    /// An EMPTY signature is valid input (the future bridge recipient
+    /// authorizes via the orchestrator's `authorizeMint` callback), so signer
+    /// recovery is skipped — but a consumed nonce is still rejected.
+    #[tokio::test]
+    async fn validate_mint_authorization_empty_signature_still_checks_nonce() {
+        let recipient = test_receiver();
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::new(),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&Bytes::from_static(&[0x60, 0x80])); // code: contract
+        let service = create_service_with_asserter(asserter);
+        service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await
+            .expect(
+                "an empty signature for a contract recipient must validate \
+                 without recovery",
+            );
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 1u64)); // nonceUsed: true
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthNonceUsed { to, nonce })
+                    if *to == recipient
+                        && *nonce == authorization.nonce
+            ),
+            "expected MintAuthNonceUsed, got {result:?}"
+        );
+    }
+
+    /// The validated nonce has a single source — the delivered
+    /// authorization itself: a query built with a DIFFERENT nonce must not
+    /// redirect any check, so the reported consumed nonce is the
+    /// authorization's, never the query's.
+    #[tokio::test]
+    async fn validate_mint_authorization_reads_nonce_from_authorization() {
+        let recipient = test_receiver();
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::new(),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 1u64)); // nonceUsed: true
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                // Diverging query nonce: must be ignored.
+                auth_query(recipient, B256::repeat_byte(0x99)),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthNonceUsed { to, nonce })
+                    if *to == recipient
+                        && *nonce == authorization.nonce
+            ),
+            "the consumed-nonce check must read the authorization's own \
+             nonce, got {result:?}"
+        );
+    }
+
+    /// An empty signature is only satisfiable by a contract recipient (the
+    /// orchestrator's `authorizeMint` callback); an EOA recipient must be
+    /// rejected at validation instead of passing preflight and reverting at
+    /// the mint.
+    #[tokio::test]
+    async fn validate_mint_authorization_empty_signature_rejects_eoa() {
+        let recipient = test_receiver();
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::new(),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&Bytes::new()); // code: EOA
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthEmptySignatureForEoa { to })
+                    if *to == recipient
+            ),
+            "an empty signature naming an EOA must be rejected, got {result:?}"
+        );
+    }
+
+    /// Signature bytes arrive over the authorization channel, so malformed
+    /// input is the expected case: a truncated signature must surface the
+    /// typed parse error, not a panic or a silent mismatch.
+    #[tokio::test]
+    async fn validate_mint_authorization_rejects_malformed_signature() {
+        let recipient = test_receiver();
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from_static(&[0xaa; 12]),
+        };
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&B256::repeat_byte(0x42)); // mintAuthDigest
+        asserter.push_success(&Bytes::new()); // code: EOA
+        let service = create_service_with_asserter(asserter);
+
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(&result, Err(VaultError::Signature(_))),
+            "a truncated signature must fail with the typed parse error, \
+             got {result:?}"
+        );
+    }
+
+    /// A contract recipient is validated via ERC-1271 `isValidSignature`:
+    /// the selector magic value accepts, anything else rejects.
+    #[tokio::test]
+    async fn validate_mint_authorization_uses_erc1271_for_contract_recipient() {
+        let recipient = test_receiver();
+        let digest = B256::repeat_byte(0x42);
+        let authorization = test_mint_authorization();
+        let contract_code = Bytes::from_static(&[0x60, 0x80]);
+        let mut magic_word = [0u8; 32];
+        magic_word[..4]
+            .copy_from_slice(&IERC1271::isValidSignatureCall::SELECTOR);
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&format!("{digest}")); // mintAuthDigest
+        asserter.push_success(&contract_code); // eth_getCode: contract
+        asserter.push_success(&B256::from(magic_word)); // isValidSignature
+        let service = create_service_with_asserter(asserter);
+        service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await
+            .expect("the ERC-1271 magic value must validate");
+
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&format!("{digest}")); // mintAuthDigest
+        asserter.push_success(&contract_code); // eth_getCode: contract
+        asserter.push_success(&B256::ZERO); // isValidSignature: wrong magic
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthRejectedByContract { to })
+                    if *to == recipient
+            ),
+            "expected MintAuthRejectedByContract, got {result:?}"
+        );
+    }
+
+    /// The remaining contract-recipient outcomes: an `isValidSignature`
+    /// revert and an empty return (a permissive fallback) are both
+    /// deliberate rejections, while a transport-level failure propagates as
+    /// retryable instead of masquerading as a rejection.
+    #[tokio::test]
+    async fn validate_mint_authorization_erc1271_failure_outcomes() {
+        let recipient = test_receiver();
+        let authorization = test_mint_authorization();
+        let contract_code = Bytes::from_static(&[0x60, 0x80]);
+
+        // Revert from the recipient — a rejection.
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&B256::repeat_byte(0x42)); // mintAuthDigest
+        asserter.push_success(&contract_code); // code: contract
+        asserter.push_failure(ErrorPayload {
+            code: 3,
+            message: "execution reverted".into(),
+            data: Some(
+                serde_json::value::to_raw_value("0x08c379a0")
+                    .expect("revert data must serialize"),
+            ),
+        }); // isValidSignature reverts
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthRejectedByContract { to })
+                    if *to == recipient
+            ),
+            "an isValidSignature revert must be a rejection, got {result:?}"
+        );
+
+        // Empty return data (no ERC-1271 implementation behind a permissive
+        // fallback) — also a rejection, not a transport failure.
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&B256::repeat_byte(0x42)); // mintAuthDigest
+        asserter.push_success(&contract_code); // code: contract
+        asserter.push_success(&Bytes::new()); // isValidSignature: empty return
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+        assert!(
+            matches!(
+                &result,
+                Err(VaultError::MintAuthRejectedByContract { to })
+                    if *to == recipient
+            ),
+            "an empty isValidSignature return must be a rejection, \
+             got {result:?}"
+        );
+
+        // A transport-level failure must propagate as retryable.
+        let asserter = Asserter::new();
+        asserter.push_success(&format!("0x{:064x}", 0u64)); // nonceUsed: false
+        asserter.push_success(&B256::repeat_byte(0x42)); // mintAuthDigest
+        asserter.push_success(&contract_code); // code: contract
+        asserter.push_failure(ErrorPayload {
+            code: -32000,
+            message: "node unavailable".into(),
+            data: None,
+        }); // isValidSignature transport failure
+        let service = create_service_with_asserter(asserter);
+        let result = service
+            .validate_mint_authorization(
+                auth_query(recipient, authorization.nonce),
+                &authorization,
+            )
+            .await;
+        assert!(
+            matches!(&result, Err(VaultError::Contract(_))),
+            "a transport failure must propagate, not read as a rejection, \
+             got {result:?}"
+        );
+    }
+
+    /// The `Minted`-log lookup only proves this mint landed on a full
+    /// `(to, nonce, token, amount)` match — a bare `(to, nonce)` hit whose
+    /// amount differs is a different mint and must not match.
+    #[traced_test]
+    #[tokio::test]
+    async fn find_orchestrator_minted_log_requires_full_match() {
+        let recipient = test_receiver();
+        let nonce = B256::repeat_byte(0x07);
+        let amount = U256::from(1_000_000u64);
+        let tx_hash = b256!(
+            "0x8888888888888888888888888888888888888888888888888888888888888888"
+        );
+
+        let minted_log = |log_amount: U256, log_nonce: B256| {
+            let minted_event = IST0xOrchestratorV1::Minted {
+                caller: address!("2222222222222222222222222222222222222222"),
+                token: test_vault_address(),
+                to: recipient,
+                amount: log_amount,
+                nonce: log_nonce,
+            };
+            vec![alloy::rpc::types::Log {
+                inner: alloy::primitives::Log {
+                    address: test_orchestrator_address(),
+                    data: minted_event.into_log_data(),
+                },
+                block_hash: None,
+                block_number: Some(0x9c4),
+                block_timestamp: None,
+                transaction_hash: Some(tx_hash),
+                transaction_index: Some(0),
+                log_index: Some(0),
+                removed: false,
+            }]
+        };
+
+        let query = MintedLogQuery {
+            orchestrator: test_orchestrator_address(),
+            to: recipient,
+            nonce,
+            token: test_vault_address(),
+            amount,
+            lookback_blocks: None,
+        };
+        let asserter = Asserter::new();
+        asserter.push_success(&100u64); // eth_blockNumber
+        asserter.push_success(&minted_log(amount, nonce)); // eth_getLogs
+        let service = create_service_with_asserter(asserter);
+        let found = service
+            .find_orchestrator_minted_log(query)
+            .await
+            .expect("log query must succeed");
+        assert_eq!(
+            found,
+            MintedLogScan::FullMatch(OrchestratorMintedLog {
+                tx_hash,
+                nonce,
+                shares_minted: amount,
+                block_number: 0x9c4,
+            })
+        );
+
+        // Same (to, nonce), different amount: the pair's one landing belongs
+        // to a DIFFERENT mint — the proven `Mismatch` verdict, never
+        // conflated with an empty scan.
+        let asserter = Asserter::new();
+        asserter.push_success(&100u64); // eth_blockNumber
+        asserter.push_success(&minted_log(U256::from(999u64), nonce));
+        let service = create_service_with_asserter(asserter);
+        let found = service
+            .find_orchestrator_minted_log(query)
+            .await
+            .expect("log query must succeed");
+        assert_eq!(
+            found,
+            MintedLogScan::Mismatch,
+            "an amount mismatch at the pair must be the proven verdict"
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &["disagrees on token/amount", "landed_amount=999",]
+        ));
+
+        // Different nonce entirely: nothing at the queried pair.
+        let asserter = Asserter::new();
+        asserter.push_success(&100u64); // eth_blockNumber
+        asserter.push_success(&minted_log(amount, B256::repeat_byte(0x08)));
+        let service = create_service_with_asserter(asserter);
+        let found = service
+            .find_orchestrator_minted_log(query)
+            .await
+            .expect("log query must succeed");
+        assert_eq!(found, MintedLogScan::NotFound);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "No Minted log at (to, nonce) within the lookback window",
+                // head 100 minus the 32-block confirmation ceiling => 68,
+                // floor 0 => 69 scanned blocks.
+                "scanned_blocks=69"
+            ]
+        ));
+    }
+
+    /// A landing at the queried `(to, nonce)` under a DIFFERENT token is the
+    /// proven `Mismatch` verdict. This is exactly why the scan must not
+    /// topic-filter on `token`: filtered, this log would never be returned
+    /// and the provable mismatch would degrade into an inconclusive
+    /// `NotFound`.
+    #[traced_test]
+    #[tokio::test]
+    async fn find_orchestrator_minted_log_reports_other_token_as_mismatch() {
+        let recipient = test_receiver();
+        let nonce = B256::repeat_byte(0x07);
+        let amount = U256::from(1_000_000u64);
+
+        let minted_event = IST0xOrchestratorV1::Minted {
+            caller: address!("2222222222222222222222222222222222222222"),
+            token: address!("0x9999999999999999999999999999999999999999"),
+            to: recipient,
+            amount,
+            nonce,
+        };
+        let other_token_log = vec![alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: test_orchestrator_address(),
+                data: minted_event.into_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(0x9c4),
+            block_timestamp: None,
+            transaction_hash: Some(b256!(
+                "0x8888888888888888888888888888888888888888888888888888888888888888"
+            )),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }];
+
+        let asserter = Asserter::new();
+        asserter.push_success(&100u64); // eth_blockNumber
+        asserter.push_success(&other_token_log); // eth_getLogs
+        let service = create_service_with_asserter(asserter);
+        let found = service
+            .find_orchestrator_minted_log(MintedLogQuery {
+                orchestrator: test_orchestrator_address(),
+                to: recipient,
+                nonce,
+                token: test_vault_address(),
+                amount,
+                lookback_blocks: None,
+            })
+            .await
+            .expect("log query must succeed");
+
+        assert_eq!(
+            found,
+            MintedLogScan::Mismatch,
+            "a different-token landing at the pair must be the proven \
+             mismatch verdict"
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &["disagrees on token/amount", "landed_token=0x9999"]
+        ));
+    }
+
+    /// `lookback_blocks` overrides the scan's backward window —
+    /// reconciliation of an inconclusive replay re-queries wider than the
+    /// default recovery-timeline window.
+    #[traced_test]
+    #[tokio::test]
+    async fn find_orchestrator_minted_log_honors_lookback_override() {
+        let asserter = Asserter::new();
+        asserter.push_success(&100u64); // eth_blockNumber
+        asserter.push_success(&Vec::<alloy::rpc::types::Log>::new());
+        let service = create_service_with_asserter(asserter);
+
+        let found = service
+            .find_orchestrator_minted_log(MintedLogQuery {
+                orchestrator: test_orchestrator_address(),
+                to: test_receiver(),
+                nonce: B256::repeat_byte(0x07),
+                token: test_vault_address(),
+                amount: U256::from(1_000_000u64),
+                lookback_blocks: Some(10),
+            })
+            .await
+            .expect("log query must succeed");
+
+        assert_eq!(found, MintedLogScan::NotFound);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "No Minted log at (to, nonce) within the lookback window",
+                // head 100 minus the 32-block ceiling => 68; floor
+                // 68 - 10 = 58 => 11 scanned blocks, not the default window.
+                "scanned_blocks=11"
+            ]
+        ));
+    }
+
+    /// `find_orchestrator_minted_log` filters with `to` as topic3 (and
+    /// deliberately NOT `token`, so a different-token landing at the same
+    /// `(to, nonce)` stays visible as the `Mismatch` verdict), which is only
+    /// correct while the ABI indexes exactly `(caller, token, to)` in that
+    /// order. The mocked provider cannot catch a wrong topic position (it
+    /// returns the pushed logs regardless of the filter), so pin the
+    /// ABI-generated topic layout the runtime filter must line up with — a
+    /// reordering or de-indexing in the contract ABI fails here instead of
+    /// silently never matching on-chain.
+    #[test]
+    fn minted_event_indexes_token_and_to_as_topics_2_and_3() {
+        let caller = address!("0x1111111111111111111111111111111111111111");
+        let token = address!("0x2222222222222222222222222222222222222222");
+        let to = address!("0x3333333333333333333333333333333333333333");
+
+        let log_data = IST0xOrchestratorV1::Minted {
+            caller,
+            token,
+            to,
+            amount: U256::from(1u8),
+            nonce: B256::repeat_byte(0x07),
+        }
+        .into_log_data();
+
+        let topics = log_data.topics();
+        assert_eq!(
+            topics.len(),
+            4,
+            "Minted must index exactly three parameters"
+        );
+        assert_eq!(topics[0], IST0xOrchestratorV1::Minted::SIGNATURE_HASH);
+        assert_eq!(topics[1], caller.into_word(), "caller must be topic1");
+        assert_eq!(topics[2], token.into_word(), "token must be topic2");
+        assert_eq!(topics[3], to.into_word(), "to must be topic3");
+    }
+
+    /// The `Minted`-log scan walks backward from the head in bounded chunks
+    /// (providers cap `eth_getLogs` ranges) and keeps going past an empty
+    /// chunk until it finds the match in an older one.
+    #[tokio::test]
+    async fn find_orchestrator_minted_log_walks_chunks_backward() {
+        let recipient = test_receiver();
+        let nonce = B256::repeat_byte(0x07);
+        let amount = U256::from(1_000_000u64);
+        let tx_hash = b256!(
+            "0x8888888888888888888888888888888888888888888888888888888888888888"
+        );
+
+        let minted_event = IST0xOrchestratorV1::Minted {
+            caller: address!("2222222222222222222222222222222222222222"),
+            token: test_vault_address(),
+            to: recipient,
+            amount,
+            nonce,
+        };
+        let older_chunk_logs = vec![alloy::rpc::types::Log {
+            inner: alloy::primitives::Log {
+                address: test_orchestrator_address(),
+                data: minted_event.into_log_data(),
+            },
+            block_hash: None,
+            block_number: Some(500),
+            block_timestamp: None,
+            transaction_hash: Some(tx_hash),
+            transaction_index: Some(0),
+            log_index: Some(0),
+            removed: false,
+        }];
+
+        // Head 3000 spans two 2000-block chunks: [1001..3000] (empty) then
+        // [0..1000] (the landing).
+        let asserter = Asserter::new();
+        asserter.push_success(&3000u64); // eth_blockNumber
+        asserter.push_success(&Vec::<alloy::rpc::types::Log>::new());
+        asserter.push_success(&older_chunk_logs);
+        let service = create_service_with_asserter(asserter);
+
+        let found = service
+            .find_orchestrator_minted_log(MintedLogQuery {
+                orchestrator: test_orchestrator_address(),
+                to: recipient,
+                nonce,
+                token: test_vault_address(),
+                amount,
+                lookback_blocks: None,
+            })
+            .await
+            .expect("log query must succeed");
+        assert_eq!(
+            found,
+            MintedLogScan::FullMatch(OrchestratorMintedLog {
+                tx_hash,
+                nonce,
+                shares_minted: amount,
+                block_number: 500,
+            })
+        );
     }
 }

--- a/tests/orchestrator_redemption.rs
+++ b/tests/orchestrator_redemption.rs
@@ -163,26 +163,19 @@ async fn wait_for_recovery_to_resolve(
     }
 }
 
-/// Fetches `GET /admin/orchestrator-health`, failing loudly on a non-OK
-/// status so a broken endpoint can never read as "healthy".
-async fn fetch_orchestrator_health(client: &Client) -> serde_json::Value {
-    authenticated_get_json(client, "/admin/orchestrator-health").await
-}
-
-/// Seeded history for a control redemption: a classified `BurnFailed`
-/// (`AllowanceInsufficient`) the reconciler provably never resolves — typed
-/// classifications are never auto-retried. Its persistent `/admin/stuck`
-/// entry proves the seeds replay and the stuck surfacing works, so a target
-/// redemption's absence in the same snapshot is positive evidence of
-/// recovery (see `wait_for_recovery_to_resolve`).
+/// Event stream for a control redemption parked in a classified
+/// `BurnFailed` — a state recovery provably never resolves (the reconciler
+/// skips typed classifications) — seeded alongside a recovery target so the
+/// absence-based assertion in [`wait_for_recovery_to_resolve`] is
+/// non-vacuous.
 fn classified_control_events(
     control_id: &str,
     control_tx_hash: B256,
     orchestrator_address: Address,
     user_wallet: Address,
     old: &str,
-) -> [(&'static str, serde_json::Value); 4] {
-    [
+) -> Vec<(&'static str, serde_json::Value)> {
+    vec![
         (
             "RedemptionEvent::Detected",
             json!({
@@ -236,6 +229,12 @@ fn classified_control_events(
             }),
         ),
     ]
+}
+
+/// Fetches `GET /admin/orchestrator-health`, failing loudly on a non-OK
+/// status so a broken endpoint can never read as "healthy".
+async fn fetch_orchestrator_health(client: &Client) -> serde_json::Value {
+    authenticated_get_json(client, "/admin/orchestrator-health").await
 }
 
 /// A burn spanning multiple orchestrator-custodied receipts: three separate
@@ -565,7 +564,7 @@ async fn orchestrator_recovery_confirms_landed_burn_without_resubmitting()
     let pool =
         SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
     for (aggregate_id, aggregate_events) in
-        [(&issuer_request_id, &events), (&control_id, &control_events)]
+        [(&issuer_request_id, &events[..]), (&control_id, &control_events[..])]
     {
         for (sequence, (event_type, payload)) in
             (1i64..).zip(aggregate_events.iter())
@@ -695,6 +694,8 @@ async fn orchestrator_crash_recovery_confirms_in_flight_burn_failed()
     let user_wallet =
         PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?.address();
 
+    // Control redemption making the absence assertion below non-vacuous —
+    // see `wait_for_recovery_to_resolve`.
     let control_tx_hash = B256::random();
     let control_id = format!("{control_tx_hash:#x}");
     let control_events = classified_control_events(
@@ -763,7 +764,7 @@ async fn orchestrator_crash_recovery_confirms_in_flight_burn_failed()
     let pool =
         SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?;
     for (aggregate_id, aggregate_events) in
-        [(&issuer_request_id, &events), (&control_id, &control_events)]
+        [(&issuer_request_id, &events[..]), (&control_id, &control_events[..])]
     {
         for (sequence, (event_type, payload)) in
             (1i64..).zip(aggregate_events.iter())
@@ -803,8 +804,8 @@ async fn orchestrator_crash_recovery_confirms_in_flight_burn_failed()
 
     // Startup recovery confirms the landed burn: the redemption leaves the
     // recoverable states and no longer surfaces in /admin/stuck — while the
-    // unresolvable control still does, proving the absence is recovery's
-    // doing rather than a seed that never replayed.
+    // unresolvable control redemption still does, proving the absence is
+    // recovery's doing rather than a seed that never replayed.
     wait_for_recovery_to_resolve(&client, &issuer_request_id, &control_id)
         .await?;
 


### PR DESCRIPTION
## Motivation

The orchestrator contract supports a `mint()` path that is distinct from vault-direct deposits: it asserts 1:1 share minting on-chain, keeps the receipt, and forwards ERC-20 shares directly to the recipient. The service layer had no support for preparing, confirming, or recovering orchestrator mints, and there was no validation path for the recipient-produced `MintAuthV1` authorization that the orchestrator requires before it will execute a mint.

Additionally, the mint-side revert reasons (`NonceReplayed`, `BadRecipientSignature`, `RecipientCallbackRejected`, `VaultAmountMismatch`) were absent from `OrchestratorRevertReason`, meaning a reverted mint transaction could not be classified and the burn failure classifier would panic on an incomplete match.

## Solution

Four new `VaultService` methods are introduced:

- `prepare_orchestrator_mint_tx` — builds and signs the `ST0xOrchestrator.mint(token, to, amount, auth, receiptInformation)` transaction without broadcasting it. The calldata carries exactly the signed `(token, to, amount, nonce)` from the authorization; there is no `previewDeposit` and no multicall.
- `confirm_orchestrator_mint` — waits for the transaction receipt, parses the `Minted` event, and on a mined-but-reverted transaction replays it as an `eth_call` to decode the typed revert reason.
- `find_orchestrator_minted_log` — queries `Minted` logs filtered by `(token, to)` and full-matches `(to, nonce, token, amount)`. A bare `(to, nonce)` hit whose token or amount differs is explicitly not a match, since the on-chain uniqueness key is only `(to, nonce)` and a partial hit means a different mint consumed the nonce.
- `validate_mint_authorization` — checks the consumed-nonce flag first, then for a non-empty signature recovers the signer via ECDSA (EOA) or ERC-1271 `isValidSignature` (contract recipient). An empty signature skips recovery entirely, covering the future bridge/`IMintRecipient` path where the recipient authorizes via the orchestrator's `authorizeMint` callback.

The `OrchestratorRevertReason` enum gains `NonceReplayed`, `BadRecipientSignature`, `RecipientCallbackRejected`, and `VaultAmountMismatch`. The burn failure classifier's `match` is updated to explicitly route all mint-side variants to `Unclassified`, with a comment explaining they cannot arise from a burn. Three new `VaultError` variants are added: `MintAuthSignerMismatch`, `MintAuthNonceUsed`, and `MintAuthRejectedByContract`. The `IERC1271` ABI binding is wired in for the ERC-1271 contract-recipient path.

The mock service is extended with full implementations of all four methods, configurable failure injection (`with_orchestrator_mint_confirm_revert`, `with_mint_auth_failure`, `with_minted_log`, `with_orchestrator_mint_result`), call counters, and `reset()` coverage for all new state.  
  
Closes [RAI-1615](https://linear.app/makeitrain/issue/RAI-1615/orchestrator-mint-preparation-confirmation-and-authorization)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Added support for orchestrator-driven minting, including transaction preparation, confirmation, minted-log recovery, and tracking mint results (nonce, amount, shares, gas, block, tx identifiers).
    - Added recipient authorization verification via signatures, including ERC-1271 contract wallet support.
- **Bug Fixes**
    - Expanded typed revert decoding and failure classification for mint scenarios (replayed nonces, invalid recipient signatures, rejected callbacks, amount mismatches) and burn-side edge cases.
- **Tests**
    - Added extensive unit-test coverage for the full mint lifecycle and log/authorization matching semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->