### PR TITLE
feat: orchestrator mint confirmation with nonce-replay recovery and failure classification

### DIFF
--- a/migrations/20260813000755_release_signer_intent_on_orchestrator_mint_events.sql
+++ b/migrations/20260813000755_release_signer_intent_on_orchestrator_mint_events.sql
@@ -1,0 +1,47 @@
+-- Release the signer-intent reservation on the orchestrator mint outcomes.
+--
+-- The release trigger predates orchestrator mode and only knew the
+-- vault-direct resolutions. An orchestrator mint's landing can be recorded
+-- as `OrchestratorMintRecovered` while the reservation from its
+-- `MintTxIntended` is still held (e.g. a crash after intent, a
+-- `NonceReplayed` rebroadcast revert parking `MintingFailed`, then recovery
+-- proving the landing) — with no release, the network-keyed row would
+-- strand, rejecting every later mint AND burn on that network until an
+-- operator `MintClosed`. `OrchestratorTokensMinted` is included for parity
+-- with `TokensMinted`: today it only fires after `MintTxSubmitted` already
+-- released the row, but the trigger must not depend on that ordering staying
+-- true.
+DROP TRIGGER release_mint_signer_intent;
+
+CREATE TRIGGER release_mint_signer_intent
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'Mint'
+ AND NEW.event_type IN (
+     'MintEvent::MintTxSubmitted',
+     'MintEvent::TokensMinted',
+     'MintEvent::ExistingMintRecovered',
+     'MintEvent::OrchestratorTokensMinted',
+     'MintEvent::OrchestratorMintRecovered',
+     'MintEvent::MintClosed'
+ )
+BEGIN
+    DELETE FROM active_signer_intents
+    WHERE aggregate_type = NEW.aggregate_type
+      AND aggregate_id = NEW.aggregate_id;
+END;
+
+-- Heal any reservation the gap already stranded: a held mint intent whose
+-- aggregate later recorded an orchestrator resolution is resolved, not
+-- unresolved — mirror the release the trigger would have performed.
+DELETE FROM active_signer_intents
+WHERE aggregate_type = 'Mint'
+  AND EXISTS (
+      SELECT 1
+      FROM events AS resolved
+      WHERE resolved.aggregate_type = 'Mint'
+        AND resolved.aggregate_id = active_signer_intents.aggregate_id
+        AND resolved.event_type IN (
+            'MintEvent::OrchestratorTokensMinted',
+            'MintEvent::OrchestratorMintRecovered'
+        )
+  );

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2463,7 +2463,10 @@ mod tests {
     };
     use crate::config::{VaultMode, VaultModeConfig};
     use crate::mint::test_utils::{TestHarness, test_config};
