### PR TITLE
feat: orchestrator mint recovery with classified failure handling

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,11 +1,13 @@
+use alloy::consensus::transaction::SignerRecoverable;
 use alloy::network::ReceiptResponse;
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, U256};
 use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use cqrs_es::AggregateError;
 use event_sorcery::{EventSourced, LifecycleError, Store};
-use rocket::http::Status;
+use rocket::http::{ContentType, Status};
+use rocket::response::{self, Responder};
 use rocket::serde::json::Json;
 use rocket::{get, post};
 use serde::{Deserialize, Serialize};
@@ -21,12 +23,14 @@ use crate::auth::InternalAuth;
 use crate::config::{Config, VaultMode};
 use crate::mint::{
     IssuerMintRequestId, ManualRecoveryDecision, Mint, MintCommand, MintEvent,
-    MintView, TokenizationRequestId, find_stuck as find_stuck_mints,
+    MintFailureClassification, MintView, TokenizationRequestId,
+    find_stuck as find_stuck_mints,
     recovery::{
-        ManualRetryOutcome, enqueue_scheduled_mint_recovery,
-        manually_retry_failed_mint,
+        ManualRetryOutcome, enqueue_manual_mint_recovery,
+        enqueue_scheduled_mint_recovery, manually_retry_failed_mint,
     },
 };
+use crate::receipt_inventory::ReceiptService;
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
     BurnManager, BurnManagerError, MAX_AUTOMATIC_BURN_RECOVERY_ATTEMPTS,
@@ -40,10 +44,11 @@ use crate::redemption::{
     next_burn_retry_external_tx_id_from_history,
 };
 use crate::tokenized_asset::schedule::{FreezeScheduleError, FreezeScheduler};
-use crate::tokenized_asset::view::list_enabled_assets;
+use crate::tokenized_asset::view::{find_vault, list_enabled_assets};
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
 use crate::vault::{
-    BurnVerification, NetworkVaultServices, TxId, VaultError, VaultService,
+    BurnTxStatus, BurnVerification, MintedLogQuery, MintedLogScan,
+    NetworkVaultServices, SendableTxWithHash, TxId, VaultError, VaultService,
 };
 
 #[async_trait]
@@ -1282,7 +1287,12 @@ const fn map_burn_manager_error(err: &BurnManagerError) -> Status {
         (status = 400, description = "Aggregate id is not a valid UUID"),
         (status = 404, description = "No mint found for this id"),
         (status = 409, description = "Mint already completed or closed"),
-        (status = 422, description = "Invalid state transition for recovery"),
+        (status = 422,
+            description = "Invalid state transition for recovery, or a \
+                deterministic recipient-authorization failure \
+                (BadRecipientSignature / RecipientCallbackRejected) that a \
+                re-drive can never fix — close the mint and re-initiate \
+                with fresh authorization"),
         (status = 500, description = "View query or internal failure")
     ),
     security(("internal_api_key" = []))
@@ -1296,7 +1306,7 @@ pub(crate) async fn reprocess_mint(
     store: &rocket::State<Arc<Store<Mint>>>,
     vault_services: &rocket::State<NetworkVaultServices>,
     aggregate_id: &str,
-) -> Result<Json<ReprocessResponse>, Status> {
+) -> Result<Json<ReprocessResponse>, ReprocessMintError> {
     let issuer_request_id: IssuerMintRequestId = aggregate_id
         .parse::<uuid::Uuid>()
         .map(IssuerMintRequestId::new)
@@ -1304,37 +1314,94 @@ pub(crate) async fn reprocess_mint(
 
     let mint = match store.load(&issuer_request_id).await {
         Ok(Some(mint)) => mint,
-        Ok(None) => return Err(Status::NotFound),
+        Ok(None) => return Err(Status::NotFound.into()),
         Err(error) => {
             error!(target: "admin", aggregate_id, error = %error, "Failed to load mint");
-            return Err(Status::InternalServerError);
+            return Err(Status::InternalServerError.into());
         }
     };
     match mint.manual_recovery_decision() {
         ManualRecoveryDecision::Eligible => {}
         ManualRecoveryDecision::AlreadyTerminal => {
-            return Err(Status::Conflict);
+            return Err(Status::Conflict.into());
         }
         ManualRecoveryDecision::Unrecoverable => {
-            return Err(Status::UnprocessableEntity);
+            return Err(Status::UnprocessableEntity.into());
         }
     }
     let Some(network) = mint.network() else {
-        return Err(Status::UnprocessableEntity);
+        return Err(Status::UnprocessableEntity.into());
     };
     if let Err(error) = vault_services.service(network) {
         error!(target: "admin", aggregate_id, ?network, error = %error,
             "No vault service configured for mint network"
         );
-        return Err(Status::UnprocessableEntity);
+        return Err(Status::UnprocessableEntity.into());
     }
     let current_state = mint.state_name().to_string();
 
-    // A failed mint is retried DIRECTLY — RetryMint plus a fresh submit job —
-    // because the scheduled-recovery loop enforces the automatic retry budget
-    // and would abandon an exhausted mint instead of retrying it. Every other
-    // eligible state enqueues the durable recovery job, the same path the
-    // automatic startup re-scan and the periodic reconciler use.
+    // A CLASSIFIED failure is never fresh-submitted from here: the
+    // manual-flagged recovery job spends exactly one re-drive through the
+    // recovery loop's classified-failure gate — without the flag this
+    // endpoint would answer "recovery initiated" for a classified mint while
+    // the automatic loop silently skips it.
+    if let Mint::MintingFailed { classification, .. } = &mint
+        && *classification != MintFailureClassification::Unclassified
+    {
+        // The recovery loop refuses re-drives of deterministic
+        // recipient-authorization failures outright (resubmitting the same
+        // stored authorization reverts the same way), so enqueuing one here
+        // and answering "Recovery initiated" would report work that will
+        // never run. Refuse at the endpoint with the actual resolution.
+        if matches!(
+            classification,
+            MintFailureClassification::BadRecipientSignature
+                | MintFailureClassification::RecipientCallbackRejected
+        ) {
+            warn!(target: "admin", aggregate_id = aggregate_id,
+                classification = ?classification,
+                "Refusing reprocess of a deterministic \
+                 recipient-authorization failure; close the mint and \
+                 re-initiate with fresh authorization"
+            );
+            return Err(ReprocessMintError::RecipientAuthorizationRefused {
+                classification: *classification,
+            });
+        }
+
+        enqueue_manual_mint_recovery(
+            pool.inner(),
+            apalis_pool.inner(),
+            issuer_request_id,
+        )
+        .await
+        .map_err(|error| {
+            error!(target: "admin", aggregate_id = aggregate_id,
+                error = %error,
+                "Failed to enqueue manual mint recovery"
+            );
+            Status::InternalServerError
+        })?;
+
+        info!(target: "admin", aggregate_id = aggregate_id,
+            previous_state = %current_state,
+            "Mint reprocess enqueued a manual re-drive of a classified failure"
+        );
+
+        return Ok(Json(ReprocessResponse {
+            aggregate_type: AggregateKind::Mint,
+            aggregate_id: aggregate_id.to_string(),
+            previous_state: current_state,
+            message: "Recovery initiated".to_string(),
+        }));
+    }
+
+    // An UNCLASSIFIED failed mint is retried DIRECTLY — RetryMint plus a
+    // fresh submit job — because the scheduled-recovery loop enforces the
+    // automatic retry budget and would abandon an exhausted mint instead of
+    // retrying it. Every other eligible state enqueues the durable recovery
+    // job, the same path the automatic startup re-scan and the periodic
+    // reconciler use.
     let message = if matches!(&mint, Mint::MintingFailed { .. }) {
         match manually_retry_failed_mint(
             store.inner(),
@@ -1396,6 +1463,56 @@ pub(crate) async fn reprocess_mint(
     }))
 }
 
+/// Mint-reprocess endpoint failure. Most causes respond as a bare status,
+/// but the recipient-authorization refusal carries a body telling the
+/// operator the actual resolution — a bare 422 would be indistinguishable
+/// from the ordinary unrecoverable-state rejection.
+#[derive(Debug)]
+pub(crate) enum ReprocessMintError {
+    Status(Status),
+    /// The failure is a deterministic recipient-authorization revert
+    /// (`BadRecipientSignature` / `RecipientCallbackRejected`): re-driving
+    /// resubmits the identical `mint()` call, which reverts the same way.
+    /// The only resolution is `CloseMint` plus a fresh `Initiate` carrying
+    /// new authorization, so the recovery loop refuses the re-drive and
+    /// this endpoint must not answer "Recovery initiated" for it.
+    RecipientAuthorizationRefused {
+        classification: MintFailureClassification,
+    },
+}
+
+impl From<Status> for ReprocessMintError {
+    fn from(status: Status) -> Self {
+        Self::Status(status)
+    }
+}
+
+impl<'r> Responder<'r, 'static> for ReprocessMintError {
+    fn respond_to(
+        self,
+        request: &'r rocket::Request<'_>,
+    ) -> response::Result<'static> {
+        match self {
+            Self::Status(status) => status.respond_to(request),
+            Self::RecipientAuthorizationRefused { classification } => {
+                let body = serde_json::json!({
+                    "error": format!(
+                        "Re-driving a {classification:?} failure resubmits \
+                         the same doomed authorization; close the mint and \
+                         re-initiate with fresh authorization instead"
+                    ),
+                })
+                .to_string();
+                rocket::Response::build()
+                    .status(Status::UnprocessableEntity)
+                    .header(ContentType::JSON)
+                    .sized_body(body.len(), std::io::Cursor::new(body))
+                    .ok()
+            }
+        }
+    }
+}
+
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct CloseMintRequest {
     reason: String,
@@ -1404,6 +1521,13 @@ pub(crate) struct CloseMintRequest {
     /// mint has no prepared identity.
     #[schema(value_type = Option<String>)]
     acknowledged_unresolved_mint_tx_hash: Option<B256>,
+    /// Required only to close a `NonceReplayUnresolved` mint, and must
+    /// exactly echo that mint's persisted authorization nonce; rejected on
+    /// any other mint. Records that an operator verified the nonce's
+    /// absence against a chain view outside this bot.
+    #[serde(default)]
+    #[schema(value_type = Option<String>)]
+    acknowledged_unresolved_mint_nonce: Option<B256>,
 }
 
 /// Admin endpoint to close a mint that cannot be automatically recovered.
@@ -1421,26 +1545,46 @@ pub(crate) struct CloseMintRequest {
     responses(
         (status = 200, description = "Mint closed by admin", body = ReprocessResponse),
         (status = 400, description = "Aggregate id is not a valid UUID"),
-        (status = 422, description = "Invalid state transition for close"),
+        (status = 422,
+            description = "Invalid state transition for close (including \
+                CallbackPending, whose on-chain mint is already recorded), \
+                a mint that landed on-chain (run recovery instead), a \
+                persisted transaction that could still land, or a \
+                NonceReplayUnresolved mint without a matching \
+                acknowledged_unresolved_mint_nonce"),
         (status = 500, description = "Internal failure")
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, store))]
+#[tracing::instrument(skip(_auth, store, pool, vault_services, receipts))]
 #[post("/admin/close/mint/<aggregate_id>", format = "json", data = "<body>")]
 pub(crate) async fn close_mint(
     _auth: InternalAuth,
     store: &rocket::State<Arc<Store<Mint>>>,
+    pool: &rocket::State<Pool<Sqlite>>,
+    vault_services: &rocket::State<NetworkVaultServices>,
+    receipts: &rocket::State<Arc<dyn ReceiptService>>,
     aggregate_id: &str,
     body: Json<CloseMintRequest>,
-) -> Result<Json<ReprocessResponse>, Status> {
+) -> Result<Json<ReprocessResponse>, CloseMintError> {
     let issuer_request_id: IssuerMintRequestId = aggregate_id
         .parse::<uuid::Uuid>()
         .map(IssuerMintRequestId::new)
         .map_err(|_| Status::BadRequest)?;
+    let CloseMintRequest {
+        reason,
+        acknowledged_unresolved_mint_tx_hash,
+        acknowledged_unresolved_mint_nonce,
+    } = body.into_inner();
 
-    let CloseMintRequest { reason, acknowledged_unresolved_mint_tx_hash } =
-        body.into_inner();
+    refuse_unsafe_close(
+        store,
+        pool,
+        vault_services,
+        receipts,
+        &issuer_request_id,
+    )
+    .await?;
 
     store
         .send(
@@ -1449,6 +1593,7 @@ pub(crate) async fn close_mint(
                 issuer_request_id: issuer_request_id.clone(),
                 reason,
                 acknowledged_unresolved_mint_tx_hash,
+                acknowledged_unresolved_mint_nonce,
             },
         )
         .await
@@ -1466,24 +1611,431 @@ pub(crate) async fn close_mint(
 
     info!(target: "admin", aggregate_id = %aggregate_id,
         acknowledged_unresolved_mint_tx_hash = ?acknowledged_unresolved_mint_tx_hash,
+        acknowledged_unresolved_mint_nonce = ?acknowledged_unresolved_mint_nonce,
         "Mint closed"
     );
 
-    let message = acknowledged_unresolved_mint_tx_hash.map_or_else(
-        || "Mint closed by admin".to_string(),
-        |acknowledged_hash| {
-            format!(
-                "Mint closed by admin after acknowledging unresolved mint {acknowledged_hash:#x}"
-            )
-        },
-    );
-
+    // The acknowledged override is attributable everywhere it matters: the
+    // terminal event carries it, the structured log above records it, and
+    // the response names it too (SPEC "Close Mint").
+    let message = match (
+        acknowledged_unresolved_mint_tx_hash,
+        acknowledged_unresolved_mint_nonce,
+    ) {
+        (Some(acknowledged_hash), _) => format!(
+            "Mint closed by admin after acknowledging unresolved mint {acknowledged_hash:#x}"
+        ),
+        (None, Some(nonce)) => format!(
+            "Mint closed by admin (acknowledged unresolved nonce {nonce})"
+        ),
+        (None, None) => "Mint closed by admin".to_string(),
+    };
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Mint,
         aggregate_id: aggregate_id.to_string(),
         previous_state: "Unknown".to_string(),
         message,
     }))
