### PR TITLE
Add `VaultModeTag` field to `TokenizedAssetStatusResponse`

### DIFF
--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -136,7 +136,7 @@ impl IssuanceClient {
 mod tests {
     use httpmock::prelude::*;
     use serde_json::json;
-    use st0x_issuance_dto::TokenizedAssetStatus;
+    use st0x_issuance_dto::{TokenizedAssetStatus, VaultModeTag};
 
     use super::*;
 
@@ -157,7 +157,8 @@ mod tests {
                 .header(API_KEY_HEADER, "test-key");
             then.status(200).json_body(json!({
                 "underlying": "SGOV",
-                "status": "frozen"
+                "status": "frozen",
+                "vault_mode": "orchestrator"
             }));
         });
 
@@ -170,6 +171,10 @@ mod tests {
         mock.assert();
         assert_eq!(status.underlying, UnderlyingSymbol::new("SGOV").unwrap());
         assert_eq!(status.status, TokenizedAssetStatus::Frozen);
+        // The mode tag is what st0x.liquidity switches its mint flow on —
+        // this is the cross-repo path, so the client must surface it, not
+        // merely tolerate it.
+        assert_eq!(status.vault_mode, VaultModeTag::Orchestrator);
     }
 
     #[tokio::test]

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -310,6 +310,28 @@ pub enum TokenizedAssetStatus {
     Frozen,
 }
 
+/// Which minting path the issuance bot uses for an asset.
+///
+/// The liquidity bot's cue for which assets need a signed `MintAuthV1`
+/// delivered before their mints can submit: `Orchestrator` assets do,
+/// `VaultDirect` assets do not. Deliberately omits the orchestrator address —
+/// consumers only need the tag; the issuance bot's config stays the single
+/// source of truth for addresses during the cutover.
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, TS,
+)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+#[serde(rename_all = "snake_case")]
+pub enum VaultModeTag {
+    /// Mints deposit directly into the vault; no recipient authorization.
+    /// The default: a server that predates the field can only vault-direct.
+    #[default]
+    VaultDirect,
+    /// Mints go through the ST0xOrchestrator and require a recipient
+    /// authorization before submission.
+    Orchestrator,
+}
+
 /// Per-asset status, returned by
 /// `GET /tokenized-assets/<underlying>/status` and consumed by the liquidity
 /// rebalance guard.