-    use crate::mint::{Quantity, TokenizationRequestId};
+    use crate::mint::{
+        ClientId, MintFailureClassification, MintView, Quantity,
+        TokenizationRequestId,
+    };
     use crate::receipt_inventory::ReceiptVaultKey;
     use crate::receipt_inventory::{
         ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
@@ -5638,7 +5641,6 @@ mod tests {
     #[test]
     fn mint_view_summary_classifies_and_timestamps_each_variant() {
         use super::StuckClass::{InProgress, TerminalFail};
-        use crate::mint::{ClientId, MintView, Network};
 
         let issuer_request_id = crate::mint::IssuerMintRequestId::random();
         let tokenization_request_id = TokenizationRequestId::new("alp-stuck-1");
@@ -5749,7 +5751,8 @@ mod tests {
             tx_hash: b256!(
                 "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             ),
-            receipt_id: U256::from(1u64),
+            receipt_id: Some(U256::from(1u64)),
+            mint_nonce: None,
             shares_minted: U256::from(100u64),
             gas_used: None,
             block_number: 1,
@@ -5774,6 +5777,7 @@ mod tests {
             journal_confirmed_at,
             error: "deposit failed".to_string(),
             failed_at,
+            classification: MintFailureClassification::Unclassified,
         };
         let s = super::mint_view_summary(&minting_failed).unwrap();
         assert_eq!(s.class, TerminalFail);
@@ -5798,7 +5802,8 @@ mod tests {
                 tx_hash: b256!(
                     "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
                 ),
-                receipt_id: U256::from(2u64),
+                receipt_id: Some(U256::from(2u64)),
+                mint_nonce: None,
                 shares_minted: U256::from(100u64),
                 gas_used: None,
                 block_number: 1,

--- a/src/mint/api/authorize.rs
+++ b/src/mint/api/authorize.rs
@@ -1,4 +1,5 @@
 use alloy::primitives::{B256, Bytes};
+use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use cqrs_es::AggregateError;
 use event_sorcery::{LifecycleError, Store};
 use rocket::http::{ContentType, Status};
@@ -15,6 +16,7 @@ use tracing::{error, info, warn};
 use super::ErrorResponse;
 use crate::auth::InternalAuth;
 use crate::config::VaultMode;
+use crate::mint::recovery::enqueue_scheduled_mint_recovery;
 use crate::mint::view::find_issuer_id_by_tokenization_request_id;
 use crate::mint::{
     IssuerMintRequestId, Mint, MintCommand, MintError, TokenizationRequestId,
@@ -173,6 +175,7 @@ pub(crate) async fn authorize_mint(
     tokenization_request_id: &str,
     mint_store: &rocket::State<Arc<Store<Mint>>>,
     pool: &rocket::State<Pool<Sqlite>>,
+    apalis_pool: &rocket::State<ApalisSqlitePool>,
     vault_services: &rocket::State<NetworkVaultServices>,
     request: Json<MintAuthorizationRequest>,
 ) -> Result<Json<MintAuthorizationResponse>, MintAuthorizationApiError> {
@@ -294,6 +297,16 @@ pub(crate) async fn authorize_mint(
             "Identical mint authorization already recorded; redelivery is a \
              no-op"
         );
+        // The first delivery's wake may have failed after the authorization
+        // was recorded, leaving the mint parked; the bot's redelivery is the
+        // caller-driven repair vector, and the enqueue's idempotency key
+        // collapses duplicates when the first wake did land.
+        wake_mint_recovery(
+            pool.inner(),
+            apalis_pool.inner(),
+            &issuer_request_id,
+        )
+        .await;
         return Ok(Json(MintAuthorizationResponse {
             issuer_request_id,
             status: "authorized".to_string(),
@@ -367,10 +380,40 @@ pub(crate) async fn authorize_mint(
         "Mint authorization validated and recorded"
     );
 
+    // The authorization's arrival is what unblocks a mint that deferred its
+    // submission waiting for it, so wake recovery now.
+    wake_mint_recovery(pool.inner(), apalis_pool.inner(), &issuer_request_id)
+        .await;
+
     Ok(Json(MintAuthorizationResponse {
         issuer_request_id,
         status: "authorized".to_string(),
     }))
+}
+
+/// Wakes mint recovery for a recorded authorization. Needed because the
+/// periodic reconciler dedups against a terminal recovery row, so a mint
+/// whose recovery job already exhausted its no-progress budget would stay
+/// parked until the next restart without this kick. An enqueue failure is
+/// tolerable — the authorization is recorded, the bot's redelivery re-drives
+/// this wake, and the startup re-scan is the last-resort fallback.
+async fn wake_mint_recovery(
+    pool: &Pool<Sqlite>,
+    apalis_pool: &ApalisSqlitePool,
+    issuer_request_id: &IssuerMintRequestId,
+) {
+    if let Err(error) = enqueue_scheduled_mint_recovery(
+        pool,
+        apalis_pool,
+        issuer_request_id.clone(),
+    )
+    .await
+    {
+        warn!(target: "mint", issuer_request_id = %issuer_request_id,
+            error = %error,
+            "Failed to enqueue mint recovery after recording the authorization"
+        );
+    }
 }
 
 fn map_authorize_command_error(
@@ -432,6 +475,7 @@ mod tests {
     use rocket::http::{ContentType, Header, Status};
     use rocket::routes;
     use rust_decimal::Decimal;
+    use std::any::type_name;
     use std::sync::Arc;
     use tracing_test::traced_test;
 
@@ -439,6 +483,7 @@ mod tests {
     use crate::auth::FailedAuthRateLimiter;
     use crate::config::VaultMode;
     use crate::mint::api::test_utils::{TestHarness, test_config};
+    use crate::mint::recovery::MintRecoveryJob;
     use crate::mint::{
         ClientId, IssuerMintRequestId, Mint, MintCommand, Network, Quantity,
         TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
@@ -517,6 +562,7 @@ mod tests {
             .manage(FailedAuthRateLimiter::new().unwrap())
             .manage(harness.mint_store.clone())
             .manage(harness.pool.clone())
+            .manage(harness.apalis_pool.clone())
             .manage(vault_services)
             .mount("/", routes![authorize_mint])
     }
@@ -621,6 +667,32 @@ mod tests {
             tracing::Level::INFO,
             &["Mint authorization validated and recorded", "tok-auth-1"]
         ));
+
+        // The recorded authorization must wake recovery: a mint whose
+        // deferred submission already exhausted its recovery job would
+        // otherwise stay parked until restart (the reconciler dedups
+        // against terminal rows). The redelivery short-circuit re-drives
+        // the wake (repairing a first delivery whose enqueue failed), and
+        // the idempotency key collapses the duplicate down to one row.
+        let recovery_jobs: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE
+                job_type = ?
+                AND idempotency_key = ?
+            ",
+        )
+        .bind(type_name::<MintRecoveryJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            recovery_jobs, 1,
+            "recording the authorization must enqueue exactly one mint \
+             recovery job"
+        );
     }
 
     #[traced_test]

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -2,6 +2,7 @@ use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
+use super::event::MintFailureClassification;
 use super::{
     ClientId, IssuerMintRequestId, MintExternalTxId, Network, Quantity,
     TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
@@ -94,6 +95,43 @@ pub(crate) enum MintCommand {
     RecordMintFailed {
         issuer_request_id: IssuerMintRequestId,
         error: String,
+        /// Typed cause when one was decoded; typed classifications are never
+        /// auto-retried. Deliberately NOT `#[serde(default)]` (see
+        /// `Initiate::mint_mode`): commands have no historical payloads, and
+        /// a silently defaulted `Unclassified` would re-enable automatic
+        /// retries for a deterministic failure.
+        classification: MintFailureClassification,
+    },
+
+    /// Records the outcome of a successful orchestrator mint confirmation
+    /// performed by a durable `ConfirmMintJob`. Pure: produces
+    /// `OrchestratorTokensMinted` from the payload, no I/O. Idempotent — a
+    /// no-op if the mint already advanced past `TxSubmitted`. The handler
+    /// rejects vault-direct mints — an orchestrator result can never complete
+    /// a vault-direct mint, or vice versa.
+    RecordOrchestratorTokensMinted {
+        issuer_request_id: IssuerMintRequestId,
+        /// The signing-backend transaction the report belongs to; a mismatch
+        /// against the stored submission is rejected.
+        tx_id: TxId,
+        tx_hash: B256,
+        nonce: B256,
+        shares_minted: U256,
+        gas_used: u64,
+        block_number: u64,
+    },
+
+    /// Records an already-landed orchestrator mint discovered by the
+    /// `Minted`-log lookup after a `NonceReplayed` revert, full-matched on
+    /// `(to, nonce, token, amount)`. Pure: produces
+    /// `OrchestratorMintRecovered`. Idempotent — a no-op once the mint has
+    /// advanced past `TxSubmitted`.
+    RecordOrchestratorMintRecovered {
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        nonce: B256,
+        shares_minted: U256,
+        block_number: u64,
     },
 
     /// Retries a failed mint by transitioning `MintingFailed` -> `Minting`,

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -12,6 +12,68 @@ use super::{
     TokenizationRequestId, UnderlyingSymbol,
 };
 
+/// Typed classification of an on-chain mint failure, persisted on
+/// `MintingFailed`. Mirrors the burn side's `BurnFailureClassification`:
+/// typed classifications are never auto-retried, and the halted-orchestrator
+/// cases are surfaced distinctly from ordinary mint failures.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize,
+)]
+pub(crate) enum MintFailureClassification {
+    /// No typed cause was decoded — retryable on the automatic schedule.
+    #[default]
+    Unclassified,
+    /// `vaultLogicIsExpected()` mismatch — the orchestrator is halted
+    /// pending upgrade; resolves environment-wide, never per-mint.
+    VaultLogicMismatch,
+    /// The orchestrator's receipt-logic version lock tripped — halted like
+    /// `VaultLogicMismatch`.
+    ReceiptLogicMismatch,
+    /// Assigned by recovery's full-match check (not decoded from a revert):
+    /// a `Minted` log at the `(to, nonce)` pair WAS found and its token or
+    /// amount disagrees with this mint's — affirmative proof a different
+    /// mint consumed the pair, so this mint can never land. Manual
+    /// reconciliation only.
+    NonceConsumedByOtherMint,
+    /// Assigned by recovery's full-match check (not decoded from a revert):
+    /// `nonceUsed(to, nonce)` reports the nonce consumed but NO `Minted`
+    /// log at the pair was found at all. The two cannot both be true of a
+    /// healthy chain view, so the lookup itself is untrusted (window too
+    /// narrow, RPC error, indexer lag) — an unknown outcome, never proof:
+    /// this mint may well have landed. Non-retryable for SUBMISSION (the
+    /// nonce is consumed either way) but retryable for RECONCILIATION:
+    /// recovery re-runs the log query over a widened window, and a later
+    /// full match resolves the mint forward (SPEC "Recipient Authorization"
+    /// -> "Nonce").
+    NonceReplayUnresolved,
+    /// `BadRecipientSignature()` revert — the recipient signature did not
+    /// recover to `to`. Deterministic for the stored authorization: only
+    /// `CloseMint` plus a fresh `Initiate` with a new authorization resolves
+    /// it (see SPEC "Failure States").
+    BadRecipientSignature,
+    /// `RecipientCallbackRejected(recipient)` revert — an `IMintRecipient`
+    /// contract refused the mint via its `authorizeMint` callback.
+    /// Deterministic like `BadRecipientSignature`.
+    RecipientCallbackRejected,
+    /// `VaultAmountMismatch(expected, actual)` revert — the orchestrator's
+    /// on-chain 1:1 assertion failed (e.g. a share-ratio rebase mid-flight).
+    /// Alert-and-investigate; the same aggregate resumes via admin reprocess
+    /// once the ratio is restored (see SPEC "Failure States").
+    VaultAmountMismatch,
+}
+
+impl MintFailureClassification {
+    /// Whether this failure is an orchestrator-wide halt
+    /// (`vaultLogicIsExpected()` / receipt-logic version lock). Per SPEC
+    /// ("Failure States"), a halt resolves environment-wide by upgrade,
+    /// never per-mint, so it must not advance the mint's automatic-retry
+    /// attempt counter — otherwise every in-flight mint would burn its whole
+    /// budget waiting out one halt.
+    pub(crate) const fn is_environment_halt(self) -> bool {
+        matches!(self, Self::VaultLogicMismatch | Self::ReceiptLogicMismatch)
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum MintEvent {
     Initiated {
@@ -66,6 +128,13 @@ pub(crate) enum MintEvent {
         issuer_request_id: IssuerMintRequestId,
         error: String,
         failed_at: DateTime<Utc>,
+        /// Typed failure classification. Absent for pre-orchestrator events,
+        /// which replay as `Unclassified`. Typed classifications are never
+        /// auto-retried: `NonceConsumedByOtherMint` needs manual
+        /// reconciliation and the logic-mismatch halts resolve
+        /// environment-wide.
+        #[serde(default)]
+        classification: MintFailureClassification,
     },
     MintCompleted {
         issuer_request_id: IssuerMintRequestId,
@@ -130,6 +199,35 @@ pub(crate) enum MintEvent {
         mint_authorization: MintAuthorization,
         received_at: DateTime<Utc>,
     },
+
+    /// Orchestrator-mode mint succeeded on-chain (the counterpart of
+    /// `TokensMinted`), parsed from the orchestrator's `Minted` event.
+    /// Carries the consumed authorization `nonce` in place of vault-direct's
+    /// `receipt_id` — the orchestrator, not the bot, holds receipt custody,
+    /// so there is no bot-side receipt to record or register.
+    OrchestratorTokensMinted {
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        /// `Minted.nonce` — the authorization nonce this mint consumed.
+        nonce: B256,
+        shares_minted: U256,
+        gas_used: u64,
+        block_number: u64,
+        minted_at: DateTime<Utc>,
+    },
+
+    /// An orchestrator-mode mint that already landed on-chain, discovered by
+    /// recovery's `Minted`-log lookup full-matching
+    /// `(to, nonce, token, amount)` after a `NonceReplayed` revert. Carries
+    /// no `gas_used` — a bare log does not expose it.
+    OrchestratorMintRecovered {
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        nonce: B256,
+        shares_minted: U256,
+        block_number: u64,
+        recovered_at: DateTime<Utc>,
+    },
 }
 
 impl DomainEvent for MintEvent {
@@ -167,6 +265,12 @@ impl DomainEvent for MintEvent {
             }
             Self::MintAuthorizationReceived { .. } => {
                 "MintEvent::MintAuthorizationReceived".to_string()
+            }
+            Self::OrchestratorTokensMinted { .. } => {
+                "MintEvent::OrchestratorTokensMinted".to_string()
+            }
+            Self::OrchestratorMintRecovered { .. } => {
+                "MintEvent::OrchestratorMintRecovered".to_string()
             }
         }
     }

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -28,8 +28,9 @@ use tracing::{debug, error, info, warn};
 
 use super::recovery::{enqueue_scheduled_mint_recovery, release_terminal_job};
 use super::{
-    IssuerMintRequestId, Mint, MintCommand, Quantity, TokenizationRequestId,
-    UnderlyingSymbol, has_unresolved_signer_intent,
+    IssuerMintRequestId, Mint, MintCommand, MintFailureClassification,
+    Quantity, TokenizationRequestId, UnderlyingSymbol,
+    has_unresolved_signer_intent, orchestrator_mint_failure_classification,
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::burn_excess::has_unresolved_excess_burn_intent;
@@ -40,8 +41,10 @@ use crate::receipt_inventory::{
 };
 use crate::tokenized_asset::Network;
 use crate::vault::{
-    MintTxStatus, NetworkVaultServices, PreparedMintTx, ReceiptInformation,
-    TxId, UnconfiguredNetworkError, VaultError, VaultService,
+    MintAuthorization, MintTxStatus, MintedLogQuery, MintedLogScan,
+    NetworkVaultServices, OrchestratorMintParams, OrchestratorRevertReason,
+    PreparedMintTx, ReceiptInformation, TxId, UnconfiguredNetworkError,
+    VaultError, VaultService,
 };
 
 /// Failure of a mint side-effect job. A domain rejection is recorded as a
@@ -123,27 +126,9 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                 wallet,
                 journal_confirmed_at,
                 mint_mode,
+                mint_authorization,
                 ..
             } => {
-                // Fail closed on the anchor: this build has no orchestrator
-                // submission path (it lands in the commits stacked above,
-                // which replace this guard), and minting an
-                // orchestrator-anchored mint through the vault-direct
-                // multicall would use the wrong custody model — mirroring
-                // the redemption side's `BurnModeMismatch` refusal. The mint
-                // stays in `Minting`, visible in `/admin/stuck` past the
-                // threshold.
-                if let VaultMode::Orchestrator { .. } = mint_mode {
-                    warn!(
-                        target: "mint",
-                        issuer_request_id = %self.issuer_request_id,
-                        "Orchestrator-anchored mint has no submission path \
-                         in this build; deferring instead of minting \
-                         vault-direct"
-                    );
-                    return Ok(());
-                }
-
                 self.submit_from_minting(
                     ctx,
                     &mint,
@@ -154,6 +139,8 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                         network: *network,
                         wallet: *wallet,
                         journal_confirmed_at: *journal_confirmed_at,
+                        mint_mode,
+                        mint_authorization: mint_authorization.as_ref(),
                     },
                 )
                 .await?;
@@ -196,13 +183,21 @@ struct SubmitFromMintingParams<'a> {
     network: Network,
     wallet: Address,
     journal_confirmed_at: DateTime<Utc>,
+    /// Mode anchor from the aggregate — decides which prepare path signs,
+    /// never live config.
+    mint_mode: &'a VaultMode,
+    /// The liquidity bot's delivered `MintAuthV1`; orchestrator-mode
+    /// preparation defers without it and never falls back to vault-direct.
+    mint_authorization: Option<&'a MintAuthorization>,
 }
 
-struct ResolvePreparedParams {
+struct ResolvePreparedParams<'a> {
     assets: U256,
     wallet: Address,
     receipt_info: ReceiptInformation,
     external_tx_id: Option<String>,
+    mint_mode: &'a VaultMode,
+    mint_authorization: Option<&'a MintAuthorization>,
 }
 
 impl SubmitMintJob {
@@ -372,6 +367,8 @@ impl SubmitMintJob {
                                     issuer_request_id: self
                                         .issuer_request_id
                                         .clone(),
+                                    classification:
+                                        MintFailureClassification::Unclassified,
                                     error: format!(
                                         "Prepared mint terminal before \
                                          rebroadcast: {recheck:?}"
@@ -469,6 +466,8 @@ impl SubmitMintJob {
                         MintCommand::RecordMintFailed {
                             issuer_request_id: self.issuer_request_id.clone(),
                             error: error.to_string(),
+                            classification:
+                                MintFailureClassification::Unclassified,
                         },
                     )
                     .await?;
@@ -503,6 +502,8 @@ impl SubmitMintJob {
                     wallet: params.wallet,
                     receipt_info,
                     external_tx_id,
+                    mint_mode: params.mint_mode,
+                    mint_authorization: params.mint_authorization,
                 },
             )
             .await?
@@ -558,12 +559,13 @@ impl SubmitMintJob {
     /// mined success; prepare replacement only after terminal dead/revert with
     /// a wallet-guard TOCTOU recheck; `None` means fail closed (caller leaves
     /// state unchanged).
+    #[allow(clippy::too_many_lines)]
     async fn resolve_prepared_for_submit(
         &self,
         ctx: &SubmitMintContext,
         vault: &dyn VaultService,
         mint: &Mint,
-        params: ResolvePreparedParams,
+        params: ResolvePreparedParams<'_>,
     ) -> Result<Option<PreparedMintTx>, MintJobError> {
         if let Some(existing) = mint.pending_prepared_tx() {
             let owner = match existing.recover_signer() {
@@ -632,17 +634,54 @@ impl SubmitMintJob {
                         return Ok(None);
                     }
 
-                    let prepared = match vault
-                        .prepare_mint_tx(
-                            self.vault,
-                            params.assets,
-                            ctx.bot,
-                            params.wallet,
-                            params.receipt_info,
-                            params.external_tx_id,
-                        )
-                        .await
-                    {
+                    let prepared = match params.mint_mode {
+                        VaultMode::VaultDirect => {
+                            vault
+                                .prepare_mint_tx(
+                                    self.vault,
+                                    params.assets,
+                                    ctx.bot,
+                                    params.wallet,
+                                    params.receipt_info,
+                                    params.external_tx_id,
+                                )
+                                .await
+                        }
+                        VaultMode::Orchestrator { address: orchestrator } => {
+                            // An orchestrator mint without its recipient
+                            // authorization cannot sign a replacement — and
+                            // never falls back to vault-direct. No event is
+                            // recorded: the mint stays visible in
+                            // `/admin/stuck` past the threshold, and the next
+                            // drive retries once the liquidity bot delivers.
+                            let Some(authorization) = params.mint_authorization
+                            else {
+                                warn!(
+                                    target: "mint",
+                                    issuer_request_id = %self.issuer_request_id,
+                                    "Orchestrator mint is awaiting its \
+                                     recipient authorization; deferring \
+                                     submission"
+                                );
+                                return Ok(None);
+                            };
+
+                            vault
+                                .prepare_orchestrator_mint_tx(
+                                    &OrchestratorMintParams {
+                                        orchestrator: *orchestrator,
+                                        token: self.vault,
+                                        to: params.wallet,
+                                        amount: params.assets,
+                                        authorization: authorization.clone(),
+                                        receipt_info: params.receipt_info,
+                                        external_tx_id: params.external_tx_id,
+                                    },
+                                )
+                                .await
+                        }
+                    };
+                    let prepared = match prepared {
                         Ok(prepared) => prepared,
                         Err(error) => {
                             // Prior prepared identity is still live on the mint.
@@ -705,17 +744,49 @@ impl SubmitMintJob {
             return Ok(None);
         }
 
-        let prepared = match vault
-            .prepare_mint_tx(
-                self.vault,
-                params.assets,
-                ctx.bot,
-                params.wallet,
-                params.receipt_info,
-                params.external_tx_id,
-            )
-            .await
-        {
+        let prepared = match params.mint_mode {
+            VaultMode::VaultDirect => {
+                vault
+                    .prepare_mint_tx(
+                        self.vault,
+                        params.assets,
+                        ctx.bot,
+                        params.wallet,
+                        params.receipt_info,
+                        params.external_tx_id,
+                    )
+                    .await
+            }
+            VaultMode::Orchestrator { address: orchestrator } => {
+                // An orchestrator mint without its recipient authorization
+                // cannot submit yet — and never falls back to vault-direct.
+                // No event is recorded: the mint stays in `Minting`, visible
+                // in `/admin/stuck` past the threshold, and the next drive
+                // retries once the liquidity bot delivers.
+                let Some(authorization) = params.mint_authorization else {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        "Orchestrator mint is awaiting its recipient \
+                         authorization; deferring submission"
+                    );
+                    return Ok(None);
+                };
+
+                vault
+                    .prepare_orchestrator_mint_tx(&OrchestratorMintParams {
+                        orchestrator: *orchestrator,
+                        token: self.vault,
+                        to: params.wallet,
+                        amount: params.assets,
+                        authorization: authorization.clone(),
+                        receipt_info: params.receipt_info,
+                        external_tx_id: params.external_tx_id,
+                    })
+                    .await
+            }
+        };
+        let prepared = match prepared {
             Ok(prepared) => prepared,
             Err(error) => {
                 // Free-prepare: no live prepared identity yet.
@@ -780,6 +851,8 @@ impl SubmitMintJob {
                         MintCommand::RecordMintFailed {
                             issuer_request_id: self.issuer_request_id.clone(),
                             error: error.to_string(),
+                            classification:
+                                MintFailureClassification::Unclassified,
                         },
                     )
                     .await?;
@@ -840,6 +913,7 @@ impl SubmitMintJob {
                 MintCommand::RecordMintFailed {
                     issuer_request_id: self.issuer_request_id.clone(),
                     error: error.to_string(),
+                    classification: MintFailureClassification::Unclassified,
                 },
             )
             .await?;
@@ -939,7 +1013,10 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
                 quantity,
                 underlying,
                 network,
+                wallet,
                 journal_confirmed_at,
+                mint_mode,
+                mint_authorization,
                 prepared_tx,
                 tx_id: stored_tx_id,
                 ..
@@ -952,7 +1029,10 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
                         quantity: quantity.clone(),
                         underlying: underlying.clone(),
                         network: *network,
+                        wallet: *wallet,
                         journal_confirmed_at: *journal_confirmed_at,
+                        mint_mode: *mint_mode,
+                        mint_authorization: mint_authorization.clone(),
                         prepared_tx: prepared_tx.clone(),
                         stored_tx_id: stored_tx_id.clone(),
                     },
@@ -1010,7 +1090,14 @@ struct ConfirmWhileTxSubmitted {
     quantity: Quantity,
     underlying: UnderlyingSymbol,
     network: Network,
+    wallet: Address,
     journal_confirmed_at: DateTime<Utc>,
+    /// Mode anchor from the aggregate — orchestrator mode confirms via the
+    /// orchestrator's `Minted` decoding, never the vault-direct `Deposit`.
+    mint_mode: VaultMode,
+    /// The delivered `MintAuthV1`, needed for the `NonceReplayed` full-match
+    /// recovery check.
+    mint_authorization: Option<MintAuthorization>,
     prepared_tx: Option<PreparedMintTx>,
     /// Aggregate's current submission identity; stale confirm jobs (older
     /// `tx_id` after a replacement) must not record `MintingFailed` for the
@@ -1166,6 +1253,8 @@ impl ConfirmMintJob {
                         MintCommand::RecordMintFailed {
                             issuer_request_id: self.issuer_request_id.clone(),
                             error: error.to_string(),
+                            classification:
+                                MintFailureClassification::Unclassified,
                         },
                     )
                     .await?;
@@ -1178,6 +1267,21 @@ impl ConfirmMintJob {
                 return Ok(());
             }
         };
+
+        if let VaultMode::Orchestrator { address: orchestrator } =
+            &params.mint_mode
+        {
+            return self
+                .confirm_orchestrator(
+                    ctx,
+                    vault,
+                    *orchestrator,
+                    params.wallet,
+                    &params.quantity,
+                    params.mint_authorization.as_ref(),
+                )
+                .await;
+        }
 
         match vault.confirm_mint(&self.tx_id).await {
             Ok(result) => {
@@ -1264,6 +1368,8 @@ impl ConfirmMintJob {
                             error: format!(
                                 "Transaction reverted on-chain: {tx_hash:?}"
                             ),
+                            classification:
+                                MintFailureClassification::Unclassified,
                         },
                     )
                     .await?;
@@ -1755,6 +1861,8 @@ impl ConfirmMintJob {
                                 "Prepared mint terminal after uncertain \
                                  confirm ({terminal:?}): {error}"
                             ),
+                            classification:
+                                MintFailureClassification::Unclassified,
                         },
                     )
                     .await?;
@@ -1799,6 +1907,246 @@ impl ConfirmMintJob {
                 )
                 .await;
             }
+        }
+
+        Ok(())
+    }
+
+    /// Orchestrator-mode confirmation: the job counterpart of
+    /// `Mint::handle_record_orchestrator_tokens_minted`. Success records
+    /// `OrchestratorTokensMinted` with NO receipt registration — the
+    /// orchestrator holds receipt custody. A decoded `NonceReplayed` revert
+    /// means an earlier transaction consumed this `(to, nonce)` pair, so the
+    /// landed `Minted` log is full-matched on `(to, nonce, token, amount)`:
+    /// only a full match may complete the mint; a consumed nonce whose token
+    /// or amount differs fails as `NonceConsumedByOtherMint` for manual
+    /// reconciliation, never a false completion.
+    async fn confirm_orchestrator(
+        &self,
+        ctx: &ConfirmMintContext,
+        vault_service: Arc<dyn VaultService>,
+        orchestrator: Address,
+        to: Address,
+        quantity: &Quantity,
+        authorization: Option<&MintAuthorization>,
+    ) -> Result<(), MintJobError> {
+        let revert = match vault_service
+            .confirm_orchestrator_mint(&self.tx_id)
+            .await
+        {
+            Ok(result) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %result.tx_hash,
+                    nonce = %result.nonce,
+                    shares_minted = %result.shares_minted,
+                    "Orchestrator mint confirmed"
+                );
+
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordOrchestratorTokensMinted {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            tx_id: self.tx_id.clone(),
+                            tx_hash: result.tx_hash,
+                            nonce: result.nonce,
+                            shares_minted: result.shares_minted,
+                            gas_used: result.gas_used,
+                            block_number: result.block_number,
+                        },
+                    )
+                    .await?;
+
+                self.enqueue_callback(ctx).await?;
+                return Ok(());
+            }
+            Err(error) => error,
+        };
+
+        let is_nonce_replayed = matches!(
+            &revert,
+            VaultError::OrchestratorReverted {
+                reason: OrchestratorRevertReason::NonceReplayed { .. },
+                ..
+            }
+        );
+
+        let (Some(authorization), true) = (authorization, is_nonce_replayed)
+        else {
+            let classification =
+                orchestrator_mint_failure_classification(&revert);
+            warn!(
+                target: "mint",
+                issuer_request_id = %self.issuer_request_id,
+                error = %revert,
+                classification = ?classification,
+                "Orchestrator mint confirmation failed"
+            );
+            self.record_classified_failure(
+                ctx,
+                revert.to_string(),
+                classification,
+            )
+            .await?;
+            return Ok(());
+        };
+
+        // A quantity that cannot be converted is deterministic for the
+        // persisted mint: record a domain failure instead of a job error
+        // apalis would re-drive forever.
+        let amount = match quantity.to_u256_with_18_decimals() {
+            Ok(amount) => amount,
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "Mint quantity cannot be converted to on-chain units"
+                );
+                self.record_classified_failure(
+                    ctx,
+                    error.to_string(),
+                    MintFailureClassification::Unclassified,
+                )
+                .await?;
+                return Ok(());
+            }
+        };
+
+        // Two outcomes, never conflated (SPEC "Recipient Authorization" ->
+        // "Nonce"): a log at the pair that disagrees on token/amount is
+        // PROOF a different mint consumed it, while an empty scan alongside
+        // the consumed nonce impeaches the chain view itself — an unknown
+        // outcome that must not be recorded as consumed-by-other, because
+        // this mint may well have landed.
+        match vault_service
+            .find_orchestrator_minted_log(MintedLogQuery {
+                orchestrator,
+                to,
+                nonce: authorization.nonce,
+                token: self.vault,
+                amount,
+                lookback_blocks: None,
+            })
+            .await
+        {
+            Ok(MintedLogScan::FullMatch(minted)) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %minted.tx_hash,
+                    nonce = %minted.nonce,
+                    shares_minted = %minted.shares_minted,
+                    "Replayed nonce full-matched an earlier landed mint; \
+                     recovering"
+                );
+
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordOrchestratorMintRecovered {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            tx_hash: minted.tx_hash,
+                            nonce: minted.nonce,
+                            shares_minted: minted.shares_minted,
+                            block_number: minted.block_number,
+                        },
+                    )
+                    .await?;
+
+                self.enqueue_callback(ctx).await?;
+            }
+            Ok(MintedLogScan::Mismatch) => {
+                error!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    to = %to,
+                    nonce = %authorization.nonce,
+                    token = %self.vault,
+                    amount = %amount,
+                    "Authorization nonce was consumed by a different mint; \
+                     manual reconciliation required"
+                );
+                self.record_classified_failure(
+                    ctx,
+                    revert.to_string(),
+                    MintFailureClassification::NonceConsumedByOtherMint,
+                )
+                .await?;
+            }
+            Ok(MintedLogScan::NotFound) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    to = %to,
+                    nonce = %authorization.nonce,
+                    token = %self.vault,
+                    amount = %amount,
+                    "Nonce is consumed but no Minted log was found at the \
+                     pair; the chain view is untrusted — parking for \
+                     reconciliation"
+                );
+                self.record_classified_failure(
+                    ctx,
+                    revert.to_string(),
+                    MintFailureClassification::NonceReplayUnresolved,
+                )
+                .await?;
+            }
+            // A failed lookup proves nothing about whose mint consumed the
+            // nonce — fail unclassified (retryable; resubmission just replays
+            // the nonce again) rather than falsely classify.
+            Err(lookup_error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %lookup_error,
+                    "Minted-log lookup failed after a replayed nonce"
+                );
+                self.record_classified_failure(
+                    ctx,
+                    lookup_error.to_string(),
+                    MintFailureClassification::Unclassified,
+                )
+                .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Records a `MintingFailed` and kicks recovery only for `Unclassified` —
+    /// typed classifications are never auto-retried for SUBMISSION
+    /// (`NonceConsumedByOtherMint` needs manual reconciliation;
+    /// `NonceReplayUnresolved` is re-driven by recovery's scheduled
+    /// reconciliation, not a submission retry; the logic-mismatch halts
+    /// resolve environment-wide, not per-mint).
+    async fn record_classified_failure(
+        &self,
+        ctx: &ConfirmMintContext,
+        error: String,
+        classification: MintFailureClassification,
+    ) -> Result<(), MintJobError> {
+        ctx.mint_store
+            .send(
+                &self.issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: self.issuer_request_id.clone(),
+                    error,
+                    classification,
+                },
+            )
+            .await?;
+
+        if classification == MintFailureClassification::Unclassified {
+            kick_mint_recovery(
+                &ctx.pool,
+                &ctx.apalis_pool,
+                &self.issuer_request_id,
+            )
+            .await;
         }
 
         Ok(())
@@ -1989,9 +2337,13 @@ mod tests {
     use crate::burn_excess::BurnExcessEvent;
     use crate::mint::MintEvent;
     use crate::mint::api::test_utils::TestHarness;
+    use crate::mint::recovery::MintRecoveryJob;
     use crate::mint::tests::{
-        BOT, VAULT, events_through_minting, events_through_tokens_minted,
-        events_through_tx_submitted,
+        BOT, ORCHESTRATOR, VAULT, events_through_minting,
+        events_through_tokens_minted, events_through_tx_submitted,
+        orchestrator_events_through_minting,
+        orchestrator_events_through_minting_authorized,
+        orchestrator_events_through_tx_submitted, test_mint_authorization,
     };
     use crate::receipt_inventory::{
         BurnPlan, BurnTrackingError, CqrsReceiptService, ReceiptInventory,
@@ -2001,10 +2353,11 @@ mod tests {
     use crate::test_utils::{
         ANVIL_CHAIN_ID, ETHEREUM_TEST_CHAIN_ID, logs_contain_at,
     };
-    use crate::vault::MintResult;
-    use crate::vault::MintTxStatus;
-    use crate::vault::NetworkVault;
     use crate::vault::mock::MockVaultService;
+    use crate::vault::{
+        MintResult, MintTxStatus, NetworkVault, OrchestratorMintResult,
+        OrchestratorMintedLog,
+    };
 
     /// Seeds raw `Mint` events directly into the event store so job tests can
     /// start from any lifecycle state, mirroring the fixtures in
@@ -2446,54 +2799,6 @@ mod tests {
         ));
     }
 
-    /// An orchestrator-anchored mint must never take the vault-direct
-    /// submission path: this build has no orchestrator submission, so the job
-    /// defers (mint stays `Minting`, vault untouched) instead of minting
-    /// through the wrong custody model.
-    #[traced_test]
-    #[tokio::test]
-    async fn submit_mint_job_defers_orchestrator_anchored_mint() {
-        let harness = TestHarness::new().await;
-        let issuer_request_id = IssuerMintRequestId::random();
-        let mut events = events_through_minting(&issuer_request_id);
-        if let Some(MintEvent::Initiated { mint_mode, .. }) = events.first_mut()
-        {
-            *mint_mode = VaultMode::Orchestrator { address: Address::random() };
-        }
-        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
-
-        let vault = Arc::new(MockVaultService::new_success());
-        let ctx = submit_ctx(&harness, vault.clone());
-
-        SubmitMintJob {
-            issuer_request_id: issuer_request_id.clone(),
-            vault: VAULT,
-            chain_id: 1,
-        }
-        .perform(&ctx)
-        .await
-        .unwrap();
-
-        let mint =
-            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        assert!(
-            matches!(mint, Mint::Minting { .. }),
-            "an orchestrator-anchored mint must stay in Minting, got: {mint:?}"
-        );
-        assert_eq!(
-            vault.get_wallet_lock_call_count(),
-            0,
-            "the vault-direct preparation must never run for an \
-             orchestrator-anchored mint"
-        );
-
-        let test = "submit_mint_job_defers_orchestrator_anchored_mint";
-        assert!(logs_contain_at!(
-            Level::WARN,
-            &[test, "no submission path", "deferring"]
-        ));
-    }
-
     #[tokio::test]
     async fn submit_mint_job_waits_for_another_persisted_wallet_intent() {
         let harness = TestHarness::new().await;
@@ -2720,6 +3025,7 @@ mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "submission outcome unknown".to_string(),
             failed_at: chrono::Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
         events.push(MintEvent::MintRetryStarted {
             issuer_request_id: issuer_request_id.clone(),
@@ -3076,6 +3382,7 @@ mod tests {
         events.push(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "uncertain confirm misrecorded as failure".to_string(),
+            classification: MintFailureClassification::Unclassified,
             failed_at: now - chrono::Duration::minutes(2),
         });
         events.push(MintEvent::MintRetryStarted {
@@ -3168,6 +3475,7 @@ mod tests {
         events.push(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "still mineable after uncertain confirm".to_string(),
+            classification: MintFailureClassification::Unclassified,
             failed_at: now - chrono::Duration::minutes(2),
         });
         events.push(MintEvent::MintRetryStarted {
@@ -3325,6 +3633,7 @@ mod tests {
         events.push(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "prior attempt dead".to_string(),
+            classification: MintFailureClassification::Unclassified,
             failed_at: now - chrono::Duration::minutes(2),
         });
         events.push(MintEvent::MintRetryStarted {
@@ -3904,6 +4213,7 @@ mod tests {
         events.push(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "earlier uncertain confirm misrecorded".to_string(),
+            classification: MintFailureClassification::Unclassified,
             failed_at: now - chrono::Duration::minutes(2),
         });
         seed_mint_events(&harness.pool, &issuer_request_id, events).await;
@@ -3966,6 +4276,7 @@ mod tests {
         events.push(MintEvent::MintingFailed {
             issuer_request_id: issuer_request_id.clone(),
             error: "prior attempt".to_string(),
+            classification: MintFailureClassification::Unclassified,
             failed_at: now - chrono::Duration::minutes(2),
         });
         seed_mint_events(&harness.pool, &issuer_request_id, events).await;
@@ -4310,5 +4621,492 @@ mod tests {
             0,
             "a callback job outside CallbackPending must not call Alpaca"
         );
+    }
+
+    /// An orchestrator mint whose authorization has not arrived must be a
+    /// silent no-op — no event, no vault call, no confirm job — so the mint
+    /// stays in `Minting` until the liquidity bot delivers.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_orchestrator_defers_without_authorization() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "an unauthorized orchestrator mint must stay in Minting, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "an orchestrator mint must never fall back to the vault-direct \
+             preparation"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be signed before the authorization arrives"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<ConfirmMintJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            0,
+            "no confirm job may be enqueued for a deferred submission"
+        );
+
+        let test = "submit_mint_job_orchestrator_defers_without_authorization";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "awaiting its recipient authorization"]
+        ));
+    }
+
+    /// With the authorization persisted, the submit job prepares via
+    /// `prepare_orchestrator_mint_tx` — carrying the anchored orchestrator
+    /// address and the delivered authorization — and hands off to the
+    /// confirm job like a vault-direct submission.
+    #[tokio::test]
+    async fn submit_mint_job_orchestrator_submits_via_orchestrator() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "an authorized orchestrator mint must submit, got: {mint:?}"
+        );
+
+        let params = vault
+            .get_last_orchestrator_mint_params()
+            .expect("orchestrator preparation must record its params");
+        assert_eq!(params.orchestrator, ORCHESTRATOR);
+        assert_eq!(params.token, VAULT);
+        assert_eq!(params.authorization, test_mint_authorization());
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "the vault-direct preparation must not be invoked"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<ConfirmMintJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            1,
+        );
+    }
+
+    /// Orchestrator confirmation records `OrchestratorTokensMinted` and never
+    /// touches the receipt service — the orchestrator custodies the receipt.
+    /// The failing receipt stub would log a warning if it were reached.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_orchestrator_records_without_receipts() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        // The confirmed values must match the fixture's authorization nonce
+        // and 18-decimal quantity — the record handler cross-checks them.
+        let ctx = confirm_ctx(
+            &harness,
+            Arc::new(
+                MockVaultService::new_success().with_orchestrator_mint_result(
+                    OrchestratorMintResult {
+                        tx_hash: B256::ZERO,
+                        nonce: test_mint_authorization().nonce,
+                        shares_minted: U256::from(
+                            100_000_000_000_000_000_000u128,
+                        ),
+                        gas_used: 50_000,
+                        block_number: 5_000,
+                    },
+                ),
+            ),
+            Arc::new(FailingReceiptService),
+        );
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::CallbackPending {
+                    receipt_id: None,
+                    mint_nonce: Some(_),
+                    ..
+                }
+            ),
+            "an orchestrator confirmation must record the nonce and no \
+             receipt, got: {mint:?}"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<SendCallbackJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            1,
+        );
+        let test = "confirm_mint_job_orchestrator_records_without_receipts";
+        assert!(
+            !logs_contain_at!(
+                Level::WARN,
+                &[test, "Failed to register minted receipt"]
+            ),
+            "the receipt service must never be called for an orchestrator mint"
+        );
+    }
+
+    /// A `NonceReplayed` revert whose `Minted` log full-matches completes the
+    /// mint via `RecordOrchestratorMintRecovered` and moves on to the
+    /// callback — no failure, no recovery kick.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_orchestrator_replayed_nonce_recovers() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let authorization = test_mint_authorization();
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_orchestrator_mint_confirm_revert(
+                    OrchestratorRevertReason::NonceReplayed {
+                        to: Address::ZERO,
+                        nonce: authorization.nonce,
+                    },
+                )
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::ZERO,
+                    nonce: authorization.nonce,
+                    // The mock full-matches like the real lookup: the landed
+                    // amount must equal the mint's 18-decimal share amount.
+                    shares_minted: U256::from(100u64)
+                        * U256::from(10u64).pow(U256::from(18u64)),
+                    block_number: 777,
+                }),
+        );
+        let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(&mint, Mint::CallbackPending { mint_nonce: Some(_), .. }),
+            "a full-matched replayed nonce must complete the mint, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<SendCallbackJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            1,
+        );
+
+        let test = "confirm_mint_job_orchestrator_replayed_nonce_recovers";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "full-matched an earlier landed mint"]
+        ));
+    }
+
+    /// A replayed nonce whose `Minted` log at the pair disagrees on amount
+    /// is the PROVEN mismatch — `NonceConsumedByOtherMint`, manual
+    /// reconciliation, no recovery kick that would auto-retry it.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_nonce_consumed_by_other_mint_never_kicks() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_orchestrator_mint_confirm_revert(
+                    OrchestratorRevertReason::NonceReplayed {
+                        to: Address::ZERO,
+                        nonce: test_mint_authorization().nonce,
+                    },
+                )
+                // The pair's one landing, under a DIFFERENT amount: the
+                // scan's proven `Mismatch` verdict.
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::ZERO,
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: U256::from(1u8),
+                    block_number: 777,
+                }),
+        );
+        let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceConsumedByOtherMint,
+                    ..
+                }
+            ),
+            "a nonce consumed by another mint must fail classified, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<MintRecoveryJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            0,
+            "a manual-reconciliation failure must not kick recovery"
+        );
+
+        let test = "confirm_mint_job_nonce_consumed_by_other_mint_never_kicks";
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[test, "consumed by a different mint"]
+        ));
+    }
+
+    /// A replayed nonce with NO `Minted` log at the pair at all is the
+    /// INCONCLUSIVE outcome — `NonceReplayUnresolved`, never conflated with
+    /// the proven mismatch: the chain view itself is in doubt and this mint
+    /// may well have landed. Parked without a recovery kick (submission can
+    /// only revert); reconciliation owns the retry.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_unresolved_replay_parks_for_reconciliation() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_orchestrator_mint_confirm_revert(
+                    OrchestratorRevertReason::NonceReplayed {
+                        to: Address::ZERO,
+                        nonce: test_mint_authorization().nonce,
+                    },
+                ),
+        );
+        let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceReplayUnresolved,
+                    ..
+                }
+            ),
+            "an empty scan alongside a consumed nonce must park as the \
+             unresolved classification, got: {mint:?}"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<MintRecoveryJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            0,
+            "an unresolved replay must not kick the submission retry"
+        );
+
+        let test =
+            "confirm_mint_job_unresolved_replay_parks_for_reconciliation";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "no Minted log was found at the pair"]
+        ));
+    }
+
+    /// Typed logic-mismatch halts are recorded without a recovery kick (they
+    /// resolve environment-wide), while an unclassified revert still kicks
+    /// the automatic retry.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_kicks_recovery_only_for_unclassified() {
+        for (reason, expected_recovery_jobs, expected_classification) in [
+            (
+                OrchestratorRevertReason::VaultLogicMismatch,
+                0,
+                "VaultLogicMismatch",
+            ),
+            (OrchestratorRevertReason::Unknown, 1, "Unclassified"),
+        ] {
+            let harness = TestHarness::new().await;
+            let issuer_request_id = IssuerMintRequestId::random();
+            seed_mint_events(
+                &harness.pool,
+                &issuer_request_id,
+                orchestrator_events_through_tx_submitted(&issuer_request_id),
+            )
+            .await;
+
+            let vault = Arc::new(
+                MockVaultService::new_success()
+                    .with_orchestrator_mint_confirm_revert(reason),
+            );
+            let ctx =
+                confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+            ConfirmMintJob {
+                issuer_request_id: issuer_request_id.clone(),
+                vault: VAULT,
+                chain_id: 1,
+                tx_id: TxId::Legacy("fb-1".to_string()),
+            }
+            .perform(&ctx)
+            .await
+            .unwrap();
+
+            let mint = harness
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(
+                matches!(&mint, Mint::MintingFailed { .. }),
+                "reason {reason:?} must record MintingFailed, got: {mint:?}"
+            );
+            assert_eq!(
+                count_jobs(
+                    &harness.pool,
+                    type_name::<MintRecoveryJob>(),
+                    &issuer_request_id.to_string(),
+                )
+                .await,
+                expected_recovery_jobs,
+                "recovery kick mismatch for {reason:?}"
+            );
+            assert!(
+                logs_contain_at!(
+                    Level::WARN,
+                    &[
+                        "Orchestrator mint confirmation failed",
+                        expected_classification
+                    ]
+                ),
+                "reason {reason:?} must WARN with its classification"
+            );
+        }
     }
 }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -13,12 +13,13 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