+}
+
+/// Close-mint endpoint failure. Most causes respond as a bare status (their
+/// detail stays in the server logs), but the landed-refusal carries a body
+/// telling the operator what to do instead — a bare 422 would be
+/// indistinguishable from the aggregate's ordinary invalid-state rejection.
+#[derive(Debug)]
+pub(crate) enum CloseMintError {
+    Status(Status),
+    MintLanded,
+    /// The authorization nonce is consumed on-chain but no full-matching
+    /// `Minted` log was found within the bounded lookback, and the mint
+    /// carries no adjudicated `NonceConsumedByOtherMint` verdict — the
+    /// landing may be this mint's, older than the scan window. Fail closed
+    /// unless the mint is classified `NonceReplayUnresolved` and the
+    /// operator supplies the matching acknowledgement.
+    LandingUnproven,
+    /// A persisted signed transaction in the mint's history could still
+    /// land (or persisted no bytes to prove anything about): the close-time
+    /// absence read is one instant, while a pending or replaceable
+    /// transaction can land afterwards — unobserved, once `MintClosed`
+    /// removes the mint from recovery and stuck queries. Fail closed until
+    /// the transaction provably cannot land (confirmed revert, or the
+    /// wallet nonce finalized past it).
+    UnresolvedPersistedTx,
+}
+
+impl From<Status> for CloseMintError {
+    fn from(status: Status) -> Self {
+        Self::Status(status)
+    }
+}
+
+impl<'r> Responder<'r, 'static> for CloseMintError {
+    fn respond_to(
+        self,
+        request: &'r rocket::Request<'_>,
+    ) -> response::Result<'static> {
+        let body_422 = |message: &str| {
+            let body = serde_json::json!({ "error": message }).to_string();
+            rocket::Response::build()
+                .status(Status::UnprocessableEntity)
+                .header(ContentType::JSON)
+                .sized_body(body.len(), std::io::Cursor::new(body))
+                .ok()
+        };
+        match self {
+            Self::Status(status) => status.respond_to(request),
+            Self::MintLanded => body_422(
+                "Mint landed on-chain; run recovery instead of closing",
+            ),
+            Self::LandingUnproven => body_422(
+                "Authorization nonce is consumed on-chain but no landing \
+                 was found within the scan window; verify whether this \
+                 mint's tokens landed before closing (a \
+                 NonceReplayUnresolved mint closes only with a matching \
+                 acknowledged_unresolved_mint_nonce)",
+            ),
+            Self::UnresolvedPersistedTx => body_422(
+                "A persisted transaction in this mint's history could \
+                 still land (or cannot be proven dead); a close would let \
+                 it land unobserved — resolve or replace it first",
+            ),
+        }
+    }
+}
+
+/// The pre-close safety gate: closing a mint whose tokens actually minted
+/// on-chain — or whose persisted transaction could still land — would
+/// strand real backed tokens unreported to Alpaca, so the close is refused
+/// until the chain proves otherwise (SPEC "Mint Aggregate" -> `CloseMint`).
+/// The `Mint` aggregate is pure (`Services = ()`), so the on-chain checks
+/// run here, before `CloseMint` is sent. Fail closed: any failed read
+/// refuses the close rather than closing blind.
+///
+/// Three layers, all read-only:
+/// 1. Every persisted signed transaction with no recorded terminal outcome
+///    must be provably unable to land — a confirmed revert, or the signing
+///    wallet's finalized nonce past it. A still-mineable transaction (or a
+///    legacy submission that persisted no bytes to prove anything about)
+///    refuses the close: the absence read is one instant, and a later
+///    landing would go unobserved once the mint leaves recovery and stuck
+///    queries.
+/// 2. Vault-direct: a receipt recorded for this `issuer_request_id` means
+///    the mint landed — the operator runs `Recover` instead.
+/// 3. Orchestrator: `nonceUsed(to, nonce)` is the unbounded non-landing
+///    proof (unconsumed means nothing landed, however long parked), and a
+///    consumed nonce takes the three-way `Minted`-log verdict — `FullMatch`
+///    refuses (landed; run recovery), `Mismatch` proves a DIFFERENT mint
+///    consumed the pair (closable), and `NotFound` is inconclusive: it
+///    refuses unless the recorded verdict already adjudicated the pair as
+///    another mint's (`NonceConsumedByOtherMint`, proven at confirm time)
+///    or the mint is `NonceReplayUnresolved` — whose close the aggregate
+///    additionally gates on the operator's explicit
+///    `acknowledged_unresolved_mint_nonce`.
+///
+/// Inherently check-then-act: a transaction landing between this check and
+/// the `CloseMint` commit still closes the mint. The window is a single
+/// command send, and a close is an operator action on a parked mint, not an
+/// in-flight one.
+#[allow(clippy::too_many_lines)]
+async fn refuse_unsafe_close(
+    store: &Store<Mint>,
+    pool: &Pool<Sqlite>,
+    vault_services: &NetworkVaultServices,
+    receipts: &Arc<dyn ReceiptService>,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(), CloseMintError> {
+    let mint = store.load(issuer_request_id).await.map_err(|err| {
+        error!(target: "admin", issuer_request_id = %issuer_request_id,
+            error = %err,
+            "Failed to load mint for the pre-close safety gate"
+        );
+        Status::InternalServerError
+    })?;
+    // An unknown mint falls through: `CloseMint` rejects it with the
+    // aggregate's own error.
+    let Some(mint) = mint else {
+        return Ok(());
+    };
+
+    // Terminal and callback-pending mints are rejected by `CloseMint`
+    // itself with their own specific errors; running the on-chain checks
+    // first would misreport them (and spend RPC lookups doing it).
+    if matches!(
+        mint,
+        Mint::Completed { .. }
+            | Mint::Closed { .. }
+            | Mint::CallbackPending { .. }
+    ) {
+        return Ok(());
+    }
+
+    let Some(network) = mint.network() else {
+        return Ok(());
+    };
+    let vault_service = vault_services.service(network).map_err(|err| {
+        error!(target: "admin", issuer_request_id = %issuer_request_id,
+            error = %err,
+            "No vault service configured for the pre-close safety gate"
+        );
+        Status::InternalServerError
+    })?;
+
+    // Layer 1: positive proof every persisted transaction can no longer
+    // land.
+    let (persisted_txs, has_unprovable) = mint.unresolved_persisted_txs();
+    if has_unprovable {
+        warn!(target: "admin", issuer_request_id = %issuer_request_id,
+            "A submission in this mint's history persisted no signed bytes; \
+             its fate cannot be proven — refusing the close (fail closed)"
+        );
+        return Err(CloseMintError::UnresolvedPersistedTx);
+    }
+    for prepared in persisted_txs {
+        let sendable = SendableTxWithHash {
+            tx: prepared.tx.clone(),
+            hash: prepared.hash,
+            nonce: prepared.nonce,
+            signed_at: prepared.signed_at,
+            dust_shares: U256::ZERO,
+        };
+        // The signer is recovered from the persisted envelope itself — the
+        // nonce comparison must run against the wallet that signed it, and
+        // the envelope is the one source that cannot disagree.
+        let signer = sendable
+            .validate()
+            .and_then(|envelope| {
+                envelope.recover_signer().map_err(VaultError::from)
+            })
+            .map_err(|err| {
+                error!(target: "admin", issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Persisted transaction failed validation during the \
+                     pre-close safety gate"
+                );
+                Status::InternalServerError
+            })?;
+        match vault_service.classify_burn_tx(signer, &sendable).await {
+            Ok(BurnTxStatus::Reverted | BurnTxStatus::ProvablyDead) => {}
+            Ok(BurnTxStatus::Mined) => {
+                warn!(target: "admin", issuer_request_id = %issuer_request_id,
+                    tx_hash = %sendable.hash,
+                    "Refusing to close: the persisted transaction landed \
+                     on-chain; run recovery instead"
+                );
+                return Err(CloseMintError::MintLanded);
+            }
+            Ok(BurnTxStatus::StillMineable) => {
+                warn!(target: "admin", issuer_request_id = %issuer_request_id,
+                    tx_hash = %sendable.hash,
+                    "Refusing to close: the persisted transaction could \
+                     still land (fail closed)"
+                );
+                return Err(CloseMintError::UnresolvedPersistedTx);
+            }
+            Err(err) => {
+                error!(target: "admin", issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "Persisted-transaction classification failed; refusing \
+                     the close (fail closed)"
+                );
+                return Err(Status::InternalServerError.into());
+            }
+        }
+    }
+
+    let (Some(underlying), Some(wallet), Some(quantity)) =
+        (mint.underlying(), mint.wallet(), mint.quantity())
+    else {
+        return Ok(());
+    };
+
+    match mint.mint_mode() {
+        // Layer 2: a recorded receipt is a vault-direct landing.
+        Some(VaultMode::VaultDirect) => {
+            let chain_id = vault_services.chain_id(network).map_err(|err| {
+                error!(target: "admin",
+                    issuer_request_id = %issuer_request_id,
+                    error = %err,
+                    "No chain id configured for the pre-close safety gate"
+                );
+                Status::InternalServerError
+            })?;
+            let vault = find_vault(pool, underlying, &network)
+                .await
+                .map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Vault lookup failed for the pre-close safety gate"
+                    );
+                    Status::InternalServerError
+                })?
+                .ok_or_else(|| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        underlying = %underlying,
+                        network = %network,
+                        "No vault registered for the pre-close safety gate"
+                    );
+                    Status::InternalServerError
+                })?;
+            let receipt = receipts
+                .find_by_issuer_request_id(chain_id, &vault, issuer_request_id)
+                .await
+                .map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Receipt lookup failed; refusing the close (fail \
+                         closed)"
+                    );
+                    Status::InternalServerError
+                })?;
+            if let Some(receipt) = receipt {
+                warn!(target: "admin", issuer_request_id = %issuer_request_id,
+                    tx_hash = %receipt.tx_hash,
+                    receipt_id = %receipt.receipt_id,
+                    "Refusing to close vault-direct mint whose receipt is \
+                     recorded; run recovery instead"
+                );
+                return Err(CloseMintError::MintLanded);
+            }
+            Ok(())
+        }
+        // Layer 3: the orchestrator nonce gate and Minted-log verdict.
+        Some(VaultMode::Orchestrator { address: orchestrator }) => {
+            let Some(authorization) = mint.mint_authorization() else {
+                // No authorization was ever delivered: no nonce exists to
+                // have been consumed, and layer 1 already proved every
+                // persisted transaction dead.
+                return Ok(());
+            };
+
+            // `nonceUsed(to, nonce)` is the unbounded, authoritative
+            // non-landing proof: `mint()` consumes the nonce, so an
+            // unconsumed nonce means nothing can have landed no matter how
+            // long the mint has been parked. The log scan below is bounded,
+            // so on its own it would fail open for a landing older than the
+            // window — exactly the long-parked mints an admin close
+            // targets.
+            let consumed = vault_service
+                .nonce_used(orchestrator, wallet, authorization.nonce)
+                .await
+                .map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Consumed-nonce read failed; refusing the close \
+                         (fail closed)"
+                    );
+                    Status::InternalServerError
+                })?;
+            if !consumed {
+                return Ok(());
+            }
+
+            let vault = find_vault(pool, underlying, &network)
+                .await
+                .map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Vault lookup failed for the pre-close safety gate"
+                    );
+                    Status::InternalServerError
+                })?
+                .ok_or_else(|| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        underlying = %underlying,
+                        network = %network,
+                        "No vault registered for the pre-close safety gate"
+                    );
+                    Status::InternalServerError
+                })?;
+            let amount =
+                quantity.to_u256_with_18_decimals().map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Persisted mint quantity failed share conversion"
+                    );
+                    Status::InternalServerError
+                })?;
+
+            let verdict = vault_service
+                .find_orchestrator_minted_log(MintedLogQuery {
+                    orchestrator,
+                    to: wallet,
+                    nonce: authorization.nonce,
+                    token: vault,
+                    amount,
+                    lookback_blocks: None,
+                })
+                .await
+                .map_err(|err| {
+                    error!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        error = %err,
+                        "Minted-log lookup failed; refusing the close (fail \
+                         closed)"
+                    );
+                    Status::InternalServerError
+                })?;
+
+            match verdict {
+                MintedLogScan::FullMatch(minted) => {
+                    warn!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        tx_hash = %minted.tx_hash,
+                        nonce = %minted.nonce,
+                        "Refusing to close orchestrator mint that landed \
+                         on-chain; run recovery instead"
+                    );
+                    Err(CloseMintError::MintLanded)
+                }
+                // The pair's one landing belongs to a different mint: this
+                // mint can never land, so the close is safe.
+                MintedLogScan::Mismatch => {
+                    info!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        nonce = %authorization.nonce,
+                        "Minted log at the pair disagrees on token/amount; \
+                         a different mint consumed it — close may proceed"
+                    );
+                    Ok(())
+                }
+                MintedLogScan::NotFound => {
+                    // Inconclusive — unless a prior verdict adjudicated the
+                    // pair as another mint's (proven at confirm time, when
+                    // the landing was necessarily recent enough to scan),
+                    // or the mint is the unresolved classification whose
+                    // close the aggregate gates on the operator's explicit
+                    // acknowledgement (echoing the persisted nonce).
+                    if matches!(
+                        mint,
+                        Mint::MintingFailed {
+                            classification:
+                                MintFailureClassification::NonceConsumedByOtherMint
+                                    | MintFailureClassification::NonceReplayUnresolved,
+                            ..
+                        }
+                    ) {
+                        return Ok(());
+                    }
+                    warn!(target: "admin",
+                        issuer_request_id = %issuer_request_id,
+                        nonce = %authorization.nonce,
+                        "Authorization nonce is consumed on-chain but no \
+                         landing was found within the scan window; refusing \
+                         the close (fail closed)"
+                    );
+                    Err(CloseMintError::LandingUnproven)
+                }
+            }
+        }
+        None => Ok(()),
+    }
 }
 
 /// In-progress states that haven't transitioned in this long are reported as