@@ -318,6 +340,14 @@ pub enum TokenizedAssetStatus {
 pub struct TokenizedAssetStatusResponse {
     pub underlying: UnderlyingSymbol,
     pub status: TokenizedAssetStatus,
+    /// Additive: absent in responses from servers that predate the field,
+    /// which only ever mint vault-direct — so the default is truthful. The
+    /// TS binding mirrors that absence-tolerance as an optional field
+    /// (`vault_mode?`), so a consumer generated from it handles the
+    /// rolling-deploy window where a pre-field server omits the value.
+    #[serde(default)]
+    #[ts(as = "Option<VaultModeTag>", optional)]
+    pub vault_mode: VaultModeTag,
 }
 
 /// One entry in the `GET /tokenized-assets` list.
@@ -366,6 +396,7 @@ pub fn export_bindings(out_dir: &Path) -> Result<(), ts_rs::ExportError> {
     AssetKey::export_all_to(out_dir)?;
     TokenizedAssetDetailResponse::export_all_to(out_dir)?;
     TokenizedAssetStatus::export_all_to(out_dir)?;
+    VaultModeTag::export_all_to(out_dir)?;
     TokenizedAssetStatusResponse::export_all_to(out_dir)?;
     TokenizedAssetResponse::export_all_to(out_dir)?;
     TokenizedAssetsListResponse::export_all_to(out_dir)?;
@@ -540,23 +571,70 @@ mod tests {
         let response = TokenizedAssetStatusResponse {
             underlying: UnderlyingSymbol::new("SGOV").unwrap(),
             status: TokenizedAssetStatus::Frozen,
+            vault_mode: VaultModeTag::Orchestrator,
         };
 
         assert_eq!(
             serde_json::to_value(&response).unwrap(),
-            json!({"underlying": "SGOV", "status": "frozen"})
+            json!({
+                "underlying": "SGOV",
+                "status": "frozen",
+                "vault_mode": "orchestrator"
+            })
         );
     }
 
     #[test]
     fn status_response_deserializes_from_wire() {
+        let response: TokenizedAssetStatusResponse =
+            serde_json::from_value(json!({
+                "underlying": "SGOV",
+                "status": "enabled",
+                "vault_mode": "vault_direct"
+            }))
+            .unwrap();
+
+        assert_eq!(response.underlying, UnderlyingSymbol::new("SGOV").unwrap());
+        assert_eq!(response.status, TokenizedAssetStatus::Enabled);
+        assert_eq!(response.vault_mode, VaultModeTag::VaultDirect);
+    }
+
+    /// A response from a server that predates `vault_mode` still parses —
+    /// and defaults to `VaultDirect`, the only mode such a server can mint.
+    #[test]
+    fn status_response_without_vault_mode_defaults_to_vault_direct() {
         let response: TokenizedAssetStatusResponse = serde_json::from_value(
             json!({"underlying": "SGOV", "status": "enabled"}),
         )
         .unwrap();
 
-        assert_eq!(response.underlying, UnderlyingSymbol::new("SGOV").unwrap());
-        assert_eq!(response.status, TokenizedAssetStatus::Enabled);
+        assert_eq!(response.vault_mode, VaultModeTag::VaultDirect);
+    }
+
+    /// The wire format is snake_case, mirroring `TokenizedAssetStatus`: the
+    /// PascalCase domain spelling and unknown variants must fail loudly.
+    #[test]
+    fn vault_mode_tag_rejects_non_snake_case_and_unknown_variants() {
+        for invalid in
+            [json!("VaultDirect"), json!("Orchestrator"), json!("direct")]
+        {
+            assert!(
+                serde_json::from_value::<VaultModeTag>(invalid.clone())
+                    .is_err(),
+                "{invalid} must not deserialize as VaultModeTag"
+            );
+        }
+
+        assert_eq!(
+            serde_json::from_value::<VaultModeTag>(json!("vault_direct"))
+                .unwrap(),
+            VaultModeTag::VaultDirect
+        );
+        assert_eq!(
+            serde_json::from_value::<VaultModeTag>(json!("orchestrator"))
+                .unwrap(),
+            VaultModeTag::Orchestrator
+        );
     }
 
     // The wire format is snake_case: the PascalCase domain spelling (`Enabled`,
@@ -739,6 +817,22 @@ mod tests {
             status_enum_ts.contains("\"enabled\"")
                 && status_enum_ts.contains("\"frozen\""),
             "TokenizedAssetStatus must be an \"enabled\" | \"frozen\" union in TS:\n{status_enum_ts}"
+        );
+
+        // Optional (`vault_mode?`), mirroring the serde default: a pre-field
+        // server omits the value, and a generated consumer must not assume
+        // it is always present during that rolling-deploy window.
+        assert!(
+            status_ts.contains("vault_mode?: VaultModeTag"),
+            "vault_mode must be an OPTIONAL reference to the VaultModeTag \
+             union in TS:\n{status_ts}"
+        );
+        let vault_mode_ts =
+            std::fs::read_to_string(out_dir.join("VaultModeTag.ts")).unwrap();
+        assert!(
+            vault_mode_ts.contains("\"vault_direct\"")
+                && vault_mode_ts.contains("\"orchestrator\""),
+            "VaultModeTag must be a \"vault_direct\" | \"orchestrator\" union in TS:\n{vault_mode_ts}"
         );
 
         // `Network` is a closed enum, so ts_rs must emit a string-literal union

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -40,6 +40,7 @@ expressed as an OpenAPI scheme."
         st0x_issuance_dto::TokenizedAssetDetailResponse,
         st0x_issuance_dto::TokenizedAssetStatusResponse,
         st0x_issuance_dto::TokenizedAssetStatus,
+        st0x_issuance_dto::VaultModeTag,
         st0x_issuance_dto::AddTokenizedAssetRequest,
         st0x_issuance_dto::AddTokenizedAssetResponse,
         st0x_issuance_dto::UnderlyingSymbol,
@@ -223,6 +224,19 @@ mod tests {
             schemas["MintAuthorizationResponse"]["properties"]["issuer_request_id"]
                 ["type"],
             "string"
+        );
+        assert_eq!(schemas["VaultModeTag"]["type"], "string");
+        assert_eq!(
+            schemas["VaultModeTag"]["enum"],
+            serde_json::json!(["vault_direct", "orchestrator"])
+        );
+        // The parent must actually carry the field: registering the enum
+        // component alone would keep the assertions above green even if a
+        // derive regression dropped `vault_mode` from the status response.
+        assert_eq!(
+            schemas["TokenizedAssetStatusResponse"]["properties"]["vault_mode"]
+                ["$ref"],
+            "#/components/schemas/VaultModeTag"
         );
     }
 }

