### PR TITLE
feat: orchestrator mint authorization endpoint (RAI-1243)

### DIFF
--- a/migrations/20260728234143_create_mint_view_tokenization_lookup_index.sql
+++ b/migrations/20260728234143_create_mint_view_tokenization_lookup_index.sql
@@ -1,0 +1,19 @@
+-- Expression index for the tokenization-request-id -> issuer-request-id
+-- lookup on the internal mint-authorization path. A mint is in exactly one
+-- lifecycle state, so at most one of these payload paths is non-null and
+-- COALESCE over them is the mint's tokenization id regardless of state
+-- (`Closed` carries none and stays out of the lookup by design). The query
+-- in `find_issuer_id_by_tokenization_request_id` uses this exact expression
+-- so SQLite can serve it from the index instead of scanning the table.
+CREATE INDEX IF NOT EXISTS idx_mint_view_live_tokenization_request_id
+    ON mint_view(COALESCE(
+        json_extract(payload, '$.Live.Initiated.tokenization_request_id'),
+        json_extract(payload, '$.Live.JournalConfirmed.tokenization_request_id'),
+        json_extract(payload, '$.Live.JournalRejected.tokenization_request_id'),
+        json_extract(payload, '$.Live.Minting.tokenization_request_id'),
+        json_extract(payload, '$.Live.TxIntended.tokenization_request_id'),
+        json_extract(payload, '$.Live.TxSubmitted.tokenization_request_id'),
+        json_extract(payload, '$.Live.CallbackPending.tokenization_request_id'),
+        json_extract(payload, '$.Live.MintingFailed.tokenization_request_id'),
+        json_extract(payload, '$.Live.Completed.tokenization_request_id')
+    ));

--- a/src/burn_excess/engine.rs
+++ b/src/burn_excess/engine.rs
@@ -1599,7 +1599,6 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
-    use crate::Quantity;
     use crate::account::ClientId;
     use crate::bindings::OffchainAssetReceiptVault;
     use crate::burn_excess::exclusion::is_excluded_funding_log;