@@ -2433,7 +2985,7 @@ mod tests {
     use alloy::rpc::types::TransactionReceipt;
     use async_trait::async_trait;
     use chrono::{DateTime, Duration as ChronoDuration, Utc};
-    use event_sorcery::{Store, test_store};
+    use event_sorcery::{Store, StoreBuilder, test_store};
     use rocket::http::Status;
     use rust_decimal::Decimal;
     use sqlx::sqlite::SqlitePoolOptions;
@@ -2462,15 +3014,19 @@ mod tests {
         RedeemRequestStatus, RedeemResponse, TokenizationRequest,
     };
     use crate::config::{VaultMode, VaultModeConfig};
-    use crate::mint::test_utils::{TestHarness, test_config};
+    use crate::mint::test_utils::{
+        TestHarness, network_vault_services, test_config,
+    };
+    use crate::mint::tests::orchestrator_events_through_tx_submitted;
     use crate::mint::{
-        ClientId, MintFailureClassification, MintView, Quantity,
+        ClientId, IssuerMintRequestId, Mint, MintCommand, MintEvent,
+        MintExternalTxId, MintFailureClassification, MintView, Quantity,
         TokenizationRequestId,
     };
     use crate::receipt_inventory::ReceiptVaultKey;
     use crate::receipt_inventory::{
-        ReceiptId, ReceiptInventory, ReceiptInventoryCommand, ReceiptSource,
-        Shares,
+        CqrsReceiptService, ReceiptId, ReceiptInventory,
+        ReceiptInventoryCommand, ReceiptService, ReceiptSource, Shares,
     };
     use crate::redemption::{BurnExternalTxId, RedemptionServices};
     use crate::redemption::{
@@ -2482,13 +3038,16 @@ mod tests {
     use crate::tokenized_asset::schedule::FreezeScheduler;
     use crate::tokenized_asset::view::TokenizedAssetView;
     use crate::tokenized_asset::{
-        AssetKey, Network, TokenSymbol, UnderlyingSymbol,
+        AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
     };
     use crate::vault::mock::MockVaultService;
     use crate::vault::{
-        BurnRange, MultiBurnEntry, NetworkVaultServices,
-        OrchestratorBurnResult, SendableTxWithHash, TxId, VaultService,
+        BurnRange, BurnTxStatus, MultiBurnEntry, NetworkVaultServices,
+        OrchestratorBurnResult, PreparedMintTx, SendableTxWithHash, TxId,
+        VaultService,
     };
+    use crate::vault::{MintAuthorization, OrchestratorMintedLog};
 
     fn mock_vault_service() -> Arc<dyn VaultService> {
         Arc::new(MockVaultService::new_success())
@@ -6580,5 +7139,1074 @@ mod tests {
         let (status, _body) = dispatch_orchestrator_health(rocket, false).await;
 
         assert_eq!(status, Status::Unauthorized);
+    }
+
+    const CLOSE_ORCHESTRATOR: Address =
+        address!("0x00000000000000000000000000000000000000aa");
+    const CLOSE_VAULT: Address =
+        address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+    const CLOSE_RECIPIENT: Address =
+        address!("0x1234567890abcdef1234567890abcdef12345678");
+
+    fn close_test_authorization() -> MintAuthorization {
+        MintAuthorization {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from_static(&[0x42; 65]),
+        }
+    }
+
+    /// Registers AAPL -> [`CLOSE_VAULT`] through the real projection so the
+    /// pre-close landed check's `find_vault` (keyed `{underlying}:{network}`)
+    /// resolves.
+    async fn seed_close_test_asset(pool: &sqlx::Pool<sqlx::Sqlite>) {
+        let (asset_store, _asset_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .expect("asset store must build");
+        asset_store
+            .send(
+                &AssetKey::new(
+                    UnderlyingSymbol::new("AAPL").unwrap(),
+                    Network::Base,
+                ),
+                TokenizedAssetCommand::Add {
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::Base,
+                    vault: CLOSE_VAULT,
+                },
+            )
+            .await
+            .expect("asset must register");
+    }
+
+    /// Seeds a mint via commands: `Initiate` with the given mode, plus the
+    /// delivered authorization for orchestrator mints (the pre-close landed
+    /// check only runs with one on record).
+    async fn seed_close_test_mint(
+        mint_store: &Store<Mint>,
+        mint_mode: VaultMode,
+    ) -> IssuerMintRequestId {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let orchestrator_mode =
+            matches!(mint_mode, VaultMode::Orchestrator { .. });
+        mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Initiate {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tokenization_request_id: TokenizationRequestId::new(
+                        "tok-close-1",
+                    ),
+                    quantity: Quantity::new(Decimal::from(100)),
+                    underlying: UnderlyingSymbol::new("AAPL").unwrap(),
+                    token: TokenSymbol::new("tAAPL"),
+                    network: Network::Base,
+                    client_id: ClientId::new(),
+                    wallet: CLOSE_RECIPIENT,
+                    mint_mode,
+                },
+            )
+            .await
+            .expect("mint must initiate");
+
+        if orchestrator_mode {
+            mint_store
+                .send(
+                    &issuer_request_id,
+                    MintCommand::AuthorizeMint {
+                        issuer_request_id: issuer_request_id.clone(),
+                        mint_authorization: close_test_authorization(),
+                    },
+                )
+                .await
+                .expect("authorization must record");
+        }
+
+        issuer_request_id
+    }
+
+    fn close_mint_rocket(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        mint_store: Arc<Store<Mint>>,
+        vault_service: Arc<dyn VaultService>,
+    ) -> rocket::Rocket<rocket::Build> {
+        let vault_services = super::NetworkVaultServices::with_single_vault(
+            Network::Base,
+            ANVIL_CHAIN_ID,
+            vault_service,
+        );
+        let receipts: Arc<dyn ReceiptService> =
+            Arc::new(CqrsReceiptService::new(Arc::new(test_store::<
+                ReceiptInventory,
+            >(
+                pool.clone(), ()
+            ))));
+        rocket::build()
+            .manage(admin_test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool.clone())
+            .manage(mint_store)
+            .manage(vault_services)
+            .manage(receipts)
+            .mount("/", rocket::routes![super::close_mint])
+    }
+
+    async fn dispatch_close_mint(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+        let response = client
+            .post(format!("/admin/close/mint/{issuer_request_id}"))
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(serde_json::json!({ "reason": "operator close" }).to_string())
+            .dispatch()
+            .await;
+        let status = response.status();
+        let body = response.into_string().await.unwrap_or_default();
+        (status, body)
+    }
+
+    /// Closing an orchestrator mint whose tokens actually landed on-chain
+    /// would strand real backed tokens unreported to Alpaca: the pre-close
+    /// landed check refuses the close and the mint stays open for recovery.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_landed_orchestrator_mint() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let vault_mock =
+            Arc::new(MockVaultService::new_success().with_minted_log(
+                OrchestratorMintedLog {
+                    tx_hash: B256::ZERO,
+                    nonce: close_test_authorization().nonce,
+                    shares_minted: U256::from(100u64)
+                        * U256::from(10u64).pow(U256::from(18u64)),
+                    block_number: 777,
+                },
+            ));
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a landed orchestrator mint must refuse the close"
+        );
+        assert!(
+            body.contains("run recovery instead"),
+            "the refusal body must tell the operator what to do, got: {body}"
+        );
+        assert_eq!(vault_mock.find_minted_log_call_count(), 1);
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            !matches!(mint, Mint::Closed { .. }),
+            "the refused close must not record MintClosed, got: {mint:?}"
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                &issuer_request_id.to_string(),
+                "Refusing to close orchestrator mint"
+            ]
+        ));
+    }
+
+    /// An unconsumed nonce is the unbounded non-landing proof: the close
+    /// proceeds without spending the bounded log scan at all — `mint()`
+    /// consumes the nonce, so nothing can have landed.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_closes_orchestrator_mint_with_unconsumed_nonce() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(status, Status::Ok);
+        assert_eq!(
+            vault_mock.find_minted_log_call_count(),
+            0,
+            "an unconsumed nonce must short-circuit the bounded log scan"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&issuer_request_id.to_string(), "Mint closed"]
+        ));
+    }
+
+    /// A consumed nonce with no full-matching landing in the bounded scan
+    /// window is inconclusive — the landing may be this mint's, older than
+    /// the window — so the close fails closed unless the mint carries the
+    /// adjudicated `NonceConsumedByOtherMint` verdict.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_consumed_nonce_without_provable_landing() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let vault_mock =
+            Arc::new(MockVaultService::new_success().with_nonce_used(true));
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a consumed nonce without a provable landing must refuse the \
+             close"
+        );
+        assert!(
+            body.contains("no landing was found within the scan window"),
+            "the refusal body must explain the inconclusive landing, got: \
+             {body}"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            !matches!(mint, Mint::Closed { .. }),
+            "the refused close must not record MintClosed, got: {mint:?}"
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                &issuer_request_id.to_string(),
+                "no landing was found within the scan window"
+            ]
+        ));
+    }
+
+    /// A mint whose confirm-time full-match already adjudicated the consumed
+    /// nonce as another mint's (`NonceConsumedByOtherMint`) may close: its
+    /// own landing is permanently impossible.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_allows_adjudicated_nonce_consumed_mint() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let tx_id = TxId::Legacy("close-consumed-1".to_string());
+        let commands = [
+            MintCommand::ConfirmJournal {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::RecordTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::signed_for_test(
+                    0,
+                    "ext-close-consumed-1".to_string(),
+                ),
+            },
+            MintCommand::RecordTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: MintExternalTxId::from_string(
+                    "ext-close-consumed-1".to_string(),
+                ),
+                tx_id,
+            },
+            MintCommand::RecordMintFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "nonce consumed by another mint".to_string(),
+                classification:
+                    MintFailureClassification::NonceConsumedByOtherMint,
+            },
+        ];
+        for command in commands {
+            mint_store
+                .send(&issuer_request_id, command)
+                .await
+                .expect("mint must advance to the classified failure");
+        }
+
+        // The persisted transaction is the NonceReplayed revert — provably
+        // unable to land — and the consumed nonce has no full-matching log.
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_burn_tx_status(BurnTxStatus::Reverted),
+        );
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::Ok,
+            "the adjudicated NonceConsumedByOtherMint verdict must permit \
+             the close"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&issuer_request_id.to_string(), "Mint closed"]
+        ));
+    }
+
+    /// The fail-closed branches: an errored consumed-nonce read or Minted-log
+    /// lookup refuses the close with a 500 rather than closing blind.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_when_landed_check_lookup_fails() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let nonce_read_error =
+            Arc::new(MockVaultService::new_success().with_nonce_used_error());
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(
+                &pool,
+                mint_store.clone(),
+                nonce_read_error.clone(),
+            ),
+            &issuer_request_id,
+        )
+        .await;
+        assert_eq!(
+            status,
+            Status::InternalServerError,
+            "an errored consumed-nonce read must refuse the close"
+        );
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[&issuer_request_id.to_string(), "Consumed-nonce read failed"]
+        ));
+
+        let find_error = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_find_minted_log_error(),
+        );
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), find_error.clone()),
+            &issuer_request_id,
+        )
+        .await;
+        assert_eq!(
+            status,
+            Status::InternalServerError,
+            "an errored Minted-log lookup must refuse the close"
+        );
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[&issuer_request_id.to_string(), "Minted-log lookup failed"]
+        ));
+
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            !matches!(mint, Mint::Closed { .. }),
+            "no refused close may record MintClosed, got: {mint:?}"
+        );
+    }
+
+    async fn dispatch_close_mint_with_body(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerMintRequestId,
+        body: serde_json::Value,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+        let response = client
+            .post(format!("/admin/close/mint/{issuer_request_id}"))
+            .header(rocket::http::ContentType::JSON)
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .body(body.to_string())
+            .dispatch()
+            .await;
+        let status = response.status();
+        let body = response.into_string().await.unwrap_or_default();
+        (status, body)
+    }
+
+    /// Drives an orchestrator close-test mint to `TxSubmitted` carrying a
+    /// genuinely signed persisted transaction, so the pre-close
+    /// proof-of-cannot-land layer has bytes to classify.
+    async fn advance_close_test_mint_to_submitted(
+        mint_store: &Store<Mint>,
+        issuer_request_id: &IssuerMintRequestId,
+    ) {
+        let commands = [
+            MintCommand::ConfirmJournal {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::RecordTxIntended {
+                issuer_request_id: issuer_request_id.clone(),
+                prepared_tx: PreparedMintTx::signed_for_test(
+                    0,
+                    "ext-close-submitted".to_string(),
+                ),
+            },
+            MintCommand::RecordTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: MintExternalTxId::from_string(
+                    "ext-close-submitted".to_string(),
+                ),
+                tx_id: TxId::Legacy("close-submitted-1".to_string()),
+            },
+        ];
+        for command in commands {
+            mint_store
+                .send(issuer_request_id, command)
+                .await
+                .expect("mint must advance to TxSubmitted");
+        }
+    }
+
+    /// A `NonceReplayUnresolved` mint closes only with the operator's
+    /// acknowledgement echoing the persisted nonce exactly: missing and
+    /// mismatched acknowledgements are 422s, the echo closes.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_unresolved_replay_requires_matching_acknowledgement() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+        advance_close_test_mint_to_submitted(&mint_store, &issuer_request_id)
+            .await;
+        mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: "nonce consumed with no log at the pair".to_string(),
+                    classification:
+                        MintFailureClassification::NonceReplayUnresolved,
+                },
+            )
+            .await
+            .expect("mint must park unresolved");
+
+        // The persisted transaction is the NonceReplayed revert (provably
+        // dead); the nonce is consumed with no full-matching log.
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_burn_tx_status(BurnTxStatus::Reverted),
+        );
+
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a missing acknowledgement must refuse the close"
+        );
+
+        let (status, _body) = dispatch_close_mint_with_body(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+            serde_json::json!({
+                "reason": "operator close",
+                "acknowledged_unresolved_mint_nonce": B256::repeat_byte(0xEE),
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a non-echoing acknowledgement must refuse the close"
+        );
+
+        let (status, body) = dispatch_close_mint_with_body(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+            serde_json::json!({
+                "reason": "operator verified absence on a second provider",
+                "acknowledged_unresolved_mint_nonce":
+                    close_test_authorization().nonce,
+            }),
+        )
+        .await;
+        assert_eq!(
+            status,
+            Status::Ok,
+            "the echoing acknowledgement must close the unresolved mint"
+        );
+        assert!(
+            body.contains("acknowledged unresolved nonce"),
+            "the response must record the override, got: {body}"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&issuer_request_id.to_string(), "Mint closed"]
+        ));
+    }
+
+    /// A persisted transaction that could still land blocks the close: the
+    /// one-instant absence read is not proof, and a later landing would go
+    /// unobserved once the mint leaves recovery and stuck queries.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_still_mineable_persisted_tx() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+        advance_close_test_mint_to_submitted(&mint_store, &issuer_request_id)
+            .await;
+
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::StillMineable),
+        );
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a still-mineable persisted transaction must refuse the close"
+        );
+        assert!(
+            body.contains("could still land"),
+            "the refusal body must explain the pending transaction, got: \
+             {body}"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(!matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                &issuer_request_id.to_string(),
+                "persisted transaction could still land"
+            ]
+        ));
+    }
+
+    /// A legacy submission that persisted no signed bytes can never be
+    /// proven dead — the close fails closed rather than letting an unknown
+    /// transaction land unobserved.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_unprovable_legacy_submission() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+        let commands = [
+            MintCommand::ConfirmJournal {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::RecordTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: MintExternalTxId::from_string(
+                    "ext-close-legacy".to_string(),
+                ),
+                tx_id: TxId::Legacy("fb-close-legacy".to_string()),
+            },
+        ];
+        for command in commands {
+            mint_store
+                .send(&issuer_request_id, command)
+                .await
+                .expect("mint must reach the legacy TxSubmitted shape");
+        }
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a byte-less legacy submission must refuse the close"
+        );
+        assert!(
+            body.contains("could still land"),
+            "the refusal body must explain the unprovable transaction, got: \
+             {body}"
+        );
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[&issuer_request_id.to_string(), "persisted no signed bytes"]
+        ));
+    }
+
+    /// A `Minted` log at the pair disagreeing on amount is affirmative proof
+    /// a DIFFERENT mint consumed it — this mint can never land, so the
+    /// close proceeds.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_allows_proven_mismatch_verdict() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::ZERO,
+                    nonce: close_test_authorization().nonce,
+                    shares_minted: U256::from(1u8),
+                    block_number: 777,
+                }),
+        );
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::Ok,
+            "the proven mismatch verdict must permit the close"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[&issuer_request_id.to_string(), "a different mint consumed it"]
+        ));
+    }
+
+    /// A vault-direct mint whose receipt is recorded in the inventory has
+    /// landed: the close refuses and points the operator at recovery.
+    #[traced_test]
+    #[tokio::test]
+    async fn close_mint_refuses_vault_direct_with_recorded_receipt() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id =
+            seed_close_test_mint(&mint_store, VaultMode::VaultDirect).await;
+
+        let receipt_store =
+            Arc::new(test_store::<ReceiptInventory>(pool.clone(), ()));
+        receipt_store
+            .send(
+                &ReceiptVaultKey::new(ANVIL_CHAIN_ID, CLOSE_VAULT),
+                crate::receipt_inventory::ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(U256::from(7)),
+                    balance: Shares::from(U256::from(100)),
+                    block_number: 4_242,
+                    tx_hash: B256::repeat_byte(0xAB),
+                    source: ReceiptSource::Itn {
+                        issuer_request_id: issuer_request_id.clone(),
+                    },
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .expect("receipt must register");
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a recorded receipt must refuse the vault-direct close"
+        );
+        assert!(
+            body.contains("run recovery"),
+            "the refusal body must point at recovery, got: {body}"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(!matches!(mint, Mint::Closed { .. }));
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                &issuer_request_id.to_string(),
+                "vault-direct mint whose receipt is recorded"
+            ]
+        ));
+    }
+
+    /// A vault-direct close never touches the on-chain landed check.
+    #[tokio::test]
+    async fn close_mint_skips_landed_check_for_vault_direct() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id =
+            seed_close_test_mint(&mint_store, VaultMode::VaultDirect).await;
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let (status, _body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(status, Status::Ok);
+        assert_eq!(
+            vault_mock.find_minted_log_call_count(),
+            0,
+            "a vault-direct close must not run the landed check"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(matches!(mint, Mint::Closed { .. }));
+    }
+
+    /// A terminal orchestrator mint short-circuits before the landed check:
+    /// the aggregate's own rejection surfaces — not the "run recovery
+    /// instead" body, which would misdirect the operator on a mint that is
+    /// already completed and reported — and no RPC lookup is spent.
+    #[tokio::test]
+    async fn close_mint_rejects_completed_mint_without_landed_check() {
+        let pool = setup_pool().await;
+        seed_close_test_asset(&pool).await;
+        let mint_store = Arc::new(test_store::<Mint>(pool.clone(), ()));
+        let issuer_request_id = seed_close_test_mint(
+            &mint_store,
+            VaultMode::Orchestrator { address: CLOSE_ORCHESTRATOR },
+        )
+        .await;
+
+        let tx_id = TxId::Legacy("close-terminal-1".to_string());
+        let commands = [
+            MintCommand::ConfirmJournal {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::Deposit {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+            MintCommand::RecordTxSubmitted {
+                issuer_request_id: issuer_request_id.clone(),
+                external_tx_id: MintExternalTxId::from_string(
+                    "ext-close-terminal-1".to_string(),
+                ),
+                tx_id: tx_id.clone(),
+            },
+            MintCommand::RecordOrchestratorTokensMinted {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_id,
+                tx_hash: B256::ZERO,
+                nonce: close_test_authorization().nonce,
+                // The seeded quantity at 18 decimals — the record handler
+                // cross-checks the reported shares against it.
+                shares_minted: U256::from(100_000_000_000_000_000_000u128),
+                gas_used: 21_000,
+                block_number: 1_000,
+            },
+            MintCommand::RecordCallbackSent {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+        ];
+        for command in commands {
+            mint_store
+                .send(&issuer_request_id, command)
+                .await
+                .expect("mint must advance to Completed");
+        }
+
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let (status, body) = dispatch_close_mint(
+            close_mint_rocket(&pool, mint_store.clone(), vault_mock.clone()),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::UnprocessableEntity,
+            "a completed mint must be rejected by the aggregate"
+        );
+        assert!(
+            !body.contains("run recovery instead"),
+            "the terminal rejection must not carry the landed-refusal body, \
+             got: {body}"
+        );
+        assert_eq!(
+            vault_mock.find_minted_log_call_count(),
+            0,
+            "the terminal guard must short-circuit before the landed check"
+        );
+        let mint = mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Completed { .. }),
+            "the refused close must leave the mint Completed, got: {mint:?}"
+        );
+    }
+
+    /// Seeds raw mint events so the endpoint's `store.load` replays them —
+    /// classified failures cannot be reached through commands without
+    /// driving the full mint flow against mocks.
+    async fn seed_raw_mint_events(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        events: Vec<MintEvent>,
+    ) {
+        let aggregate_id = issuer_request_id.to_string();
+
+        for (offset, event) in events.into_iter().enumerate() {
+            let sequence = i64::try_from(offset).unwrap() + 1;
+            let payload = serde_json::to_value(&event).unwrap();
+            let variant = payload
+                .as_object()
+                .and_then(|map| map.keys().next())
+                .expect("MintEvent serializes as an externally-tagged enum")
+                .clone();
+            let event_type = format!("MintEvent::{variant}");
+            let payload_str = payload.to_string();
+
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(&aggregate_id)
+            .bind(sequence)
+            .bind(&event_type)
+            .bind(&payload_str)
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+    }
+
+    async fn seed_classified_failed_mint(
+        harness: &TestHarness,
+        classification: MintFailureClassification,
+    ) -> IssuerMintRequestId {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "mint reverted".to_string(),
+            failed_at: Utc::now(),
+            classification,
+        });
+        seed_raw_mint_events(&harness.pool, &issuer_request_id, events).await;
+        issuer_request_id
+    }
+
+    fn reprocess_mint_rocket(
+        harness: &TestHarness,
+    ) -> rocket::Rocket<rocket::Build> {
+        rocket::build()
+            .manage(test_config())
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(harness.pool.clone())
+            .manage(harness.apalis_pool.clone())
+            .manage(harness.mint_store.clone())
+            .manage(network_vault_services(harness.vault.clone()))
+            .mount("/", rocket::routes![super::reprocess_mint])
+    }
+
+    async fn dispatch_reprocess_mint(
+        rocket: rocket::Rocket<rocket::Build>,
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> (Status, String) {
+        let client =
+            rocket::local::asynchronous::Client::tracked(rocket).await.unwrap();
+        let response = client
+            .post(format!("/admin/reprocess/mint/{issuer_request_id}"))
+            .header(rocket::http::Header::new(
+                "X-API-KEY",
+                "test-key-12345678901234567890123456",
+            ))
+            .remote("127.0.0.1:8000".parse().unwrap())
+            .dispatch()
+            .await;
+        let status = response.status();
+        let body = response.into_string().await.unwrap_or_default();
+        (status, body)
+    }
+
+    async fn count_queued_jobs(pool: &sqlx::Pool<sqlx::Sqlite>) -> i64 {
+        sqlx::query_scalar("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(pool)
+            .await
+            .unwrap()
+    }
+
+    /// The recovery loop refuses re-drives of deterministic
+    /// recipient-authorization failures (the identical stored authorization
+    /// reverts the same way), so the endpoint must answer 422 with the
+    /// actual resolution instead of enqueuing a job and reporting
+    /// "Recovery initiated" for work that will never run.
+    #[traced_test]
+    #[tokio::test]
+    async fn reprocess_mint_refuses_recipient_authorization_failures() {
+        let harness = TestHarness::new().await;
+
+        for classification in [
+            MintFailureClassification::BadRecipientSignature,
+            MintFailureClassification::RecipientCallbackRejected,
+        ] {
+            let issuer_request_id =
+                seed_classified_failed_mint(&harness, classification).await;
+
+            let (status, body) = dispatch_reprocess_mint(
+                reprocess_mint_rocket(&harness),
+                &issuer_request_id,
+            )
+            .await;
+
+            assert_eq!(
+                status,
+                Status::UnprocessableEntity,
+                "{classification:?} must refuse the re-drive"
+            );
+            assert!(
+                body.contains("re-initiate with fresh authorization"),
+                "the refusal body must name the resolution, got: {body}"
+            );
+            assert_eq!(
+                count_queued_jobs(&harness.pool).await,
+                0,
+                "{classification:?} must not enqueue a recovery job"
+            );
+        }
+
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                "Refusing reprocess of a deterministic",
+                "close the mint and",
+                "re-initiate with fresh authorization"
+            ]
+        ));
+    }
+
+    /// Other typed classifications keep the manual re-drive path: one
+    /// manual-flagged recovery job, answered as "Recovery initiated".
+    #[traced_test]
+    #[tokio::test]
+    async fn reprocess_mint_still_enqueues_other_classified_failures() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = seed_classified_failed_mint(
+            &harness,
+            MintFailureClassification::VaultLogicMismatch,
+        )
+        .await;
+
+        let (status, body) = dispatch_reprocess_mint(
+            reprocess_mint_rocket(&harness),
+            &issuer_request_id,
+        )
+        .await;
+
+        assert_eq!(
+            status,
+            Status::Ok,
+            "a re-drivable classified failure must enqueue, got: {body}"
+        );
+        assert!(
+            body.contains("Recovery initiated"),
+            "the response must report the enqueued re-drive, got: {body}"
+        );
+        assert_eq!(
+            count_queued_jobs(&harness.pool).await,
+            1,
+            "exactly one manual recovery job must be enqueued"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Mint reprocess enqueued a manual re-drive"]
+        ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,7 @@ pub async fn initialize_rocket(
         vault_services: network_vault_services,
         configured_networks,
         freeze_scheduler,
+        receipts: Arc::new(CqrsReceiptService::new(receipt_inventory_store)),
         shutdown: shutdown_tx,
     }))
 }