-use crate::config::VaultMode;
+use crate::config::{VaultMode, VaultModeKind};
 use crate::tokenized_asset::view::{
     TokenizedAssetViewError, TokenizedAssetViewFailure,
 };
 use crate::vault::{
-    MintAuthorization, PreparedMintTx, TxId, UnconfiguredNetworkError,
+    MintAuthorization, OrchestratorRevertReason, PreparedMintTx, TxId,
+    UnconfiguredNetworkError, VaultError,
 };
 
 pub use api::MintResponse;
@@ -27,7 +28,7 @@ pub use api::MintResponse;
 pub(crate) use api::test_utils;
 pub(crate) use api::{authorize_mint, confirm_journal, initiate_mint};
 pub(crate) use cmd::MintCommand;
-pub(crate) use event::MintEvent;
+pub(crate) use event::{MintEvent, MintFailureClassification};
 pub(crate) use view::{MintView, find_all_recoverable_mints, find_stuck};
 
 /// Returns whether any signed transaction on the same signer network — a
@@ -335,7 +336,15 @@ pub(crate) enum Mint {
         mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
-        receipt_id: U256,
+        /// Vault-direct audit data: the ERC-1155 receipt id the deposit
+        /// minted to the bot. `None` for orchestrator-mode mints — the
+        /// orchestrator holds receipt custody, and `mint_nonce` is the
+        /// analogous proof.
+        receipt_id: Option<U256>,
+        /// Orchestrator audit data: the authorization nonce the mint
+        /// consumed. `None` for vault-direct mints.
+        #[serde(default)]
+        mint_nonce: Option<B256>,
         shares_minted: U256,
         gas_used: Option<u64>,
         block_number: u64,
@@ -367,6 +376,10 @@ pub(crate) enum Mint {
         journal_confirmed_at: DateTime<Utc>,
         error: String,
         failed_at: DateTime<Utc>,
+        /// Typed failure cause from `MintingFailed.classification`; typed
+        /// classifications are never auto-retried.
+        #[serde(default)]
+        classification: MintFailureClassification,
         /// 1-indexed attempt number of the *next* retry, driving the automatic
         /// delay schedule and exhaustion cap. Unlike the `external_tx_id`-
         /// derived attempt (see `next_retry_attempt`), this advances on every
@@ -415,7 +428,15 @@ pub(crate) enum Mint {
         mint_authorization: Option<MintAuthorization>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
-        receipt_id: U256,
+        /// Vault-direct audit data: the ERC-1155 receipt id the deposit
+        /// minted to the bot. `None` for orchestrator-mode mints — the
+        /// orchestrator holds receipt custody, and `mint_nonce` is the
+        /// analogous proof.
+        receipt_id: Option<U256>,
+        /// Orchestrator audit data: the authorization nonce the mint
+        /// consumed. `None` for vault-direct mints.
+        #[serde(default)]
+        mint_nonce: Option<B256>,
         shares_minted: U256,
         gas_used: Option<u64>,
         block_number: u64,
@@ -439,6 +460,75 @@ struct ConfirmedMint {
     gas_used: u64,
     block_number: u64,
 }
+
+/// Audit payload `apply_tokens_minted` lands into `CallbackPending`, shared
+/// by the vault-direct and orchestrator success events (which differ only in
+/// receipt-id vs nonce audit data).
+#[derive(Clone, Copy)]
+struct MintedAudit {
+    tx_hash: B256,
+    receipt_id: Option<U256>,
+    mint_nonce: Option<B256>,
+    shares_minted: U256,
+    gas_used: Option<u64>,
+    block_number: u64,
+    minted_at: DateTime<Utc>,
+}
+
+/// Orchestrator counterpart of [`ConfirmedMint`]: the `Minted` event carries
+/// the consumed authorization `nonce` instead of a bot-held receipt id.
+struct ConfirmedOrchestratorMint {
+    tx_id: TxId,
+    tx_hash: B256,
+    nonce: B256,
+    shares_minted: U256,
+    gas_used: u64,
+    block_number: u64,
+}
+
+/// Maps a decoded orchestrator mint revert to its typed classification.
+/// Only the environment-wide logic-version halts classify from a revert;
+/// `NonceConsumedByOtherMint` is assigned exclusively by the full-match
+/// check after a `NonceReplayed` revert, and everything else stays
+/// `Unclassified` (retryable).
+const fn orchestrator_mint_failure_classification(
+    error: &VaultError,
+) -> MintFailureClassification {
+    match error {
+        // The reason match is exhaustive on purpose: a new revert reason
+        // must not silently fall into the retryable bucket — adding one
+        // forces an explicit classification decision here.
+        VaultError::OrchestratorReverted { reason, .. } => match reason {
+            OrchestratorRevertReason::VaultLogicMismatch => {
+                MintFailureClassification::VaultLogicMismatch
+            }
+            OrchestratorRevertReason::ReceiptLogicMismatch => {
+                MintFailureClassification::ReceiptLogicMismatch
+            }
+            OrchestratorRevertReason::BadRecipientSignature => {
+                MintFailureClassification::BadRecipientSignature
+            }
+            OrchestratorRevertReason::RecipientCallbackRejected { .. } => {
+                MintFailureClassification::RecipientCallbackRejected
+            }
+            OrchestratorRevertReason::VaultAmountMismatch { .. } => {
+                MintFailureClassification::VaultAmountMismatch
+            }
+            // `NonceReplayed` is a recovery signal, not a failure verdict —
+            // it only reaches here when no authorization exists to
+            // full-match against, where retrying is the honest default.
+            // `InsufficientReceipts` is a burn-path reason; on the mint path
+            // it proves nothing, like an undecodable revert.
+            OrchestratorRevertReason::NonceReplayed { .. }
+            | OrchestratorRevertReason::InsufficientReceipts { .. }
+            | OrchestratorRevertReason::Unknown => {
+                MintFailureClassification::Unclassified
+            }
+        },
+        _ => MintFailureClassification::Unclassified,
+    }
+}
+
 /// Failure history preserved across a `MintRetryStarted` transition
 /// (`MintingFailed` -> `Minting`). Without it a failed retry would restart
 /// the automatic-retry schedule at attempt 1 and lose the
@@ -1068,12 +1158,23 @@ impl Mint {
             Self::TxSubmitted {
                 issuer_request_id: expected_id,
                 tx_id: stored_tx_id,
+                mint_mode,
                 ..
             } => {
                 Self::validate_issuer_request_id(
                     expected_id,
                     &issuer_request_id,
                 )?;
+
+                // A vault-direct result can never complete an orchestrator
+                // mint: the recorded audit data (receipt id vs nonce) and the
+                // receipt-custody implications differ.
+                if let VaultMode::Orchestrator { .. } = mint_mode {
+                    return Err(MintError::MintModeMismatch {
+                        expected: mint_mode.kind(),
+                        found: VaultModeKind::VaultDirect,
+                    });
+                }
 
                 if stored_tx_id != &tx_id {
                     return Err(MintError::TxIdMismatch {
@@ -1090,6 +1191,140 @@ impl Mint {
                     gas_used,
                     block_number,
                     minted_at: Utc::now(),
+                }])
+            }
+            Self::CallbackPending { .. } | Self::Completed { .. } => Ok(vec![]),
+            _ => Err(MintError::NotInSubmittedState {
+                current_state: self.state_name().to_string(),
+            }),
+        }
+    }
+
+    /// Records a successful orchestrator mint confirmation reported by a
+    /// durable `ConfirmMintJob`. Pure — emits `OrchestratorTokensMinted`.
+    /// Idempotent: a no-op once the mint has advanced past `TxSubmitted`.
+    fn handle_record_orchestrator_tokens_minted(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+        confirmed: ConfirmedOrchestratorMint,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        let ConfirmedOrchestratorMint {
+            tx_id,
+            tx_hash,
+            nonce,
+            shares_minted,
+            gas_used,
+            block_number,
+        } = confirmed;
+
+        match self {
+            Self::TxSubmitted {
+                issuer_request_id: expected_id,
+                tx_id: stored_tx_id,
+                mint_mode,
+                mint_authorization,
+                quantity,
+                ..
+            } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+
+                if matches!(mint_mode, VaultMode::VaultDirect) {
+                    return Err(MintError::MintModeMismatch {
+                        expected: mint_mode.kind(),
+                        found: VaultModeKind::Orchestrator,
+                    });
+                }
+
+                if stored_tx_id != &tx_id {
+                    return Err(MintError::TxIdMismatch {
+                        expected: stored_tx_id.clone(),
+                        provided: tx_id,
+                    });
+                }
+
+                // The chain-reported values must equal what this mint was
+                // authorized and prepared with — the orchestrator emits the
+                // `Minted` fields from our own calldata, so a divergence
+                // means a contract anomaly and must fail loudly rather than
+                // become the persisted audit record.
+                let authorization = mint_authorization
+                    .as_ref()
+                    .ok_or(MintError::MissingMintAuthorization)?;
+                if nonce != authorization.nonce {
+                    return Err(MintError::MintedNonceMismatch {
+                        expected: authorization.nonce,
+                        actual: nonce,
+                    });
+                }
+                let authorized_shares = quantity
+                    .to_u256_with_18_decimals()
+                    .map_err(|error| MintError::QuantityConversion {
+                        message: error.to_string(),
+                    })?;
+                if shares_minted != authorized_shares {
+                    return Err(MintError::MintedSharesMismatch {
+                        expected: authorized_shares,
+                        actual: shares_minted,
+                    });
+                }
+
+                Ok(vec![MintEvent::OrchestratorTokensMinted {
+                    issuer_request_id,
+                    tx_hash,
+                    nonce,
+                    shares_minted,
+                    gas_used,
+                    block_number,
+                    minted_at: Utc::now(),
+                }])
+            }
+            Self::CallbackPending { .. } | Self::Completed { .. } => Ok(vec![]),
+            _ => Err(MintError::NotInSubmittedState {
+                current_state: self.state_name().to_string(),
+            }),
+        }
+    }
+
+    /// Records an orchestrator mint proven landed by the full-match
+    /// `Minted`-log lookup after a `NonceReplayed` revert. Pure — emits
+    /// `OrchestratorMintRecovered`. Idempotent: a no-op once the mint has
+    /// advanced past `TxSubmitted`.
+    fn handle_record_orchestrator_mint_recovered(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+        tx_hash: B256,
+        nonce: B256,
+        shares_minted: U256,
+        block_number: u64,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
+            Self::TxSubmitted {
+                issuer_request_id: expected_id,
+                mint_mode,
+                ..
+            } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+
+                if matches!(mint_mode, VaultMode::VaultDirect) {
+                    return Err(MintError::MintModeMismatch {
+                        expected: mint_mode.kind(),
+                        found: VaultModeKind::Orchestrator,
+                    });
+                }
+
+                Ok(vec![MintEvent::OrchestratorMintRecovered {
+                    issuer_request_id,
+                    tx_hash,
+                    nonce,
+                    shares_minted,
+                    block_number,
+                    recovered_at: Utc::now(),
                 }])
             }
             Self::CallbackPending { .. } | Self::Completed { .. } => Ok(vec![]),
@@ -1135,6 +1370,7 @@ impl Mint {
         &self,
         issuer_request_id: IssuerMintRequestId,
         error: String,
+        classification: MintFailureClassification,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::Minting { issuer_request_id: expected_id, .. }
@@ -1149,6 +1385,7 @@ impl Mint {
                     issuer_request_id,
                     error,
                     failed_at: Utc::now(),
+                    classification,
                 }])
             }
             _ => Ok(vec![]),