@@ -1620,6 +1619,7 @@ mod tests {
     use crate::vault::{
         BurnTxStatus, MultiBurnResult, MultiBurnResultEntry, SendableTxWithHash,
     };
+    use crate::{Quantity, VaultMode};
 
     const TEST_OA_SCHEMA: &str =
         "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
@@ -1693,6 +1693,7 @@ mod tests {
             client_id: ClientId::new(),
             wallet: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
             initiated_at: Utc::now(),
+            mint_mode: VaultMode::VaultDirect,
         };
         sqlx::query(
             "

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -580,6 +580,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
                 tokenized_asset::add_tokenized_asset,
                 mint::initiate_mint,
                 mint::confirm_journal,
+                mint::authorize_mint,
                 admin::recover_redemption,
                 admin::close_redemption,
                 admin::force_complete_redemption,

--- a/src/mint/api/authorize.rs
+++ b/src/mint/api/authorize.rs
@@ -1,0 +1,1001 @@
+use alloy::primitives::{B256, Bytes};
+use cqrs_es::AggregateError;
+use event_sorcery::{LifecycleError, Store};
+use rocket::http::{ContentType, Status};
+use rocket::post;
+use rocket::response::{self, Responder};
+use rocket::serde::json::Json;
+use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Sqlite};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::time::timeout;
+use tracing::{error, info, warn};
+
+use super::ErrorResponse;
+use crate::auth::InternalAuth;
+use crate::config::VaultMode;
+use crate::mint::view::find_issuer_id_by_tokenization_request_id;
+use crate::mint::{
+    IssuerMintRequestId, Mint, MintCommand, MintError, TokenizationRequestId,
+};
+use crate::tokenized_asset::view::find_vault;
+use crate::vault::{
+    MintAuthorization, MintedLogQuery, NetworkVaultServices, VaultError,
+};
+
+/// Wire shape of the liquidity bot's mint-authorization delivery
+/// (RAI-1243). The signature is opaque bytes; `"0x"` (empty) is valid input
+/// for recipients authorized via the orchestrator's `authorizeMint`
+/// callback.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub(crate) struct MintAuthorizationRequest {
+    /// Recipient-chosen random 32-byte nonce, hex-encoded.
+    #[schema(value_type = String)]
+    pub(crate) nonce: B256,
+    /// EIP-712 `MintAuthV1` signature over `(token, to, amount, nonce)` by
+    /// the recipient wallet key, hex-encoded; may be `"0x"`.
+    #[schema(value_type = String)]
+    pub(crate) signature: Bytes,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub(crate) struct MintAuthorizationResponse {
+    #[schema(value_type = String)]
+    pub(crate) issuer_request_id: IssuerMintRequestId,
+    pub(crate) status: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum MintAuthorizationApiError {
+    #[error("No mint found for tokenization request {0}")]
+    UnknownTokenizationRequest(TokenizationRequestId),
+
+    #[error("Mint {0} is vault-direct; it never consumes an authorization")]
+    VaultDirectMint(TokenizationRequestId),
+
+    #[error("Authorization not acceptable: mint is in state {0}")]
+    NotAcceptable(String),
+
+    #[error("A different authorization is already recorded for this mint")]
+    ConflictingAuthorization,
+
+    #[error("The mint was modified concurrently; retry the delivery")]
+    DeliveryRace,
+
+    #[error("Invalid authorization: {0}")]
+    InvalidAuthorization(VaultError),
+
+    #[error("On-chain validation failed: {0}")]
+    OnChainValidationFailed(VaultError),
+
+    #[error("On-chain validation timed out")]
+    OnChainValidationTimedOut,
+
+    #[error("Internal error")]
+    Internal,
+}
+
+/// Upper bound on the on-chain reads validating one authorization (up to
+/// four sequential RPCs: `nonceUsed`, `mintAuthDigest`, `eth_getCode`, and
+/// ERC-1271 `isValidSignature`). The HTTP provider has no request timeout of
+/// its own, so without this deadline an unresponsive RPC node would hold the
+/// liquidity bot's delivery request open indefinitely.
+#[cfg(not(test))]
+const ON_CHAIN_VALIDATION_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Unit tests hang the mock validation forever to exercise the deadline; a
+/// millisecond-scale bound keeps that test fast in real time. A paused
+/// tokio clock is not an option here — auto-advance also fires sqlx's
+/// pool-acquire timers, failing the request with `PoolTimedOut` before
+/// validation is ever reached whenever an acquire has to wait.
+#[cfg(test)]
+const ON_CHAIN_VALIDATION_TIMEOUT: Duration = Duration::from_millis(50);
+
+impl<'r> Responder<'r, 'static> for MintAuthorizationApiError {
+    fn respond_to(
+        self,
+        _req: &'r rocket::Request<'_>,
+    ) -> response::Result<'static> {
+        let (status, message) = match &self {
+            Self::UnknownTokenizationRequest(_) => {
+                (Status::NotFound, self.to_string())
+            }
+            Self::VaultDirectMint(_) | Self::InvalidAuthorization(_) => {
+                (Status::UnprocessableEntity, self.to_string())
+            }
+            Self::NotAcceptable(_)
+            | Self::ConflictingAuthorization
+            | Self::DeliveryRace => (Status::Conflict, self.to_string()),
+            // Unlike the deliberately descriptive 422s, the read-failure
+            // body stays generic: the underlying `VaultError` can carry
+            // transport/provider detail (RPC endpoints, connection errors)
+            // that must not leave the process. The full error is already
+            // ERROR-logged where this variant is constructed.
+            Self::OnChainValidationFailed(_)
+            | Self::OnChainValidationTimedOut => (
+                Status::BadGateway,
+                "On-chain validation is currently unavailable".to_string(),
+            ),
+            Self::Internal => (
+                Status::InternalServerError,
+                "Internal server error".to_string(),
+            ),
+        };
+
+        let body = serde_json::to_string(&ErrorResponse { error: message })
+            .map_err(|_| Status::InternalServerError)?;
+        rocket::Response::build()
+            .status(status)
+            .header(ContentType::JSON)
+            .sized_body(body.len(), std::io::Cursor::new(body))
+            .ok()
+    }
+}
+
+/// Receives the liquidity bot's `MintAuthV1` for one orchestrator-mode mint,
+/// validates it on-chain against the mint's own persisted facts
+/// (`token`, `to`, `amount` — the bot MUST mint with exactly the signed
+/// values), and records it on the aggregate. Delivered out-of-band from the
+/// Alpaca flow: Alpaca cannot carry the authorization, so it arrives on the
+/// same internal channel the liquidity bot already uses for the asset-status
+/// endpoint.
+#[utoipa::path(
+    post,
+    path = "/internal/mints/{tokenization_request_id}/authorization",
+    tag = "internal",
+    params(
+        ("tokenization_request_id" = String, Path,
+            description = "Alpaca tokenization request id the mint was initiated with")
+    ),
+    request_body = MintAuthorizationRequest,
+    responses(
+        (status = 200, description = "Authorization validated and recorded (idempotent)",
+            body = MintAuthorizationResponse),
+        (status = 404, description = "No mint for this tokenization request"),
+        (status = 409,
+            description = "Conflicting authorization, or the mint already signed its transaction"),
+        (status = 422,
+            description = "Vault-direct mint, invalid or malformed signer, \
+                empty signature for an EOA recipient, or consumed nonce"),
+        (status = 502, description = "On-chain validation read failure")
+    ),
+    security(("internal_api_key" = []))
+)]
+#[tracing::instrument(skip(_auth, mint_store, pool, vault_services, request))]
+#[post(
+    "/internal/mints/<tokenization_request_id>/authorization",
+    format = "json",
+    data = "<request>"
+)]
+pub(crate) async fn authorize_mint(
+    _auth: InternalAuth,
+    tokenization_request_id: &str,
+    mint_store: &rocket::State<Arc<Store<Mint>>>,
+    pool: &rocket::State<Pool<Sqlite>>,
+    vault_services: &rocket::State<NetworkVaultServices>,
+    request: Json<MintAuthorizationRequest>,
+) -> Result<Json<MintAuthorizationResponse>, MintAuthorizationApiError> {
+    let tokenization_request_id =
+        TokenizationRequestId(tokenization_request_id.to_string());
+    let request = request.into_inner();
+
+    let issuer_request_id = find_issuer_id_by_tokenization_request_id(
+        pool.inner(),
+        &tokenization_request_id,
+    )
+    .await
+    .map_err(|err| {
+        error!(target: "mint", error = %err,
+            "Failed to look up mint by tokenization request id"
+        );
+        MintAuthorizationApiError::Internal
+    })?
+    .ok_or_else(|| {
+        warn!(target: "mint",
+            tokenization_request_id = %tokenization_request_id,
+            "Authorization delivered for an unknown tokenization request"
+        );
+        MintAuthorizationApiError::UnknownTokenizationRequest(
+            tokenization_request_id.clone(),
+        )
+    })?;
+
+    let mint = mint_store
+        .load(&issuer_request_id)
+        .await
+        .map_err(|err| {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %err, "Failed to load mint aggregate"
+            );
+            MintAuthorizationApiError::Internal
+        })?
+        .ok_or_else(|| {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                "Mint aggregate missing for known tokenization request"
+            );
+            MintAuthorizationApiError::Internal
+        })?;
+
+    // A mint with no live mode (`Closed`) is not a vault-direct mint — it
+    // cannot accept an authorization in any mode, so it must not take the
+    // vault-direct rejection below with its untrue cause.
+    let Some(mode) = mint.mint_mode() else {
+        return Err(MintAuthorizationApiError::NotAcceptable(
+            mint.state_name().to_string(),
+        ));
+    };
+
+    // The orchestrator address comes from the mint's own persisted
+    // `mint_mode` anchor — never live config. A vault-direct mint has no
+    // orchestrator to validate against and never consumes an authorization.
+    let VaultMode::Orchestrator { address: orchestrator } = mode else {
+        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+            "Authorization delivered for a vault-direct mint; rejecting"
+        );
+        return Err(MintAuthorizationApiError::VaultDirectMint(
+            tokenization_request_id.clone(),
+        ));
+    };
+
+    let (Some(network), Some(underlying), Some(to), Some(quantity)) =
+        (mint.network(), mint.underlying(), mint.wallet(), mint.quantity())
+    else {
+        return Err(MintAuthorizationApiError::NotAcceptable(
+            mint.state_name().to_string(),
+        ));
+    };
+
+    let amount = quantity.to_u256_with_18_decimals().map_err(|err| {
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = %err, "Persisted mint quantity failed share conversion"
+        );
+        MintAuthorizationApiError::Internal
+    })?;
+
+    let vault = find_vault(pool.inner(), underlying, &network)
+        .await
+        .map_err(|err| {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %err, "Vault lookup failed"
+            );
+            MintAuthorizationApiError::Internal
+        })?
+        .ok_or_else(|| {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                underlying = %underlying.as_str(),
+                "No vault for the mint's asset"
+            );
+            MintAuthorizationApiError::Internal
+        })?;
+
+    let vault_service = vault_services.service(network).map_err(|err| {
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = %err,
+            "No vault service for the mint's network"
+        );
+        MintAuthorizationApiError::Internal
+    })?;
+
+    let authorization = MintAuthorization {
+        nonce: request.nonce,
+        signature: request.signature,
+    };
+
+    // An identical redelivery is the common retry case (a delivery whose
+    // response was lost): answer from the recorded state without re-running
+    // the on-chain validation — the recorded authorization already passed
+    // it, and re-validating burns up to four RPC reads per retry.
+    if mint.accepts_mint_authorization()
+        && mint.mint_authorization() == Some(&authorization)
+    {
+        info!(target: "mint", issuer_request_id = %issuer_request_id,
+            tokenization_request_id = %tokenization_request_id,
+            "Identical mint authorization already recorded; redelivery is a \
+             no-op"
+        );
+        return Ok(Json(MintAuthorizationResponse {
+            issuer_request_id,
+            status: "authorized".to_string(),
+        }));
+    }
+
+    // Validate on receipt so a bad delivery is an actionable failure on this
+    // internal call, not a post-journal surprise at the on-chain step.
+    timeout(
+        ON_CHAIN_VALIDATION_TIMEOUT,
+        vault_service.validate_mint_authorization(
+            MintedLogQuery {
+                orchestrator,
+                token: vault,
+                to,
+                amount,
+                nonce: authorization.nonce,
+                // Validation reads on-chain state and never scans logs.
+                lookback_blocks: None,
+            },
+            &authorization,
+        ),
+    )
+    .await
+    .map_err(|_| {
+        error!(target: "mint", issuer_request_id = %issuer_request_id,
+            timeout_secs = ON_CHAIN_VALIDATION_TIMEOUT.as_secs(),
+            "On-chain mint-authorization validation timed out"
+        );
+        MintAuthorizationApiError::OnChainValidationTimedOut
+    })?
+    .map_err(|err| match &err {
+        VaultError::MintAuthSignerMismatch { .. }
+        | VaultError::MintAuthNonceUsed { .. }
+        | VaultError::MintAuthRejectedByContract { .. }
+        | VaultError::MintAuthEmptySignatureForEoa { .. }
+        | VaultError::Signature(_) => {
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %err, "Rejected invalid mint authorization"
+            );
+            MintAuthorizationApiError::InvalidAuthorization(err)
+        }
+        _ => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %err,
+                "On-chain mint-authorization validation failed"
+            );
+            MintAuthorizationApiError::OnChainValidationFailed(err)
+        }
+    })?;
+
+    mint_store
+        .send(
+            &issuer_request_id,
+            MintCommand::AuthorizeMint {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: authorization,
+            },
+        )
+        .await
+        .map_err(|err| {
+            map_authorize_command_error(
+                &issuer_request_id,
+                &tokenization_request_id,
+                &err,
+            )
+        })?;
+
+    info!(target: "mint", issuer_request_id = %issuer_request_id,
+        tokenization_request_id = %tokenization_request_id,
+        "Mint authorization validated and recorded"
+    );
+
+    Ok(Json(MintAuthorizationResponse {
+        issuer_request_id,
+        status: "authorized".to_string(),
+    }))
+}
+
+fn map_authorize_command_error(
+    issuer_request_id: &IssuerMintRequestId,
+    tokenization_request_id: &TokenizationRequestId,
+    error: &AggregateError<LifecycleError<Mint>>,
+) -> MintAuthorizationApiError {
+    // A lost optimistic-lock race is the bot's cue to retry, not a server
+    // fault — map it to 409 like the sibling endpoints do.
+    if matches!(error, AggregateError::AggregateConflict) {
+        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+            "Concurrent mint modification during authorization delivery"
+        );
+        return MintAuthorizationApiError::DeliveryRace;
+    }
+
+    if let AggregateError::UserError(LifecycleError::Apply(mint_error)) = error
+    {
+        match mint_error {
+            MintError::AuthorizationForVaultDirectAsset { .. } => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    "Authorization rejected for vault-direct mint"
+                );
+                // The wire error names the tokenization id — the only mint
+                // identifier the caller supplied and can correlate on — the
+                // same id the endpoint's own mode-anchor rejection reports.
+                return MintAuthorizationApiError::VaultDirectMint(
+                    tokenization_request_id.clone(),
+                );
+            }
+            MintError::ConflictingMintAuthorization => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    "Conflicting mint authorization rejected"
+                );
+                return MintAuthorizationApiError::ConflictingAuthorization;
+            }
+            MintError::AuthorizationNotAcceptable { current_state } => {
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    current_state = %current_state,
+                    "Authorization rejected: mint state does not accept one"
+                );
+                return MintAuthorizationApiError::NotAcceptable(
+                    current_state.clone(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    error!(target: "mint", issuer_request_id = %issuer_request_id,
+        error = %error, "Failed to record mint authorization"
+    );
+    MintAuthorizationApiError::Internal
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, B256, Bytes, address};
+    use rocket::http::{ContentType, Header, Status};
+    use rocket::routes;
+    use rust_decimal::Decimal;
+    use std::sync::Arc;
+    use tracing_test::traced_test;
+
+    use super::authorize_mint;
+    use crate::auth::FailedAuthRateLimiter;
+    use crate::config::VaultMode;
+    use crate::mint::api::test_utils::{TestHarness, test_config};
+    use crate::mint::{
+        ClientId, IssuerMintRequestId, Mint, MintCommand, Network, Quantity,
+        TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+    };
+    use crate::test_utils::{ANVIL_CHAIN_ID, logs_contain_at};
+    use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
+    use crate::vault::mock::{MockMintAuthFailure, MockVaultService};
+    use crate::vault::{
+        MintAuthorization, NetworkVaultServices, PreparedMintTx, VaultService,
+    };
+
+    const ORCHESTRATOR: Address =
+        address!("0x00000000000000000000000000000000000000aa");
+    const RECIPIENT: Address =
+        address!("0x1234567890abcdef1234567890abcdef12345678");
+    const API_KEY: &str = "test-key-12345678901234567890123456";
+
+    async fn seed_mint(
+        harness: &TestHarness,
+        tokenization_request_id: &str,
+        mint_mode: VaultMode,
+    ) -> IssuerMintRequestId {
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        let network = Network::Base;
+        let vault = address!("0x9999999999999999999999999999999999999999");
+        // Adding twice is idempotent per test DB; ignore the duplicate error
+        // when a test seeds two mints for the same asset.
+        let _ = harness
+            .asset_store
+            .send(
+                &AssetKey::new(underlying.clone(), network),
+                TokenizedAssetCommand::Add {
+                    underlying: underlying.clone(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network,
+                    vault,
+                },
+            )
+            .await;
+
+        let issuer_request_id = IssuerMintRequestId::random();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Initiate {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: TokenizationRequestId::new(
+                        tokenization_request_id,
+                    ),
+                    quantity: Quantity::new(Decimal::from(100)),
+                    underlying,
+                    token: TokenSymbol::new("tAAPL"),
+                    network,
+                    client_id: ClientId::new(),
+                    wallet: RECIPIENT,
+                    mint_mode,
+                },
+            )
+            .await
+            .expect("mint must initiate");
+        issuer_request_id
+    }
+
+    fn authorization_rocket(
+        harness: &TestHarness,
+        vault_mock: Arc<dyn VaultService>,
+    ) -> rocket::Rocket<rocket::Build> {
+        let vault_services = NetworkVaultServices::with_single_vault(
+            Network::Base,
+            ANVIL_CHAIN_ID,
+            vault_mock,
+        );
+        rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(harness.mint_store.clone())
+            .manage(harness.pool.clone())
+            .manage(vault_services)
+            .mount("/", routes![authorize_mint])
+    }
+
+    /// Delivers an authorization with the internal API key attached — the
+    /// authenticated shape every test but the auth-rejection one uses.
+    async fn deliver<'client>(
+        client: &'client rocket::local::asynchronous::Client,
+        tokenization_request_id: &str,
+        nonce: B256,
+        signature: &str,
+    ) -> rocket::local::asynchronous::LocalResponse<'client> {
+        delivery_request(client, tokenization_request_id, nonce, signature)
+            .header(Header::new("X-API-KEY", API_KEY))
+            .dispatch()
+            .await
+    }
+
+    /// Delivers an authorization WITHOUT the API key, for asserting the
+    /// authentication rejection.
+    async fn deliver_without_key<'client>(
+        client: &'client rocket::local::asynchronous::Client,
+        tokenization_request_id: &str,
+        nonce: B256,
+        signature: &str,
+    ) -> rocket::local::asynchronous::LocalResponse<'client> {
+        delivery_request(client, tokenization_request_id, nonce, signature)
+            .dispatch()
+            .await
+    }
+
+    fn delivery_request<'client>(
+        client: &'client rocket::local::asynchronous::Client,
+        tokenization_request_id: &str,
+        nonce: B256,
+        signature: &str,
+    ) -> rocket::local::asynchronous::LocalRequest<'client> {
+        client
+            .post(format!(
+                "/internal/mints/{tokenization_request_id}/authorization"
+            ))
+            .header(ContentType::JSON)
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(
+                serde_json::json!({
+                    "nonce": nonce,
+                    "signature": signature,
+                })
+                .to_string(),
+            )
+    }
+
+    /// A valid delivery (including an EMPTY "0x" signature — the bridge
+    /// recipient shape) is validated, recorded, and idempotent on redelivery.
+    #[traced_test]
+    #[tokio::test]
+    async fn records_valid_authorization_and_redelivery_is_idempotent() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = seed_mint(
+            &harness,
+            "tok-auth-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let nonce = B256::repeat_byte(0x07);
+        for _ in 0..2 {
+            let response = deliver(&client, "tok-auth-1", nonce, "0x").await;
+            assert_eq!(response.status(), Status::Ok);
+            let body: serde_json::Value =
+                response.into_json().await.expect("response must be JSON");
+            assert_eq!(
+                body["issuer_request_id"],
+                issuer_request_id.to_string()
+            );
+            assert_eq!(body["status"], "authorized");
+        }
+
+        // Validated once, recorded once: the identical redelivery answers
+        // from the recorded state without re-running the on-chain reads.
+        assert_eq!(vault_mock.mint_auth_validation_call_count(), 1);
+        let mint = harness
+            .mint_store
+            .load(&issuer_request_id)
+            .await
+            .expect("aggregate must load")
+            .expect("aggregate must exist");
+        assert!(matches!(
+            mint,
+            Mint::Initiated {
+                mint_authorization: Some(authorization),
+                ..
+            } if authorization.nonce == nonce
+                && authorization.signature.is_empty()
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Mint authorization validated and recorded", "tok-auth-1"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn unknown_tokenization_request_is_not_found() {
+        let harness = TestHarness::new().await;
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-nope", B256::repeat_byte(0x07), "0x").await;
+
+        assert_eq!(response.status(), Status::NotFound);
+        assert_eq!(vault_mock.mint_auth_validation_call_count(), 0);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["unknown tokenization request", "tok-nope"]
+        ));
+    }
+
+    /// A vault-direct mint never consumes an authorization: rejected
+    /// actionably, never stored, and never validated on-chain.
+    #[traced_test]
+    #[tokio::test]
+    async fn vault_direct_mint_delivery_is_rejected_actionably() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id =
+            seed_mint(&harness, "tok-direct-1", VaultMode::VaultDirect).await;
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-direct-1", B256::repeat_byte(0x07), "0x")
+                .await;
+
+        assert_eq!(response.status(), Status::UnprocessableEntity);
+        let body: serde_json::Value =
+            response.into_json().await.expect("error body must be JSON");
+        assert!(
+            body["error"]
+                .as_str()
+                .expect("error string")
+                .contains("vault-direct"),
+            "the rejection must name the cause, got {body}"
+        );
+        assert_eq!(
+            vault_mock.mint_auth_validation_call_count(),
+            0,
+            "a vault-direct delivery must never reach on-chain validation"
+        );
+        let mint = harness
+            .mint_store
+            .load(&issuer_request_id)
+            .await
+            .expect("aggregate must load")
+            .expect("aggregate must exist");
+        assert!(
+            matches!(mint, Mint::Initiated { mint_authorization: None, .. }),
+            "a rejected authorization must never be stored"
+        );
+        assert!(logs_contain_at!(tracing::Level::WARN, &["vault-direct mint"]));
+    }
+
+    /// A closed mint is unreachable by delivery: `Closed` carries no
+    /// tokenization request id, so the lookup 404s — and must NOT surface
+    /// the vault-direct 422, whose cause would be untrue for it. (The
+    /// endpoint's no-live-mode guard covers the load-after-close race the
+    /// lookup cannot.)
+    #[tokio::test]
+    async fn closed_mint_delivery_is_not_found_never_vault_direct() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = seed_mint(
+            &harness,
+            "tok-closed-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::CloseMint {
+                    issuer_request_id: issuer_request_id.clone(),
+                    reason: "operator close".to_string(),
+                    acknowledged_unresolved_mint_tx_hash: None,
+                },
+            )
+            .await
+            .expect("mint must close");
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-closed-1", B256::repeat_byte(0x07), "0x")
+                .await;
+
+        assert_eq!(response.status(), Status::NotFound);
+        assert_eq!(vault_mock.mint_auth_validation_call_count(), 0);
+    }
+
+    /// Invalid authorizations (wrong signer / consumed nonce) map to
+    /// distinct actionable 422s on this internal call — not a post-journal
+    /// surprise at the on-chain step.
+    #[traced_test]
+    #[tokio::test]
+    async fn invalid_authorization_is_unprocessable() {
+        for (failure, expected_snippet) in [
+            (MockMintAuthFailure::SignerMismatch, "recovered"),
+            (MockMintAuthFailure::NonceUsed, "already consumed"),
+            (MockMintAuthFailure::EmptySignatureForEoa, "has no code"),
+        ] {
+            let harness = TestHarness::new().await;
+            let issuer_request_id = seed_mint(
+                &harness,
+                "tok-invalid-1",
+                VaultMode::Orchestrator { address: ORCHESTRATOR },
+            )
+            .await;
+            let vault_mock = Arc::new(
+                MockVaultService::new_success().with_mint_auth_failure(failure),
+            );
+            let rocket = authorization_rocket(&harness, vault_mock.clone());
+            let client = rocket::local::asynchronous::Client::tracked(rocket)
+                .await
+                .expect("valid rocket");
+
+            let response = deliver(
+                &client,
+                "tok-invalid-1",
+                B256::repeat_byte(0x07),
+                "0xaaaa",
+            )
+            .await;
+
+            assert_eq!(response.status(), Status::UnprocessableEntity);
+            let body: serde_json::Value =
+                response.into_json().await.expect("error body must be JSON");
+            assert!(
+                body["error"]
+                    .as_str()
+                    .expect("error string")
+                    .contains(expected_snippet),
+                "{failure:?} must surface its cause, got {body}"
+            );
+            let mint = harness
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .expect("aggregate must load")
+                .expect("aggregate must exist");
+            assert!(
+                matches!(
+                    mint,
+                    Mint::Initiated { mint_authorization: None, .. }
+                ),
+                "an invalid authorization must never be stored"
+            );
+            assert!(
+                logs_contain_at!(
+                    tracing::Level::WARN,
+                    &["Rejected invalid mint authorization", expected_snippet]
+                ),
+                "{failure:?} must WARN with its cause"
+            );
+        }
+    }
+
+    /// A conflicting second authorization is rejected with 409 — the nonce
+    /// can never be swapped mid-flight.
+    #[traced_test]
+    #[tokio::test]
+    async fn conflicting_authorization_is_a_conflict() {
+        let harness = TestHarness::new().await;
+        seed_mint(
+            &harness,
+            "tok-conflict-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let first =
+            deliver(&client, "tok-conflict-1", B256::repeat_byte(0x07), "0x")
+                .await;
+        assert_eq!(first.status(), Status::Ok);
+
+        let second =
+            deliver(&client, "tok-conflict-1", B256::repeat_byte(0x08), "0x")
+                .await;
+        assert_eq!(second.status(), Status::Conflict);
+        assert!(logs_contain_at!(
+            tracing::Level::WARN,
+            &["Conflicting mint authorization rejected"]
+        ));
+    }
+
+    /// A non-authorization on-chain read failure surfaces as 502 with a
+    /// generic body — never a 422 rejection, and never the underlying
+    /// transport/provider detail.
+    #[traced_test]
+    #[tokio::test]
+    async fn on_chain_read_failure_is_a_bad_gateway() {
+        let harness = TestHarness::new().await;
+        seed_mint(
+            &harness,
+            "tok-502-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_auth_failure(MockMintAuthFailure::ReadFailed),
+        );
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-502-1", B256::repeat_byte(0x07), "0x").await;
+
+        assert_eq!(response.status(), Status::BadGateway);
+        let body: serde_json::Value =
+            response.into_json().await.expect("error body must be JSON");
+        assert_eq!(
+            body["error"], "On-chain validation is currently unavailable",
+            "the 502 body must stay generic, got {body}"
+        );
+        assert_eq!(vault_mock.mint_auth_validation_call_count(), 1);
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["On-chain mint-authorization validation failed"]
+        ));
+    }
+
+    /// Once the mint is past intent, its signed transaction already binds a
+    /// nonce: a late delivery is a 409 through the HTTP layer, naming the
+    /// state.
+    #[tokio::test]
+    async fn post_intent_delivery_is_a_conflict() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = seed_mint(
+            &harness,
+            "tok-late-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+
+        let authorization = MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::new(),
+        };
+        for command in [
+            MintCommand::AuthorizeMint {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: authorization,
+            },
+            MintCommand::ConfirmJournal {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::RecordTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::valid_for_test(
+                    1,
+                    format!("mint-{issuer_request_id}"),
+                ),
+            },
+        ] {
+            harness
+                .mint_store
+                .send(&issuer_request_id, command)
+                .await
+                .expect("mint must advance to intent");
+        }
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-late-1", B256::repeat_byte(0x07), "0x").await;
+
+        assert_eq!(response.status(), Status::Conflict);
+        let body: serde_json::Value =
+            response.into_json().await.expect("error body must be JSON");
+        assert!(
+            body["error"]
+                .as_str()
+                .expect("error string")
+                .contains("MintIntended"),
+            "the conflict must name the rejecting state, got {body}"
+        );
+    }
+
+    /// An unresponsive provider must fail the delivery with a 502 at the
+    /// validation deadline, not hold the request open indefinitely. The
+    /// mock's validation hangs forever; the test-profile deadline is
+    /// milliseconds, so the timeout fires in real time.
+    #[traced_test]
+    #[tokio::test]
+    async fn unresponsive_provider_times_out_as_bad_gateway() {
+        let harness = TestHarness::new().await;
+        seed_mint(
+            &harness,
+            "tok-hang-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        let rocket = authorization_rocket(
+            &harness,
+            Arc::new(MockVaultService::new_success().with_mint_auth_hang()),
+        );
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response =
+            deliver(&client, "tok-hang-1", B256::repeat_byte(0x07), "0x").await;
+
+        assert_eq!(response.status(), Status::BadGateway);
+        let body: serde_json::Value =
+            response.into_json().await.expect("error body must be JSON");
+        assert_eq!(
+            body["error"], "On-chain validation is currently unavailable",
+            "the timeout body must stay generic like other 502s"
+        );
+        assert!(logs_contain_at!(
+            tracing::Level::ERROR,
+            &["validation timed out", "timeout_secs"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn missing_api_key_is_unauthorized() {
+        let harness = TestHarness::new().await;
+        seed_mint(
+            &harness,
+            "tok-noauth-1",
+            VaultMode::Orchestrator { address: ORCHESTRATOR },
+        )
+        .await;
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let rocket = authorization_rocket(&harness, vault_mock.clone());
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket");
+
+        let response = deliver_without_key(
+            &client,
+            "tok-noauth-1",
+            B256::repeat_byte(0x07),
+            "0x",
+        )
+        .await;
+
+        assert_eq!(response.status(), Status::Unauthorized);
+        assert_eq!(vault_mock.mint_auth_validation_call_count(), 0);
+    }
+}

--- a/src/mint/api/confirm.rs
+++ b/src/mint/api/confirm.rs
@@ -261,6 +261,7 @@ mod tests {
 
     use super::confirm_journal;
     use crate::auth::FailedAuthRateLimiter;
+    use crate::config::VaultMode;
     use crate::mint::api::test_utils::{
         TestAccountAndAsset, TestHarness, network_vault_services, test_config,
     };
@@ -284,6 +285,7 @@ mod tests {
         let tokenization_request_id = TokenizationRequestId::new("alp-ok-test");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -346,6 +348,7 @@ mod tests {
             TokenizationRequestId::new("alp-reject-ok-test");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -409,6 +412,7 @@ mod tests {
             TokenizationRequestId::new("alp-complete-123");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -501,6 +505,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 MintCommand::Initiate {
+                    mint_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: tokenization_request_id.clone(),
                     quantity: Quantity::new(Decimal::from(100)),
@@ -580,6 +585,7 @@ mod tests {
             TokenizationRequestId::new("alp-view-123");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -662,6 +668,7 @@ mod tests {
             TokenizationRequestId::new("alp-reject-123");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -742,6 +749,7 @@ mod tests {
             TokenizationRequestId::new("alp-reject-view-123");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),
@@ -828,6 +836,7 @@ mod tests {
             TokenizationRequestId::new("alp-wrong");
 
         let initiate_cmd = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: correct_tokenization_request_id.clone(),
             quantity: Quantity::new(Decimal::from(100)),

--- a/src/mint/api/initiate.rs
+++ b/src/mint/api/initiate.rs
@@ -11,6 +11,7 @@ use super::{
     MintApiError, MintResponse, validate_asset_exists, validate_client_eligible,
 };
 use crate::auth::IssuerAuth;
+use crate::config::Config;
 use crate::mint::{
     ClientId, IssuerMintRequestId, Mint, MintCommand, MintView, Network,
     Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
@@ -32,7 +33,7 @@ pub(crate) struct MintRequest {
     pub(crate) wallet: Address,
 }
 
-#[tracing::instrument(skip(_auth, mint_store, pool), fields(
+#[tracing::instrument(skip(_auth, mint_store, pool, config), fields(
     tokenization_request_id = %request.tokenization_request_id.0,
     underlying = %request.underlying.as_str(),
     client_id = %request.client_id,
@@ -43,6 +44,7 @@ pub(crate) async fn initiate_mint(
     _auth: IssuerAuth,
     mint_store: &rocket::State<Arc<Store<Mint>>>,
     pool: &rocket::State<sqlx::Pool<sqlx::Sqlite>>,
+    config: &rocket::State<Config>,
     request: Json<MintRequest>,
 ) -> Result<Json<MintResponse>, MintApiError> {
     let request = request.into_inner();
@@ -64,6 +66,12 @@ pub(crate) async fn initiate_mint(
 
     let issuer_request_id = IssuerMintRequestId::random();
 
+    // Resolve the asset's mode from config exactly once, here at initiate
+    // time: the persisted anchor on `Initiated` is what every later
+    // mode-dependent step derives from, even if the asset's configured
+    // vault_mode flips mid-flight.
+    let mint_mode = config.vault_mode_for(&request.underlying);
+
     let command = MintCommand::Initiate {
         issuer_request_id: issuer_request_id.clone(),
         tokenization_request_id: request.tokenization_request_id,
@@ -73,6 +81,7 @@ pub(crate) async fn initiate_mint(
         network: request.network,
         client_id: request.client_id,
         wallet: request.wallet,
+        mint_mode,
     };
 
     mint_store.send(&issuer_request_id, command).await.map_err(|error| {
@@ -103,18 +112,20 @@ mod tests {
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
     use rust_decimal::Decimal;
+    use std::collections::HashMap;
     use std::str::FromStr;
     use tracing_test::traced_test;
 
     use super::initiate_mint;
     use crate::account::{AccountCommand, AlpacaAccountNumber, Email};
     use crate::auth::FailedAuthRateLimiter;
+    use crate::config::{Config, VaultMode, VaultModeConfig};
     use crate::mint::api::test_utils::{
         TestAccountAndAsset, TestHarness, test_config,
     };
     use crate::mint::api::{ErrorResponse, MintResponse};
     use crate::mint::{
-        ClientId, IssuerMintRequestId, MintCommand, MintView, Network,
+        ClientId, IssuerMintRequestId, Mint, MintCommand, MintView, Network,
         Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
         view::find_by_issuer_request_id,
     };
@@ -221,6 +232,137 @@ mod tests {
 
         assert!(!mint_response.issuer_request_id.to_string().is_empty());
         assert_eq!(mint_response.status, "created");
+    }
+
+    /// The persisted `Initiated.mint_mode` anchor is resolved from the
+    /// per-asset config at initiate time: under a mixed config, an
+    /// orchestrator-mode asset's mint anchors `Orchestrator` while a
+    /// default-mode asset's mint anchors `VaultDirect`, side by side.
+    #[traced_test]
+    #[tokio::test]
+    async fn initiate_persists_configured_per_asset_mint_mode() {
+        let harness = TestHarness::new().await;
+        let TestAccountAndAsset { client_id, underlying, network, .. } =
+            harness.setup_account_and_asset().await;
+
+        // Second asset on the same deployment, left on the vault-direct
+        // default.
+        let msft = UnderlyingSymbol::new("MSFT").unwrap();
+        let msft_token = TokenSymbol::new("tMSFT");
+        harness
+            .asset_store
+            .send(
+                &AssetKey::new(msft.clone(), network),
+                TokenizedAssetCommand::Add {
+                    underlying: msft.clone(),
+                    token: msft_token.clone(),
+                    network,
+                    vault: address!(
+                        "0x9999999999999999999999999999999999999999"
+                    ),
+                },
+            )
+            .await
+            .expect("Failed to add second asset");
+
+        let TestHarness {
+            pool,
+            account_store,
+            asset_store: tokenized_asset_store,
+            mint_store,
+            ..
+        } = harness;
+        let store_handle = mint_store.clone();
+
+        let orchestrator_address =
+            address!("0x00000000000000000000000000000000000000aa");
+        let config = Config {
+            vault_mode_config: VaultModeConfig::new(
+                HashMap::from([(
+                    underlying.as_str().to_string(),
+                    VaultMode::Orchestrator { address: orchestrator_address },
+                )]),
+                VaultMode::VaultDirect,
+            ),
+            ..test_config()
+        };
+
+        let rocket = rocket::build()
+            .manage(config)
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(mint_store)
+            .manage(account_store)
+            .manage(tokenized_asset_store)
+            .manage(pool)
+            .mount("/", routes![initiate_mint]);
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        let mut anchored = Vec::new();
+        for (tokenization_id, symbol, token_symbol) in [
+            ("alp-orch-1", underlying.as_str(), "tAAPL"),
+            ("alp-direct-1", msft.as_str(), "tMSFT"),
+        ] {
+            let request_body = serde_json::json!({
+                "tokenization_request_id": tokenization_id,
+                "qty": "100.5",
+                "underlying_symbol": symbol,
+                "token_symbol": token_symbol,
+                "network": "base",
+                "client_id": client_id,
+                "wallet_address":
+                    "0x1234567890abcdef1234567890abcdef12345678"
+            });
+            let response = client
+                .post("/inkind/issuance")
+                .header(ContentType::JSON)
+                .header(Header::new(
+                    "X-API-KEY",
+                    "test-key-12345678901234567890123456",
+                ))
+                .remote("127.0.0.1:8000".parse().unwrap())
+                .body(request_body.to_string())
+                .dispatch()
+                .await;
+            assert_eq!(response.status(), Status::Ok);
+            let mint_response: MintResponse = serde_json::from_str(
+                &response.into_string().await.expect("valid response body"),
+            )
+            .expect("valid JSON response");
+            anchored.push(mint_response.issuer_request_id);
+        }
+
+        let orchestrator_mint = store_handle
+            .load(&anchored[0])
+            .await
+            .expect("aggregate must load")
+            .expect("aggregate must exist");
+        assert!(
+            matches!(
+                &orchestrator_mint,
+                Mint::Initiated {
+                    mint_mode: VaultMode::Orchestrator { address },
+                    ..
+                } if *address == orchestrator_address
+            ),
+            "orchestrator-mode asset must anchor Orchestrator, \
+             got {orchestrator_mint:?}"
+        );
+
+        let vault_direct_mint = store_handle
+            .load(&anchored[1])
+            .await
+            .expect("aggregate must load")
+            .expect("aggregate must exist");
+        assert!(
+            matches!(
+                &vault_direct_mint,
+                Mint::Initiated { mint_mode: VaultMode::VaultDirect, .. }
+            ),
+            "default-mode asset must anchor VaultDirect, \
+             got {vault_direct_mint:?}"
+        );
     }
 
     #[traced_test]
@@ -942,6 +1084,7 @@ mod tests {
         let issuer_request_id = IssuerMintRequestId::random();
 
         let command = MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: TokenizationRequestId::new("alp-123"),
             quantity: Quantity::new(Decimal::from(100)),

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -15,12 +15,17 @@ use crate::account::{AccountView, view::find_by_client_id};
 use crate::tokenized_asset::view::load_asset_by_network;
 use crate::underlying::load_freeze_status;
 
+mod authorize;
 mod confirm;
 mod initiate;
 
 #[cfg(test)]
 pub(crate) mod test_utils;
 
+pub(crate) use authorize::{
+    __path_authorize_mint, MintAuthorizationRequest, MintAuthorizationResponse,
+    authorize_mint,
+};
 pub(crate) use confirm::confirm_journal;
 pub(crate) use initiate::initiate_mint;
 

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -6,7 +6,8 @@ use super::{
     ClientId, IssuerMintRequestId, MintExternalTxId, Network, Quantity,
     TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
 };
-use crate::vault::{PreparedMintTx, TxId};
+use crate::config::VaultMode;
+use crate::vault::{MintAuthorization, PreparedMintTx, TxId};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum MintCommand {
@@ -19,6 +20,14 @@ pub(crate) enum MintCommand {
         network: Network,
         client_id: ClientId,
         wallet: Address,
+        /// The asset's `VaultMode` resolved from config at initiate time.
+        /// Persisted on `Initiated` to anchor mode derivation for the whole
+        /// mint lifecycle. Deliberately NOT `#[serde(default)]`: commands
+        /// have no historical payloads to stay compatible with (unlike
+        /// `MintEvent::Initiated`), and a silently defaulted `VaultDirect`
+        /// would mis-anchor the mint — omission must be a hard
+        /// deserialization error.
+        mint_mode: VaultMode,
     },
     ConfirmJournal {
         issuer_request_id: IssuerMintRequestId,
@@ -144,5 +153,20 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
         acknowledged_unresolved_mint_tx_hash: Option<B256>,
+    },
+
+    /// Associates the liquidity bot's validated `MintAuthV1` with this mint,
+    /// delivered out-of-band via the internal mint-authorization call after
+    /// `Initiate` (orchestrator mode only). The handler rejects delivery when
+    /// this mint's persisted `mint_mode` is `VaultDirect` (an authorization
+    /// for a vault-direct mint is meaningless — nothing will ever consume
+    /// it), is idempotent on redelivery of an identical authorization, and
+    /// rejects a conflicting one so the nonce cannot be swapped mid-flight.
+    /// Produces `MintAuthorizationReceived`; does not change the lifecycle
+    /// state. On-chain validation (signer, `nonceUsed`) happens at the
+    /// endpoint before this command — the aggregate stays deterministic.
+    AuthorizeMint {
+        issuer_request_id: IssuerMintRequestId,
+        mint_authorization: MintAuthorization,
     },
 }

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -4,7 +4,8 @@ use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::vault::{PreparedMintTx, TxId};
+use crate::config::VaultMode;
+use crate::vault::{MintAuthorization, PreparedMintTx, TxId};
 
 use super::{
     ClientId, IssuerMintRequestId, Network, Quantity, TokenSymbol,
@@ -23,6 +24,15 @@ pub(crate) enum MintEvent {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// The asset's `VaultMode` resolved from config at initiate time,
+        /// before any possible mint submission. Anchors mode-derivation for
+        /// this mint the same way `RedemptionDetected.burn_mode` anchors it
+        /// for redemptions: `SubmitMint`/`ConfirmMint`/`Recover` derive mode
+        /// from this persisted field, never from live config, and never from
+        /// the presence of `mint_authorization`. Absent on historical events,
+        /// which all predate orchestrator mode (`VaultDirect`).
+        #[serde(default)]
+        mint_mode: VaultMode,
     },
     JournalConfirmed {
         issuer_request_id: IssuerMintRequestId,
@@ -109,6 +119,17 @@ pub(crate) enum MintEvent {
         manual_retry_id: Option<Uuid>,
         started_at: DateTime<Utc>,
     },
+
+    /// The liquidity bot's validated `MintAuthV1` for this mint, delivered
+    /// out-of-band via the internal mint-authorization call (orchestrator
+    /// mode only). This is the persistence point for the nonce — `Initiated`
+    /// is written on the Alpaca POST, strictly before the authorization
+    /// exists, so it cannot carry one. Does not change the lifecycle state.
+    MintAuthorizationReceived {
+        issuer_request_id: IssuerMintRequestId,
+        mint_authorization: MintAuthorization,
+        received_at: DateTime<Utc>,
+    },
 }
 
 impl DomainEvent for MintEvent {
@@ -143,6 +164,9 @@ impl DomainEvent for MintEvent {
             }
             Self::MintRetryStarted { .. } => {
                 "MintEvent::MintRetryStarted".to_string()
+            }
+            Self::MintAuthorizationReceived { .. } => {
+                "MintEvent::MintAuthorizationReceived".to_string()
             }
         }
     }

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -33,6 +33,7 @@ use super::{
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::burn_excess::has_unresolved_excess_burn_intent;
+use crate::config::VaultMode;
 use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
@@ -121,8 +122,28 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                 network,
                 wallet,
                 journal_confirmed_at,
+                mint_mode,
                 ..
             } => {
+                // Fail closed on the anchor: this build has no orchestrator
+                // submission path (it lands in the commits stacked above,
+                // which replace this guard), and minting an
+                // orchestrator-anchored mint through the vault-direct
+                // multicall would use the wrong custody model — mirroring
+                // the redemption side's `BurnModeMismatch` refusal. The mint
+                // stays in `Minting`, visible in `/admin/stuck` past the
+                // threshold.
+                if let VaultMode::Orchestrator { .. } = mint_mode {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        "Orchestrator-anchored mint has no submission path \
+                         in this build; deferring instead of minting \
+                         vault-direct"
+                    );
+                    return Ok(());
+                }
+
                 self.submit_from_minting(
                     ctx,
                     &mint,
@@ -2422,6 +2443,54 @@ mod tests {
         assert!(logs_contain_at!(
             Level::WARN,
             &[test, "Mint submission failed"]
+        ));
+    }
+
+    /// An orchestrator-anchored mint must never take the vault-direct
+    /// submission path: this build has no orchestrator submission, so the job
+    /// defers (mint stays `Minting`, vault untouched) instead of minting
+    /// through the wrong custody model.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_defers_orchestrator_anchored_mint() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events = events_through_minting(&issuer_request_id);
+        if let Some(MintEvent::Initiated { mint_mode, .. }) = events.first_mut()
+        {
+            *mint_mode = VaultMode::Orchestrator { address: Address::random() };
+        }
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "an orchestrator-anchored mint must stay in Minting, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_wallet_lock_call_count(),
+            0,
+            "the vault-direct preparation must never run for an \
+             orchestrator-anchored mint"
+        );
+
+        let test = "submit_mint_job_defers_orchestrator_anchored_mint";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "no submission path", "deferring"]
         ));
     }
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1,4 +1,4 @@
-mod api;
+pub(crate) mod api;
 mod cmd;
 mod event;
 pub(crate) mod job;
@@ -13,16 +13,19 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
+use crate::config::VaultMode;
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, TokenizedAssetViewFailure,
 };
-use crate::vault::{PreparedMintTx, TxId, UnconfiguredNetworkError};
+use crate::vault::{
+    MintAuthorization, PreparedMintTx, TxId, UnconfiguredNetworkError,
+};
 
 pub use api::MintResponse;
 
 #[cfg(test)]
 pub(crate) use api::test_utils;
-pub(crate) use api::{confirm_journal, initiate_mint};
+pub(crate) use api::{authorize_mint, confirm_journal, initiate_mint};
 pub(crate) use cmd::MintCommand;
 pub(crate) use event::MintEvent;
 pub(crate) use view::{MintView, find_all_recoverable_mints, find_stuck};
@@ -148,6 +151,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
     },
     JournalConfirmed {
         issuer_request_id: IssuerMintRequestId,
@@ -159,6 +175,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
     },
     JournalRejected {
@@ -171,6 +200,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         reason: String,
         rejected_at: DateTime<Utc>,
     },
@@ -184,6 +226,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
         /// Failure history carried across a retry transition
@@ -206,6 +261,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
         prepared_tx: PreparedMintTx,
@@ -223,6 +291,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         minting_started_at: DateTime<Utc>,
         prepared_tx: Option<PreparedMintTx>,
@@ -239,6 +320,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
         receipt_id: U256,
@@ -257,6 +351,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         error: String,
         failed_at: DateTime<Utc>,
@@ -293,6 +400,19 @@ pub(crate) enum Mint {
         client_id: ClientId,
         wallet: Address,
         initiated_at: DateTime<Utc>,
+        /// Mode anchor from `Initiated.mint_mode` — every mode-dependent mint
+        /// step derives from this persisted value, never from live config.
+        /// Snapshots persisted before orchestrator mode default to
+        /// `VaultDirect`.
+        #[serde(default)]
+        mint_mode: VaultMode,
+        /// The liquidity bot's validated `MintAuthV1`, absent until the
+        /// internal mint-authorization call arrives (orchestrator mode only;
+        /// always `None` for vault-direct mints). Orthogonal to `mint_mode` —
+        /// an orchestrator mint whose authorization has not arrived yet is
+        /// still an orchestrator mint.
+        #[serde(default)]
+        mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
         receipt_id: U256,
@@ -592,6 +712,193 @@ impl Mint {
                 Some(tokenization_request_id)
             }
             Self::Closed { .. } => None,
+        }
+    }
+
+    /// The mode anchored on `Initiated` — the only source mode-dependent
+    /// steps derive from.
+    pub(crate) const fn mint_mode(&self) -> Option<VaultMode> {
+        match self {
+            Self::Initiated { mint_mode, .. }
+            | Self::JournalConfirmed { mint_mode, .. }
+            | Self::JournalRejected { mint_mode, .. }
+            | Self::Minting { mint_mode, .. }
+            | Self::TxIntended { mint_mode, .. }
+            | Self::TxSubmitted { mint_mode, .. }
+            | Self::CallbackPending { mint_mode, .. }
+            | Self::MintingFailed { mint_mode, .. }
+            | Self::Completed { mint_mode, .. } => Some(*mint_mode),
+            Self::Closed { .. } => None,
+        }
+    }
+
+    pub(crate) const fn underlying(&self) -> Option<&UnderlyingSymbol> {
+        match self {
+            Self::Initiated { underlying, .. }
+            | Self::JournalConfirmed { underlying, .. }
+            | Self::JournalRejected { underlying, .. }
+            | Self::Minting { underlying, .. }
+            | Self::TxIntended { underlying, .. }
+            | Self::TxSubmitted { underlying, .. }
+            | Self::CallbackPending { underlying, .. }
+            | Self::MintingFailed { underlying, .. }
+            | Self::Completed { underlying, .. } => Some(underlying),
+            Self::Closed { .. } => None,
+        }
+    }
+
+    /// The recipient wallet — the `to` a mint authorization must be signed
+    /// over.
+    pub(crate) const fn wallet(&self) -> Option<Address> {
+        match self {
+            Self::Initiated { wallet, .. }
+            | Self::JournalConfirmed { wallet, .. }
+            | Self::JournalRejected { wallet, .. }
+            | Self::Minting { wallet, .. }
+            | Self::TxIntended { wallet, .. }
+            | Self::TxSubmitted { wallet, .. }
+            | Self::CallbackPending { wallet, .. }
+            | Self::MintingFailed { wallet, .. }
+            | Self::Completed { wallet, .. } => Some(*wallet),
+            Self::Closed { .. } => None,
+        }
+    }
+
+    pub(crate) const fn quantity(&self) -> Option<&Quantity> {
+        match self {
+            Self::Initiated { quantity, .. }
+            | Self::JournalConfirmed { quantity, .. }
+            | Self::JournalRejected { quantity, .. }
+            | Self::Minting { quantity, .. }
+            | Self::TxIntended { quantity, .. }
+            | Self::TxSubmitted { quantity, .. }
+            | Self::CallbackPending { quantity, .. }
+            | Self::MintingFailed { quantity, .. }
+            | Self::Completed { quantity, .. } => Some(quantity),
+            Self::Closed { .. } => None,
+        }
+    }
+
+    /// Whether this mint's lifecycle state can still accept a recipient
+    /// authorization — the exact states [`Self::handle_authorize_mint`]
+    /// destructures (keep the two in sync). The tokenization-id lookup uses
+    /// this to prefer a live mint over stale same-id duplicates.
+    pub(crate) const fn mint_authorization(
+        &self,
+    ) -> Option<&MintAuthorization> {
+        match self {
+            Self::Initiated { mint_authorization, .. }
+            | Self::JournalConfirmed { mint_authorization, .. }
+            | Self::JournalRejected { mint_authorization, .. }
+            | Self::Minting { mint_authorization, .. }
+            | Self::TxIntended { mint_authorization, .. }
+            | Self::TxSubmitted { mint_authorization, .. }
+            | Self::CallbackPending { mint_authorization, .. }
+            | Self::MintingFailed { mint_authorization, .. }
+            | Self::Completed { mint_authorization, .. } => {
+                mint_authorization.as_ref()
+            }
+            Self::Closed { .. } => None,
+        }
+    }
+
+    pub(crate) const fn accepts_mint_authorization(&self) -> bool {
+        matches!(
+            self,
+            Self::Initiated { .. }
+                | Self::JournalConfirmed { .. }
+                | Self::Minting { .. }
+        )
+    }
+
+    /// Associates the liquidity bot's validated authorization with this mint
+    /// without changing the lifecycle state.
+    ///
+    /// Valid only before a transaction is intended: once `PrepareMint` signs,
+    /// the nonce is baked into the persisted bytes, so a late delivery could
+    /// not change what gets submitted. Idempotent on redelivery of an
+    /// identical authorization; a conflicting one is rejected so the nonce
+    /// can never be swapped mid-flight. On-chain validation (signer,
+    /// `nonceUsed`) happens at the endpoint before this command — the
+    /// aggregate enforces only mode and lifecycle invariants. The accepted
+    /// states below must stay in sync with
+    /// [`Self::accepts_mint_authorization`].
+    fn handle_authorize_mint(
+        &self,
+        provided_id: IssuerMintRequestId,
+        mint_authorization: MintAuthorization,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let (Self::Initiated {
+            issuer_request_id: expected_id,
+            underlying,
+            mint_mode,
+            mint_authorization: existing,
+            ..
+        }
+        | Self::JournalConfirmed {
+            issuer_request_id: expected_id,
+            underlying,
+            mint_mode,
+            mint_authorization: existing,
+            ..
+        }
+        | Self::Minting {
+            issuer_request_id: expected_id,
+            underlying,
+            mint_mode,
+            mint_authorization: existing,
+            ..
+        }) = self
+        else {
+            return Err(MintError::AuthorizationNotAcceptable {
+                current_state: self.state_name().to_string(),
+            });
+        };
+
+        Self::validate_issuer_request_id(expected_id, &provided_id)?;
+
+        if matches!(mint_mode, VaultMode::VaultDirect) {
+            return Err(MintError::AuthorizationForVaultDirectAsset {
+                underlying: underlying.clone(),
+            });
+        }
+
+        match existing {
+            Some(existing) if *existing == mint_authorization => Ok(vec![]),
+            Some(_) => Err(MintError::ConflictingMintAuthorization),
+            None => Ok(vec![MintEvent::MintAuthorizationReceived {
+                issuer_request_id: provided_id,
+                mint_authorization,
+                received_at: Utc::now(),
+            }]),
+        }
+    }
+
+    /// Sets the delivered authorization on the current state; the lifecycle
+    /// position is untouched.
+    /// Mirrors [`Self::handle_authorize_mint`]'s accepted states: the event
+    /// is only ever emitted from these three, so any other state is an
+    /// impossible replay and applies as a no-op — a hypothetical late
+    /// emission must never attach a nonce after the transaction is signed
+    /// (states past intent still CARRY the authorization; they receive it
+    /// through the state-transition applies, not through this event).
+    fn apply_mint_authorization_received(
+        &mut self,
+        authorization: MintAuthorization,
+    ) {
+        match self {
+            Self::Initiated { mint_authorization, .. }
+            | Self::JournalConfirmed { mint_authorization, .. }
+            | Self::Minting { mint_authorization, .. } => {
+                *mint_authorization = Some(authorization);
+            }
+            Self::JournalRejected { .. }
+            | Self::TxIntended { .. }
+            | Self::TxSubmitted { .. }
+            | Self::CallbackPending { .. }
+            | Self::MintingFailed { .. }
+            | Self::Completed { .. }
+            | Self::Closed { .. } => {}
         }
     }
 
@@ -990,6 +1297,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
         } = self.clone()
         else {
             return;
@@ -1005,6 +1314,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at: confirmed_at,
         };
     }
@@ -1024,6 +1335,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
         } = self.clone()
         else {
             return;
@@ -1039,6 +1352,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             reason,
             rejected_at,
         };
@@ -1055,6 +1370,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
         } = self.clone()
         else {
@@ -1071,6 +1388,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at: started_at,
             retry: None,
@@ -1103,6 +1422,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at,
             retry: _,
@@ -1117,6 +1438,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at,
             ..
@@ -1135,6 +1458,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at,
             prepared_tx,
@@ -1154,6 +1479,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at,
             retry: _,
@@ -1172,6 +1499,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at,
             prepared_tx,
@@ -1197,6 +1526,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1210,6 +1541,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1223,6 +1556,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }) = self.clone()
@@ -1240,6 +1575,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             tx_hash,
             receipt_id,
@@ -1313,6 +1650,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1326,6 +1665,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1339,6 +1680,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }) = self.clone()
@@ -1356,6 +1699,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             error,
             failed_at,
@@ -1375,6 +1720,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             tx_hash,
             receipt_id,
@@ -1397,6 +1744,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             tx_hash,
             receipt_id,
@@ -1426,6 +1775,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1439,6 +1790,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1452,6 +1805,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }
@@ -1465,6 +1820,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             ..
         }) = self.clone()
@@ -1482,6 +1839,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             tx_hash,
             receipt_id,
@@ -1528,6 +1887,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             attempts,
             failed_from,
@@ -1547,6 +1908,8 @@ impl Mint {
             client_id,
             wallet,
             initiated_at,
+            mint_mode,
+            mint_authorization,
             journal_confirmed_at,
             minting_started_at: started_at,
             retry: Some(MintRetryContext { attempts, failed_from, tx_hash }),
@@ -1655,6 +2018,7 @@ impl EventSourced for Mint {
                 client_id,
                 wallet,
                 initiated_at,
+                mint_mode,
             } => Some(Self::Initiated {
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: tokenization_request_id.clone(),
@@ -1665,6 +2029,10 @@ impl EventSourced for Mint {
                 client_id: *client_id,
                 wallet: *wallet,
                 initiated_at: *initiated_at,
+                mint_mode: *mint_mode,
+                // The authorization arrives out-of-band strictly after
+                // `Initiated` is persisted; a fresh mint never has one.
+                mint_authorization: None,
             }),
             _ => None,
         }
@@ -1693,6 +2061,7 @@ impl EventSourced for Mint {
                 network,
                 client_id,
                 wallet,
+                mint_mode,
             } => Ok(vec![MintEvent::Initiated {
                 issuer_request_id,
                 tokenization_request_id,
@@ -1703,10 +2072,16 @@ impl EventSourced for Mint {
                 client_id,
                 wallet,
                 initiated_at: Utc::now(),
+                mint_mode,
             }]),
             MintCommand::ConfirmJournal { .. }
             | MintCommand::RejectJournal { .. } => {
                 Err(MintError::NotInInitiatedState {
+                    current_state: "Uninitialized".to_string(),
+                })
+            }
+            MintCommand::AuthorizeMint { .. } => {
+                Err(MintError::AuthorizationNotAcceptable {
                     current_state: "Uninitialized".to_string(),
                 })
             }
@@ -1756,6 +2131,7 @@ impl EventSourced for Mint {
                 network,
                 client_id,
                 wallet,
+                mint_mode,
             } => {
                 if matches!(self, Self::Initiated { .. }) {
                     Err(MintError::AlreadyInitiated {
@@ -1772,9 +2148,15 @@ impl EventSourced for Mint {
                         client_id,
                         wallet,
                         initiated_at: Utc::now(),
+                        mint_mode,
                     }])
                 }
             }
+            MintCommand::AuthorizeMint {
+                issuer_request_id,
+                mint_authorization,
+            } => self
+                .handle_authorize_mint(issuer_request_id, mint_authorization),
             MintCommand::ConfirmJournal { issuer_request_id } => {
                 self.handle_confirm_journal(issuer_request_id)
             }
@@ -1869,6 +2251,7 @@ impl Mint {
                 client_id,
                 wallet,
                 initiated_at,
+                mint_mode,
             } => {
                 *self = Self::Initiated {
                     issuer_request_id,
@@ -1880,8 +2263,17 @@ impl Mint {
                     client_id,
                     wallet,
                     initiated_at,
+                    mint_mode,
+                    // The authorization arrives out-of-band strictly after
+                    // `Initiated`; a fresh mint never has one.
+                    mint_authorization: None,
                 };
             }
+            MintEvent::MintAuthorizationReceived {
+                issuer_request_id: _,
+                mint_authorization,
+                received_at: _,
+            } => self.apply_mint_authorization_received(mint_authorization),
             MintEvent::JournalConfirmed {
                 issuer_request_id: _,
                 confirmed_at,
@@ -1976,6 +2368,18 @@ pub(crate) enum MintError {
         "Mint already initiated for tokenization request: {tokenization_request_id}"
     )]
     AlreadyInitiated { tokenization_request_id: String },
+    #[error(
+        "Mint authorization delivered for vault-direct mint of {underlying}: nothing will ever consume it"
+    )]
+    AuthorizationForVaultDirectAsset { underlying: UnderlyingSymbol },
+    #[error(
+        "A different mint authorization is already recorded for this mint; the nonce cannot be swapped mid-flight"
+    )]
+    ConflictingMintAuthorization,
+    #[error(
+        "Mint authorization cannot be accepted in state {current_state}: authorizations are only accepted before the mint transaction is prepared"
+    )]
+    AuthorizationNotAcceptable { current_state: String },
     #[error("Mint not in Initiated state. Current state: {current_state}")]
     NotInInitiatedState { current_state: String },
     #[error(