@@ -527,6 +528,9 @@ struct RocketState {
     vault_services: NetworkVaultServices,
     configured_networks: ConfiguredNetworks,
     freeze_scheduler: tokenized_asset::schedule::FreezeScheduler,
+    /// Receipt inventory reads for the admin close-mint safety gate (the
+    /// vault-direct landed check).
+    receipts: Arc<dyn ReceiptService>,
     /// Stops the spawned chain-scanning loops when the server shuts down.
     shutdown: tokio::sync::watch::Sender<bool>,
 }
@@ -567,6 +571,7 @@ fn build_rocket(state: RocketState) -> rocket::Rocket<rocket::Build> {
         .manage(state.pool)
         .manage(state.apalis_pool)
         .manage(state.freeze_scheduler)
+        .manage(state.receipts)
         .mount(
             "/",
             routes![

--- a/src/mint/api/authorize.rs
+++ b/src/mint/api/authorize.rs
@@ -784,6 +784,7 @@ mod tests {
                     issuer_request_id: issuer_request_id.clone(),
                     reason: "operator close".to_string(),
                     acknowledged_unresolved_mint_tx_hash: None,
+                    acknowledged_unresolved_mint_nonce: None,
                 },
             )
             .await

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -191,6 +191,13 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
         acknowledged_unresolved_mint_tx_hash: Option<B256>,
+        /// Required exactly when the mint is classified
+        /// `NonceReplayUnresolved`, and must echo its persisted
+        /// authorization nonce: the bot's own chain view is the thing in
+        /// doubt there, so the close records that an operator verified the
+        /// absence against an independent chain view. Rejected on any other
+        /// mint (SPEC "Mint Aggregate" -> `CloseMint`).
+        acknowledged_unresolved_mint_nonce: Option<B256>,
     },
 
     /// Associates the liquidity bot's validated `MintAuthV1` with this mint,

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -160,6 +160,14 @@ pub(crate) enum MintEvent {
         #[serde(default)]
         acknowledged_unresolved_mint_tx_hash: Option<B256>,
         closed_at: DateTime<Utc>,
+        /// Present only when closing a `NonceReplayUnresolved` mint: the
+        /// operator's recorded acknowledgement that the nonce's absence was
+        /// verified against a chain view outside this bot, echoing the
+        /// mint's persisted authorization nonce exactly (SPEC "Mint
+        /// Aggregate" -> `CloseMint`). Additive: historic closes replay as
+        /// `None`.
+        #[serde(default)]
+        acknowledged_unresolved_mint_nonce: Option<B256>,
     },
 
     /// Mint transaction submitted to the signing backend (Turnkey or local).

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -20,7 +20,8 @@
 use alloy::primitives::{Address, U256};
 use apalis_sqlite::SqlitePool;
 use chrono::{DateTime, Utc};
-use event_sorcery::{SendError, Store};
+use cqrs_es::AggregateError;
+use event_sorcery::{LifecycleError, SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
@@ -28,9 +29,10 @@ use tracing::{debug, error, info, warn};
 
 use super::recovery::{enqueue_scheduled_mint_recovery, release_terminal_job};
 use super::{
-    IssuerMintRequestId, Mint, MintCommand, MintFailureClassification,
-    Quantity, TokenizationRequestId, UnderlyingSymbol,
-    has_unresolved_signer_intent, orchestrator_mint_failure_classification,
+    IssuerMintRequestId, Mint, MintCommand, MintError,
+    MintFailureClassification, Quantity, TokenizationRequestId,
+    UnderlyingSymbol, has_unresolved_signer_intent,
+    orchestrator_mint_failure_classification,
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::burn_excess::has_unresolved_excess_burn_intent;
@@ -2274,7 +2276,7 @@ async fn record_existing_receipt_from_inventory(
         block_number = receipt.block_number,
         "Found existing receipt, recording recovery"
     );
-    mint_store
+    match mint_store
         .send(
             issuer_request_id,
             MintCommand::RecordExistingMint {
@@ -2285,7 +2287,30 @@ async fn record_existing_receipt_from_inventory(
                 block_number: receipt.block_number,
             },
         )
-        .await?;
+        .await
+    {
+        Ok(()) => {}
+        // The aggregate's mode guard is a permanent domain refusal — a
+        // receipt mis-attributed to an orchestrator-anchored mint. Retry
+        // cannot fix it, so stop this drive loudly instead of surfacing a
+        // retryable job error that burns the budget and reports
+        // retry-exhausted instead of the real anomaly.
+        Err(AggregateError::UserError(LifecycleError::Apply(
+            MintError::MintModeMismatch { .. },
+        ))) => {
+            error!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %receipt.tx_hash,
+                receipt_id = %receipt.receipt_id,
+                "Vault receipt mis-attributed to an orchestrator-anchored \
+                 mint; refusing vault-direct completion — manual \
+                 investigation required"
+            );
+            return Ok(true);
+        }
+        Err(error) => return Err(error.into()),
+    }
     callback_queue
         .clone()
         .push_with_idempotency_key(

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -552,6 +552,17 @@ pub(crate) enum AutomaticRetryDecision {
     Wait(std::time::Duration),
     Exhausted,
     NotRecoverable,
+    /// The failure carries a typed classification — never auto-retried
+    /// (`NonceConsumedByOtherMint` needs manual reconciliation; the
+    /// logic-mismatch halts resolve environment-wide). Only the operator's
+    /// manual recovery may proceed.
+    ManualOnly(MintFailureClassification),
+    /// `NonceReplayUnresolved`: never RESUBMITTED (the nonce is consumed
+    /// either way, a resubmission can only revert) but retried for
+    /// RECONCILIATION — recovery re-runs the `Minted`-log full-match over a
+    /// widened window on its normal schedule, and a later match resolves
+    /// the mint forward (SPEC "Recipient Authorization" -> "Nonce").
+    ReconcileOnly,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -720,7 +731,9 @@ impl Mint {
         &self,
         now: DateTime<Utc>,
     ) -> AutomaticRetryDecision {
-        let Self::MintingFailed { failed_at, attempts, .. } = self else {
+        let Self::MintingFailed { failed_at, attempts, classification, .. } =
+            self
+        else {
             return match self {
                 Self::JournalConfirmed { .. }
                 | Self::Minting { .. }
@@ -730,6 +743,18 @@ impl Mint {
                 _ => AutomaticRetryDecision::NotRecoverable,
             };
         };
+
+        // Typed classifications are never auto-RESUBMITTED — decided before
+        // any attempt/budget bookkeeping so exhaustion accounting is
+        // untouched (mirrors the burn side's classified-skip). The
+        // inconclusive replay is the one classification recovery keeps
+        // touching: reconciliation-only, never a resubmission.
+        if *classification == MintFailureClassification::NonceReplayUnresolved {
+            return AutomaticRetryDecision::ReconcileOnly;
+        }
+        if *classification != MintFailureClassification::Unclassified {
+            return AutomaticRetryDecision::ManualOnly(*classification);
+        }
 
         if *attempts > Self::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT {
             return AutomaticRetryDecision::Exhausted;
@@ -873,6 +898,44 @@ impl Mint {
     /// authorization — the exact states [`Self::handle_authorize_mint`]
     /// destructures (keep the two in sync). The tokenization-id lookup uses
     /// this to prefer a live mint over stale same-id duplicates.
+    /// Every persisted signed transaction in this mint's history with no
+    /// recorded terminal on-chain outcome, plus whether the history holds a
+    /// submission that persisted NO signed bytes (legacy custodian-era
+    /// submissions) — which can never be proven dead and therefore blocks a
+    /// guarded close (SPEC "Mint Aggregate" -> `CloseMint`). Walks the
+    /// `failed_from` predecessor chain, since a `MintingFailed` (or a
+    /// retrying `Minting`) still carries the transaction that put it there.
+    pub(crate) fn unresolved_persisted_txs(
+        &self,
+    ) -> (Vec<&PreparedMintTx>, bool) {
+        match self {
+            Self::TxIntended { prepared_tx, .. } => (vec![prepared_tx], false),
+            Self::TxSubmitted { prepared_tx, .. } => {
+                prepared_tx.as_ref().map_or_else(
+                    || (Vec::new(), true),
+                    |prepared| (vec![prepared], false),
+                )
+            }
+            Self::MintingFailed { failed_from, .. } => {
+                failed_from.unresolved_persisted_txs()
+            }
+            Self::Minting { retry: Some(context), .. } => {
+                context.failed_from.unresolved_persisted_txs()
+            }
+            _ => (Vec::new(), false),
+        }
+    }
+
+    pub(crate) const fn accepts_mint_authorization(&self) -> bool {
+        matches!(
+            self,
+            Self::Initiated { .. }
+                | Self::JournalConfirmed { .. }
+                | Self::Minting { .. }
+        )
+    }
+
+    /// The recipient authorization delivered by the liquidity bot, if any.
     pub(crate) const fn mint_authorization(
         &self,
     ) -> Option<&MintAuthorization> {
@@ -890,15 +953,6 @@ impl Mint {
             }
             Self::Closed { .. } => None,
         }
-    }
-
-    pub(crate) const fn accepts_mint_authorization(&self) -> bool {
-        matches!(
-            self,
-            Self::Initiated { .. }
-                | Self::JournalConfirmed { .. }
-                | Self::Minting { .. }
-        )
     }
 
     /// Associates the liquidity bot's validated authorization with this mint
@@ -1301,9 +1355,32 @@ impl Mint {
         block_number: u64,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
-            Self::TxSubmitted {
+            Self::Minting {
                 issuer_request_id: expected_id,
                 mint_mode,
+                mint_authorization,
+                quantity,
+                ..
+            }
+            | Self::TxIntended {
+                issuer_request_id: expected_id,
+                mint_mode,
+                mint_authorization,
+                quantity,
+                ..
+            }
+            | Self::TxSubmitted {
+                issuer_request_id: expected_id,
+                mint_mode,
+                mint_authorization,
+                quantity,
+                ..
+            }
+            | Self::MintingFailed {
+                issuer_request_id: expected_id,
+                mint_mode,
+                mint_authorization,
+                quantity,
                 ..
             } => {
                 Self::validate_issuer_request_id(
@@ -1315,6 +1392,34 @@ impl Mint {
                     return Err(MintError::MintModeMismatch {
                         expected: mint_mode.kind(),
                         found: VaultModeKind::Orchestrator,
+                    });
+                }
+
+                // Same defense-in-depth invariants as the confirmation
+                // handler above: the recovery scan's full-match already
+                // compared the log against this mint's request facts, but
+                // the aggregate must not trust its callers — a recovered
+                // record diverging from what this mint was authorized for
+                // must fail loudly rather than become the persisted audit
+                // record.
+                let authorization = mint_authorization
+                    .as_ref()
+                    .ok_or(MintError::MissingMintAuthorization)?;
+                if nonce != authorization.nonce {
+                    return Err(MintError::MintedNonceMismatch {
+                        expected: authorization.nonce,
+                        actual: nonce,
+                    });
+                }
+                let authorized_shares = quantity
+                    .to_u256_with_18_decimals()
+                    .map_err(|error| MintError::QuantityConversion {
+                        message: error.to_string(),
+                    })?;
+                if shares_minted != authorized_shares {
+                    return Err(MintError::MintedSharesMismatch {
+                        expected: authorized_shares,
+                        actual: shares_minted,
                     });
                 }
 
@@ -1376,6 +1481,32 @@ impl Mint {
             Self::Minting { issuer_request_id: expected_id, .. }
             | Self::TxIntended { issuer_request_id: expected_id, .. }
             | Self::TxSubmitted { issuer_request_id: expected_id, .. } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+
+                Ok(vec![MintEvent::MintingFailed {
+                    issuer_request_id,
+                    error,
+                    failed_at: Utc::now(),
+                    classification,
+                }])
+            }
+            // The one verdict a later failure may supersede: the
+            // INCONCLUSIVE `NonceReplayUnresolved` upgrades to the proven
+            // `NonceConsumedByOtherMint` once reconciliation's widened scan
+            // actually finds the pair's landing disagreeing on token/amount
+            // (SPEC "Nonce", two outcomes). Every other `MintingFailed`
+            // re-record stays a no-op — a proven or halt verdict is never
+            // silently rewritten.
+            Self::MintingFailed {
+                issuer_request_id: expected_id,
+                classification: MintFailureClassification::NonceReplayUnresolved,
+                ..
+            } if classification
+                == MintFailureClassification::NonceConsumedByOtherMint =>
+            {
                 Self::validate_issuer_request_id(
                     expected_id,
                     &issuer_request_id,
@@ -1489,6 +1620,10 @@ impl Mint {
     /// exists), reported by the `SubmitMintJob` before it re-submitted. Pure —
     /// emits `ExistingMintRecovered`, advancing to `CallbackPending` without
     /// re-minting. Idempotent: a no-op once the mint is already minted.
+    /// Rejects orchestrator-anchored mints: the bot never custodies a receipt
+    /// for them, so a receipt-discovery delivery would be a mis-attribution
+    /// (receipt ingestion filters on bot ownership, but the anchor is the
+    /// authoritative guard).
     fn handle_record_existing_mint(
         &self,
         issuer_request_id: IssuerMintRequestId,
@@ -1498,10 +1633,24 @@ impl Mint {
         block_number: u64,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
-            Self::Minting { issuer_request_id: expected_id, .. }
-            | Self::TxIntended { issuer_request_id: expected_id, .. }
-            | Self::TxSubmitted { issuer_request_id: expected_id, .. }
-            | Self::MintingFailed { issuer_request_id: expected_id, .. } => {
+            Self::Minting {
+                issuer_request_id: expected_id, mint_mode, ..
+            }
+            | Self::TxIntended {
+                issuer_request_id: expected_id,
+                mint_mode,
+                ..
+            }
+            | Self::TxSubmitted {
+                issuer_request_id: expected_id,
+                mint_mode,
+                ..
+            }
+            | Self::MintingFailed {
+                issuer_request_id: expected_id,
+                mint_mode,
+                ..
+            } => {
                 Self::validate_issuer_request_id(
                     expected_id,
                     &issuer_request_id,
@@ -1511,9 +1660,9 @@ impl Mint {
                 // custodies a receipt for an orchestrator mint, so this path
                 // should be unreachable for one — the guard mirrors the
                 // other record handlers as defence in depth.
-                if let Some(VaultMode::Orchestrator { .. }) = self.mint_mode() {
+                if let VaultMode::Orchestrator { .. } = mint_mode {
                     return Err(MintError::MintModeMismatch {
-                        expected: VaultModeKind::Orchestrator,
+                        expected: mint_mode.kind(),
                         found: VaultModeKind::VaultDirect,
                     });
                 }
@@ -2286,16 +2435,31 @@ impl Mint {
             retry: Some(MintRetryContext { attempts, failed_from, tx_hash }),
         };
     }
+
+    /// Admin-closes a mint. Pure — the aggregate has no services, so the
+    /// orchestrator landed-`Minted`-log pre-close check (closing a mint whose
+    /// tokens actually minted on-chain would strand real backed tokens
+    /// unreported to Alpaca) runs in the admin `close_mint` endpoint before
+    /// this command is sent.
     fn handle_close_mint(
         &self,
         issuer_request_id: IssuerMintRequestId,
         reason: String,
         acknowledged_unresolved_mint_tx_hash: Option<B256>,
+        acknowledged_unresolved_mint_nonce: Option<B256>,
     ) -> Result<Vec<MintEvent>, MintError> {
         if matches!(self, Self::Completed { .. } | Self::Closed { .. }) {
             return Err(MintError::NotRecoverable {
                 current_state: self.state_name().to_string(),
             });
+        }
+
+        // `CallbackPending` already records an on-chain mint in this
+        // aggregate's own history — an economically committed mint must
+        // resolve through the success path (the callback), never a close
+        // that would strand real backed tokens unreported.
+        if matches!(self, Self::CallbackPending { .. }) {
+            return Err(MintError::CloseAfterMintRecorded);
         }
 
         // A legacy `TxSubmitted { prepared_tx: None }` carries no prepared
@@ -2309,10 +2473,25 @@ impl Mint {
             .or_else(|| {
                 self.latest_known_tx_id().and_then(|tx_id| tx_id.to_hash())
             });
+        // A typed classification is the aggregate's own adjudication that the
+        // persisted transaction can no longer land (and the admin close path
+        // re-proves the landing question on-chain before sending this
+        // command), so the tx-hash acknowledgement is demanded only for
+        // unclassified failure chains — for `NonceReplayUnresolved` the nonce
+        // acknowledgement below is the required operator claim instead.
+        let classified_terminal = matches!(
+            self,
+            Self::MintingFailed { classification, .. }
+                if !matches!(
+                    classification,
+                    MintFailureClassification::Unclassified
+                )
+        );
         let acknowledged_unresolved_mint_tx_hash = match (
             unresolved_mint_tx_hash,
             acknowledged_unresolved_mint_tx_hash,
         ) {
+            (Some(_), None) if classified_terminal => None,
             (Some(mint_tx_hash), acknowledgement) => {
                 Some(Self::require_unresolved_mint_acknowledgement(
                     mint_tx_hash,
@@ -2329,10 +2508,48 @@ impl Mint {
             (None, None) => None,
         };
 
+        // The nonce acknowledgement is the operator's recorded claim that the
+        // nonce's absence was verified against a chain view OUTSIDE this
+        // bot — meaningful exactly when the bot's own view is the thing in
+        // doubt (`NonceReplayUnresolved`), and rejected anywhere else so it
+        // can never become a general-purpose close override.
+        let unresolved_nonce = match self {
+            Self::MintingFailed {
+                classification: MintFailureClassification::NonceReplayUnresolved,
+                mint_authorization,
+                ..
+            } => mint_authorization
+                .as_ref()
+                .map(|authorization| authorization.nonce),
+            _ => None,
+        };
+        match (unresolved_nonce, acknowledged_unresolved_mint_nonce) {
+            (Some(expected), Some(provided)) if expected != provided => {
+                return Err(MintError::AcknowledgedNonceMismatch {
+                    expected,
+                    provided,
+                });
+            }
+            (Some(expected), None) => {
+                return Err(
+                    MintError::UnresolvedReplayAcknowledgementRequired {
+                        nonce: expected,
+                    },
+                );
+            }
+            (None, Some(provided)) => {
+                return Err(MintError::AcknowledgementNotApplicable {
+                    provided,
+                });
+            }
+            _ => {}
+        }
+
         Ok(vec![MintEvent::MintClosed {
             issuer_request_id,
             reason,
             acknowledged_unresolved_mint_tx_hash,
+            acknowledged_unresolved_mint_nonce,
             closed_at: Utc::now(),
         }])
     }
@@ -2640,10 +2857,12 @@ impl EventSourced for Mint {
                 issuer_request_id,
                 reason,
                 acknowledged_unresolved_mint_tx_hash,
+                acknowledged_unresolved_mint_nonce,
             } => self.handle_close_mint(
                 issuer_request_id,
                 reason,
                 acknowledged_unresolved_mint_tx_hash,
+                acknowledged_unresolved_mint_nonce,
             ),
         }
     }
@@ -2793,6 +3012,9 @@ impl Mint {
                 issuer_request_id,
                 reason,
                 acknowledged_unresolved_mint_tx_hash,
+                // The nonce acknowledgement is audit data on the event; the
+                // `Closed` state carries the lifecycle facts.
+                acknowledged_unresolved_mint_nonce: _,
                 closed_at,
             } => {
                 *self = Self::Closed {
@@ -2828,6 +3050,29 @@ pub(crate) enum MintError {
         "Mint result mode mismatch: the mint's persisted anchor is {expected}, the recorded result is {found}"
     )]
     MintModeMismatch { expected: VaultModeKind, found: VaultModeKind },
+    #[error(
+        "Mint cannot be closed from CallbackPending: an on-chain mint is \
+         already recorded — resolve it through the callback path instead"
+    )]
+    CloseAfterMintRecorded,
+    #[error(
+        "Closing a NonceReplayUnresolved mint requires \
+         acknowledged_unresolved_mint_nonce echoing its persisted nonce \
+         {nonce}: the bot's own chain view is in doubt, so an operator must \
+         verify the absence against an independent chain view first"
+    )]
+    UnresolvedReplayAcknowledgementRequired { nonce: B256 },
+    #[error(
+        "acknowledged_unresolved_mint_nonce {provided} does not echo the \
+         mint's persisted nonce {expected}"
+    )]
+    AcknowledgedNonceMismatch { expected: B256, provided: B256 },
+    #[error(
+        "acknowledged_unresolved_mint_nonce {provided} was supplied but this \
+         mint is not classified NonceReplayUnresolved; the acknowledgement \
+         is not a general-purpose close override"
+    )]
+    AcknowledgementNotApplicable { provided: B256 },
     #[error("Orchestrator mint has no recorded authorization to check against")]
     MissingMintAuthorization,
     #[error(
@@ -3765,6 +4010,265 @@ pub(crate) mod tests {
         events
     }
 
+    /// Terminal mints are un-closeable: `Completed` already reported to
+    /// Alpaca, and `Closed` is already closed. Both must reject with
+    /// `NotRecoverable` rather than record a second terminal event.
+    #[tokio::test]
+    async fn close_mint_rejects_terminal_states() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events_through_completed(&issuer_request_id))
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::NotRecoverable { .. })
+            ),
+            "closing a Completed mint must be rejected, got {error:?}"
+        );
+
+        let mut closed_events = events_through_minting(&issuer_request_id);
+        closed_events.push(MintEvent::MintClosed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "first close".to_string(),
+            closed_at: Utc::now(),
+            acknowledged_unresolved_mint_tx_hash: None,
+            acknowledged_unresolved_mint_nonce: None,
+        });
+        let error = TestHarness::<Mint>::with(())
+            .given(closed_events)
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "second close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::NotRecoverable { .. })
+            ),
+            "closing an already-Closed mint must be rejected, got {error:?}"
+        );
+    }
+
+    /// `CallbackPending` already records an on-chain mint in this
+    /// aggregate's own history — closing it would strand real backed tokens
+    /// unreported (SPEC "Mint Aggregate" -> `CloseMint`).
+    #[tokio::test]
+    async fn close_mint_rejects_callback_pending() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::OrchestratorTokensMinted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: B256::ZERO,
+            nonce: test_mint_authorization().nonce,
+            shares_minted: uint!(100_000000000000000000_U256),
+            gas_used: 21_000,
+            block_number: 1_000,
+            minted_at: Utc::now(),
+        });
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::CloseAfterMintRecorded)
+            ),
+            "closing from CallbackPending must be rejected, got {error:?}"
+        );
+    }
+
+    /// The close acknowledgement is scoped to exactly the
+    /// `NonceReplayUnresolved` classification: required there (echoing the
+    /// persisted nonce), rejected everywhere else — never a general-purpose
+    /// close override.
+    #[tokio::test]
+    async fn close_mint_acknowledgement_rules() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let unresolved = orchestrator_minting_failed_events(
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+            MintFailureClassification::NonceReplayUnresolved,
+        );
+        let nonce = test_mint_authorization().nonce;
+
+        let error = TestHarness::<Mint>::with(())
+            .given(unresolved.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::UnresolvedReplayAcknowledgementRequired { .. }
+                )
+            ),
+            "an unresolved mint must demand the acknowledgement, got \
+             {error:?}"
+        );
+
+        let error = TestHarness::<Mint>::with(())
+            .given(unresolved.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: Some(B256::repeat_byte(
+                    0xEE,
+                )),
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::AcknowledgedNonceMismatch { .. }
+                )
+            ),
+            "a non-echoing acknowledgement must be rejected, got {error:?}"
+        );
+
+        let events = TestHarness::<Mint>::with(())
+            .given(unresolved)
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator verified absence".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: Some(nonce),
+            })
+            .await
+            .events();
+        assert!(
+            matches!(
+                events.as_slice(),
+                [MintEvent::MintClosed {
+                    acknowledged_unresolved_mint_nonce: Some(acknowledged),
+                    ..
+                }] if *acknowledged == nonce
+            ),
+            "the echoing acknowledgement must close and be recorded, got \
+             {events:?}"
+        );
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events_through_minting(&issuer_request_id))
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator close".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: Some(nonce),
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::AcknowledgementNotApplicable { .. }
+                )
+            ),
+            "the acknowledgement on any other mint must be rejected, got \
+             {error:?}"
+        );
+    }
+
+    /// Historic `MintClosed` events predate the acknowledgement field; they
+    /// must replay with it absent.
+    #[test]
+    fn mint_closed_without_acknowledgement_replays_as_none() {
+        let historic = serde_json::json!({
+            "MintClosed": {
+                "issuer_request_id": IssuerMintRequestId::random().to_string(),
+                "reason": "operator close",
+                "closed_at": "2025-01-01T00:00:00Z"
+            }
+        });
+
+        let event: MintEvent = serde_json::from_value(historic).unwrap();
+
+        assert!(matches!(
+            event,
+            MintEvent::MintClosed {
+                acknowledged_unresolved_mint_nonce: None,
+                ..
+            }
+        ));
+    }
+
+    /// The close gate's history walk: every persisted signed transaction
+    /// with no terminal outcome is surfaced, following the `failed_from`
+    /// chain, and a byte-less legacy submission flags as unprovable.
+    #[test]
+    fn unresolved_persisted_txs_walk_the_failure_chain() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let mut intended =
+            orchestrator_events_through_minting_authorized(&issuer_request_id);
+        intended.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                7,
+                "ext-walk-1".to_string(),
+            ),
+            intended_at: Utc::now(),
+        });
+        let mint = replay::<Mint>(intended).unwrap().unwrap();
+        let (txs, unprovable) = mint.unresolved_persisted_txs();
+        assert_eq!(txs.len(), 1);
+        assert_eq!(txs[0].nonce, 7);
+        assert!(!unprovable);
+
+        let failed = orchestrator_minting_failed_events(
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+            MintFailureClassification::Unclassified,
+        );
+        let mint = replay::<Mint>(failed).unwrap().unwrap();
+        let (txs, unprovable) = mint.unresolved_persisted_txs();
+        // The fixture's TxSubmitted persisted no signed bytes (legacy
+        // shape), carried through the failure's `failed_from` chain.
+        assert!(txs.is_empty());
+        assert!(
+            unprovable,
+            "a byte-less submission in the chain must flag as unprovable"
+        );
+
+        let mint = replay::<Mint>(events_through_minting(&issuer_request_id))
+            .unwrap()
+            .unwrap();
+        let (txs, unprovable) = mint.unresolved_persisted_txs();
+        assert!(txs.is_empty());
+        assert!(!unprovable, "no submission history means nothing to prove");
+    }
+
     #[test]
     fn manual_recovery_decision_rejects_nonrecoverable_states() {
         let issuer_request_id = IssuerMintRequestId::random();
@@ -4091,7 +4595,7 @@ pub(crate) mod tests {
         events
     }
 
-    pub(super) fn orchestrator_events_through_tx_submitted(
+    pub(crate) fn orchestrator_events_through_tx_submitted(
         issuer_request_id: &IssuerMintRequestId,
     ) -> Vec<MintEvent> {
         let mut events =
@@ -6420,6 +6924,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed pre-prepare".to_string(),
                 acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .events();
@@ -6455,6 +6960,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed legacy submitted".to_string(),
                 acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .then_expect_error();
@@ -6477,6 +6983,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed legacy submitted".to_string(),
                 acknowledged_unresolved_mint_tx_hash: Some(wrong_hash),
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .then_expect_error();
@@ -6499,6 +7006,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed legacy submitted".to_string(),
                 acknowledged_unresolved_mint_tx_hash: Some(submitted_hash),
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .events();
@@ -6526,6 +7034,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed intended".to_string(),
                 acknowledged_unresolved_mint_tx_hash: None,
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .then_expect_error();
@@ -6549,6 +7058,7 @@ pub(crate) mod tests {
                 acknowledged_unresolved_mint_tx_hash: Some(b256!(
                     "0x1111111111111111111111111111111111111111111111111111111111111111"
                 )),
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .then_expect_error();
@@ -6571,6 +7081,7 @@ pub(crate) mod tests {
                 issuer_request_id: issuer_request_id.clone(),
                 reason: "operator closed intended".to_string(),
                 acknowledged_unresolved_mint_tx_hash: Some(prepared_hash),
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .events();
@@ -6596,6 +7107,7 @@ pub(crate) mod tests {
                 issuer_request_id,
                 reason: "ack without intent".to_string(),
                 acknowledged_unresolved_mint_tx_hash: Some(unexpected),
+                acknowledged_unresolved_mint_nonce: None,
             })
             .await
             .then_expect_error();
@@ -6824,9 +7336,8 @@ pub(crate) mod tests {
         }
     }
 
-    /// A vault-direct confirmation result can never complete an orchestrator
-    /// mint, and vice versa — the record handlers enforce the persisted
-    /// mode anchor.
+    /// A vault-direct result can never complete an orchestrator mint, and
+    /// vice versa — every record handler enforces the persisted mode anchor.
     #[tokio::test]
     async fn record_handlers_reject_cross_mode_results() {
         let issuer_request_id = IssuerMintRequestId::random();
@@ -6872,6 +7383,30 @@ pub(crate) mod tests {
                 LifecycleError::Apply(MintError::MintModeMismatch { .. })
             ),
             "an orchestrator result must not complete a vault-direct mint, \
+             got {error:?}"
+        );
+
+        // Receipt-discovery recovery is vault-direct machinery: the bot never
+        // custodies a receipt for an orchestrator mint, so a delivery here
+        // would be a mis-attribution even though receipt ingestion filters on
+        // bot ownership upstream.
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordExistingMint {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                receipt_id: uint!(1_U256),
+                shares_minted: uint!(1_U256),
+                block_number: 1,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintModeMismatch { .. })
+            ),
+            "a receipt discovery must not complete an orchestrator mint, \
              got {error:?}"
         );
     }