@@ -1269,6 +1506,17 @@ impl Mint {
                     expected_id,
                     &issuer_request_id,
                 )?;
+
+                // A vault receipt is a vault-direct proof: the bot never
+                // custodies a receipt for an orchestrator mint, so this path
+                // should be unreachable for one — the guard mirrors the
+                // other record handlers as defence in depth.
+                if let Some(VaultMode::Orchestrator { .. }) = self.mint_mode() {
+                    return Err(MintError::MintModeMismatch {
+                        expected: VaultModeKind::Orchestrator,
+                        found: VaultModeKind::VaultDirect,
+                    });
+                }
 
                 Ok(vec![MintEvent::ExistingMintRecovered {
                     issuer_request_id,
@@ -1507,15 +1755,16 @@ impl Mint {
         };
     }
 
-    fn apply_tokens_minted(
-        &mut self,
-        tx_hash: B256,
-        receipt_id: U256,
-        shares_minted: U256,
-        gas_used: Option<u64>,
-        block_number: u64,
-        minted_at: DateTime<Utc>,
-    ) {
+    fn apply_tokens_minted(&mut self, audit: MintedAudit) {
+        let MintedAudit {
+            tx_hash,
+            receipt_id,
+            mint_nonce,
+            shares_minted,
+            gas_used,
+            block_number,
+            minted_at,
+        } = audit;
         let (Self::Minting {
             issuer_request_id,
             tokenization_request_id,
@@ -1580,6 +1829,7 @@ impl Mint {
             journal_confirmed_at,
             tx_hash,
             receipt_id,
+            mint_nonce,
             shares_minted,
             gas_used,
             block_number,
@@ -1591,6 +1841,7 @@ impl Mint {
         &mut self,
         error: String,
         failed_at: DateTime<Utc>,
+        classification: MintFailureClassification,
     ) {
         // Re-failure while already in MintingFailed (e.g. a recovery confirm
         // or resubmission attempt failed again): refresh error/failed_at and
@@ -1600,13 +1851,21 @@ impl Mint {
         if let Self::MintingFailed {
             error: existing_error,
             failed_at: existing_failed_at,
+            classification: existing_classification,
             attempts,
             ..
         } = self
         {
             *existing_error = error;
             *existing_failed_at = failed_at;
-            *attempts += 1;
+            *existing_classification = classification;
+            // An orchestrator-wide halt does not advance the per-mint
+            // counter (SPEC "Failure States"): it resolves by upgrade, and
+            // advancing here would exhaust every in-flight mint's budget
+            // during one halt window.
+            if !classification.is_environment_halt() {
+                *attempts += 1;
+            }
             return;
         }
 
@@ -1630,13 +1889,21 @@ impl Mint {
                     + 1,
                 Box::new(self.clone()),
             ),
-            Self::Minting { retry: Some(context), .. } => {
-                // Keep the retry wrapper, not only its older predecessor: the
-                // wrapper may carry transaction-hash provenance that a manual
-                // retry must never flatten away. `non_failed_predecessor`
-                // already traverses this chain for automatic retry identity.
-                (context.attempts + 1, Box::new(self.clone()))
-            }
+            // A retry that failed to an environment-wide halt keeps the
+            // preserved counter (SPEC "Failure States" — halts never advance
+            // it); any other failure escalates the schedule. Keep the retry
+            // wrapper, not only its older predecessor: the wrapper may carry
+            // transaction-hash provenance that a manual retry must never
+            // flatten away. `non_failed_predecessor` already traverses this
+            // chain for automatic retry identity.
+            Self::Minting { retry: Some(context), .. } => (
+                if classification.is_environment_halt() {
+                    context.attempts
+                } else {
+                    context.attempts + 1
+                },
+                Box::new(self.clone()),
+            ),
             _ => (1, Box::new(self.clone())),
         };
 
@@ -1704,6 +1971,7 @@ impl Mint {
             journal_confirmed_at,
             error,
             failed_at,
+            classification,
             attempts,
             failed_from,
         };
@@ -1725,6 +1993,7 @@ impl Mint {
             journal_confirmed_at,
             tx_hash,
             receipt_id,
+            mint_nonce,
             shares_minted,
             gas_used,
             block_number,
@@ -1749,6 +2018,7 @@ impl Mint {
             journal_confirmed_at,
             tx_hash,
             receipt_id,
+            mint_nonce,
             shares_minted,
             gas_used,
             block_number,
@@ -1843,7 +2113,108 @@ impl Mint {
             mint_authorization,
             journal_confirmed_at,
             tx_hash,
-            receipt_id,
+            receipt_id: Some(receipt_id),
+            mint_nonce: None,
+            shares_minted,
+            gas_used: None,
+            block_number,
+            minted_at: recovered_at,
+        };
+    }
+
+    /// Mirrors `apply_existing_mint_recorded` for an orchestrator mint whose
+    /// landing was proven by the full-match `Minted`-log lookup: same
+    /// lifecycle landing (`CallbackPending`), orchestrator-shaped audit data
+    /// (`mint_nonce` in place of `receipt_id`), and no `gas_used` — a bare
+    /// log does not expose it.
+    fn apply_orchestrator_mint_recovered(
+        &mut self,
+        tx_hash: B256,
+        nonce: B256,
+        shares_minted: U256,
+        block_number: u64,
+        recovered_at: DateTime<Utc>,
+    ) {
+        let (Self::Minting {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            mint_mode,
+            mint_authorization,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::TxIntended {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            mint_mode,
+            mint_authorization,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::TxSubmitted {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            mint_mode,
+            mint_authorization,
+            journal_confirmed_at,
+            ..
+        }
+        | Self::MintingFailed {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            mint_mode,
+            mint_authorization,
+            journal_confirmed_at,
+            ..
+        }) = self.clone()
+        else {
+            return;
+        };
+
+        *self = Self::CallbackPending {
+            issuer_request_id,
+            tokenization_request_id,
+            quantity,
+            underlying,
+            token,
+            network,
+            client_id,
+            wallet,
+            initiated_at,
+            mint_mode,
+            mint_authorization,
+            journal_confirmed_at,
+            tx_hash,
+            receipt_id: None,
+            mint_nonce: Some(nonce),
             shares_minted,
             gas_used: None,
             block_number,
@@ -2109,6 +2480,8 @@ impl EventSourced for Mint {
             }
             MintCommand::RecordMintFailed { .. }
             | MintCommand::RetryMint { .. }
+            | MintCommand::RecordOrchestratorTokensMinted { .. }
+            | MintCommand::RecordOrchestratorMintRecovered { .. }
             | MintCommand::ManualRetryMint { .. } => Ok(vec![]),
             MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
                 current_state: "Uninitialized".to_string(),
@@ -2201,9 +2574,47 @@ impl EventSourced for Mint {
             MintCommand::RecordCallbackSent { issuer_request_id } => {
                 self.handle_record_callback_sent(issuer_request_id)
             }
-            MintCommand::RecordMintFailed { issuer_request_id, error } => {
-                self.handle_record_mint_failed(issuer_request_id, error)
-            }
+            MintCommand::RecordMintFailed {
+                issuer_request_id,
+                error,
+                classification,
+            } => self.handle_record_mint_failed(
+                issuer_request_id,
+                error,
+                classification,
+            ),
+            MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id,
+                tx_id,
+                tx_hash,
+                nonce,
+                shares_minted,
+                gas_used,
+                block_number,
+            } => self.handle_record_orchestrator_tokens_minted(
+                issuer_request_id,
+                ConfirmedOrchestratorMint {
+                    tx_id,
+                    tx_hash,
+                    nonce,
+                    shares_minted,
+                    gas_used,
+                    block_number,
+                },
+            ),
+            MintCommand::RecordOrchestratorMintRecovered {
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                shares_minted,
+                block_number,
+            } => self.handle_record_orchestrator_mint_recovered(
+                issuer_request_id,
+                tx_hash,
+                nonce,
+                shares_minted,
+                block_number,
+            ),
             MintCommand::RetryMint { issuer_request_id } => {
                 self.handle_retry_mint(issuer_request_id)
             }
@@ -2299,19 +2710,52 @@ impl Mint {
                 gas_used,
                 block_number,
                 minted_at,
-            } => self.apply_tokens_minted(
+            } => self.apply_tokens_minted(MintedAudit {
                 tx_hash,
-                receipt_id,
+                receipt_id: Some(receipt_id),
+                mint_nonce: None,
                 shares_minted,
-                Some(gas_used),
+                gas_used: Some(gas_used),
                 block_number,
                 minted_at,
+            }),
+            MintEvent::OrchestratorTokensMinted {
+                issuer_request_id: _,
+                tx_hash,
+                nonce,
+                shares_minted,
+                gas_used,
+                block_number,
+                minted_at,
+            } => self.apply_tokens_minted(MintedAudit {
+                tx_hash,
+                receipt_id: None,
+                mint_nonce: Some(nonce),
+                shares_minted,
+                gas_used: Some(gas_used),
+                block_number,
+                minted_at,
+            }),
+            MintEvent::OrchestratorMintRecovered {
+                issuer_request_id: _,
+                tx_hash,
+                nonce,
+                shares_minted,
+                block_number,
+                recovered_at,
+            } => self.apply_orchestrator_mint_recovered(
+                tx_hash,
+                nonce,
+                shares_minted,
+                block_number,
+                recovered_at,
             ),
             MintEvent::MintingFailed {
                 issuer_request_id: _,
                 error,
                 failed_at,
-            } => self.apply_minting_failed(error, failed_at),
+                classification,
+            } => self.apply_minting_failed(error, failed_at, classification),
             MintEvent::MintCompleted { issuer_request_id: _, completed_at } => {
                 self.apply_mint_completed(completed_at);
             }
@@ -2380,6 +2824,20 @@ pub(crate) enum MintError {
         "Mint authorization cannot be accepted in state {current_state}: authorizations are only accepted before the mint transaction is prepared"
     )]
     AuthorizationNotAcceptable { current_state: String },
+    #[error(
+        "Mint result mode mismatch: the mint's persisted anchor is {expected}, the recorded result is {found}"
+    )]
+    MintModeMismatch { expected: VaultModeKind, found: VaultModeKind },
+    #[error("Orchestrator mint has no recorded authorization to check against")]
+    MissingMintAuthorization,
+    #[error(
+        "Minted nonce diverges from the recorded authorization: expected {expected}, chain reported {actual}"
+    )]
+    MintedNonceMismatch { expected: B256, actual: B256 },
+    #[error(
+        "Minted shares diverge from the authorized amount: expected {expected}, chain reported {actual}"
+    )]
+    MintedSharesMismatch { expected: U256, actual: U256 },
     #[error("Mint not in Initiated state. Current state: {current_state}")]
     NotInInitiatedState { current_state: String },
     #[error(
@@ -2489,7 +2947,8 @@ impl From<UnconfiguredNetworkError> for MintError {
 #[cfg(test)]
 pub(crate) mod tests {
     use alloy::primitives::{Address, B256, Bytes, address, b256, uint};
-    use chrono::{DateTime, Utc};
+    use chrono::{DateTime, Duration as ChronoDuration, Utc};
+    use cqrs_es::DomainEvent;
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
     use rust_decimal::Decimal;
@@ -2500,10 +2959,11 @@ pub(crate) mod tests {
     use uuid::{Uuid, uuid};
 
     use super::{
-        ClientId, IssuerMintRequestId, ManualRecoveryDecision, Mint,
-        MintCommand, MintError, MintEvent, MintExternalTxId, Network, Quantity,
+        AutomaticRetryDecision, ClientId, IssuerMintRequestId,
+        ManualRecoveryDecision, Mint, MintCommand, MintError, MintEvent,
+        MintExternalTxId, MintFailureClassification, Network, Quantity,
         TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
-        has_unresolved_signer_intent,
+        has_unresolved_signer_intent, orchestrator_mint_failure_classification,
     };
     use crate::config::VaultMode;
     use crate::prepare_event_sourced_startup;
@@ -2511,7 +2971,10 @@ pub(crate) mod tests {
     use crate::tokenized_asset::{
         AssetKey, TokenizedAsset, TokenizedAssetCommand,
     };
-    use crate::vault::{MintAuthorization, PreparedMintTx, TxId};
+    use crate::vault::{
+        MintAuthorization, OrchestratorRevertReason, PreparedMintTx, TxId,
+        VaultError,
+    };
 
     pub(super) const VAULT: Address =
         address!("0xcccccccccccccccccccccccccccccccccccccccc");
@@ -3069,6 +3532,67 @@ pub(crate) mod tests {
         .expect("a closed mint must not block the next same-network intent");
     }
 
+    /// An orchestrator mint's landing can be recorded while the intent's
+    /// reservation is still held (recovery proving the landing without a
+    /// `MintTxSubmitted` ever committing). Both orchestrator resolutions
+    /// must release the network's reservation, or the row strands and every
+    /// later mint AND burn on that network is rejected until an operator
+    /// close.
+    #[tokio::test]
+    async fn orchestrator_resolutions_release_the_signer_reservation() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+
+        for (aggregate_id, resolution) in [
+            ("mint-recovered", "MintEvent::OrchestratorMintRecovered"),
+            ("mint-orch-minted", "MintEvent::OrchestratorTokensMinted"),
+        ] {
+            for (sequence, event_type, payload) in [
+                (
+                    1,
+                    "MintEvent::Initiated",
+                    r#"{"Initiated":{"network":"base"}}"#,
+                ),
+                (2, "MintEvent::MintTxIntended", "{}"),
+            ] {
+                insert_raw_event(
+                    &pool,
+                    "Mint",
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    payload,
+                )
+                .await
+                .expect("test history should insert");
+            }
+            assert!(
+                has_unresolved_signer_intent(&pool, Network::Base, None)
+                    .await
+                    .expect("intent query should succeed"),
+                "the intent must reserve the network before {resolution}"
+            );
+
+            insert_raw_event(&pool, "Mint", aggregate_id, 3, resolution, "{}")
+                .await
+                .expect("the orchestrator resolution event should insert");
+
+            assert!(
+                !has_unresolved_signer_intent(&pool, Network::Base, None)
+                    .await
+                    .expect("intent query should succeed"),
+                "{resolution} must release the network's signer reservation"
+            );
+        }
+    }
+
     /// The validation trigger's third branch: a network value outside the
     /// known set must abort the intent append, not reserve an ambiguous
     /// signer domain.
@@ -3151,6 +3675,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "terminal transaction failure".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             },
         ]
     }
@@ -3260,6 +3785,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             });
         }
         let exhausted = replay::<Mint>(exhausted_events).unwrap().unwrap();
@@ -3296,6 +3822,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "signing rejected".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
 
         let emitted = TestHarness::<Mint>::with(())
@@ -3325,6 +3852,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "first attempt failed".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
         events.push(MintEvent::MintRetryStarted {
             issuer_request_id: issuer_request_id.clone(),
@@ -3336,6 +3864,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "retry failed".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
 
         let error = TestHarness::<Mint>::with(())
@@ -3373,6 +3902,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "signing rejected".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
 
         let error = TestHarness::<Mint>::with(())
@@ -3464,6 +3994,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "reverted".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
         let failed = replay::<Mint>(events).unwrap().unwrap();
         let prepared = failed
@@ -3518,6 +4049,60 @@ pub(crate) mod tests {
             events.as_slice(),
             [MintEvent::MintTxIntended { .. }]
         ));
+    }
+
+    pub(super) const ORCHESTRATOR: Address =
+        address!("0xdddddddddddddddddddddddddddddddddddddddd");
+
+    pub(super) fn test_mint_authorization() -> MintAuthorization {
+        MintAuthorization {
+            nonce: b256!(
+                "0x1111111111111111111111111111111111111111111111111111111111111111"
+            ),
+            signature: Bytes::from(vec![0x42; 65]),
+        }
+    }
+
+    /// `events_through_minting` with the `Initiated` mode anchor flipped to
+    /// orchestrator — no authorization delivered yet.
+    pub(super) fn orchestrator_events_through_minting(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = events_through_minting(issuer_request_id);
+        if let Some(MintEvent::Initiated { mint_mode, .. }) = events.first_mut()
+        {
+            *mint_mode = VaultMode::Orchestrator { address: ORCHESTRATOR };
+        }
+        events
+    }
+
+    pub(super) fn orchestrator_events_through_minting_authorized(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events = orchestrator_events_through_minting(issuer_request_id);
+        events.insert(
+            1,
+            MintEvent::MintAuthorizationReceived {
+                issuer_request_id: issuer_request_id.clone(),
+                mint_authorization: test_mint_authorization(),
+                received_at: Utc::now(),
+            },
+        );
+        events
+    }
+
+    pub(super) fn orchestrator_events_through_tx_submitted(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events =
+            orchestrator_events_through_minting_authorized(issuer_request_id);
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: "ext-1".to_string(),
+            tx_id: TxId::Legacy("fb-1".to_string()),
+            submitted_at: Utc::now(),
+        });
+        events
     }
 
     #[tokio::test]