@@ -2084,7 +2488,7 @@ impl From<UnconfiguredNetworkError> for MintError {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, B256, address, b256, uint};
+    use alloy::primitives::{Address, B256, Bytes, address, b256, uint};
     use chrono::{DateTime, Utc};
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
@@ -2101,12 +2505,13 @@ pub(crate) mod tests {
         TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
         has_unresolved_signer_intent,
     };
+    use crate::config::VaultMode;
     use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
-    use crate::vault::{PreparedMintTx, TxId};
+    use crate::vault::{MintAuthorization, PreparedMintTx, TxId};
 
     pub(super) const VAULT: Address =
         address!("0xcccccccccccccccccccccccccccccccccccccccc");
@@ -2717,6 +3122,7 @@ pub(crate) mod tests {
     ) -> Vec<MintEvent> {
         vec![
             MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
@@ -2755,6 +3161,7 @@ pub(crate) mod tests {
         let now = Utc::now();
         vec![
             MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
@@ -3583,6 +3990,7 @@ pub(crate) mod tests {
         let events = TestHarness::<Mint>::with(())
             .given_no_previous_events()
             .when(MintCommand::Initiate {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: tokenization_request_id.clone(),
                 quantity: quantity.clone(),
@@ -3608,6 +4016,7 @@ pub(crate) mod tests {
                 client_id: event_client_id,
                 wallet: event_wallet,
                 initiated_at,
+                mint_mode,
             } => {
                 assert_eq!(event_issuer_id, &issuer_request_id);
                 assert_eq!(event_tokenization_id, &tokenization_request_id);
@@ -3618,6 +4027,7 @@ pub(crate) mod tests {
                 assert_eq!(event_client_id, &client_id);
                 assert_eq!(event_wallet, &wallet);
                 assert!(initiated_at.timestamp() > 0);
+                assert_eq!(mint_mode, &VaultMode::VaultDirect);
             }
             MintEvent::JournalConfirmed { .. }
             | MintEvent::JournalRejected { .. }
@@ -3629,9 +4039,569 @@ pub(crate) mod tests {
             | MintEvent::MintCompleted { .. }
             | MintEvent::ExistingMintRecovered { .. }
             | MintEvent::MintRetryStarted { .. }
+            | MintEvent::MintAuthorizationReceived { .. }
             | MintEvent::MintClosed { .. } => {
                 panic!("Expected MintInitiated event, got {:?}", &events[0])
             }
+        }
+    }
+
+    /// Historic `Initiated` events predate `mint_mode` entirely; they must
+    /// replay as `VaultDirect` — the only mode that existed when they were
+    /// written.
+    #[test]
+    fn initiated_event_without_mint_mode_replays_as_vault_direct() {
+        let historic = serde_json::json!({
+            "Initiated": {
+                "issuer_request_id": IssuerMintRequestId::random().to_string(),
+                "tokenization_request_id": "alp-legacy-1",
+                "quantity": "100",
+                "underlying": "AAPL",
+                "token": "tAAPL",
+                "network": "base",
+                "client_id": ClientId::new(),
+                "wallet": "0x1234567890abcdef1234567890abcdef12345678",
+                "initiated_at": "2025-01-01T00:00:00Z"
+            }
+        });
+
+        let event: MintEvent = serde_json::from_value(historic)
+            .expect("historic Initiated event must deserialize");
+        let MintEvent::Initiated { mint_mode, .. } = &event else {
+            panic!("expected Initiated, got {event:?}");
+        };
+        assert_eq!(mint_mode, &VaultMode::VaultDirect);
+
+        let mint = replay::<Mint>(vec![event])
+            .expect("historic event must replay")
+            .expect("mint must exist");
+        assert!(matches!(
+            mint,
+            Mint::Initiated { mint_mode: VaultMode::VaultDirect, .. }
+        ));
+    }
+
+    /// Pre-orchestrator aggregate snapshots lack `mint_mode`; deserializing
+    /// them must default to `VaultDirect` rather than fail.
+    #[test]
+    fn state_snapshot_without_mint_mode_deserializes_as_vault_direct() {
+        let mint = Mint::Initiated {
+            mint_authorization: None,
+            issuer_request_id: IssuerMintRequestId::random(),
+            tokenization_request_id: TokenizationRequestId::new("alp-snap-1"),
+            quantity: Quantity::new(Decimal::from(100)),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::Base,
+            client_id: ClientId::new(),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            initiated_at: Utc::now(),
+            mint_mode: VaultMode::Orchestrator {
+                address: address!("0x00000000000000000000000000000000000000aa"),
+            },
+        };
+
+        let mut old_snapshot =
+            serde_json::to_value(&mint).expect("state must serialize");
+        old_snapshot
+            .pointer_mut("/Initiated")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("Initiated snapshot object")
+            .remove("mint_mode");
+
+        let restored: Mint = serde_json::from_value(old_snapshot)
+            .expect("old snapshot must deserialize");
+        assert!(matches!(
+            restored,
+            Mint::Initiated { mint_mode: VaultMode::VaultDirect, .. }
+        ));
+    }
+
+    /// The mode anchored on `Initiated` flows through every lifecycle
+    /// transition: replay derives it from the mint's own event history alone
+    /// (live config is not an input to replay), so a mint initiated while its
+    /// asset was orchestrator-mode stays orchestrator-mode through
+    /// journal-confirm, minting, intent, submission, and failure — regardless
+    /// of what the asset's configured vault_mode says later.
+    #[test]
+    fn mint_mode_anchor_survives_replay_through_lifecycle() {
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+        let issuer_request_id = IssuerMintRequestId::random();
+        let base_events = vec![
+            MintEvent::Initiated {
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new(
+                    "alp-anchor-1",
+                ),
+                quantity: Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::Base,
+                client_id: ClientId::new(),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                initiated_at: Utc::now(),
+                mint_mode: orchestrator,
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: Utc::now(),
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: Utc::now(),
+            },
+            MintEvent::MintTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::default(),
+                intended_at: Utc::now(),
+            },
+            MintEvent::MintTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: "mint-anchor-1".to_string(),
+                tx_id: TxId::Hash(B256::repeat_byte(0x22)),
+                submitted_at: Utc::now(),
+            },
+        ];
+
+        let submitted = replay::<Mint>(base_events.clone())
+            .expect("lifecycle must replay")
+            .expect("mint must exist");
+        assert!(
+            matches!(
+                &submitted,
+                Mint::TxSubmitted { mint_mode, .. } if *mint_mode == orchestrator
+            ),
+            "TxSubmitted must carry the orchestrator anchor, got {submitted:?}"
+        );
+
+        let mut failed_events = base_events;
+        failed_events.push(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "boom".to_string(),
+            failed_at: Utc::now(),
+        });
+        let failed = replay::<Mint>(failed_events)
+            .expect("failed lifecycle must replay")
+            .expect("mint must exist");
+        assert!(
+            matches!(
+                &failed,
+                Mint::MintingFailed { mint_mode, .. }
+                    if *mint_mode == orchestrator
+            ),
+            "MintingFailed must carry the orchestrator anchor, got {failed:?}"
+        );
+    }
+
+    /// The anchor also survives the transitions the lifecycle test does not
+    /// reach: the recovery retry (`MintingFailed -> Minting`), the recovered
+    /// and terminal success states (`CallbackPending`, `Completed`), and the
+    /// journal-rejection terminal. Retry preservation is what keeps a
+    /// recovered orchestrator mint on the orchestrator path.
+    #[test]
+    fn mint_mode_anchor_survives_retry_rejection_and_terminal_states() {
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+        let issuer_request_id = IssuerMintRequestId::random();
+        let initiated = MintEvent::Initiated {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: TokenizationRequestId::new("alp-anchor-2"),
+            quantity: Quantity::new(Decimal::from(100)),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::Base,
+            client_id: ClientId::new(),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            initiated_at: Utc::now(),
+            mint_mode: orchestrator,
+        };
+
+        let mut events = vec![
+            initiated.clone(),
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: Utc::now(),
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: Utc::now(),
+            },
+            MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "boom".to_string(),
+                failed_at: Utc::now(),
+            },
+            MintEvent::MintRetryStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: None,
+                started_at: Utc::now(),
+                manual_retry_id: None,
+            },
+        ];
+        let retried = replay::<Mint>(events.clone())
+            .expect("retry lifecycle must replay")
+            .expect("mint must exist");
+        assert!(
+            matches!(
+                &retried,
+                Mint::Minting { mint_mode, .. } if *mint_mode == orchestrator
+            ),
+            "the retry transition must preserve the anchor, got {retried:?}"
+        );
+
+        events.push(MintEvent::ExistingMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::repeat_byte(0x33),
+            receipt_id: uint!(1_U256),
+            shares_minted: uint!(100_000000000000000000_U256),
+            block_number: 1000,
+            recovered_at: Utc::now(),
+        });
+        let recovered = replay::<Mint>(events.clone())
+            .expect("recovered lifecycle must replay")
+            .expect("mint must exist");
+        assert!(
+            matches!(
+                &recovered,
+                Mint::CallbackPending { mint_mode, .. }
+                    if *mint_mode == orchestrator
+            ),
+            "CallbackPending must carry the anchor, got {recovered:?}"
+        );
+
+        events.push(MintEvent::MintCompleted {
+            issuer_request_id: issuer_request_id.clone(),
+            completed_at: Utc::now(),
+        });
+        let completed = replay::<Mint>(events)
+            .expect("completed lifecycle must replay")
+            .expect("mint must exist");
+        assert!(
+            matches!(
+                &completed,
+                Mint::Completed { mint_mode, .. }
+                    if *mint_mode == orchestrator
+            ),
+            "Completed must carry the anchor, got {completed:?}"
+        );
+
+        let rejected = replay::<Mint>(vec![
+            initiated,
+            MintEvent::JournalRejected {
+                issuer_request_id,
+                reason: "insufficient shares".to_string(),
+                rejected_at: Utc::now(),
+            },
+        ])
+        .expect("rejected lifecycle must replay")
+        .expect("mint must exist");
+        assert!(
+            matches!(
+                &rejected,
+                Mint::JournalRejected { mint_mode, .. }
+                    if *mint_mode == orchestrator
+            ),
+            "JournalRejected must carry the anchor, got {rejected:?}"
+        );
+    }
+
+    fn orchestrator_initiated_event(
+        issuer_request_id: &IssuerMintRequestId,
+        mint_mode: VaultMode,
+    ) -> MintEvent {
+        MintEvent::Initiated {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: TokenizationRequestId::new("alp-auth-1"),
+            quantity: Quantity::new(Decimal::from(100)),
+            underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+            token: TokenSymbol::new("tAAPL"),
+            network: Network::Base,
+            client_id: ClientId::new(),
+            wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+            initiated_at: Utc::now(),
+            mint_mode,
+        }
+    }
+
+    fn test_authorization() -> MintAuthorization {
+        MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from_static(&[0xaa; 65]),
+        }
+    }
+
+    /// `MintAuthorizationReceived` applies only in the states
+    /// `handle_authorize_mint` emits from: a hypothetical late emission must
+    /// never swap the nonce after the transaction is signed — past intent it
+    /// replays as a no-op and the originally bound authorization stays.
+    #[test]
+    fn late_authorization_event_replays_as_a_noop_past_intent() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+
+        let history = vec![
+            orchestrator_initiated_event(&issuer_request_id, orchestrator),
+            MintEvent::MintAuthorizationReceived {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: test_authorization(),
+                received_at: Utc::now(),
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: Utc::now(),
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: Utc::now(),
+            },
+            MintEvent::MintTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::valid_for_test(
+                    1,
+                    "mint-late-auth".to_string(),
+                ),
+                intended_at: Utc::now(),
+            },
+            // No command emits this past intent; if one ever does, it must
+            // not rebind the nonce the signed transaction already carries.
+            MintEvent::MintAuthorizationReceived {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: MintAuthorization {
+                    nonce: B256::repeat_byte(0x08),
+                    signature: Bytes::from_static(&[0xbb; 65]),
+                },
+                received_at: Utc::now(),
+            },
+        ];
+
+        let mint = replay::<Mint>(history)
+            .expect("history must replay")
+            .expect("mint must exist");
+
+        assert!(
+            matches!(
+                &mint,
+                Mint::TxIntended { mint_authorization: Some(authorization), .. }
+                    if *authorization == test_authorization()
+            ),
+            "the late event must not rebind the authorization, got {mint:?}"
+        );
+    }
+
+    /// `AuthorizeMint` records the authorization on an orchestrator-mode mint
+    /// from every pre-intent state — without changing the lifecycle position.
+    #[tokio::test]
+    async fn authorize_mint_records_authorization_without_lifecycle_change() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+        let initiated =
+            orchestrator_initiated_event(&issuer_request_id, orchestrator);
+        let journal_confirmed = MintEvent::JournalConfirmed {
+            issuer_request_id: issuer_request_id.clone(),
+            confirmed_at: Utc::now(),
+        };
+        let minting_started = MintEvent::MintingStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            started_at: Utc::now(),
+        };
+
+        let cases: Vec<(Vec<MintEvent>, &str)> = vec![
+            (vec![initiated.clone()], "Initiated"),
+            (
+                vec![initiated.clone(), journal_confirmed.clone()],
+                "JournalConfirmed",
+            ),
+            (vec![initiated, journal_confirmed, minting_started], "Minting"),
+        ];
+
+        for (given, expected_state) in cases {
+            let events = TestHarness::<Mint>::with(())
+                .given(given.clone())
+                .when(MintCommand::AuthorizeMint {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mint_authorization: test_authorization(),
+                })
+                .await
+                .events();
+
+            assert_eq!(events.len(), 1, "from {expected_state}");
+            let MintEvent::MintAuthorizationReceived {
+                mint_authorization, ..
+            } = &events[0]
+            else {
+                panic!(
+                    "expected MintAuthorizationReceived from {expected_state}, \
+                     got {:?}",
+                    events[0]
+                );
+            };
+            assert_eq!(mint_authorization, &test_authorization());
+
+            // Applying the event sets the authorization but leaves the
+            // lifecycle position untouched.
+            let mut history = given;
+            history.push(events[0].clone());
+            let mint = replay::<Mint>(history)
+                .expect("history must replay")
+                .expect("mint must exist");
+            assert_eq!(mint.state_name(), expected_state);
+            assert!(matches!(
+                &mint,
+                Mint::Initiated {
+                    mint_authorization: Some(authorization),
+                    ..
+                } | Mint::JournalConfirmed {
+                    mint_authorization: Some(authorization),
+                    ..
+                } | Mint::Minting {
+                    mint_authorization: Some(authorization),
+                    ..
+                } if *authorization == test_authorization()
+            ));
+        }
+    }
+
+    /// An authorization for a vault-direct mint is meaningless — nothing will
+    /// ever consume it — so delivery is rejected and never stored.
+    #[tokio::test]
+    async fn authorize_mint_rejects_vault_direct_mint() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let error = TestHarness::<Mint>::with(())
+            .given(vec![orchestrator_initiated_event(
+                &issuer_request_id,
+                VaultMode::VaultDirect,
+            )])
+            .when(MintCommand::AuthorizeMint {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: test_authorization(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(
+                    MintError::AuthorizationForVaultDirectAsset { .. }
+                )
+            ),
+            "expected AuthorizationForVaultDirectAsset, got {error:?}"
+        );
+    }
+
+    /// Redelivery of the identical authorization is a no-op (the liquidity
+    /// bot retries deliveries); a different one is rejected so the nonce can
+    /// never be swapped mid-flight.
+    #[tokio::test]
+    async fn authorize_mint_is_idempotent_and_rejects_conflicts() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+        let given = vec![
+            orchestrator_initiated_event(&issuer_request_id, orchestrator),
+            MintEvent::MintAuthorizationReceived {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: test_authorization(),
+                received_at: Utc::now(),
+            },
+        ];
+
+        let events = TestHarness::<Mint>::with(())
+            .given(given.clone())
+            .when(MintCommand::AuthorizeMint {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: test_authorization(),
+            })
+            .await
+            .events();
+        assert!(
+            events.is_empty(),
+            "identical redelivery must be a no-op, got {events:?}"
+        );
+
+        let conflicting = MintAuthorization {
+            nonce: B256::repeat_byte(0x08),
+            signature: Bytes::from_static(&[0xbb; 65]),
+        };
+        let error = TestHarness::<Mint>::with(())
+            .given(given)
+            .when(MintCommand::AuthorizeMint {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: conflicting,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                &error,
+                LifecycleError::Apply(MintError::ConflictingMintAuthorization)
+            ),
+            "expected ConflictingMintAuthorization, got {error:?}"
+        );
+    }
+
+    /// Once `PrepareMint` signs, the nonce is baked into the persisted bytes;
+    /// a late delivery could not change what gets submitted and is rejected.
+    #[tokio::test]
+    async fn authorize_mint_rejected_after_transaction_intent() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let orchestrator = VaultMode::Orchestrator {
+            address: address!("0x00000000000000000000000000000000000000aa"),
+        };
+        let mut given = vec![
+            orchestrator_initiated_event(&issuer_request_id, orchestrator),
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: Utc::now(),
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: Utc::now(),
+            },
+            MintEvent::MintTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::default(),
+                intended_at: Utc::now(),
+            },
+        ];
+
+        for expected_state in ["MintIntended", "TxSubmitted"] {
+            let error = TestHarness::<Mint>::with(())
+                .given(given.clone())
+                .when(MintCommand::AuthorizeMint {
+                    issuer_request_id: issuer_request_id.clone(),
+                    mint_authorization: test_authorization(),
+                })
+                .await
+                .then_expect_error();
+
+            assert!(
+                matches!(
+                    &error,
+                    LifecycleError::Apply(
+                        MintError::AuthorizationNotAcceptable {
+                            current_state,
+                        }
+                    ) if current_state == expected_state
+                ),
+                "expected AuthorizationNotAcceptable from {expected_state}, \
+                 got {error:?}"
+            );
+
+            given.push(MintEvent::MintTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: "mint-auth-late".to_string(),
+                tx_id: TxId::Hash(B256::repeat_byte(0x22)),
+                submitted_at: Utc::now(),
+            });
         }
     }
 