@@ -7012,6 +7547,53 @@ pub(crate) mod tests {
             .await
             .events();
         assert!(events.is_empty(), "a re-delivered recovery must be a no-op");
+    }
+
+    /// The recovered-mint record carries the same defense-in-depth
+    /// invariants as the confirmation record: a nonce or share total
+    /// diverging from what this mint was authorized for must fail loudly
+    /// instead of becoming the persisted audit record.
+    #[tokio::test]
+    async fn record_orchestrator_mint_recovered_rejects_diverging_facts() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorMintRecovered {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                nonce: B256::repeat_byte(0xEE),
+                shares_minted: uint!(100_000000000000000000_U256),
+                block_number: 777,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintedNonceMismatch { .. })
+            ),
+            "a diverging nonce must be rejected, got {error:?}"
+        );
+
+        let error = TestHarness::<Mint>::with(())
+            .given(orchestrator_events_through_tx_submitted(&issuer_request_id))
+            .when(MintCommand::RecordOrchestratorMintRecovered {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: B256::ZERO,
+                nonce: test_mint_authorization().nonce,
+                shares_minted: uint!(1_U256),
+                block_number: 777,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(MintError::MintedSharesMismatch { .. })
+            ),
+            "diverging shares must be rejected, got {error:?}"
+        );
     }
 
     /// A vault receipt is a vault-direct proof: the bot never custodies a