@@ -3582,6 +4167,7 @@ pub(crate) mod tests {
             issuer_request_id,
             error: "legacy broadcast failed".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
 
         assert!(
@@ -3754,6 +4340,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "terminal signer failure".to_string(),
             failed_at: now,
+            classification: MintFailureClassification::Unclassified,
         });
 
         mint.apply_event(MintEvent::MintRetryStarted {
@@ -3782,6 +4369,7 @@ pub(crate) mod tests {
             issuer_request_id,
             error: "retry submission rejected".to_string(),
             failed_at: now,
+            classification: MintFailureClassification::Unclassified,
         });
 
         let Mint::MintingFailed { attempts, failed_from, .. } = &mint else {
@@ -3831,6 +4419,7 @@ pub(crate) mod tests {
             issuer_request_id,
             error: "retry submission outcome unknown".to_string(),
             failed_at: now,
+            classification: MintFailureClassification::Unclassified,
         });
 
         let Mint::MintingFailed { attempts, .. } = mint else {
@@ -3880,6 +4469,7 @@ pub(crate) mod tests {
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
                 error: "submission rejected".to_string(),
+                classification: MintFailureClassification::Unclassified,
             })
             .await
             .events();
@@ -3901,6 +4491,7 @@ pub(crate) mod tests {
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
                 error: "confirmation failed".to_string(),
+                classification: MintFailureClassification::Unclassified,
             })
             .await
             .events();