@@ -3648,6 +4618,7 @@ pub(crate) mod tests {
 
         let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: tokenization_request_id.clone(),
                 quantity: quantity.clone(),
@@ -3659,6 +4630,7 @@ pub(crate) mod tests {
                 initiated_at: chrono::Utc::now(),
             }])
             .when(MintCommand::Initiate {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id,
                 tokenization_request_id,
                 quantity,
@@ -3702,11 +4674,14 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
         }])
         .unwrap()
         .unwrap();
 
         let Mint::Initiated {
+            mint_authorization: _,
+            mint_mode: _,
             issuer_request_id: applied_issuer_id,
             tokenization_request_id: applied_tokenization_id,
             quantity: applied_quantity,
@@ -3745,6 +4720,7 @@ pub(crate) mod tests {
         let initiated_at = Utc::now();
 
         let mut mint = Mint::Initiated {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -3754,6 +4730,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
         };
 
         let confirmed_at = Utc::now();
@@ -3789,6 +4766,7 @@ pub(crate) mod tests {
         let initiated_at = Utc::now();
 
         let mut mint = Mint::Initiated {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -3798,6 +4776,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
         };
 
         let rejected_at = Utc::now();
@@ -3837,6 +4816,7 @@ pub(crate) mod tests {
 
         let events = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
                 quantity,
@@ -3885,6 +4865,7 @@ pub(crate) mod tests {
         let error = TestHarness::<Mint>::with(())
             .given(vec![
                 MintEvent::Initiated {
+                    mint_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id,
                     quantity,
@@ -3924,6 +4905,7 @@ pub(crate) mod tests {
 
         let events = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id,
                 quantity,
@@ -3985,6 +4967,7 @@ pub(crate) mod tests {
 
         let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
                 quantity,
@@ -4026,6 +5009,7 @@ pub(crate) mod tests {
 
         let error = TestHarness::<Mint>::with(())
             .given(vec![MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: correct_issuer_request_id,
                 tokenization_request_id,
                 quantity,
@@ -4067,6 +5051,7 @@ pub(crate) mod tests {
         let journal_confirmed_at = Utc::now();
 
         let mut mint = Mint::JournalConfirmed {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id: tokenization_request_id.clone(),
             quantity: quantity.clone(),
@@ -4076,6 +5061,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
             journal_confirmed_at,
         };
 
@@ -4086,6 +5072,8 @@ pub(crate) mod tests {
         });
 
         let Mint::Minting {
+            mint_authorization: _,
+            mint_mode: _,
             issuer_request_id: state_issuer_id,
             tokenization_request_id: state_tok_id,
             quantity: state_quantity,
@@ -4135,6 +5123,7 @@ pub(crate) mod tests {
         let minting_started_at = Utc::now();
 
         let mut mint = Mint::Minting {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -4144,6 +5133,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
             journal_confirmed_at,
             minting_started_at,
             retry: None,
@@ -4206,6 +5196,7 @@ pub(crate) mod tests {
         let minting_started_at = Utc::now();
 
         let mut mint = Mint::Minting {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -4215,6 +5206,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
             journal_confirmed_at,
             minting_started_at,
             retry: None,
@@ -4276,6 +5268,7 @@ pub(crate) mod tests {
         let minted_at = Utc::now();
 
         let mut mint = Mint::CallbackPending {
+            mint_authorization: None,
             issuer_request_id: issuer_request_id.clone(),
             tokenization_request_id,
             quantity,
@@ -4285,6 +5278,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
             journal_confirmed_at,
             tx_hash,
             receipt_id,
@@ -4359,6 +5353,7 @@ pub(crate) mod tests {
             client_id,
             wallet,
             initiated_at,
+            mint_mode: VaultMode::VaultDirect,
         }])
         .unwrap()
         .unwrap();

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1451,6 +1451,7 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::*;
+    use crate::config::VaultMode;
     use crate::mint::api::test_utils::{
         TestAccountAndAsset, TestHarness, network_vault_services,
     };
@@ -1793,6 +1794,7 @@ mod tests {
 
         vec![
             MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
                 issuer_request_id: issuer_request_id.clone(),
                 tokenization_request_id: TokenizationRequestId::new("tok-123"),
                 quantity: Quantity::new(Decimal::from(100)),
@@ -2357,6 +2359,7 @@ mod tests {
             .send(
                 issuer_request_id,
                 MintCommand::Initiate {
+                    mint_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: TokenizationRequestId::new(
                         "tok-reconcile",

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, Utc};
 use event_sorcery::{Projection, ProjectionError};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
+use uuid::Uuid;
 
 use super::{
     ClientId, IssuerMintRequestId, Mint, Network, Quantity, TokenSymbol,
@@ -16,6 +17,17 @@ pub(crate) enum MintViewError {
     Projection(#[from] ProjectionError<Mint>),
     #[error("Deserialization error: {0}")]
     Deserialization(#[from] serde_json::Error),
+    #[error("Database error: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("mint view row id {view_id} is not a valid issuer request id")]
+    InvalidViewId { view_id: String },
+    #[error(
+        "tokenization request {tokenization_request_id} matches {matches} mints; refusing ambiguous authorization routing"
+    )]
+    AmbiguousTokenizationRequest {
+        tokenization_request_id: TokenizationRequestId,
+        matches: usize,
+    },
 }
 
 /// Query-oriented representation of a live `Mint` projection.
@@ -217,6 +229,96 @@ pub(crate) async fn find_by_issuer_request_id(
         .map_err(Into::into)
 }
 
+/// Maps Alpaca's `tokenization_request_id` to our issuer id. The internal
+/// mint-authorization call is keyed by the tokenization id — the only mint id
+/// the liquidity bot shares with us; `IssuerMintRequestId` is minted here and
+/// never leaves the Alpaca channel.
+///
+/// SQL only PRUNES candidate rows (served by the
+/// `idx_mint_view_live_tokenization_request_id` expression index — the query
+/// must keep the exact COALESCE expression the index is built on); every
+/// candidate is then loaded through the type-safe projection and re-verified
+/// against `Mint::tokenization_request_id()`, so no domain value is ever
+/// parsed out of the view JSON here.
+///
+/// Nothing enforces tokenization-id uniqueness across mints, so matches are
+/// partitioned by [`Mint::accepts_mint_authorization`]: exactly one
+/// still-accepting mint wins regardless of stale same-id duplicates (a
+/// completed mint from a reused id must never wedge the live one's
+/// authorization), and a sole non-accepting match is still returned so late
+/// deliveries keep their informative rejections (409 naming the state,
+/// vault-direct 422). Anything genuinely ambiguous fails loudly rather than
+/// routing an authorization to an arbitrary aggregate.
+pub(crate) async fn find_issuer_id_by_tokenization_request_id(
+    pool: &Pool<Sqlite>,
+    tokenization_request_id: &TokenizationRequestId,
+) -> Result<Option<IssuerMintRequestId>, MintViewError> {
+    let candidate_ids: Vec<String> =
+        sqlx::query_scalar(tokenization_id_candidate_query())
+            .bind(&tokenization_request_id.0)
+            .fetch_all(pool)
+            .await?;
+
+    let projection = Projection::<Mint>::sqlite(pool.clone());
+    let mut accepting = Vec::new();
+    let mut stale = Vec::new();
+    for view_id in candidate_ids {
+        let issuer_request_id = view_id
+            .parse::<Uuid>()
+            .map(IssuerMintRequestId::new)
+            .map_err(|_| MintViewError::InvalidViewId { view_id })?;
+
+        let Some(mint) = projection.load(&issuer_request_id).await? else {
+            continue;
+        };
+        if mint.tokenization_request_id() != Some(tokenization_request_id) {
+            continue;
+        }
+
+        if mint.accepts_mint_authorization() {
+            accepting.push(issuer_request_id);
+        } else {
+            stale.push(issuer_request_id);
+        }
+    }
+
+    // The ambiguity error reports every matching mint — accepting AND stale
+    // — so the operator sees the true collision size (an `(accepting, _)`
+    // binding would silently under-count when both kinds exist).
+    let matches = accepting.len() + stale.len();
+    match (accepting.len(), stale.len()) {
+        (1, _) => Ok(accepting.pop()),
+        (0, 0 | 1) => Ok(stale.pop()),
+        _ => Err(MintViewError::AmbiguousTokenizationRequest {
+            tokenization_request_id: tokenization_request_id.clone(),
+            matches,
+        }),
+    }
+}
+
+/// The candidate-pruning query behind
+/// [`find_issuer_id_by_tokenization_request_id`]. Its WHERE clause must
+/// structurally match the COALESCE expression
+/// `idx_mint_view_live_tokenization_request_id` is built on, or SQLite falls
+/// back to a table scan — pinned by the query-plan test.
+const fn tokenization_id_candidate_query() -> &'static str {
+    "
+    SELECT view_id
+    FROM mint_view
+    WHERE COALESCE(
+        json_extract(payload, '$.Live.Initiated.tokenization_request_id'),
+        json_extract(payload, '$.Live.JournalConfirmed.tokenization_request_id'),
+        json_extract(payload, '$.Live.JournalRejected.tokenization_request_id'),
+        json_extract(payload, '$.Live.Minting.tokenization_request_id'),
+        json_extract(payload, '$.Live.TxIntended.tokenization_request_id'),
+        json_extract(payload, '$.Live.TxSubmitted.tokenization_request_id'),
+        json_extract(payload, '$.Live.CallbackPending.tokenization_request_id'),
+        json_extract(payload, '$.Live.MintingFailed.tokenization_request_id'),
+        json_extract(payload, '$.Live.Completed.tokenization_request_id')
+    ) = ?
+    "
+}
+
 /// Finds all mints that need recovery (not in terminal states).
 ///
 /// Returns mints in JournalConfirmed, Minting, MintingFailed, or CallbackPending states.
@@ -296,6 +398,7 @@ mod tests {
     use sqlx::{Pool, Sqlite, sqlite::SqlitePoolOptions};
 
     use super::*;
+    use crate::config::VaultMode;
     use crate::mint::{Mint, MintCommand};
 
     /// Inserts a `Lifecycle<Mint>`-shaped row into `mint_view` for a given
@@ -397,6 +500,7 @@ mod tests {
             .send(
                 &issuer_request_id,
                 MintCommand::Initiate {
+                    mint_mode: VaultMode::VaultDirect,
                     issuer_request_id: issuer_request_id.clone(),
                     tokenization_request_id: TokenizationRequestId::new(
                         "alp-888",
@@ -455,6 +559,214 @@ mod tests {
             .expect("Query should succeed");
 
         assert!(result.is_none());
+    }
+
+    fn initiate_command(
+        issuer_request_id: &IssuerMintRequestId,
+        tokenization_request_id: &str,
+    ) -> MintCommand {
+        MintCommand::Initiate {
+            mint_mode: VaultMode::VaultDirect,
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: TokenizationRequestId::new(
+                tokenization_request_id,
+            ),
+            quantity: Quantity::new(Decimal::from(50)),
+            underlying: UnderlyingSymbol::new("TSLA").unwrap(),
+            token: TokenSymbol::new("tTSLA"),
+            network: Network::Base,
+            client_id: ClientId::new(),
+            wallet: address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd"),
+        }
+    }
+
+    /// The tokenization-id lookup prunes candidates in SQL across every live
+    /// state's payload path, then confirms through the projection — so it
+    /// must keep finding a mint after it advances past `Initiated`, and must
+    /// ignore other mints' ids.
+    #[tokio::test]
+    async fn find_issuer_id_by_tokenization_id_follows_state_changes() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
+            .build(())
+            .await
+            .expect("Failed to build mint store");
+
+        let issuer_request_id = IssuerMintRequestId::random();
+        store
+            .send(
+                &issuer_request_id,
+                initiate_command(&issuer_request_id, "alp-tok-lookup"),
+            )
+            .await
+            .expect("Failed to initiate mint");
+        let other_id = IssuerMintRequestId::random();
+        store
+            .send(&other_id, initiate_command(&other_id, "alp-tok-other"))
+            .await
+            .expect("Failed to initiate other mint");
+
+        let found = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-lookup"),
+        )
+        .await
+        .expect("lookup must succeed");
+        assert_eq!(found, Some(issuer_request_id.clone()));
+
+        // Advance past Initiated: the lookup must match the
+        // JournalConfirmed payload path too.
+        store
+            .send(
+                &issuer_request_id,
+                MintCommand::ConfirmJournal {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .expect("Failed to confirm journal");
+        let found = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-lookup"),
+        )
+        .await
+        .expect("lookup must succeed");
+        assert_eq!(found, Some(issuer_request_id));
+
+        let missing = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-unknown"),
+        )
+        .await
+        .expect("lookup must succeed");
+        assert_eq!(missing, None);
+    }
+
+    /// The candidate query must be served by
+    /// `idx_mint_view_live_tokenization_request_id` — SQLite only uses an
+    /// expression index when the WHERE clause structurally matches the
+    /// indexed expression, so any drift between the migration and the query
+    /// silently regresses to a table scan. Pin the query plan.
+    #[tokio::test]
+    async fn find_issuer_id_by_tokenization_id_lookup_uses_expression_index() {
+        let pool = setup_test_db().await;
+
+        let plan: Vec<(i64, i64, i64, String)> =
+            sqlx::query_as(sqlx::AssertSqlSafe(format!(
+                "EXPLAIN QUERY PLAN {}",
+                super::tokenization_id_candidate_query()
+            )))
+            .bind("alp-tok-plan")
+            .fetch_all(&pool)
+            .await
+            .expect("query plan must be explainable");
+
+        assert!(
+            plan.iter().any(|(_, _, _, detail)| detail
+                .contains("idx_mint_view_live_tokenization_request_id")),
+            "the lookup must be served by the expression index, got plan: \
+             {plan:?}"
+        );
+    }
+
+    /// A stale terminal mint from a reused tokenization id must never wedge
+    /// the live one: the lookup prefers the single still-accepting mint, and
+    /// still returns a sole stale match so late deliveries keep their
+    /// informative rejections.
+    #[tokio::test]
+    async fn find_issuer_id_by_tokenization_id_prefers_live_over_stale() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
+            .build(())
+            .await
+            .expect("Failed to build mint store");
+
+        // The stale duplicate: initiated with the same tokenization id, then
+        // journal-rejected — terminal, can never accept an authorization.
+        let stale_id = IssuerMintRequestId::random();
+        store
+            .send(&stale_id, initiate_command(&stale_id, "alp-tok-reused"))
+            .await
+            .expect("Failed to initiate stale mint");
+        store
+            .send(
+                &stale_id,
+                MintCommand::RejectJournal {
+                    issuer_request_id: stale_id.clone(),
+                    reason: "journal failed".to_string(),
+                },
+            )
+            .await
+            .expect("Failed to reject journal");
+
+        // Only the stale mint exists yet: it must still be returned so a
+        // late delivery gets its informative rejection instead of a 404.
+        let found = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-reused"),
+        )
+        .await
+        .expect("lookup must succeed");
+        assert_eq!(found, Some(stale_id.clone()));
+
+        // The live mint reusing the id: it must win over the stale one.
+        let live_id = IssuerMintRequestId::random();
+        store
+            .send(&live_id, initiate_command(&live_id, "alp-tok-reused"))
+            .await
+            .expect("Failed to initiate live mint");
+
+        let found = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-reused"),
+        )
+        .await
+        .expect("lookup must succeed despite the stale duplicate");
+        assert_eq!(
+            found,
+            Some(live_id),
+            "the live mint must win over the stale terminal duplicate"
+        );
+    }
+
+    /// Nothing enforces tokenization-id uniqueness across mints, so an
+    /// ambiguous id must fail loudly instead of routing an authorization to
+    /// an arbitrary aggregate.
+    #[tokio::test]
+    async fn find_issuer_id_by_tokenization_id_rejects_ambiguous_matches() {
+        let pool = setup_test_db().await;
+        let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
+            .build(())
+            .await
+            .expect("Failed to build mint store");
+
+        for _ in 0..2 {
+            let issuer_request_id = IssuerMintRequestId::random();
+            store
+                .send(
+                    &issuer_request_id,
+                    initiate_command(&issuer_request_id, "alp-tok-dup"),
+                )
+                .await
+                .expect("Failed to initiate mint");
+        }
+
+        let result = find_issuer_id_by_tokenization_request_id(
+            &pool,
+            &TokenizationRequestId::new("alp-tok-dup"),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                result,
+                Err(MintViewError::AmbiguousTokenizationRequest {
+                    matches: 2,
+                    ..
+                })
+            ),
+            "a duplicated tokenization id must be rejected, got {result:?}"
+        );
     }
 
     fn test_mint_fields() -> TestMintFields {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -23,6 +23,7 @@ expressed as an OpenAPI scheme."
         crate::tokenized_asset::api::get_tokenized_asset,
         crate::tokenized_asset::api::get_tokenized_asset_status,
         crate::tokenized_asset::api::add_tokenized_asset,
+        crate::mint::api::authorize_mint,
         crate::account::api::register_account,
         crate::account::api::whitelist_wallet,
         crate::account::api::unwhitelist_wallet,
@@ -48,6 +49,8 @@ expressed as an OpenAPI scheme."
         crate::account::api::RegisterAccountResponse,
         crate::account::api::WhitelistWalletRequest,
         crate::account::api::WhitelistWalletResponse,
+        crate::mint::api::MintAuthorizationRequest,
+        crate::mint::api::MintAuthorizationResponse,
         crate::admin::AggregateKind,
         crate::admin::ReprocessResponse,
         crate::admin::StuckAggregate,
@@ -118,6 +121,7 @@ mod tests {
             "/admin/reprocess/mint/{aggregate_id}",
             "/admin/close/mint/{aggregate_id}",
             "/admin/freeze-schedules",
+            "/internal/mints/{tokenization_request_id}/authorization",
         ] {
             assert!(
                 paths.contains_key(path),
@@ -201,6 +205,24 @@ mod tests {
         assert_eq!(
             schemas["TokenizedAssetStatus"]["enum"],
             serde_json::json!(["enabled", "frozen"])
+        );
+
+        // The authorization DTOs carry `schema(value_type = String)` over
+        // `B256`/`Bytes`/`IssuerMintRequestId`; the overrides must hold so
+        // the schema advertises the 0x-hex strings the liquidity bot sends
+        // rather than alloy's internal representations.
+        assert_eq!(
+            schemas["MintAuthorizationRequest"]["properties"]["nonce"]["type"],
+            "string"
+        );
+        assert_eq!(
+            schemas["MintAuthorizationRequest"]["properties"]["signature"]["type"],
+            "string"
+        );
+        assert_eq!(
+            schemas["MintAuthorizationResponse"]["properties"]["issuer_request_id"]
+                ["type"],
+            "string"
         );
     }
 }

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -307,6 +307,7 @@ mod tests {
     use sqlx::SqlitePool;
 
     use super::*;
+    use crate::config::VaultMode;
     use crate::mint::{ClientId, Network, Quantity, TokenizationRequestId};
 
     async fn migrated_pool() -> SqlitePool {
@@ -355,6 +356,7 @@ mod tests {
         wallet: Address,
     ) -> MintEvent {
         MintEvent::Initiated {
+            mint_mode: VaultMode::VaultDirect,
             issuer_request_id: IssuerMintRequestId::random(),
             tokenization_request_id: TokenizationRequestId::new(
                 tokenization_request_id,

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -208,6 +208,10 @@ struct OrchestratorMockState {
     /// When set, `validate_mint_authorization` fails with this outcome.
     #[cfg(test)]
     mint_auth_failure: Mutex<Option<MockMintAuthFailure>>,
+    /// When set, `validate_mint_authorization` never resolves, standing in
+    /// for an unresponsive RPC provider so deadline handling is testable.
+    #[cfg(test)]
+    mint_auth_hang: Mutex<bool>,
     #[cfg(test)]
     last_mint_params: Mutex<Option<OrchestratorMintParams>>,
     #[cfg(test)]
@@ -226,6 +230,12 @@ struct OrchestratorMockState {
 pub(crate) enum MockMintAuthFailure {
     SignerMismatch,
     NonceUsed,
+    /// An empty-signature authorization naming an EOA recipient — only a
+    /// contract can answer the orchestrator's `authorizeMint` callback.
+    EmptySignatureForEoa,
+    /// A non-authorization failure (e.g. an RPC read error) — the outcome the
+    /// endpoint must surface as a 502, never as a 422 rejection.
+    ReadFailed,
 }
 
 /// Mock blockchain service for testing.
@@ -558,6 +568,7 @@ impl MockVaultService {
         *self.orchestrator.minted_log.lock().unwrap() = None;
         *self.orchestrator.minted_log_binding.lock().unwrap() = None;
         *self.orchestrator.mint_auth_failure.lock().unwrap() = None;
+        *self.orchestrator.mint_auth_hang.lock().unwrap() = false;
         *self.orchestrator.last_mint_params.lock().unwrap() = None;
         self.orchestrator
             .mint_preparation_call_count
@@ -918,6 +929,14 @@ impl MockVaultService {
         failure: MockMintAuthFailure,
     ) -> Self {
         *self.orchestrator.mint_auth_failure.lock().unwrap() = Some(failure);
+        self
+    }
+
+    /// Configures `validate_mint_authorization` to never resolve, standing
+    /// in for an unresponsive RPC provider.
+    #[cfg(test)]
+    pub(crate) fn with_mint_auth_hang(self) -> Self {
+        *self.orchestrator.mint_auth_hang.lock().unwrap() = true;
         self
     }
 
@@ -1943,6 +1962,9 @@ impl VaultService for MockVaultService {
             self.orchestrator
                 .mint_auth_validation_call_count
                 .fetch_add(1, Ordering::Relaxed);
+            if *self.orchestrator.mint_auth_hang.lock().unwrap() {
+                std::future::pending::<()>().await;
+            }
             let failure_opt =
                 *self.orchestrator.mint_auth_failure.lock().unwrap();
             match failure_opt {
@@ -1957,6 +1979,16 @@ impl VaultService for MockVaultService {
                         to: query.to,
                         nonce: query.nonce,
                     });
+                }
+                Some(MockMintAuthFailure::EmptySignatureForEoa) => {
+                    return Err(VaultError::MintAuthEmptySignatureForEoa {
+                        to: query.to,
+                    });
+                }
+                Some(MockMintAuthFailure::ReadFailed) => {
+                    return Err(VaultError::Rpc(
+                        TransportErrorKind::custom_str("mock RPC failure"),
+                    ));
                 }
                 None => {}
             }


### PR DESCRIPTION
## Motivation

Orchestrator-mode mints require a `MintAuthV1` EIP-712 signature from the liquidity bot before the on-chain transaction can be submitted. Alpaca cannot carry this authorization through its flow, so it must arrive out-of-band on an internal channel. Without a dedicated endpoint and aggregate command to receive and persist it, orchestrator-mode mints have no way to acquire the authorization they need before the `PrepareMint` step.

Additionally, the `VaultMode` for a mint was previously derived from live config at each step, meaning a config change mid-flight could alter the behavior of an in-progress mint. The mode needs to be anchored at initiation time and carried through the entire lifecycle.

## Solution

A `mint_mode` field (`VaultDirect` | `Orchestrator { address }`) is resolved from config exactly once at `Initiate` time and persisted on the `Initiated` event and all subsequent lifecycle states. Every mode-dependent step derives from this persisted anchor rather than live config. Historical events and snapshots that predate this field default to `VaultDirect` via `#[serde(default)]`.

A `mint_authorization` field (`Option<MintAuthorization>`) is added to all pre-terminal `Mint` states to carry the liquidity bot's validated `MintAuthV1` nonce and signature. It is always `None` on a freshly initiated mint and populated by the new `MintAuthorizationReceived` event.

A new `POST /internal/mints/{tokenization_request_id}/authorization` endpoint (`authorize_mint`) accepts the liquidity bot's authorization delivery. It:

- Looks up the mint by `tokenization_request_id` (the only mint identifier shared with the liquidity bot)
- Rejects delivery for vault-direct mints with `422`
- Validates the authorization on-chain (signer identity, nonce consumption) before touching the aggregate, so a bad delivery is an actionable failure at this call rather than a post-journal surprise
- Issues `MintCommand::AuthorizeMint`, which produces `MintAuthorizationReceived` without changing the lifecycle state
- Is idempotent on redelivery of an identical authorization and returns `409` for a conflicting nonce

The aggregate enforces that authorization is only accepted in `Initiated`, `JournalConfirmed`, and `Minting` states — once `PrepareMint` signs, the nonce is baked into the persisted transaction bytes and a late delivery cannot change what gets submitted.  
  
Closes [RAI-1616](https://linear.app/makeitrain/issue/RAI-1616/orchestrator-mint-authorization-endpoint)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mint authorization with validation, recording, and idempotent redelivery handling.
  * Mint workflows now preserve vault mode and authorization details throughout their lifecycle.
  * Added tokenization-request lookup to route authorizations to the correct mint.
* **Bug Fixes**
  * Improved handling of stale, duplicate, closed, unsupported, and ambiguous authorization requests.
  * Prevented orchestrator-anchored mints from using the direct-vault submission flow.
* **Documentation**
  * Documented the mint authorization endpoint and its request and response formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->