@@ -7235,6 +7817,118 @@ pub(crate) mod tests {
         assert_eq!(
             serde_json::from_value::<MintEvent>(recovered_wire).unwrap(),
             recovered
+        );
+    }
+
+    fn orchestrator_minting_failed_events(
+        issuer_request_id: &IssuerMintRequestId,
+        base: Vec<MintEvent>,
+        classification: MintFailureClassification,
+    ) -> Vec<MintEvent> {
+        let mut events = base;
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "confirmation failed".to_string(),
+            failed_at: Utc::now(),
+            classification,
+        });
+        events
+    }
+
+    /// Typed classifications opt out of the automatic retry schedule before
+    /// any budget bookkeeping; only `Unclassified` stays on it.
+    #[test]
+    fn automatic_retry_decision_manual_only_for_typed_classifications() {
+        for classification in [
+            MintFailureClassification::VaultLogicMismatch,
+            MintFailureClassification::ReceiptLogicMismatch,
+            MintFailureClassification::NonceConsumedByOtherMint,
+        ] {
+            let issuer_request_id = IssuerMintRequestId::random();
+            let mint = replay::<Mint>(orchestrator_minting_failed_events(
+                &issuer_request_id,
+                orchestrator_events_through_tx_submitted(&issuer_request_id),
+                classification,
+            ))
+            .unwrap()
+            .unwrap();
+
+            assert_eq!(
+                mint.automatic_retry_decision(Utc::now()),
+                AutomaticRetryDecision::ManualOnly(classification),
+            );
+        }
+
+        // The inconclusive replay is the one classification recovery keeps
+        // touching: reconciliation-only, never `ManualOnly`, never a
+        // resubmission.
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mint = replay::<Mint>(orchestrator_minting_failed_events(
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+            MintFailureClassification::NonceReplayUnresolved,
+        ))
+        .unwrap()
+        .unwrap();
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::ReconcileOnly,
+            "an unresolved replay must be reconciliation-only"
+        );
+
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mint = replay::<Mint>(orchestrator_minting_failed_events(
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+            MintFailureClassification::Unclassified,
+        ))
+        .unwrap()
+        .unwrap();
+        assert!(
+            !matches!(
+                mint.automatic_retry_decision(Utc::now()),
+                AutomaticRetryDecision::ManualOnly(_)
+            ),
+            "Unclassified must stay on the automatic schedule"
+        );
+
+        // Classification wins over exhaustion, not just over an under-budget
+        // schedule: with the attempt counter already past the automatic
+        // budget, the decision must stay `ManualOnly` — `Exhausted` would
+        // route recovery through the receipt re-check/abandon path instead
+        // of the classified skip.
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        for _ in 0..6 {
+            events.push(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at: Utc::now(),
+                classification: MintFailureClassification::Unclassified,
+            });
+        }
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id,
+            error: "nonce consumed by another mint".to_string(),
+            failed_at: Utc::now(),
+            classification: MintFailureClassification::NonceConsumedByOtherMint,
+        });
+        let mint = replay::<Mint>(events).unwrap().unwrap();
+        let Mint::MintingFailed { attempts, .. } = &mint else {
+            panic!("expected MintingFailed, got {mint:?}");
+        };
+        assert!(
+            *attempts > Mint::MAX_AUTOMATIC_MINT_RETRY_ATTEMPT,
+            "the fixture must drive attempts past the automatic budget, got \
+             {attempts}"
+        );
+        assert_eq!(
+            mint.automatic_retry_decision(Utc::now()),
+            AutomaticRetryDecision::ManualOnly(
+                MintFailureClassification::NonceConsumedByOtherMint
+            ),
+            "an exhausted counter must not displace the classified verdict"
         );
     }
 }

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -14,14 +14,17 @@ use uuid::Uuid;
 
 use super::job::{ConfirmMintJob, SendCallbackJob, SubmitMintJob};
 use super::{
-    AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand, Network,
-    UnderlyingSymbol, find_all_recoverable_mints,
+    AutomaticRetryDecision, IssuerMintRequestId, Mint, MintCommand,
+    MintFailureClassification, MintView, Network, UnderlyingSymbol,
+    find_all_recoverable_mints,
 };
+use crate::config::VaultMode;
 use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{ItnReceiptHandler, ReceiptService};
 use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
 use crate::vault::{
-    MintTxStatus, NetworkVaultServices, TxId, UnconfiguredNetworkError,
+    MintTxStatus, MintedLogQuery, MintedLogScan, NetworkVaultServices, TxId,
+    UnconfiguredNetworkError,
 };
 
 /// Dependencies the scheduled mint-recovery worker needs to re-drive a stuck or