@@ -3922,6 +4513,7 @@ pub(crate) mod tests {
             .when(MintCommand::RecordMintFailed {
                 issuer_request_id,
                 error: "stale failure report".to_string(),
+                classification: MintFailureClassification::Unclassified,
             })
             .await
             .events();
@@ -4040,6 +4632,8 @@ pub(crate) mod tests {
             | MintEvent::ExistingMintRecovered { .. }
             | MintEvent::MintRetryStarted { .. }
             | MintEvent::MintAuthorizationReceived { .. }
+            | MintEvent::OrchestratorTokensMinted { .. }
+            | MintEvent::OrchestratorMintRecovered { .. }
             | MintEvent::MintClosed { .. } => {
                 panic!("Expected MintInitiated event, got {:?}", &events[0])
             }
@@ -4181,6 +4775,7 @@ pub(crate) mod tests {
             issuer_request_id,
             error: "boom".to_string(),
             failed_at: Utc::now(),
+            classification: MintFailureClassification::Unclassified,
         });
         let failed = replay::<Mint>(failed_events)
             .expect("failed lifecycle must replay")
@@ -4233,6 +4828,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "boom".to_string(),
                 failed_at: Utc::now(),
+                classification: MintFailureClassification::Unclassified,
             },
             MintEvent::MintRetryStarted {
                 issuer_request_id: issuer_request_id.clone(),
@@ -5174,7 +5770,7 @@ pub(crate) mod tests {
 
         assert_eq!(state_issuer_id, issuer_request_id);
         assert_eq!(state_tx_hash, tx_hash);
-        assert_eq!(state_receipt_id, receipt_id);
+        assert_eq!(state_receipt_id, Some(receipt_id));
         assert_eq!(state_shares_minted, shares_minted);
         assert_eq!(state_gas_used, Some(gas_used));
         assert_eq!(state_block_number, block_number);
@@ -5219,6 +5815,7 @@ pub(crate) mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: error_message.to_string(),
             failed_at,
+            classification: MintFailureClassification::Unclassified,
         });
 
         let Mint::MintingFailed {
@@ -5281,7 +5878,8 @@ pub(crate) mod tests {
             mint_mode: VaultMode::VaultDirect,
             journal_confirmed_at,
             tx_hash,
-            receipt_id,
+            receipt_id: Some(receipt_id),
+            mint_nonce: None,
             shares_minted,
             gas_used: Some(gas_used),
             block_number,
@@ -5312,7 +5910,7 @@ pub(crate) mod tests {
 
         assert_eq!(state_issuer_id, issuer_request_id);
         assert_eq!(state_tx_hash, tx_hash);
-        assert_eq!(state_receipt_id, receipt_id);
+        assert_eq!(state_receipt_id, Some(receipt_id));
         assert_eq!(state_shares_minted, shares_minted);
         assert_eq!(state_gas_used, Some(gas_used));
         assert_eq!(state_block_number, block_number);
@@ -6011,6 +6609,632 @@ pub(crate) mod tests {
                 ) if provided == unexpected
             ),
             "unexpected ack must fail, got {error:?}"
+        );
+    }
+
+    /// Submission failures that produce no TxSubmitted event (pre-acceptance)
+    /// must still escalate the retry schedule and eventually exhaust, while the
+    /// external_tx_id stays at retry-1 so resubmission is idempotent.
+    #[test]
+    fn pre_acceptance_failures_escalate_attempts_but_reuse_external_id() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let now = Utc::now();
+        let mut mint = replay::<Mint>(vec![
+            MintEvent::Initiated {
+                mint_mode: VaultMode::VaultDirect,
+                issuer_request_id: issuer_request_id.clone(),
+                tokenization_request_id: TokenizationRequestId::new("tok-123"),
+                quantity: Quantity::new(Decimal::from(100)),
+                underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                token: TokenSymbol::new("tAAPL"),
+                network: Network::Base,
+                client_id: ClientId::new(),
+                wallet: address!("0x1234567890abcdef1234567890abcdef12345678"),
+                initiated_at: now,
+            },
+            MintEvent::JournalConfirmed {
+                issuer_request_id: issuer_request_id.clone(),
+                confirmed_at: now,
+            },
+            MintEvent::MintingStarted {
+                issuer_request_id: issuer_request_id.clone(),
+                started_at: now,
+            },
+        ])
+        .unwrap()
+        .unwrap();
+
+        // failed_at far in the past so every retry window has elapsed; the
+        // decision then turns only on the escalating attempt counter.
+        let failed_at = now - ChronoDuration::hours(3);
+
+        // First submission failure from Minting: attempts = 1, retryable.
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "submission rejected".to_string(),
+            failed_at,
+            classification: MintFailureClassification::Unclassified,
+        });
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Ready
+        );
+
+        // Three more pre-acceptance failures push attempts to 4 (still the last
+        // retryable attempt), then a fifth exhausts the automatic schedule —
+        // proving the counter escalates without a TxSubmitted record.
+        for _ in 0..3 {
+            mint.apply_event(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+                classification: MintFailureClassification::Unclassified,
+            });
+        }
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Ready
+        );
+
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "submission rejected".to_string(),
+            failed_at,
+            classification: MintFailureClassification::Unclassified,
+        });
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::Exhausted
+        );
+
+        // The external_tx_id attempt never advanced — retries reuse retry-1.
+        assert_eq!(mint.next_retry_attempt(), 1);
+    }
+
+    /// An environment-wide halt (`VaultLogicMismatch`/`ReceiptLogicMismatch`)
+    /// must not advance the attempt counter (SPEC "Failure States"): the halt
+    /// resolves by upgrade, so re-failures during the halt window leave the
+    /// per-mint budget untouched, while an unclassified failure still
+    /// escalates the schedule.
+    #[test]
+    fn halt_classified_failures_do_not_advance_attempts() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let failed_at = Utc::now();
+        let mut mint = replay::<Mint>(
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+        )
+        .expect("orchestrator mint must replay")
+        .expect("mint must exist");
+
+        for _ in 0..6 {
+            mint.apply_event(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "vault logic mismatch".to_string(),
+                failed_at,
+                classification: MintFailureClassification::VaultLogicMismatch,
+            });
+        }
+        let Mint::MintingFailed { attempts, .. } = &mint else {
+            panic!("expected MintingFailed, got {mint:?}");
+        };
+        assert_eq!(
+            *attempts, 1,
+            "halt re-failures must leave the attempt counter untouched"
+        );
+
+        // A retry cycle that fails back to a halt keeps the preserved
+        // counter too.
+        mint.apply_event(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            started_at: failed_at,
+            manual_retry_id: None,
+        });
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "vault logic mismatch".to_string(),
+            failed_at,
+            classification: MintFailureClassification::VaultLogicMismatch,
+        });
+        let Mint::MintingFailed { attempts, .. } = &mint else {
+            panic!("expected MintingFailed, got {mint:?}");
+        };
+        assert_eq!(
+            *attempts, 1,
+            "a retry that failed back to a halt must not escalate"
+        );
+
+        mint.apply_event(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "timeout".to_string(),
+            failed_at,
+            classification: MintFailureClassification::Unclassified,
+        });
+        let Mint::MintingFailed { attempts, .. } = &mint else {
+            panic!("expected MintingFailed, got {mint:?}");
+        };
+        assert_eq!(
+            *attempts, 2,
+            "an unclassified failure must still escalate the schedule"
+        );
+    }
+
+    /// Every deterministic orchestrator revert decodes to its typed
+    /// classification; only the reasons that prove nothing about a retry
+    /// (`NonceReplayed` without an authorization to full-match,
+    /// `InsufficientReceipts`, `Unknown`) stay `Unclassified`.
+    #[test]
+    fn orchestrator_revert_reasons_classify_deterministic_failures() {
+        let cases = [
+            (
+                OrchestratorRevertReason::VaultLogicMismatch,
+                MintFailureClassification::VaultLogicMismatch,
+            ),
+            (
+                OrchestratorRevertReason::ReceiptLogicMismatch,
+                MintFailureClassification::ReceiptLogicMismatch,
+            ),
+            (
+                OrchestratorRevertReason::BadRecipientSignature,
+                MintFailureClassification::BadRecipientSignature,
+            ),
+            (
+                OrchestratorRevertReason::RecipientCallbackRejected {
+                    recipient: Address::ZERO,
+                },
+                MintFailureClassification::RecipientCallbackRejected,
+            ),
+            (
+                OrchestratorRevertReason::VaultAmountMismatch {
+                    expected: uint!(2_U256),
+                    actual: uint!(1_U256),
+                },
+                MintFailureClassification::VaultAmountMismatch,
+            ),
+            (
+                OrchestratorRevertReason::NonceReplayed {
+                    to: Address::ZERO,
+                    nonce: B256::ZERO,
+                },
+                MintFailureClassification::Unclassified,
+            ),
+            (
+                OrchestratorRevertReason::InsufficientReceipts {
+                    token: Address::ZERO,
+                    shortfall: uint!(1_U256),
+                },
+                MintFailureClassification::Unclassified,
+            ),
+            (
+                OrchestratorRevertReason::Unknown,
+                MintFailureClassification::Unclassified,
+            ),
+        ];
+
+        for (reason, expected) in cases {
+            let error = VaultError::OrchestratorReverted {
+                tx_hash: B256::ZERO,
+                reason,
+            };
+            assert_eq!(
+                orchestrator_mint_failure_classification(&error),
+                expected,
+                "revert reason {reason:?} must classify as {expected:?}"
+            );
+        }
+    }
+
+    /// A vault-direct confirmation result can never complete an orchestrator
+    /// mint, and vice versa — the record handlers enforce the persisted
+    /// mode anchor.
+    #[tokio::test]
+    async fn record_handlers_reject_cross_mode_results() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_hash: B256::ZERO,
+                receipt_id: uint!(1_U256),
+                shares_minted: uint!(1_U256),
+                gas_used: 1,
+                block_number: 1,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintModeMismatch { .. })
+            ),
+            "a vault-direct result must not complete an orchestrator mint, \
+             got {error:?}"
+        );
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_hash: B256::ZERO,
+                nonce: B256::ZERO,
+                shares_minted: uint!(1_U256),
+                gas_used: 1,
+                block_number: 1,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintModeMismatch { .. })
+            ),
+            "an orchestrator result must not complete a vault-direct mint, \
+             got {error:?}"
+        );
+    }
+
+    /// A re-delivered orchestrator confirmation after the mint already
+    /// advanced is a no-op, mirroring the vault-direct record handlers.
+    #[tokio::test]
+    async fn record_orchestrator_tokens_minted_noop_past_tx_submitted() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::OrchestratorTokensMinted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce: test_mint_authorization().nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            gas_used: 21_000,
+            block_number: 1_000,
+            minted_at: Utc::now(),
+        });
+
+        let events = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_hash: B256::ZERO,
+                nonce: test_mint_authorization().nonce,
+                shares_minted: uint!(100_000000000000000000_U256),
+                gas_used: 21_000,
+                block_number: 1_000,
+            })
+            .await
+            .events();
+
+        assert!(
+            events.is_empty(),
+            "a re-delivered orchestrator confirmation must be a no-op"
+        );
+    }
+
+    /// The chain-reported `(nonce, shares)` must equal the recorded
+    /// authorization and journaled quantity — a divergence is a contract
+    /// anomaly that fails loudly instead of becoming the audit record.
+    #[tokio::test]
+    async fn record_orchestrator_tokens_minted_rejects_diverging_values() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_hash: B256::ZERO,
+                nonce: B256::repeat_byte(0xEE),
+                shares_minted: uint!(100_000000000000000000_U256),
+                gas_used: 21_000,
+                block_number: 1_000,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintedNonceMismatch { .. })
+            ),
+            "a diverging nonce must be rejected, got {error:?}"
+        );
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id: TxId::Legacy("fb-1".to_string()),
+                tx_hash: B256::ZERO,
+                nonce: test_mint_authorization().nonce,
+                shares_minted: uint!(1_U256),
+                gas_used: 21_000,
+                block_number: 1_000,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintedSharesMismatch { .. })
+            ),
+            "diverging shares must be rejected, got {error:?}"
+        );
+    }
+
+    /// The recovered-mint path enforces its guards through the command
+    /// handler, not just apply: a vault-direct mint rejects the cross-mode
+    /// completion and a mint already past `TxSubmitted` no-ops.
+    #[tokio::test]
+    async fn record_orchestrator_mint_recovered_guards_via_command() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorMintRecovered {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                nonce: B256::ZERO,
+                shares_minted: uint!(1_U256),
+                block_number: 1,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintModeMismatch { .. })
+            ),
+            "an orchestrator recovery must not complete a vault-direct mint, \
+             got {error:?}"
+        );
+
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::OrchestratorMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce: test_mint_authorization().nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            block_number: 777,
+            recovered_at: Utc::now(),
+        });
+        let events = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::RecordOrchestratorMintRecovered {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                nonce: test_mint_authorization().nonce,
+                shares_minted: uint!(100_000000000000000000_U256),
+                block_number: 777,
+            })
+            .await
+            .events();
+        assert!(events.is_empty(), "a re-delivered recovery must be a no-op");
+    }
+
+    /// A vault receipt is a vault-direct proof: the bot never custodies a
+    /// receipt for an orchestrator mint, so an existing-receipt record for
+    /// one is a cross-mode anomaly the handler must refuse.
+    #[tokio::test]
+    async fn record_existing_mint_rejects_orchestrator_anchored_mint() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordExistingMint {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                receipt_id: uint!(1_U256),
+                shares_minted: uint!(1_U256),
+                block_number: 1,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintModeMismatch { .. })
+            ),
+            "a vault receipt record must not complete an orchestrator mint, \
+             got {error:?}"
+        );
+    }
+
+    /// `OrchestratorTokensMinted` and `OrchestratorMintRecovered` replay into
+    /// `CallbackPending` with the nonce as audit data and no receipt id.
+    #[test]
+    fn orchestrator_mint_events_replay_to_callback_pending() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let nonce = test_mint_authorization().nonce;
+
+        let mut minted_events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        minted_events.push(MintEvent::OrchestratorTokensMinted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            gas_used: 21_000,
+            block_number: 1_000,
+            minted_at: Utc::now(),
+        });
+        let minted = replay::<Mint>(minted_events)
+            .expect("orchestrator mint must replay")
+            .expect("mint must exist");
+        assert!(matches!(
+            &minted,
+            Mint::CallbackPending {
+                receipt_id: None,
+                mint_nonce: Some(event_nonce),
+                gas_used: Some(21_000),
+                ..
+            } if *event_nonce == nonce
+        ));
+
+        let mut recovered_events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        recovered_events.push(MintEvent::OrchestratorMintRecovered {
+            issuer_request_id,
+            tx_hash: B256::ZERO,
+            nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            block_number: 777,
+            recovered_at: Utc::now(),
+        });
+        let recovered = replay::<Mint>(recovered_events)
+            .expect("recovered orchestrator mint must replay")
+            .expect("mint must exist");
+        assert!(matches!(
+            &recovered,
+            Mint::CallbackPending {
+                receipt_id: None,
+                mint_nonce: Some(event_nonce),
+                gas_used: None,
+                block_number: 777,
+                ..
+            } if *event_nonce == nonce
+        ));
+    }
+
+    /// Historic `MintingFailed` events predate `classification`; they must
+    /// replay as `Unclassified`.
+    #[test]
+    fn minting_failed_without_classification_replays_as_unclassified() {
+        let historic = serde_json::json!({
+            "MintingFailed": {
+                "issuer_request_id": IssuerMintRequestId::random().to_string(),
+                "error": "timeout",
+                "failed_at": "2025-01-01T00:00:00Z"
+            }
+        });
+
+        let event: MintEvent = serde_json::from_value(historic).unwrap();
+
+        assert!(matches!(
+            event,
+            MintEvent::MintingFailed {
+                classification: MintFailureClassification::Unclassified,
+                ..
+            }
+        ));
+    }
+
+    /// The classifications' wire strings are permanent event schema
+    /// (embedded in persisted `MintingFailed` payloads) — pin every variant
+    /// against literals so a rename fails here instead of silently
+    /// re-shaping history (a renamed halt variant would replay historic
+    /// failures as `Unclassified` and re-enter the retry schedule).
+    #[test]
+    fn every_classification_pins_its_wire_string() {
+        for (classification, wire) in [
+            (MintFailureClassification::Unclassified, "Unclassified"),
+            (
+                MintFailureClassification::VaultLogicMismatch,
+                "VaultLogicMismatch",
+            ),
+            (
+                MintFailureClassification::ReceiptLogicMismatch,
+                "ReceiptLogicMismatch",
+            ),
+            (
+                MintFailureClassification::NonceConsumedByOtherMint,
+                "NonceConsumedByOtherMint",
+            ),
+            (
+                MintFailureClassification::NonceReplayUnresolved,
+                "NonceReplayUnresolved",
+            ),
+            (
+                MintFailureClassification::BadRecipientSignature,
+                "BadRecipientSignature",
+            ),
+            (
+                MintFailureClassification::RecipientCallbackRejected,
+                "RecipientCallbackRejected",
+            ),
+            (
+                MintFailureClassification::VaultAmountMismatch,
+                "VaultAmountMismatch",
+            ),
+        ] {
+            assert_eq!(
+                serde_json::to_value(classification).unwrap(),
+                serde_json::json!(wire)
+            );
+            assert_eq!(
+                serde_json::from_value::<MintFailureClassification>(
+                    serde_json::json!(wire)
+                )
+                .unwrap(),
+                classification
+            );
+        }
+    }
+
+    /// The new orchestrator events' on-disk shape is a permanent event
+    /// schema — pin it against literal JSON (a serde round-trip can never
+    /// catch a field rename) along with the permanent `event_type` names.
+    #[test]
+    fn orchestrator_mint_events_pin_wire_shape() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let timestamp: DateTime<Utc> = "2026-01-02T03:04:05Z".parse().unwrap();
+        let nonce = B256::repeat_byte(0x07);
+
+        let minted = MintEvent::OrchestratorTokensMinted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            gas_used: 21_000,
+            block_number: 1_000,
+            minted_at: timestamp,
+        };
+        assert_eq!(minted.event_type(), "MintEvent::OrchestratorTokensMinted");
+        let minted_wire = serde_json::json!({
+            "OrchestratorTokensMinted": {
+                "issuer_request_id": issuer_request_id.to_string(),
+                "tx_hash": format!("{:?}", B256::ZERO),
+                "nonce": format!("{nonce:?}"),
+                "shares_minted": "0x56bc75e2d63100000",
+                "gas_used": 21_000,
+                "block_number": 1_000,
+                "minted_at": "2026-01-02T03:04:05Z",
+            }
+        });
+        assert_eq!(serde_json::to_value(&minted).unwrap(), minted_wire);
+        assert_eq!(
+            serde_json::from_value::<MintEvent>(minted_wire).unwrap(),
+            minted
+        );
+
+        let recovered = MintEvent::OrchestratorMintRecovered {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            block_number: 777,
+            recovered_at: timestamp,
+        };
+        assert_eq!(
+            recovered.event_type(),
+            "MintEvent::OrchestratorMintRecovered"
+        );
+        let recovered_wire = serde_json::json!({
+            "OrchestratorMintRecovered": {
+                "issuer_request_id": issuer_request_id.to_string(),
+                "tx_hash": format!("{:?}", B256::ZERO),
+                "nonce": format!("{nonce:?}"),
+                "shares_minted": "0x56bc75e2d63100000",
+                "block_number": 777,
+                "recovered_at": "2026-01-02T03:04:05Z",
+            }
+        });
+        assert_eq!(serde_json::to_value(&recovered).unwrap(), recovered_wire);
+        assert_eq!(
+            serde_json::from_value::<MintEvent>(recovered_wire).unwrap(),
+            recovered
         );
     }
 }

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1457,8 +1457,9 @@ mod tests {
     };
     use crate::mint::tests::VAULT;
     use crate::mint::{
-        ClientId, IssuerMintRequestId, MintEvent, MintExternalTxId, Network,
-        Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        ClientId, IssuerMintRequestId, MintEvent, MintExternalTxId,
+        MintFailureClassification, Network, Quantity, TokenSymbol,
+        TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::receipt_inventory::{
         BurnPlan, BurnTrackingError, CqrsReceiptService, MintedReceiptParams,
@@ -1706,6 +1707,7 @@ mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "prepare or pre-submit failure".to_string(),
             failed_at,
+            classification: MintFailureClassification::Unclassified,
         });
 
         events