--- a/src/tokenized_asset/api.rs
+++ b/src/tokenized_asset/api.rs
@@ -6,7 +6,7 @@ use sqlx::{Pool, Sqlite};
 use st0x_issuance_dto::{
     AddTokenizedAssetRequest, AddTokenizedAssetResponse, AssetKey,
     TokenizedAssetDetailResponse, TokenizedAssetResponse,
-    TokenizedAssetStatusResponse, TokenizedAssetsListResponse,
+    TokenizedAssetStatusResponse, TokenizedAssetsListResponse, VaultModeTag,
 };
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -18,7 +18,19 @@ use super::{
 };
 use crate::auth::{InternalAuth, IssuerAuth};
 use crate::chain::ConfiguredNetworks;
+use crate::config::{Config, VaultMode};
 use crate::underlying::load_freeze_status;
+
+impl From<VaultMode> for VaultModeTag {
+    fn from(mode: VaultMode) -> Self {
+        match mode {
+            VaultMode::VaultDirect => Self::VaultDirect,
+            // The tag deliberately drops the orchestrator address — the
+            // liquidity bot only needs to know an authorization is required.
+            VaultMode::Orchestrator { .. } => Self::Orchestrator,
+        }
+    }
+}
 
 fn merge_token_listing(
     views: Vec<TokenizedAssetView>,
@@ -141,12 +153,13 @@ pub(crate) async fn get_tokenized_asset(
     ),
     security(("internal_api_key" = []))
 )]
-#[tracing::instrument(skip(_auth, pool))]
+#[tracing::instrument(skip(_auth, pool, config))]
 #[get("/tokenized-assets/<underlying>/status")]
 pub(crate) async fn get_tokenized_asset_status(
     underlying: &str,
     _auth: InternalAuth,
     pool: &rocket::State<Pool<Sqlite>>,
+    config: &rocket::State<Config>,
 ) -> Result<Json<TokenizedAssetStatusResponse>, Status> {
     let underlying = UnderlyingSymbol::new(underlying)
         .map_err(|_| Status::UnprocessableEntity)?;
@@ -177,7 +190,13 @@ pub(crate) async fn get_tokenized_asset_status(
             Status::InternalServerError
         })?;
 
-    Ok(Json(TokenizedAssetStatusResponse { underlying, status: status.into() }))
+    let vault_mode = config.vault_mode_for(&underlying).into();
+
+    Ok(Json(TokenizedAssetStatusResponse {
+        underlying,
+        status: status.into(),
+        vault_mode,
+    }))
 }
 
 #[tracing::instrument(skip(_auth, pool))]