@@ -116,6 +119,13 @@ const MAX_SCHEDULED_RECOVERY_NO_PROGRESS_POLLS: usize = 360;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct MintRecoveryJob {
     issuer_request_id: IssuerMintRequestId,
+    /// Set by the admin reprocess endpoint ([`enqueue_manual_mint_recovery`]):
+    /// permits exactly one re-drive of a classified (`ManualOnly`) failure
+    /// that the automatic loop refuses to touch. Defaults to `false` for
+    /// every automatic producer (startup re-scan, reconciler, recovery
+    /// kicks), so a deserialized pre-existing job row stays automatic.
+    #[serde(default)]
+    manual: bool,
 }
 
 impl Job<MintRecoveryContext> for MintRecoveryJob {
@@ -131,6 +141,7 @@ impl Job<MintRecoveryContext> for MintRecoveryJob {
             &self.issuer_request_id,
             SCHEDULED_RECOVERY_BACKOFF,
             MAX_SCHEDULED_RECOVERY_NO_PROGRESS_POLLS,
+            self.manual,
         )
         .await
         {
@@ -229,6 +240,25 @@ pub(crate) async fn enqueue_scheduled_mint_recovery(
 ) -> Result<(), anyhow::Error> {
     release_terminal_recovery_job(pool, &issuer_request_id).await?;
     push_mint_recovery_job(apalis_pool, issuer_request_id).await
+}
+
+/// Admin-reprocess variant of [`enqueue_scheduled_mint_recovery`]: the pushed
+/// job carries the `manual` flag, permitting exactly one re-drive of a
+/// classified failure the automatic loop refuses. A concurrent ACTIVE
+/// automatic job for the same mint dedups this push (idempotency key), but a
+/// classified mint's automatic job has already concluded and been released
+/// here, so the admin path is not raced in practice.
+pub(crate) async fn enqueue_manual_mint_recovery(
+    pool: &Pool<Sqlite>,
+    apalis_pool: &SqlitePool,
+    issuer_request_id: IssuerMintRequestId,
+) -> Result<(), anyhow::Error> {
+    release_terminal_recovery_job(pool, &issuer_request_id).await?;
+    push_recovery_job(
+        apalis_pool,
+        MintRecoveryJob { issuer_request_id, manual: true },
+    )
+    .await
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -380,20 +410,30 @@ pub(crate) async fn push_mint_recovery_job(
     apalis_pool: &SqlitePool,
     issuer_request_id: IssuerMintRequestId,
 ) -> Result<(), anyhow::Error> {
+    push_recovery_job(
+        apalis_pool,
+        MintRecoveryJob { issuer_request_id, manual: false },
+    )
+    .await
+}
+
+async fn push_recovery_job(
+    apalis_pool: &SqlitePool,
+    job: MintRecoveryJob,
+) -> Result<(), anyhow::Error> {
     let mut attempt = 0;
     // The queue handle is reusable across attempts
     // (`push_with_idempotency_key` takes `&mut self`); build it once rather
     // than reconstructing it on every retry.
     let mut queue = JobQueue::<MintRecoveryJob>::new(apalis_pool);
+    let issuer_request_id = job.issuer_request_id.clone();
 
     loop {
         attempt += 1;
 
         match queue
             .push_with_idempotency_key(
-                MintRecoveryJob {
-                    issuer_request_id: issuer_request_id.clone(),
-                },
+                job.clone(),
                 issuer_request_id.to_string(),
             )
             .await
@@ -675,10 +715,30 @@ pub(crate) async fn reconcile_recoverable_mints(
     }
 
     let count = recoverable_mints.len();
-    for (issuer_request_id, _view) in recoverable_mints {
-        if let Err(error) =
+    for (issuer_request_id, view) in recoverable_mints {
+        // An unresolved replay is reconciled on the NORMAL SCHEDULE (SPEC
+        // "Nonce"): each pass re-runs one widened `Minted`-log query. Its
+        // previous pass's job row is terminal by design, so this push must
+        // release the terminal key first — the plain dedup push below would
+        // silently park the mint after its first pass.
+        let result = if matches!(
+            view,
+            MintView::MintingFailed {
+                classification:
+                    MintFailureClassification::NonceReplayUnresolved,
+                ..
+            }
+        ) {
+            enqueue_scheduled_mint_recovery(
+                pool,
+                apalis_pool,
+                issuer_request_id.clone(),
+            )
+            .await
+        } else {
             push_mint_recovery_job(apalis_pool, issuer_request_id.clone()).await
-        {
+        };
+        if let Err(error) = result {
             warn!(target: "mint", issuer_request_id = %issuer_request_id,
                 error = %error,
                 "Failed to re-enqueue recoverable mint during reconcile"
@@ -689,7 +749,8 @@ pub(crate) async fn reconcile_recoverable_mints(
     debug!(target: "mint", recoverable_mints = count,
         "Reconcile pass pushed an idempotent recovery job for each recoverable \
          mint; pushes for mints that already have a Pending, Running, Done, or \
-         Killed job are silent no-ops"
+         Killed job are silent no-ops (unresolved replays release their \
+         terminal row first, so their reconciliation re-runs every pass)"
     );
 }
 
@@ -725,6 +786,7 @@ impl fmt::Display for AbandonReason {
 /// Why [`recover_mint_until_automatic_budget_exhausted`] stopped, so the durable
 /// [`MintRecoveryJob`] records a clean success versus an abandoned mint that is
 /// still incomplete and needs surfacing.
+#[derive(Debug)]
 enum RecoveryConclusion {
     /// Recovery reached a definitive conclusion: the mint completed, is
     /// genuinely non-recoverable, or no longer exists. Nothing more to do.
@@ -767,16 +829,26 @@ async fn minting_failed_receipt_exists_with_backoff(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn recover_mint_until_automatic_budget_exhausted(
     ctx: &MintRecoveryContext,
     issuer_request_id: &IssuerMintRequestId,
     backoff: Duration,
     max_no_progress_polls: usize,
+    manual: bool,
 ) -> RecoveryConclusion {
     let mut mint_load_failure_backoffs = 0;
     let mut receipt_load_failure_backoffs = 0;
     let mut no_progress_polls = 0;
     let mut last_state: Option<&'static str> = None;
+    // The operator's `manual` flag buys exactly one re-drive of a classified
+    // failure: after it is spent, a re-failure that classifies again stops
+    // at the `ManualOnly` arm like the automatic path does.
+    let mut manual_redrive_available = manual;
+    // An unresolved replay gets exactly one widened reconciliation query per
+    // job run; the periodic reconciler re-enqueues the job each pass, which
+    // IS the "normal schedule" its re-query runs on (SPEC "Nonce").
+    let mut reconcile_attempted = false;
 
     loop {
         let mint = match ctx.mint_store.load(issuer_request_id).await {
@@ -888,6 +960,102 @@ async fn recover_mint_until_automatic_budget_exhausted(
                 return RecoveryConclusion::Abandoned {
                     reason: AbandonReason::AutomaticRetriesExhausted,
                 };
+            }
+            // Typed classifications are never auto-retried: the scheduled
+            // loop stops here, before any wakeup/budget bookkeeping, and the
+            // admin re-drive is the only way forward (mirrors the burn
+            // side's classified-skip). The admin path reaches this same
+            // loop, so its job carries a `manual` flag that spends exactly
+            // one re-drive here — without it the reprocess endpoint would
+            // answer "recovery initiated" while nothing runs.
+            AutomaticRetryDecision::ManualOnly(classification) => {
+                // Deterministic recipient-authorization failures can never
+                // succeed with the same stored authorization: re-driving one
+                // resubmits the identical `mint()` call, which reverts the
+                // same way and only burns gas and a wallet nonce. Per SPEC
+                // ("BadRecipientSignature / RecipientCallbackRejected"), the
+                // only resolution is `CloseMint` plus a fresh `Initiate`
+                // carrying new authorization — so the operator re-drive is
+                // refused outright rather than spent on a doomed submission.
+                if matches!(
+                    classification,
+                    MintFailureClassification::BadRecipientSignature
+                        | MintFailureClassification::RecipientCallbackRejected
+                ) {
+                    warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                        classification = ?classification,
+                        "Refusing re-drive of a deterministic \
+                         recipient-authorization failure; close the mint and \
+                         re-initiate with fresh authorization"
+                    );
+                    return RecoveryConclusion::Resolved;
+                }
+
+                if manual_redrive_available {
+                    manual_redrive_available = false;
+                    info!(target: "mint", issuer_request_id = %issuer_request_id,
+                        classification = ?classification,
+                        "Operator-requested re-drive of a classified mint \
+                         failure"
+                    );
+                    // The operator's adjudication IS the resubmission
+                    // authority here: the wallet-guard deferrals in
+                    // `drive_minting_failed_step` protect UNATTENDED retries
+                    // of vault-direct identities, while a classified failure
+                    // is nonce-anchored — a replay of a consumed nonce can
+                    // only revert, never double-mint.
+                    let redrive = async {
+                        let Mint::MintingFailed { underlying, network, .. } =
+                            &mint
+                        else {
+                            return Ok(());
+                        };
+                        let vault =
+                            resolve_vault(ctx, underlying, *network).await?;
+                        authorize_resubmit(ctx, issuer_request_id, vault).await
+                    };
+                    if let Err(error) = redrive.await {
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            error = %error,
+                            "Manual re-drive step failed; backing off"
+                        );
+                    }
+                    tokio::time::sleep(backoff).await;
+                    continue;
+                }
+
+                warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                    classification = ?classification,
+                    "Skipping non-retryable classified mint failure; manual \
+                     recovery required"
+                );
+                return RecoveryConclusion::Resolved;
+            }
+            // The inconclusive replay is reconciled, never resubmitted: one
+            // widened `Minted`-log re-query per pass. A full match advances
+            // the mint and the next iteration keeps driving it forward; a
+            // proven mismatch upgrades the classification (and the next
+            // iteration parks it via the `ManualOnly` arm); still nothing
+            // found retires this pass — the reconciler re-enqueues the next
+            // one.
+            AutomaticRetryDecision::ReconcileOnly => {
+                if reconcile_attempted {
+                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                        "Unresolved replay still has no Minted log at its pair; awaiting the next reconcile pass"
+                    );
+                    return RecoveryConclusion::Resolved;
+                }
+                reconcile_attempted = true;
+                if let Err(error) =
+                    reconcile_unresolved_replay(ctx, &mint, issuer_request_id)
+                        .await
+                {
+                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                        error = %error,
+                        "Unresolved-replay reconciliation failed; awaiting the next pass"
+                    );
+                }
+                tokio::time::sleep(backoff).await;
             }
             AutomaticRetryDecision::Wait(wait) => {
                 let receipt_exists =
@@ -1057,6 +1225,16 @@ async fn drive_one_step(
         | Mint::TxIntended { underlying, network, .. } => {
             let vault = resolve_vault(ctx, underlying, *network).await?;
             enqueue_submit(ctx, issuer_request_id, vault).await?;
+        }
+        // The inconclusive replay is never resubmitted — the nonce is
+        // consumed either way, so a resubmission can only revert. Its drive
+        // IS the widened reconciliation query, whichever path reaches it
+        // (the scheduled `ReconcileOnly` arm or an operator re-drive).
+        Mint::MintingFailed {
+            classification: MintFailureClassification::NonceReplayUnresolved,
+            ..
+        } => {
+            reconcile_unresolved_replay(ctx, mint, issuer_request_id).await?;
         }
         // Failed mint: classify any live prepared identity under the wallet
         // guard before RetryMint. StillMineable / Uncertain never authorize a
@@ -1290,6 +1468,138 @@ async fn drive_minting_failed_step(
     Ok(())
 }
 
+/// Widened backward window for reconciling an unresolved replay: the
+/// default scan window was sized for the live recovery timeline, and its
+/// coming up empty is exactly what parked the mint — the re-query must look
+/// further back than whatever the original lookup covered (SPEC "Recipient
+/// Authorization" -> "Nonce"). ~23 days on Base's 2s blocks.
+const UNRESOLVED_REPLAY_LOOKBACK_BLOCKS: u64 = 1_000_000;
+
+/// One reconciliation attempt for a `NonceReplayUnresolved` mint: re-runs
+/// the `Minted`-log full-match over [`UNRESOLVED_REPLAY_LOOKBACK_BLOCKS`].
+/// A `FullMatch` resolves the mint forward
+/// (`RecordOrchestratorMintRecovered` — the loop's next iteration drives
+/// the callback); a `Mismatch` upgrades the classification to the proven
+/// `NonceConsumedByOtherMint`; `NotFound` (and any read failure, which
+/// proves nothing) leaves the mint parked for the next pass.
+async fn reconcile_unresolved_replay(
+    ctx: &MintRecoveryContext,
+    mint: &Mint,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(), MintRecoveryStepError> {
+    let Mint::MintingFailed {
+        underlying,
+        network,
+        wallet,
+        quantity,
+        mint_mode,
+        mint_authorization,
+        ..
+    } = mint
+    else {
+        return Ok(());
+    };
+    let (
+        VaultMode::Orchestrator { address: orchestrator },
+        Some(authorization),
+    ) = (mint_mode, mint_authorization)
+    else {
+        // `NonceReplayUnresolved` is only ever recorded for an
+        // orchestrator mint holding an authorization; anything else is an
+        // impossible replay and there is nothing to reconcile.
+        return Ok(());
+    };
+
+    let vault = resolve_vault(ctx, underlying, *network).await?;
+    let vault_service = ctx.vault_services.service(*network)?;
+    let amount = match quantity.to_u256_with_18_decimals() {
+        Ok(amount) => amount,
+        Err(error) => {
+            // Deterministic for the persisted quantity: reconciliation can
+            // never build the full-match query, so the mint stays parked
+            // and stuck-visible rather than looping a doomed conversion.
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Unresolved-replay quantity cannot convert to on-chain units"
+            );
+            return Ok(());
+        }
+    };
+
+    match vault_service
+        .find_orchestrator_minted_log(MintedLogQuery {
+            orchestrator: *orchestrator,
+            to: *wallet,
+            nonce: authorization.nonce,
+            token: vault.address,
+            amount,
+            lookback_blocks: Some(UNRESOLVED_REPLAY_LOOKBACK_BLOCKS),
+        })
+        .await
+    {
+        Ok(MintedLogScan::FullMatch(minted)) => {
+            info!(target: "mint", issuer_request_id = %issuer_request_id,
+                tx_hash = %minted.tx_hash,
+                nonce = %minted.nonce,
+                shares_minted = %minted.shares_minted,
+                "Widened reconciliation full-matched the unresolved replay; \
+                 recovering the landed mint"
+            );
+            ctx.mint_store
+                .send(
+                    issuer_request_id,
+                    MintCommand::RecordOrchestratorMintRecovered {
+                        issuer_request_id: issuer_request_id.clone(),
+                        tx_hash: minted.tx_hash,
+                        nonce: minted.nonce,
+                        shares_minted: minted.shares_minted,
+                        block_number: minted.block_number,
+                    },
+                )
+                .await?;
+        }
+        Ok(MintedLogScan::Mismatch) => {
+            error!(target: "mint", issuer_request_id = %issuer_request_id,
+                to = %wallet,
+                nonce = %authorization.nonce,
+                token = %vault.address,
+                amount = %amount,
+                "Widened reconciliation proved the nonce was consumed by a \
+                 different mint; manual reconciliation required"
+            );
+            ctx.mint_store
+                .send(
+                    issuer_request_id,
+                    MintCommand::RecordMintFailed {
+                        issuer_request_id: issuer_request_id.clone(),
+                        error: "widened Minted-log scan found the pair's \
+                                landing disagreeing on token/amount"
+                            .to_string(),
+                        classification:
+                            MintFailureClassification::NonceConsumedByOtherMint,
+                    },
+                )
+                .await?;
+        }
+        Ok(MintedLogScan::NotFound) => {
+            debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                nonce = %authorization.nonce,
+                "Widened reconciliation still found no Minted log at the \
+                 pair; the mint stays parked for the next pass"
+            );
+        }
+        Err(error) => {
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Unresolved-replay reconciliation lookup failed; the mint \
+                 stays parked for the next pass"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// `RetryMint` + enqueue `SubmitMintJob` — shared by free-prepare-safe and
 /// rebroadcast / replacement-authorized recovery paths under `MintingFailed`.
 async fn authorize_resubmit(
@@ -1455,11 +1765,14 @@ mod tests {
     use crate::mint::api::test_utils::{
         TestAccountAndAsset, TestHarness, network_vault_services,
     };
-    use crate::mint::tests::VAULT;
+    use crate::mint::tests::{
+        VAULT, orchestrator_events_through_minting_authorized,
+        orchestrator_events_through_tx_submitted, test_mint_authorization,
+    };
     use crate::mint::{
         ClientId, IssuerMintRequestId, MintEvent, MintExternalTxId,
         MintFailureClassification, Network, Quantity, TokenSymbol,
-        TokenizationRequestId, UnderlyingSymbol,
+        TokenizationRequestId, UnderlyingSymbol, has_unresolved_signer_intent,
     };
     use crate::receipt_inventory::{
         BurnPlan, BurnTrackingError, CqrsReceiptService, MintedReceiptParams,
@@ -1470,7 +1783,9 @@ mod tests {
     use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
     use crate::vault::mock::MockVaultService;
-    use crate::vault::{MintTxStatus, PreparedMintTx, VaultService};
+    use crate::vault::{
+        MintTxStatus, OrchestratorMintedLog, PreparedMintTx, VaultService,
+    };
 
     /// Configurable `ReceiptService` stub for recovery tests. Only
     /// `find_by_issuer_request_id` is behavior-specific; other methods are
@@ -1639,6 +1954,18 @@ mod tests {
         /// Override the vault service used by recovery (classification mocks).
         fn with_vault(self, vault: Arc<dyn VaultService>) -> Self {
             Self { vault_services: network_vault_services(vault), ..self }
+        }
+
+        /// Like [`Self::context`] but over a caller-configured vault mock —
+        /// the reconciliation tests steer the `Minted`-log verdict.
+        fn context_with_vault(
+            &self,
+            vault: Arc<dyn VaultService>,
+        ) -> MintRecoveryContext {
+            MintRecoveryContext {
+                vault_services: network_vault_services(vault),
+                ..self.context()
+            }
         }
 
         /// Seeds the event store with raw `Mint` events, putting the aggregate
@@ -1859,6 +2186,7 @@ mod tests {
             &issuer_request_id,
             backoff,
             max_no_progress_polls,
+            false,
         )
         .await;
         let elapsed = start.elapsed();
@@ -2095,6 +2423,7 @@ mod tests {
             &issuer_request_id,
             Duration::from_millis(1),
             2,
+            false,
         )
         .await;
 
@@ -2128,7 +2457,7 @@ mod tests {
         let fixture = MintRecoveryFixture::new().await;
         let issuer_request_id = test_issuer_request_id();
 
-        let result = MintRecoveryJob { issuer_request_id }
+        let result = MintRecoveryJob { issuer_request_id, manual: false }
             .perform(&fixture.context())
             .await;
 
@@ -2176,6 +2505,7 @@ mod tests {
             &issuer_request_id,
             Duration::from_millis(1),
             3,
+            false,
         )
         .await;
 
@@ -2220,6 +2550,7 @@ mod tests {
             &lookup_failure_id,
             Duration::from_millis(1),
             3,
+            false,
         )
         .await;
 
@@ -2267,6 +2598,7 @@ mod tests {
             &issuer_request_id,
             Duration::from_millis(1),
             3,
+            false,
         )
         .await;
 
@@ -2327,7 +2659,7 @@ mod tests {
         let fixture = MintRecoveryFixture::new().await;
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
-        let error = MintRecoveryJob { issuer_request_id }
+        let error = MintRecoveryJob { issuer_request_id, manual: false }
             .perform(&fixture.context())
             .await
             .expect_err("an exhausted mint must abort, not resolve");
@@ -3594,6 +3926,497 @@ mod tests {
         assert!(logs_contain_at!(
             Level::WARN,
             &[test, "Cannot recover signer", "fail closed"]
+        ));
+    }
+
+    /// Typed classifications are never auto-retried: the scheduled loop
+    /// retires as `Resolved` before any wakeup/budget bookkeeping, leaves
+    /// the classified failure untouched, and enqueues no per-state job. The
+    /// `failed_at` is far in the past, so an `Unclassified` failure would be
+    /// `Ready` — proving the skip comes from the classification, not the
+    /// retry window (the no-progress test above is that contrast: same-age
+    /// `Unclassified` failures keep driving).
+    #[traced_test]
+    #[tokio::test]
+    async fn scheduled_recovery_skips_classified_mint_failure() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::hours(24);
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "confirmation failed".to_string(),
+            failed_at,
+            classification: MintFailureClassification::VaultLogicMismatch,
+        });
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            8,
+            false,
+        )
+        .await;
+
+        assert!(
+            matches!(conclusion, RecoveryConclusion::Resolved),
+            "a classified failure must retire the job as Resolved"
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::VaultLogicMismatch,
+                    ..
+                }
+            ),
+            "the classified failure must be left untouched, got: {}",
+            mint.state_name()
+        );
+
+        let queued_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(&fixture.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            queued_jobs, 0,
+            "the classified skip must not enqueue any per-state job"
+        );
+
+        let test = "scheduled_recovery_skips_classified_mint_failure";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Skipping non-retryable classified mint failure"]
+        ));
+    }
+
+    /// The admin reprocess path reaches the same recovery loop that skips
+    /// classified failures, so its job carries the `manual` flag: one
+    /// re-drive is spent on the classified mint (`RetryMint` fires, a
+    /// submission job is enqueued) instead of retiring as a silent no-op —
+    /// the endpoint's "recovery initiated" answer must mean something ran.
+    #[traced_test]
+    #[tokio::test]
+    async fn manual_recovery_redrives_classified_mint_failure_once() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::hours(24);
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "nonce consumed by another mint".to_string(),
+            failed_at,
+            classification: MintFailureClassification::NonceConsumedByOtherMint,
+        });
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            8,
+            true,
+        )
+        .await;
+
+        // No worker drains the enqueued submission in this fixture, so the
+        // loop exhausts its no-progress budget — the point is that the
+        // re-drive actually ran, unlike the automatic path's silent skip.
+        assert!(
+            matches!(
+                conclusion,
+                RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::NoProgressBudgetExhausted
+                }
+            ),
+            "expected the fixture loop to stop on its no-progress budget, \
+             got {conclusion:?}"
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "the operator re-drive must retry the classified failure back \
+             into Minting, got: {}",
+            mint.state_name()
+        );
+
+        let submit_jobs: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE job_type = ?
+            ",
+        )
+        .bind(job_type::<SubmitMintJob>())
+        .fetch_one(&fixture.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            submit_jobs, 1,
+            "the manual re-drive must enqueue exactly one submission job"
+        );
+
+        let test = "manual_recovery_redrives_classified_mint_failure_once";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Operator-requested re-drive"]
+        ));
+    }
+
+    /// A deterministic recipient-authorization failure resubmitted with the
+    /// same stored authorization reverts identically — the re-drive must be
+    /// refused outright (no `RetryMint`, no submission job, no wallet nonce
+    /// burned), leaving `CloseMint` + a fresh `Initiate` as the only path.
+    #[traced_test]
+    #[tokio::test]
+    async fn manual_recovery_refuses_deterministic_authorization_failure() {
+        let issuer_request_id = test_issuer_request_id();
+        let mut events =
+            orchestrator_events_through_tx_submitted(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "BadRecipientSignature()".to_string(),
+            failed_at: Utc::now() - chrono::Duration::hours(24),
+            classification: MintFailureClassification::BadRecipientSignature,
+        });
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            8,
+            true,
+        )
+        .await;
+
+        assert!(
+            matches!(conclusion, RecoveryConclusion::Resolved),
+            "the refused re-drive must retire the job cleanly, got \
+             {conclusion:?}"
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::BadRecipientSignature,
+                    ..
+                }
+            ),
+            "the deterministic failure must be left untouched, got: {}",
+            mint.state_name()
+        );
+
+        let queued_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(&fixture.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            queued_jobs, 0,
+            "a refused re-drive must not enqueue any submission"
+        );
+
+        let test =
+            "manual_recovery_refuses_deterministic_authorization_failure";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                test,
+                "Refusing re-drive of a deterministic",
+                "re-initiate with fresh authorization"
+            ]
+        ));
+    }
+
+    fn unresolved_replay_events(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events =
+            orchestrator_events_through_tx_submitted(issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "nonce consumed with no log at the pair".to_string(),
+            failed_at: Utc::now() - chrono::Duration::hours(24),
+            classification: MintFailureClassification::NonceReplayUnresolved,
+        });
+        events
+    }
+
+    /// A widened reconciliation that full-matches resolves the unresolved
+    /// replay forward: the landed mint is recorded and the loop keeps
+    /// driving it (the callback job is enqueued) — no resubmission ever
+    /// happens.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciliation_resolves_unresolved_replay_forward() {
+        let issuer_request_id = test_issuer_request_id();
+        let fixture = MintRecoveryFixture::new().await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id,
+                unresolved_replay_events(&issuer_request_id),
+            )
+            .await;
+
+        let vault = Arc::new(MockVaultService::new_success().with_minted_log(
+            OrchestratorMintedLog {
+                tx_hash: B256::repeat_byte(0xcc),
+                nonce: test_mint_authorization().nonce,
+                shares_minted: U256::from(100u64)
+                    * U256::from(10u64).pow(U256::from(18u64)),
+                block_number: 777,
+            },
+        ));
+
+        recover_mint_until_automatic_budget_exhausted(
+            &fixture.context_with_vault(vault.clone()),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            2,
+            false,
+        )
+        .await;
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "a full-matched reconciliation must resolve the mint forward, \
+             got: {}",
+            mint.state_name()
+        );
+        let callback_jobs: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE job_type = ?
+            ",
+        )
+        .bind(job_type::<SendCallbackJob>())
+        .fetch_one(&fixture.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            callback_jobs, 1,
+            "the resolved mint must be driven on to its callback"
+        );
+
+        let test = "reconciliation_resolves_unresolved_replay_forward";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Widened reconciliation full-matched"]
+        ));
+    }
+
+    /// Full-path regression for the release-trigger migration: a crash after
+    /// `MintTxIntended` leaves the signer reservation held with no
+    /// `MintTxSubmitted` ever committing; when reconciliation proves the
+    /// landing and records `OrchestratorMintRecovered`, the reservation must
+    /// release — otherwise every later mint and burn on the network is
+    /// rejected until an operator close.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciled_recovery_releases_the_held_signer_reservation() {
+        let issuer_request_id = test_issuer_request_id();
+        let fixture = MintRecoveryFixture::new().await;
+        let mut events =
+            orchestrator_events_through_minting_authorized(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: Utc::now(),
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "nonce consumed with no log at the pair".to_string(),
+            failed_at: Utc::now() - chrono::Duration::hours(24),
+            classification: MintFailureClassification::NonceReplayUnresolved,
+        });
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        assert!(
+            has_unresolved_signer_intent(&fixture.pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "the crash-after-intent history must hold the reservation"
+        );
+
+        let vault = Arc::new(MockVaultService::new_success().with_minted_log(
+            OrchestratorMintedLog {
+                tx_hash: B256::repeat_byte(0xcc),
+                nonce: test_mint_authorization().nonce,
+                shares_minted: U256::from(100u64)
+                    * U256::from(10u64).pow(U256::from(18u64)),
+                block_number: 777,
+            },
+        ));
+
+        recover_mint_until_automatic_budget_exhausted(
+            &fixture.context_with_vault(vault),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            2,
+            false,
+        )
+        .await;
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "the full-matched reconciliation must resolve the mint forward, \
+             got: {}",
+            mint.state_name()
+        );
+        assert!(
+            !has_unresolved_signer_intent(&fixture.pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "OrchestratorMintRecovered must release the signer reservation"
+        );
+    }
+
+    /// A widened reconciliation that finds the pair's landing disagreeing on
+    /// amount upgrades the verdict to the PROVEN `NonceConsumedByOtherMint`
+    /// — which then parks manual-only; nothing is ever resubmitted.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciliation_upgrades_unresolved_replay_to_proven_mismatch() {
+        let issuer_request_id = test_issuer_request_id();
+        let fixture = MintRecoveryFixture::new().await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id,
+                unresolved_replay_events(&issuer_request_id),
+            )
+            .await;
+
+        let vault = Arc::new(MockVaultService::new_success().with_minted_log(
+            OrchestratorMintedLog {
+                tx_hash: B256::repeat_byte(0xcc),
+                nonce: test_mint_authorization().nonce,
+                shares_minted: U256::from(1u8),
+                block_number: 777,
+            },
+        ));
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context_with_vault(vault.clone()),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            4,
+            false,
+        )
+        .await;
+
+        assert!(
+            matches!(conclusion, RecoveryConclusion::Resolved),
+            "the upgraded verdict must retire via the manual-only skip, got \
+             {conclusion:?}"
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceConsumedByOtherMint,
+                    ..
+                }
+            ),
+            "the mismatching landing must upgrade the classification, got: \
+             {mint:?}"
+        );
+        let queued_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(&fixture.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            queued_jobs, 0,
+            "an upgraded verdict must never enqueue a submission"
+        );
+
+        let test =
+            "reconciliation_upgrades_unresolved_replay_to_proven_mismatch";
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[test, "proved the nonce was consumed by a different mint"]
+        ));
+    }
+
+    /// A widened reconciliation that still finds nothing leaves the mint
+    /// parked — one query per pass, no state change, no submission — for
+    /// the reconciler's next pass.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconciliation_leaves_still_unresolved_replay_parked() {
+        let issuer_request_id = test_issuer_request_id();
+        let fixture = MintRecoveryFixture::new().await;
+        fixture
+            .seed_mint_events(
+                &issuer_request_id,
+                unresolved_replay_events(&issuer_request_id),
+            )
+            .await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context_with_vault(vault.clone()),
+            &issuer_request_id,
+            Duration::from_millis(5),
+            4,
+            false,
+        )
+        .await;
+
+        assert!(
+            matches!(conclusion, RecoveryConclusion::Resolved),
+            "a still-unresolved replay must retire the pass cleanly, got \
+             {conclusion:?}"
+        );
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceReplayUnresolved,
+                    ..
+                }
+            ),
+            "a still-empty scan must leave the mint parked unchanged, got: \
+             {mint:?}"
+        );
+        let queued_jobs: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Jobs")
+            .fetch_one(&fixture.pool)
+            .await
+            .unwrap();
+        assert_eq!(
+            queued_jobs, 0,
+            "an unresolved replay must never enqueue a submission"
+        );
+
+        let test = "reconciliation_leaves_still_unresolved_replay_parked";
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[test, "still found no Minted log"]
         ));
     }
 }

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -335,7 +335,16 @@ const fn tokenization_id_candidate_query() -> &'static str {
 
 /// Finds all mints that need recovery (not in terminal states).
 ///