@@ -1723,6 +1725,7 @@ mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "terminal signer failure".to_string(),
             failed_at,
+            classification: MintFailureClassification::Unclassified,
         });
 
         events
@@ -1756,6 +1759,7 @@ mod tests {
             issuer_request_id: issuer_request_id.clone(),
             error: "prior confirm uncertain or reverted".to_string(),
             failed_at,
+            classification: MintFailureClassification::Unclassified,
         });
         events
     }
@@ -2157,6 +2161,7 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             });
         }
         let fixture = MintRecoveryFixture::new().await;
@@ -2201,6 +2206,7 @@ mod tests {
                 issuer_request_id: lookup_failure_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             });
         }
         fixture
@@ -2250,6 +2256,7 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             });
         }
         let fixture = MintRecoveryFixture::new().await;
@@ -2314,6 +2321,7 @@ mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 error: "submission rejected".to_string(),
                 failed_at,
+                classification: MintFailureClassification::Unclassified,
             });
         }
         let fixture = MintRecoveryFixture::new().await;
@@ -2551,6 +2559,7 @@ mod tests {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "Turnkey HTTP response was not successful: 403"
                         .to_string(),
+                    classification: MintFailureClassification::Unclassified,
                 },
             )
             .await
@@ -2635,6 +2644,7 @@ mod tests {
                 MintCommand::RecordMintFailed {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "prepare failed".to_string(),
+                    classification: MintFailureClassification::Unclassified,
                 },
             )
             .await