@@ -311,13 +330,14 @@ mod tests {
     use rocket::routes;
     use serde_json::{Value, json};
     use sqlx::sqlite::SqlitePoolOptions;
+    use std::collections::HashMap;
     use tracing_test::traced_test;
     use url::Url;
 
     use super::*;
     use crate::alpaca::service::AlpacaConfig;
     use crate::auth::{FailedAuthRateLimiter, test_auth_config};
-    use crate::config::{Config, Environment, LogLevel};
+    use crate::config::{Config, Environment, LogLevel, VaultModeConfig};
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
@@ -1033,7 +1053,11 @@ mod tests {
             before.into_json().await.expect("valid JSON response");
         assert_eq!(
             before_body,
-            json!({ "underlying": "AAPL", "status": "enabled" })
+            json!({
+                "underlying": "AAPL",
+                "status": "enabled",
+                "vault_mode": "vault_direct"
+            })
         );
 
         let underlying = UnderlyingSymbol::new("AAPL").unwrap();
@@ -1066,7 +1090,11 @@ mod tests {
             after.into_json().await.expect("valid JSON response");
         assert_eq!(
             after_body,
-            json!({ "underlying": "AAPL", "status": "frozen" })
+            json!({
+                "underlying": "AAPL",
+                "status": "frozen",
+                "vault_mode": "vault_direct"
+            })
         );
 
         // Unfreezing must flip the status back to `enabled` — the other half of
@@ -1098,7 +1126,11 @@ mod tests {
             unfrozen.into_json().await.expect("valid JSON response");
         assert_eq!(
             unfrozen_body,
-            json!({ "underlying": "AAPL", "status": "enabled" })
+            json!({
+                "underlying": "AAPL",
+                "status": "enabled",
+                "vault_mode": "vault_direct"
+            })
         );
     }
 
@@ -1200,6 +1232,83 @@ mod tests {
                 "status": "frozen"
             })
         );
+    }
+
+    /// Under a mixed config the status endpoint reports each asset's own
+    /// mode tag: the per-asset orchestrator override for AAPL, the
+    /// vault-direct default for MSFT — the liquidity bot's cue for which
+    /// assets need a `MintAuthV1` before their mints can submit.
+    #[tokio::test]
+    async fn test_get_status_reports_vault_mode_per_asset_under_mixed_config() {
+        let pool = migrated_in_memory_pool().await;
+        let store = setup_tokenized_asset_store(&pool).await;
+
+        for (underlying, token) in [("AAPL", "tAAPL"), ("MSFT", "tMSFT")] {
+            let underlying = UnderlyingSymbol::new(underlying).unwrap();
+            let key = AssetKey::new(underlying.clone(), Network::Base);
+            store
+                .send(
+                    &key,
+                    TokenizedAssetCommand::Add {
+                        underlying,
+                        token: TokenSymbol::new(token),
+                        network: Network::Base,
+                        vault: address!(
+                            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        ),
+                    },
+                )
+                .await
+                .expect("Failed to add asset");
+        }
+
+        let config = Config {
+            vault_mode_config: VaultModeConfig::new(
+                HashMap::from([(
+                    "AAPL".to_string(),
+                    VaultMode::Orchestrator {
+                        address: address!(
+                            "0xdddddddddddddddddddddddddddddddddddddddd"
+                        ),
+                    },
+                )]),
+                VaultMode::VaultDirect,
+            ),
+            ..test_config()
+        };
+
+        let rocket = rocket::build()
+            .manage(config)
+            .manage(FailedAuthRateLimiter::new().unwrap())
+            .manage(pool)
+            .mount("/", routes![get_tokenized_asset_status]);
+        let client = rocket::local::asynchronous::Client::tracked(rocket)
+            .await
+            .expect("valid rocket instance");
+
+        for (underlying, expected_mode) in
+            [("AAPL", "orchestrator"), ("MSFT", "vault_direct")]
+        {
+            let response = client
+                .get(format!("/tokenized-assets/{underlying}/status"))
+                .header(internal_api_key())
+                .remote("127.0.0.1:8000".parse().unwrap())
+                .dispatch()
+                .await;
+
+            assert_eq!(response.status(), Status::Ok);
+            let body: Value =
+                response.into_json().await.expect("valid JSON response");
+            assert_eq!(
+                body,
+                json!({
+                    "underlying": underlying,
+                    "status": "enabled",
+                    "vault_mode": expected_mode
+                }),
+                "unexpected status body for {underlying}"
+            );
+        }
     }
 
     #[traced_test]
@@ -1332,7 +1441,14 @@ mod tests {
 
         let body: Value =
             response.into_json().await.expect("valid JSON response");
-        assert_eq!(body, json!({ "underlying": "AAPL", "status": "enabled" }));
+        assert_eq!(
+            body,
+            json!({
+                "underlying": "AAPL",
+                "status": "enabled",
+                "vault_mode": "vault_direct"
+            })
+        );
     }
 
     // The detail endpoint shares `load_asset_by_underlying`, so a non-live


### PR DESCRIPTION
## Motivation

The liquidity bot needs to know which minting path each asset uses — either depositing directly into the vault (`VaultDirect`) or routing through the ST0xOrchestrator (`Orchestrator`) — so it can determine which assets require a signed `MintAuthV1` to be delivered before their mints can be submitted. Previously, the `GET /tokenized-assets/<underlying>/status` response had no way to communicate this, leaving the liquidity bot without a reliable signal.

## Solution

A new `VaultModeTag` enum (`vault_direct` | `orchestrator`) is introduced in the DTO crate and added as a `vault_mode` field on `TokenizedAssetStatusResponse`. The field is additive and defaults to `VaultDirect` when absent, so responses from servers that predate the field remain valid — a server that predates the field can only ever mint vault-direct, making the default truthful.

The status endpoint now reads the per-asset vault mode from the server's `Config` and maps it to the tag via a `From<VaultMode> for VaultModeTag` conversion. The orchestrator address is intentionally dropped in this mapping; the liquidity bot only needs the tag, and the issuance bot's config remains the single source of truth for addresses during the cutover.

`VaultModeTag` is also registered in the OpenAPI schema and TypeScript bindings exports, with wire format enforced as `snake_case` (matching `TokenizedAssetStatus`).

Closes [RAI-1619](https://linear.app/makeitrain/issue/RAI-1619/vaultmodetag)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tokenized asset status responses now indicate the vault mode: `vault_direct` or `orchestrator`.
  - API documentation and generated type definitions include the new vault mode information.

- **Bug Fixes**
  - Older responses without vault mode information remain compatible and default to direct vault mode.
  - Status reporting now accurately reflects mixed vault-mode configurations across assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->