-/// Returns mints in JournalConfirmed, Minting, MintingFailed, or CallbackPending states.
+/// Returns mints in JournalConfirmed, Minting, MintingFailed, or
+/// CallbackPending states. A `MintingFailed` with a typed classification is
+/// excluded: it is never auto-retried, so returning it would only make the
+/// reconciler re-enqueue the same skipped job every pass (the recovery
+/// driver's `ManualOnly` arm stays as the defense if one slips through).
+/// Classified failures remain operator-visible via [`find_stuck`]. The one
+/// classified EXCEPTION is `NonceReplayUnresolved`: recovery keeps
+/// reconciling it (a widened `Minted`-log re-query, never a resubmission),
+/// so it stays in the recoverable set (SPEC "Recipient Authorization" ->
+/// "Nonce").
 pub(crate) async fn find_all_recoverable_mints(
     pool: &Pool<Sqlite>,
 ) -> Result<Vec<(IssuerMintRequestId, MintView)>, MintViewError> {
@@ -357,7 +366,12 @@ pub(crate) async fn find_all_recoverable_mints(
                         | MintView::Minting { .. }
                         | MintView::MintIntended { .. }
                         | MintView::MintTxSubmitted { .. }
-                        | MintView::MintingFailed { .. }
+                        | MintView::MintingFailed {
+                            classification:
+                                MintFailureClassification::Unclassified
+                                    | MintFailureClassification::NonceReplayUnresolved,
+                            ..
+                        }
                         | MintView::CallbackPending { .. }
                 ))
             ) || result.is_err()
@@ -996,6 +1010,84 @@ mod tests {
         let pool = setup_test_db().await;
         let results = find_all_recoverable_mints(&pool).await.unwrap();
         assert!(results.is_empty());
+    }
+
+    /// A `MintingFailed` carrying a typed classification is never
+    /// auto-retried, so the recoverable query excludes it — otherwise the
+    /// reconciler would re-enqueue the same skipped job every pass. It must
+    /// still surface to the operator via `find_stuck`.
+    #[tokio::test]
+    async fn test_find_all_recoverable_mints_excludes_classified_failures() {
+        let pool = setup_test_db().await;
+        let now = Utc::now();
+        let fields = test_mint_fields();
+        let classified_id = fields.issuer_request_id.clone();
+        insert_mint_view(
+            &pool,
+            &classified_id,
+            &MintView::MintingFailed {
+                issuer_request_id: classified_id.clone(),
+                tokenization_request_id: fields.tokenization_request_id.clone(),
+                quantity: fields.quantity.clone(),
+                underlying: fields.underlying.clone(),
+                token: fields.token.clone(),
+                network: fields.network,
+                client_id: fields.client_id,
+                wallet: fields.wallet,
+                initiated_at: fields.initiated_at,
+                journal_confirmed_at: now,
+                error: "nonce consumed by another mint".to_string(),
+                failed_at: now,
+                classification:
+                    MintFailureClassification::NonceConsumedByOtherMint,
+            },
+        )
+        .await;
+
+        // The one classified exception: an unresolved replay stays in the
+        // recoverable set so the reconciler keeps scheduling its widened
+        // `Minted`-log re-query (never a resubmission).
+        let unresolved_fields = test_mint_fields();
+        let unresolved_id = unresolved_fields.issuer_request_id.clone();
+        insert_mint_view(
+            &pool,
+            &unresolved_id,
+            &MintView::MintingFailed {
+                issuer_request_id: unresolved_id.clone(),
+                tokenization_request_id: unresolved_fields
+                    .tokenization_request_id
+                    .clone(),
+                quantity: unresolved_fields.quantity.clone(),
+                underlying: unresolved_fields.underlying.clone(),
+                token: unresolved_fields.token.clone(),
+                network: unresolved_fields.network,
+                client_id: unresolved_fields.client_id,
+                wallet: unresolved_fields.wallet,
+                initiated_at: unresolved_fields.initiated_at,
+                journal_confirmed_at: now,
+                error: "nonce consumed with no log at the pair".to_string(),
+                failed_at: now,
+                classification:
+                    MintFailureClassification::NonceReplayUnresolved,
+            },
+        )
+        .await;
+
+        let recoverable = find_all_recoverable_mints(&pool).await.unwrap();
+        assert!(
+            !recoverable.iter().any(|(id, _)| id == &classified_id),
+            "a proven classified failure must not be auto-recoverable"
+        );
+        assert!(
+            recoverable.iter().any(|(id, _)| id == &unresolved_id),
+            "an unresolved replay must stay recoverable for reconciliation"
+        );
+
+        let stuck = find_stuck(&pool).await.unwrap();
+        assert!(
+            stuck.iter().any(|(id, _)| id == &classified_id),
+            "the classified failure must stay operator-visible in find_stuck"
+        );
     }
 
     #[tokio::test]

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -205,6 +205,17 @@ struct OrchestratorMockState {
     /// (`nonce`, `shares_minted`) cannot express.
     #[cfg(test)]
     minted_log_binding: Mutex<Option<(Address, Address, Address)>>,
+    /// Override for `nonce_used`; `None` mirrors the chain by deriving from
+    /// whether the configured `minted_log` carries the queried nonce.
+    #[cfg(test)]
+    nonce_used: Mutex<Option<bool>>,
+    /// When set, `nonce_used` fails with an RPC-style error.
+    #[cfg(test)]
+    nonce_used_should_error: Mutex<bool>,
+    /// When set, `find_orchestrator_minted_log` fails with an RPC-style
+    /// error.
+    #[cfg(test)]
+    find_minted_log_should_error: Mutex<bool>,
     /// When set, `validate_mint_authorization` fails with this outcome.
     #[cfg(test)]
     mint_auth_failure: Mutex<Option<MockMintAuthFailure>>,
@@ -567,6 +578,9 @@ impl MockVaultService {
         *self.orchestrator.mint_confirm_revert.lock().unwrap() = None;
         *self.orchestrator.minted_log.lock().unwrap() = None;
         *self.orchestrator.minted_log_binding.lock().unwrap() = None;
+        *self.orchestrator.nonce_used.lock().unwrap() = None;
+        *self.orchestrator.nonce_used_should_error.lock().unwrap() = false;
+        *self.orchestrator.find_minted_log_should_error.lock().unwrap() = false;
         *self.orchestrator.mint_auth_failure.lock().unwrap() = None;
         *self.orchestrator.mint_auth_hang.lock().unwrap() = false;
         *self.orchestrator.last_mint_params.lock().unwrap() = None;
@@ -887,6 +901,29 @@ impl MockVaultService {
         result: OrchestratorMintResult,
     ) -> Self {
         *self.orchestrator.pending_mint_result.lock().unwrap() = Some(result);
+        self
+    }
+
+    /// Overrides the `nonce_used` consumed flag, e.g. `true` with no (or a
+    /// non-matching) `minted_log` exercises the consumed-but-unproven path.
+    #[cfg(test)]
+    pub(crate) fn with_nonce_used(self, consumed: bool) -> Self {
+        *self.orchestrator.nonce_used.lock().unwrap() = Some(consumed);
+        self
+    }
+
+    /// Configures `nonce_used` to fail with an RPC-style error.
+    #[cfg(test)]
+    pub(crate) fn with_nonce_used_error(self) -> Self {
+        *self.orchestrator.nonce_used_should_error.lock().unwrap() = true;
+        self
+    }
+
+    /// Configures `find_orchestrator_minted_log` to fail with an RPC-style
+    /// error.
+    #[cfg(test)]
+    pub(crate) fn with_find_minted_log_error(self) -> Self {
+        *self.orchestrator.find_minted_log_should_error.lock().unwrap() = true;
         self
     }
 
@@ -1913,6 +1950,9 @@ impl VaultService for MockVaultService {
             self.orchestrator
                 .find_minted_log_call_count
                 .fetch_add(1, Ordering::Relaxed);
+            if *self.orchestrator.find_minted_log_should_error.lock().unwrap() {
+                return Err(VaultError::InvalidReceipt);
+            }
             // Mirror the real scan's three-way verdict. The stored log
             // carries `nonce`/`shares_minted`; the optional
             // `(orchestrator, to, token)` binding stands in for the address
@@ -1949,6 +1989,39 @@ impl VaultService for MockVaultService {
         {
             let _ = (nonce, amount);
             Ok(MintedLogScan::NotFound)
+        }
+    }
+
+    async fn nonce_used(
+        &self,
+        _orchestrator: Address,
+        _to: Address,
+        nonce: B256,
+    ) -> Result<bool, VaultError> {
+        #[cfg(test)]
+        {
+            if *self.orchestrator.nonce_used_should_error.lock().unwrap() {
+                return Err(VaultError::InvalidReceipt);
+            }
+            let value = *self.orchestrator.nonce_used.lock().unwrap();
+            if let Some(overridden) = value {
+                return Ok(overridden);
+            }
+            // Mirror the chain by default: a configured landed log carrying
+            // this nonce means the nonce is consumed.
+            return Ok(self
+                .orchestrator
+                .minted_log
+                .lock()
+                .unwrap()
+                .as_ref()
+                .is_some_and(|log| log.nonce == nonce));
+        }
+
+        #[cfg(not(test))]
+        {
+            let _ = nonce;
+            Ok(false)
         }
     }
 

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -328,6 +328,20 @@ pub(crate) trait VaultService: Send + Sync {
         Err(VaultError::InvalidReceipt)
     }
 
+    /// Reads the orchestrator's `nonceUsed(to, nonce)` consumed flag — the
+    /// single cheap read gating [`Self::find_orchestrator_minted_log`]'s
+    /// full lookback scan: `false` proves nothing can have landed under this
+    /// mint's nonce (the on-chain uniqueness key), so the scan is skipped on
+    /// every ordinary first submission.
+    async fn nonce_used(
+        &self,
+        _orchestrator: Address,
+        _to: Address,
+        _nonce: B256,
+    ) -> Result<bool, VaultError> {
+        Err(VaultError::InvalidReceipt)
+    }
+
     /// Validates a delivered recipient authorization before it is stored:
     /// the signature must recover to `query.to` over the orchestrator's own
     /// `mintAuthDigest(token, to, amount, nonce)` (ECDSA, or ERC-1271 when
@@ -563,6 +577,39 @@ impl PreparedMintTx {
     pub(crate) fn signer_for_test(&self) -> Address {
         self.recover_signer()
             .expect("test mint transaction signature should recover")
+    }
+
+    /// Like [`Self::valid_for_test`] but GENUINELY signed (fixed test key),
+    /// so tests exercising signer recovery — the admin close gate's
+    /// proof-of-cannot-land classification — get a recoverable signature.
+    #[cfg(test)]
+    pub(crate) fn signed_for_test(nonce: u64, external_tx_id: String) -> Self {
+        use alloy::signers::SignerSync;
+        use alloy::signers::local::PrivateKeySigner;
+
+        let transaction = TxLegacy {
+            chain_id: Some(1),
+            nonce,
+            gas_price: 1,
+            gas_limit: 21_000,
+            to: TxKind::Call(Address::ZERO),
+            value: U256::ZERO,
+            input: Bytes::new(),
+        };
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(0x42))
+            .expect("fixed test key is valid");
+        let signature = signer
+            .sign_hash_sync(&transaction.signature_hash())
+            .expect("fixed test key signs");
+        let envelope = TxEnvelope::from(transaction.into_signed(signature));
+
+        Self {
+            tx: envelope.encoded_2718(),
+            hash: *envelope.tx_hash(),
+            nonce: envelope.nonce(),
+            signed_at: Utc::now(),
+            external_tx_id,
+        }
     }
 }
 

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -1330,6 +1330,16 @@ impl VaultService for RealBlockchainService {
         }
     }
 
+    async fn nonce_used(
+        &self,
+        orchestrator: Address,
+        to: Address,
+        nonce: B256,
+    ) -> Result<bool, VaultError> {
+        let contract = IST0xOrchestratorV1::new(orchestrator, &self.provider);
+        Ok(contract.nonceUsed(to, nonce).call().await?)
+    }
+
     async fn validate_mint_authorization(
         &self,
         query: MintedLogQuery,


### PR DESCRIPTION
## Motivation

Orchestrator mints follow a different custody model than vault-direct mints: the orchestrator holds custody of the on-chain receipt rather than the bot, so the existing vault-direct recovery paths (receipt lookup, `RecoverFromReceipt`) cannot be used for them. Without orchestrator-aware recovery, a failed orchestrator mint has no safe path to completion or closure — resubmitting blindly risks double-minting, and closing blindly risks stranding real backed tokens unreported to Alpaca.

Additionally, certain failure classifications (e.g. `NonceConsumedByOtherMint`, `VaultLogicMismatch`) require manual operator intervention and must never be automatically retried, but the automatic retry scheduler had no way to express this distinction.

## Solution

**Orchestrator recovery paths:**

- `TxIntended` and `Minting` recovery now branch on `VaultMode`: vault-direct uses the existing receipt lookup; orchestrator mints use a new `recover_from_landed_orchestrator_mint` helper that queries for a landed `Minted` log full-matching `(to, nonce, token, amount)` as the double-mint guard before any resubmission.
- A new `confirm_recovery_orchestrator_mint` method handles the known-tx confirmation branch for orchestrator mints. A `NonceReplayed` revert here — after the landed-log pre-check found nothing — means a different mint consumed the nonce, which produces a `NonceConsumedByOtherMint` classified failure requiring manual reconciliation rather than a resubmission. Any other confirmed revert consumed nothing, so a fresh transaction is submitted. Transient errors defer to the next pass.
- The existing `confirm_recovery_vault_direct_mint` logic is extracted into its own method to keep the two paths cleanly separated.
- `RecoverFromReceipt` now explicitly rejects orchestrator mints with `MintModeMismatch`, since the bot never custodies a receipt for them and a receipt-discovery delivery would be a mis-attribution.

**Classified failure handling:**

`AutomaticRetryDecision::ManualOnly(classification)` stops the scheduler and reconciler on any typed classification before budget bookkeeping; halt classifications don't advance the attempt counter (per SPEC); the admin reprocess endpoint pushes a `manual`\-flagged recovery job that spends exactly one re-drive of a classified failure, so "recovery initiated" always means something ran. `RecordExistingMint` rejects orchestrator-anchored mints (`MintModeMismatch`) and the submit job treats that rejection as terminal. **Safe close for orchestrator mints:** the pre-close check gates on `nonceUsed` (unbounded non-landing proof), full-matches the bounded `Minted`\-log scan, honours the adjudicated `NonceConsumedByOtherMint` verdict, and otherwise fails closed (`MintLanded` / `LandingUnproven` 422s; lookup errors refuse with 500). Vault-direct closes are untouched. Adds the `nonce_used` vault read and the `Mint::mint_authorization` accessor.

**Safe close for orchestrator mints:**

- `handle_close_mint` is made `async` and now runs the landed-`Minted`\-log check for orchestrator mints that have received an authorization. A full-match refuses the close with `CloseRefusedMintLanded` — the operator must run recovery instead. A lookup failure also refuses the close (fail-closed). Vault-direct closes are unchanged and never run the check.

**New** **`mint_authorization`** **accessor:**

- A `mint_authorization` const accessor is added to `Mint` to allow the close handler and other callers to retrieve the delivered authorization without pattern-matching every state.

Closes [RAI-1618](https://linear.app/makeitrain/issue/RAI-1618/orchestrator-mint-recovery-with-classified-failure-handling)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safer mint closure validation using transaction, receipt, nonce, and event checks.
  - Added nonce acknowledgement support for unresolved replay cases.
  - Added manual mint recovery options for eligible failures.

- **Bug Fixes**
  - Prevented closure when mint completion cannot be proven or verification fails.
  - Stopped futile automatic retries for deterministic authorization failures.
  - Improved recovery reconciliation for unresolved nonce replays.

- **Tests**
  - Expanded coverage for closure validation, recovery decisions, reconciliation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->