@@ -2715,6 +2725,7 @@ mod tests {
                 MintCommand::RecordMintFailed {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "prepare failed".to_string(),
+                    classification: MintFailureClassification::Unclassified,
                 },
             )
             .await
@@ -2835,6 +2846,7 @@ mod tests {
                 MintCommand::RecordMintFailed {
                     issuer_request_id: issuer_request_id.clone(),
                     error: "confirmation timed out".to_string(),
+                    classification: MintFailureClassification::Unclassified,
                 },
             )
             .await

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -6,8 +6,8 @@ use sqlx::{Pool, Sqlite};
 use uuid::Uuid;
 
 use super::{
-    ClientId, IssuerMintRequestId, Mint, Network, Quantity, TokenSymbol,
-    TokenizationRequestId, UnderlyingSymbol,
+    ClientId, IssuerMintRequestId, Mint, MintFailureClassification, Network,
+    Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
 };
 use crate::vault::{PreparedMintTx, TxId};
 
@@ -129,7 +129,12 @@ pub(crate) enum MintView {
         initiated_at: DateTime<Utc>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
-        receipt_id: U256,
+        /// Vault-direct audit data; `None` for orchestrator mints, whose
+        /// receipts are custodied by the orchestrator.
+        receipt_id: Option<U256>,
+        /// The consumed authorization nonce; `None` for vault-direct mints.
+        #[serde(default)]
+        mint_nonce: Option<B256>,
         shares_minted: U256,
         gas_used: Option<u64>,
         block_number: u64,
@@ -148,6 +153,10 @@ pub(crate) enum MintView {
         journal_confirmed_at: DateTime<Utc>,
         error: String,
         failed_at: DateTime<Utc>,
+        /// Typed failure classification mirrored from the aggregate state;
+        /// defaults to `Unclassified` on rows written before it existed.
+        #[serde(default)]
+        classification: MintFailureClassification,
     },
     Completed {
         issuer_request_id: IssuerMintRequestId,
@@ -161,7 +170,12 @@ pub(crate) enum MintView {
         initiated_at: DateTime<Utc>,
         journal_confirmed_at: DateTime<Utc>,
         tx_hash: B256,
-        receipt_id: U256,
+        /// Vault-direct audit data; `None` for orchestrator mints, whose
+        /// receipts are custodied by the orchestrator.
+        receipt_id: Option<U256>,
+        /// The consumed authorization nonce; `None` for vault-direct mints.
+        #[serde(default)]
+        mint_nonce: Option<B256>,
         shares_minted: U256,
         gas_used: Option<u64>,
         block_number: u64,
@@ -870,6 +884,7 @@ mod tests {
                 journal_confirmed_at: now,
                 error: "Transaction reverted".to_string(),
                 failed_at: now,
+                classification: MintFailureClassification::Unclassified,
             },
             MintView::CallbackPending {
                 issuer_request_id: fields[5].issuer_request_id.clone(),
@@ -887,7 +902,8 @@ mod tests {
                 tx_hash: b256!(
                     "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
                 ),
-                receipt_id: uint!(1_U256),
+                receipt_id: Some(uint!(1_U256)),
+                mint_nonce: None,
                 shares_minted: uint!(100_000000000000000000_U256),
                 gas_used: Some(50000),
                 block_number: 1000,
@@ -936,7 +952,8 @@ mod tests {
             initiated_at: fields.initiated_at,
             journal_confirmed_at: now,
             tx_hash: b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-            receipt_id: uint!(2_U256),
+            receipt_id: Some(uint!(2_U256)),
+            mint_nonce: None,
             shares_minted: uint!(100_000000000000000000_U256),
             gas_used: Some(50000),
             block_number: 1001,
@@ -1048,7 +1065,8 @@ mod tests {
             initiated_at: completed_fields.initiated_at,
             journal_confirmed_at: now,
             tx_hash: b256!("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"),
-            receipt_id: uint!(2_U256),
+            receipt_id: Some(uint!(2_U256)),
+            mint_nonce: None,
             shares_minted: uint!(100_000000000000000000_U256),
             gas_used: Some(50000),
             block_number: 1001,

--- a/src/receipt_inventory/view.rs
+++ b/src/receipt_inventory/view.rs
@@ -308,7 +308,10 @@ mod tests {
 
     use super::*;
     use crate::config::VaultMode;
-    use crate::mint::{ClientId, Network, Quantity, TokenizationRequestId};
+    use crate::mint::{
+        ClientId, MintFailureClassification, Network, Quantity,
+        TokenizationRequestId,
+    };
 
     async fn migrated_pool() -> SqlitePool {
         let pool = sqlx::sqlite::SqlitePoolOptions::new()
@@ -737,6 +740,7 @@ mod tests {
                 issuer_request_id: IssuerMintRequestId::random(),
                 error: "test error".to_string(),
                 failed_at: Utc::now(),
+                classification: MintFailureClassification::Unclassified,
             },
             MintEvent::MintCompleted {
                 issuer_request_id: IssuerMintRequestId::random(),

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -293,11 +293,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// multicall — the orchestrator asserts 1:1 on-chain and forwards shares
     /// to the recipient. The call uses exactly the signed
     /// `(token, to, amount, nonce)` from the authorization.
-    ///
-    /// Production callers land with the orchestrator mint aggregate arms
-    /// (mirroring how `check_orchestrator_burn_readiness` above awaited its
-    /// caller); the allow is removed then.
-    #[allow(dead_code)]
     async fn prepare_orchestrator_mint_tx(
         &self,
         _params: &OrchestratorMintParams,
@@ -309,7 +304,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// orchestrator's `Minted` event. A mined-but-reverted mint fails with
     /// [`VaultError::OrchestratorReverted`] carrying the decoded typed reason
     /// (`NonceReplayed`, `VaultLogicMismatch`, ...).
-    #[allow(dead_code)]
     async fn confirm_orchestrator_mint(
         &self,
         _tx_id: &TxId,
@@ -346,7 +340,6 @@ pub(crate) trait VaultService: Send + Sync {
     /// is read from the delivered `authorization` itself (never
     /// `query.nonce`), so the validated pair is exactly the one the mint
     /// will consume.
-    #[allow(dead_code)]
     async fn validate_mint_authorization(
         &self,
         _query: MintedLogQuery,


### PR DESCRIPTION
## Motivation

Orchestrator-mode mints previously had no end-to-end submission or confirmation path. The `prepare_orchestrator_mint_tx`, `confirm_orchestrator_mint`, and `find_orchestrator_minted_log` vault methods existed but were gated behind `#[allow(dead_code)]` and never wired into the mint lifecycle. Mints anchored to `VaultMode::Orchestrator` would silently fall through to vault-direct preparation, producing incorrect audit data and bypassing the orchestrator's receipt custody model entirely.

Additionally, mint failures carried no typed classification, making it impossible to distinguish environment-wide halts (`VaultLogicMismatch`, `ReceiptLogicMismatch`) from ordinary retryable failures or nonces consumed by a different mint (`NonceConsumedByOtherMint`), all of which require different resolution paths.

## Solution

Orchestrator-mode mints now have a complete submission and confirmation path in both the command handler (`Mint::execute_orchestrator_mint_confirmation`) and the durable job (`ConfirmMintJob::confirm_orchestrator`).

**Submission:** `PrepareMint` and `SubmitMintJob` branch on the persisted `VaultMode` anchor. An orchestrator mint without its recipient authorization defers silently — no event, no vault call — leaving the mint in `Minting` until the liquidity bot delivers. Once authorized, preparation routes to `prepare_orchestrator_mint_tx` carrying the anchored orchestrator address and the delivered `MintAuthorization`.

**Confirmation:** Success emits the new `OrchestratorTokensMinted` event carrying the consumed authorization `nonce` in place of a receipt id — the orchestrator holds receipt custody, so no receipt is registered. A `NonceReplayed` revert triggers a full-match lookup of the `Minted` log on `(to, nonce, token, amount)`: a hit emits `OrchestratorMintRecovered` and completes the mint; no hit means a different mint consumed the nonce, which fails as `NonceConsumedByOtherMint` for manual reconciliation only.

**Failure classification:** `MintFailureClassification` is introduced on `MintingFailed` events and the `MintingFailed` aggregate state. Typed classifications (`VaultLogicMismatch`, `ReceiptLogicMismatch`, `NonceConsumedByOtherMint`) are never auto-retried and never kick the recovery scheduler. `Unclassified` preserves the existing automatic retry behavior. The field defaults to `Unclassified` so historic events replay correctly.

**Mode enforcement:** `RecordTokensMinted` rejects orchestrator-anchored mints, and `RecordOrchestratorTokensMinted` / `RecordOrchestratorMintRecovered` reject vault-direct-anchored mints, preventing cross-mode completions. `receipt_id` on `CallbackPending` and `Completed` is now `Option<U256>`, and a new `mint_nonce: Option<B256>` field carries the orchestrator audit data.

The `#[allow(dead_code)]` suppressions on the three orchestrator vault trait methods are removed now that all three have production callers.  
  
Closes [RAI-1617](https://linear.app/makeitrain/issue/RAI-1617/orchestrator-mint-confirmation-with-nonce-replay-recovery-and-failure)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added orchestrator-backed mint submission, confirmation, and recovery.
  * Added detailed mint failure classifications and tracking for mint nonces and transaction details.
* **Bug Fixes**
  * Prevented duplicate recovery jobs from repeated authorization requests.
  * Improved handling of replayed, mismatched, and unresolved mint confirmations.
  * Preserved signer reservations across additional mint resolution events.
* **Improvements**
  * Environment-related failures can avoid consuming retry attempts.
  * Mint status responses remain compatible with older records.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->