### PR TITLE
feat: orchestrator-mode mint path with recipient authorization and e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,38 @@ endpoints.
 2. We validate and respond with `issuer_request_id`
 3. Alpaca journals shares from AP to our custodian account
 4. Alpaca confirms journal → we receive `/inkind/issuance/confirm`
-5. We mint tokens on-chain via `vault.deposit()`
+5. We mint tokens on-chain (vault-direct: `vault.deposit()`; orchestrator:
+   `ST0xOrchestrator.mint()` — see below)
 6. We call Alpaca's callback endpoint
+
+Each mint anchors its mode at initiation from the per-asset `vault_mode` config
+(see SPEC.md "Orchestrator Migration"): vault-direct assets mint via the
+`vault.deposit()` multicall with the receipt held by the bot; orchestrator
+assets mint via a single `ST0xOrchestrator.mint()` — the orchestrator custodies
+the receipt and forwards the shares to the recipient wallet.
+
+An orchestrator-mode mint additionally requires a **recipient authorization**:
+the liquidity bot signs the orchestrator's EIP-712 `MintAuthV1` digest over
+`(token, to, amount, nonce)` with the recipient wallet's key and delivers
+`{nonce, signature}` via the internal
+`POST /internal/mints/<tokenization_request_id>/authorization` endpoint, which
+validates the signer and nonce on-chain before recording it. Until the
+authorization arrives the mint waits — it never falls back to vault-direct. The
+consumed nonce is single-use on-chain, making it the mint's idempotency key:
+recovery of a landed mint full-matches the orchestrator's `Minted` log against
+`(to, nonce, token, amount)` and completes without resubmitting. A consumed
+nonce that does not full-match takes one of two verdicts, never conflated: a log
+at the pair disagreeing on token/amount is proof a different mint consumed it
+(parked as `NonceConsumedByOtherMint` for manual reconciliation), while an empty
+scan is an inconclusive chain view (parked as `NonceReplayUnresolved`,
+re-queried by recovery over a widened window and resolved forward once the
+landing becomes visible — closable only with an explicit operator
+acknowledgement). The `vault_mode` field on
+`GET /tokenized-assets/<underlying>/status` tells the liquidity bot which assets
+will need authorizations for _new_ mints, but the authoritative requirement for
+any given mint is its own persisted `mint_mode` anchor: a mint initiated before
+a config flip keeps the mode it was initiated with, so the bot must answer the
+mint it was asked about, not the asset's current config.
 
 ## Redemption Flow
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1513,24 +1513,24 @@ reference these as "Decision N".
    (whether Alpaca's ITN flow can carry an AP-produced signature through to us):
    the signature never goes through Alpaca. We validate the authorization
    (EIP-712/1271 signer check + `nonceUsed()` view) when the liquidity bot
-   delivers it, and associate it with the corresponding mint (e.g. by
-   `tokenization_request_id`) before the on-chain mint step. It is persisted by
+   delivers it, and associate it with the corresponding mint by
+   `tokenization_request_id` before the on-chain mint step. It is persisted by
    its own `AuthorizeMint` -> `MintAuthorizationReceived` pair, not on
-   `Initiated`, which is already written by the time it arrives. The exact
-   internal-call wire shape and correlation key are implementation details owned
-   by RAI-1220 (issuance side) plus the liquidity bot. **The launch scope is
-   deliberately staged:** this migration implements only the liquidity-bot
-   signature path (liquidity bot as the sole AP and recipient). A later phase
-   (the Atomic Bridge project) adds an atomic-bridge contract as a second
-   recipient type, using the orchestrator's `IMintRecipient.authorizeMint`
-   callback path — for that recipient `MintAuthV1.signature` is **empty** and
-   the orchestrator gates the mint on the contract's own on-chain intent instead
-   of a signature. We do not build that now, but we must not preclude it: the
-   issuance bot's authorization handling must treat the signature as opaque,
-   tolerate an **empty** signature (the callback case), and must not hardcode
-   "the recipient is always the liquidity bot." (A third option, the bot
-   self-signing and forwarding, stays a last resort only — it defeats the
-   compromised-mint-key protection this feature exists for.) Blocks RAI-1220.
+   `Initiated`, which is already written by the time it arrives. The concrete
+   internal-call wire shape and correlation key are settled — see "Recipient
+   Authorization" below. **The launch scope is deliberately staged:** this
+   migration implements only the liquidity-bot signature path (liquidity bot as
+   the sole AP and recipient). A later phase (the Atomic Bridge project) adds an
+   atomic-bridge contract as a second recipient type, using the orchestrator's
+   `IMintRecipient.authorizeMint` callback path — for that recipient
+   `MintAuthV1.signature` is **empty** and the orchestrator gates the mint on
+   the contract's own on-chain intent instead of a signature. We do not build
+   that now, but we must not preclude it: the issuance bot's authorization
+   handling must treat the signature as opaque, tolerate an **empty** signature
+   (the callback case), and must not hardcode "the recipient is always the
+   liquidity bot." (A third option, the bot self-signing and forwarding, stays a
+   last resort only — it defeats the compromised-mint-key protection this
+   feature exists for.) Blocks RAI-1220.
 2. **Nonce strategy** — _settled._ The nonce is fixed per mint, persisted in the
    event stream on `MintAuthorizationReceived` (before the first submission),
    and reused unchanged on retry, so `NonceReplayed` means the earlier mint
@@ -3744,7 +3744,11 @@ We run an HTTP server that implements these endpoints.
    address for AP
 4. **`POST /tokenized-assets`** - Add a new tokenized asset
 5. **`GET /tokenized-assets/<underlying>/status`** - Per-asset listing + freeze
-   status, consumed by the liquidity rebalance guard
+   status + `vault_mode`, consumed by the liquidity rebalance guard
+6. **`POST /internal/mints/<tokenization_request_id>/authorization`** - The
+   liquidity bot delivers its `MintAuthV1 { nonce, signature }` recipient
+   authorization for an orchestrator-mode mint (see "Orchestrator Migration" ->
+   "Recipient Authorization" for the wire shape and semantics)
 
 ### Endpoints We Call
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -2738,12 +2738,19 @@ fn mint_view_summary(view: &MintView) -> Option<MintStuckSummary> {
             tokenization_request_id,
             error,
             failed_at,
+            classification,
             ..
         } => Some(MintStuckSummary {
             class: TerminalFail,
             tokenization_request_id: Some(tokenization_request_id.clone()),
             state: "MintingFailed".to_string(),
-            detail: error.clone(),
+            // The typed classification leads the detail: it is the operator's
+            // retry-exclusion signal (a classified failure is never
+            // auto-retried), and the free-text error alone cannot convey it.
+            detail: match classification {
+                MintFailureClassification::Unclassified => error.clone(),
+                classified => format!("{classified:?}: {error}"),
+            },
             timestamp: *failed_at,
         }),
         MintView::CallbackPending {

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -153,9 +153,27 @@ impl Job<SubmitMintContext> for SubmitMintJob {
             // rebroadcast only when StillMineable/MinedSuccess; terminal
             // dead/revert records MintingFailed so recovery may replace;
             // uncertain observation preserves MintIntended (no MintingFailed).
-            Mint::TxIntended { prepared_tx, network, .. } => {
-                self.submit_from_tx_intended(ctx, prepared_tx, *network)
-                    .await?;
+            Mint::TxIntended {
+                prepared_tx,
+                network,
+                quantity,
+                wallet,
+                mint_mode,
+                mint_authorization,
+                ..
+            } => {
+                self.submit_from_tx_intended(
+                    ctx,
+                    prepared_tx,
+                    SubmitFromTxIntendedParams {
+                        network: *network,
+                        wallet: *wallet,
+                        quantity,
+                        mint_mode,
+                        mint_authorization: mint_authorization.as_ref(),
+                    },
+                )
+                .await?;
             }
             // A re-run after the submission was already recorded: the
             // confirm job may not have been enqueued before a crash, so
@@ -202,6 +220,34 @@ struct ResolvePreparedParams<'a> {
     mint_authorization: Option<&'a MintAuthorization>,
 }
 
+struct SubmitFromTxIntendedParams<'a> {
+    network: Network,
+    wallet: Address,
+    quantity: &'a Quantity,
+    /// Mode anchor from the aggregate — decides whether the pre-submit
+    /// double-mint guard runs before the prepared bytes are rebroadcast.
+    mint_mode: &'a VaultMode,
+    mint_authorization: Option<&'a MintAuthorization>,
+}
+
+/// Outcome of the orchestrator pre-submit double-mint guard
+/// ([`SubmitMintJob::recover_landed_orchestrator_mint`]).
+enum OrchestratorPreSubmitOutcome {
+    /// A landed mint full-matched and was recorded; the confirm job owns the
+    /// rest of the chain.
+    Recovered,
+    /// An on-chain read failed — nothing is provable, so submission defers
+    /// to the next recovery pass rather than proceeding blind.
+    Defer,
+    /// The nonce is consumed and a classified `MintingFailed` was recorded
+    /// (`NonceConsumedByOtherMint` on the proven mismatch,
+    /// `NonceReplayUnresolved` on an empty scan). Submission must not run;
+    /// recovery's reconciliation or the operator owns the mint now.
+    Parked,
+    /// Nothing landed under this mint's nonce; submission proceeds.
+    Proceed,
+}
+
 impl SubmitMintJob {
     /// Refuses while another persisted intent holds this signer's nonce domain.
     ///
@@ -239,26 +285,127 @@ impl SubmitMintJob {
         })
     }
 
+    /// Pre-submit orchestrator health gate, the mint counterpart of the burn
+    /// side's `VaultLogicMismatch` deferral: a halted orchestrator
+    /// (`vaultLogicIsExpected()` false) deterministically reverts `mint()`,
+    /// so submission defers — no event, no retry counter advance — leaving
+    /// the mint in place for the next recovery drive, which re-checks
+    /// health. A failed read proves nothing and defers likewise. Runs after
+    /// the nonce guard so a halted orchestrator still recovers an
+    /// already-landed mint. Returns `true` when submission may proceed.
+    async fn orchestrator_logic_is_expected(
+        &self,
+        vault: &Arc<dyn VaultService>,
+        orchestrator: Address,
+        stage: &'static str,
+    ) -> bool {
+        match vault.vault_logic_is_expected(orchestrator).await {
+            Ok(true) => true,
+            Ok(false) => {
+                warn!(target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    orchestrator = %orchestrator,
+                    stage,
+                    "Orchestrator halted (vault logic mismatch); deferring \
+                     mint submission without recording failure"
+                );
+                false
+            }
+            Err(error) => {
+                warn!(target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    orchestrator = %orchestrator,
+                    stage,
+                    error = %error,
+                    "Orchestrator health read failed; deferring mint \
+                     submission"
+                );
+                false
+            }
+        }
+    }
+
     /// Rebroadcast a legacy `TxIntended` prepared identity under the wallet
     /// lock, after burn-parity classification (aligned with
     /// [`Self::resolve_prepared_for_submit`]).
+    #[allow(clippy::too_many_lines)]
     async fn submit_from_tx_intended(
         &self,
         ctx: &SubmitMintContext,
         prepared_tx: &PreparedMintTx,
-        network: Network,
+        params: SubmitFromTxIntendedParams<'_>,
     ) -> Result<(), MintJobError> {
         if self.record_existing_receipt(ctx).await? {
             return Ok(());
         }
 
-        let Some(vault) = self.resolve_vault_service(ctx, network).await?
+        let Some(vault) =
+            self.resolve_vault_service(ctx, params.network).await?
         else {
             return Ok(());
         };
 
+        // The same pre-submit double-mint guard as the `Minting` path: a
+        // crash after `MintTxIntended` may have left the authorization nonce
+        // consumed — by these very bytes landing, or by a sibling — and a
+        // blind rebroadcast of a consumed nonce can only revert
+        // `NonceReplayed`, parking the mint as `Unclassified` instead of
+        // recovering the landing forward or parking under the typed verdict.
+        if let (
+            VaultMode::Orchestrator { address: orchestrator },
+            Some(authorization),
+        ) = (params.mint_mode, params.mint_authorization)
+        {
+            let assets = match params.quantity.to_u256_with_18_decimals() {
+                Ok(assets) => assets,
+                Err(error) => {
+                    // The quantity converted once already, at prepare time —
+                    // an inconvertible value here is state corruption; fail
+                    // closed without touching the chain.
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        error = %error,
+                        "Prepared mint quantity cannot be converted to \
+                         on-chain units; preserving MintIntended"
+                    );
+                    return Ok(());
+                }
+            };
+            match self
+                .recover_landed_orchestrator_mint(
+                    ctx,
+                    &vault,
+                    *orchestrator,
+                    params.wallet,
+                    authorization,
+                    assets,
+                )
+                .await?
+            {
+                OrchestratorPreSubmitOutcome::Recovered
+                | OrchestratorPreSubmitOutcome::Defer
+                | OrchestratorPreSubmitOutcome::Parked => {
+                    return Ok(());
+                }
+                OrchestratorPreSubmitOutcome::Proceed => {}
+            }
+
+            if !self
+                .orchestrator_logic_is_expected(
+                    &vault,
+                    *orchestrator,
+                    "MintIntended",
+                )
+                .await
+            {
+                return Ok(());
+            }
+        }
+
         let wallet_guard = vault.lock_wallet().await;
-        self.refuse_behind_wallet_intents(ctx, network, "submission").await?;
+        self.refuse_behind_wallet_intents(ctx, params.network, "submission")
+            .await?;
 
         let owner = match prepared_tx.recover_signer() {
             Ok(owner) => owner,
@@ -430,9 +577,13 @@ impl SubmitMintJob {
         Ok(())
     }
 
-    /// Prepare (or rebroadcast) and submit while the aggregate is `Minting`.
-    /// Classification of any live prepared identity gates replacement under
-    /// the wallet guard so uncertain observation never signs a second deposit.
+    /// Drives a `Minting`-state submission: existing-receipt short-circuit,
+    /// the orchestrator pre-submit double-mint guard, mode-branched
+    /// preparation (vault-direct deposit multicall vs `orchestrator.mint()`),
+    /// intent persistence, broadcast, and confirm-job handoff. An
+    /// orchestrator mint whose recipient authorization has not arrived
+    /// defers silently — no event, no vault call — leaving the mint in
+    /// `Minting` for the next recovery drive. Any other state is a no-op.
     async fn submit_from_minting(
         &self,
         ctx: &SubmitMintContext,
@@ -477,6 +628,48 @@ impl SubmitMintJob {
                 return Ok(());
             }
         };
+        // Runs before the wallet lock, so the answer can age between the
+        // read and the send — benign, because the on-chain nonce is the
+        // real double-mint guard: a submission racing a landing reverts
+        // `NonceReplayed` and reconciles through this same full-match on
+        // the next drive. This check exists to discover recoveries and
+        // spare doomed submissions, not to be the safety boundary.
+        if let (
+            VaultMode::Orchestrator { address: orchestrator },
+            Some(authorization),
+        ) = (params.mint_mode, params.mint_authorization)
+        {
+            match self
+                .recover_landed_orchestrator_mint(
+                    ctx,
+                    &vault,
+                    *orchestrator,
+                    params.wallet,
+                    authorization,
+                    assets,
+                )
+                .await?
+            {
+                OrchestratorPreSubmitOutcome::Recovered
+                | OrchestratorPreSubmitOutcome::Defer
+                | OrchestratorPreSubmitOutcome::Parked => {
+                    return Ok(());
+                }
+                OrchestratorPreSubmitOutcome::Proceed => {}
+            }
+
+            if !self
+                .orchestrator_logic_is_expected(
+                    &vault,
+                    *orchestrator,
+                    "Minting",
+                )
+                .await
+            {
+                return Ok(());
+            }
+        }
+
         let receipt_info = ReceiptInformation::new(
             params.tokenization_request_id.clone(),
             self.issuer_request_id.clone(),
@@ -812,6 +1005,168 @@ impl SubmitMintJob {
             )
             .await?;
         Ok(Some(prepared))
+    }
+
+    /// Orchestrator counterpart of [`Self::record_existing_receipt`]: the
+    /// bot never custodies a receipt for an orchestrator mint, so the
+    /// double-mint guard is the landed `Minted` log full-matching
+    /// `(to, nonce, token, amount)`. A full match records the landing
+    /// instead of re-submitting (whose consumed nonce would only revert); a
+    /// consumed nonce that does NOT full-match applies the same two-outcome
+    /// split as the confirm-side recheck (SPEC "Nonce"): a log at the pair
+    /// disagreeing on token/amount is the proven `NonceConsumedByOtherMint`,
+    /// while an empty scan is the inconclusive `NonceReplayUnresolved` —
+    /// stuck-visible and re-queried by recovery's widened reconciliation,
+    /// which resolves the fresh-landing case forward once the
+    /// reorg-confirmation buffer moves past it. A failed read defers to the
+    /// next recovery pass rather than deciding blind.
+    ///
+    /// A single `nonceUsed` read gates the log scan: `false` proves nothing
+    /// can have landed under this mint's nonce (the on-chain uniqueness
+    /// key), sparing the full lookback scan on every ordinary first
+    /// submission.
+    async fn recover_landed_orchestrator_mint(
+        &self,
+        ctx: &SubmitMintContext,
+        vault: &Arc<dyn VaultService>,
+        orchestrator: Address,
+        wallet: Address,
+        authorization: &MintAuthorization,
+        assets: U256,
+    ) -> Result<OrchestratorPreSubmitOutcome, MintJobError> {
+        let consumed = match vault
+            .nonce_used(orchestrator, wallet, authorization.nonce)
+            .await
+        {
+            Ok(consumed) => consumed,
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "Consumed-nonce read failed; deferring submission to \
+                     the next recovery pass"
+                );
+                return Ok(OrchestratorPreSubmitOutcome::Defer);
+            }
+        };
+        if !consumed {
+            return Ok(OrchestratorPreSubmitOutcome::Proceed);
+        }
+
+        match vault
+            .find_orchestrator_minted_log(MintedLogQuery {
+                orchestrator,
+                to: wallet,
+                nonce: authorization.nonce,
+                token: self.vault,
+                amount: assets,
+                lookback_blocks: None,
+            })
+            .await
+        {
+            Ok(MintedLogScan::FullMatch(minted)) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %minted.tx_hash,
+                    nonce = %minted.nonce,
+                    "Found landed orchestrator mint, recording recovery \
+                     instead of re-submitting"
+                );
+
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordOrchestratorMintRecovered {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            tx_hash: minted.tx_hash,
+                            nonce: minted.nonce,
+                            shares_minted: minted.shares_minted,
+                            block_number: minted.block_number,
+                        },
+                    )
+                    .await?;
+
+                // The confirm job's CallbackPending re-run arm pushes the
+                // callback job, completing the chain.
+                self.enqueue_confirm(ctx, TxId::Hash(minted.tx_hash)).await?;
+                Ok(OrchestratorPreSubmitOutcome::Recovered)
+            }
+            // The pair's one landing disagrees on token/amount: affirmative
+            // proof a DIFFERENT mint consumed it — this mint can never
+            // land. Park it under the proven verdict; only `CloseMint` plus
+            // a fresh `Initiate` resolves it.
+            Ok(MintedLogScan::Mismatch) => {
+                error!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    to = %wallet,
+                    nonce = %authorization.nonce,
+                    token = %self.vault,
+                    amount = %assets,
+                    "Authorization nonce was consumed by a different mint; \
+                     manual reconciliation required"
+                );
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordMintFailed {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            error: "Minted log at (to, nonce) disagrees on \
+                                    token/amount; a different mint consumed \
+                                    the pair"
+                                .to_string(),
+                            classification:
+                                MintFailureClassification::NonceConsumedByOtherMint,
+                        },
+                    )
+                    .await?;
+                Ok(OrchestratorPreSubmitOutcome::Parked)
+            }
+            // Consumed nonce with NO log at the pair at all: the two facts
+            // cannot both be true of a healthy chain view (our own landing
+            // may still sit inside the reorg-confirmation buffer the scan
+            // excludes), so this is the inconclusive
+            // `NonceReplayUnresolved` — never a submission (the consumed
+            // nonce can only revert) and never the proven mismatch.
+            // Recovery's widened reconciliation re-queries it each pass and
+            // resolves the fresh-landing case forward once the buffer moves
+            // past it.
+            Ok(MintedLogScan::NotFound) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    nonce = %authorization.nonce,
+                    "Nonce is consumed but no Minted log was found at the \
+                     pair; parking for reconciliation"
+                );
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordMintFailed {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            error: "authorization nonce consumed on-chain \
+                                    with no Minted log at the pair"
+                                .to_string(),
+                            classification:
+                                MintFailureClassification::NonceReplayUnresolved,
+                        },
+                    )
+                    .await?;
+                Ok(OrchestratorPreSubmitOutcome::Parked)
+            }
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "Landed-mint lookup failed; deferring submission to the \
+                     next recovery pass"
+                );
+                Ok(OrchestratorPreSubmitOutcome::Defer)
+            }
+        }
     }
 
     async fn record_existing_receipt(
@@ -2348,7 +2703,7 @@ async fn kick_mint_recovery(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{B256, Bytes, U256};
+    use alloy::primitives::{B256, Bytes, U256, address};
     use async_trait::async_trait;
     use cqrs_es::{AggregateError, DomainEvent};
     use event_sorcery::test_store;
@@ -4767,6 +5122,658 @@ mod tests {
         );
     }
 
+    /// The pre-submit double-mint guard: a landed `Minted` log full-matching
+    /// the mint's `(to, nonce, token, amount)` proves it already minted —
+    /// the submit job records `OrchestratorMintRecovered` and hands off to
+    /// the confirm job, never preparing a re-submission whose consumed nonce
+    /// could only revert.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_orchestrator_records_landed_mint_without_submitting()
+     {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let landed_tx_hash = B256::repeat_byte(0xcc);
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: landed_tx_hash,
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: U256::from(100u64)
+                        * U256::from(10u64).pow(U256::from(18u64)),
+                    block_number: 777,
+                })
+                // Bound to the fixture's exact orchestrator, recipient, and
+                // token: a lookup passing any wrong address must miss.
+                .with_minted_log_binding(
+                    ORCHESTRATOR,
+                    address!("0x1234567890abcdef1234567890abcdef12345678"),
+                    VAULT,
+                ),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::CallbackPending {
+                    receipt_id: None,
+                    mint_nonce: Some(_),
+                    ..
+                }
+            ),
+            "the landed mint must be recorded as recovered, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "a landed mint must never be re-submitted"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "the vault-direct preparation must not be invoked either"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<ConfirmMintJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            1,
+            "the recovered mint must hand off to the confirm job for the \
+             callback"
+        );
+
+        let test = "submit_mint_job_orchestrator_records_landed_mint_without_submitting";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Found landed orchestrator mint"]
+        ));
+    }
+
+    /// The `nonceUsed` gate spares the full lookback scan on the ordinary
+    /// first submission: an unconsumed nonce proves nothing landed, so the
+    /// `Minted`-log lookup never runs and the mint submits normally.
+    #[tokio::test]
+    async fn submit_mint_job_orchestrator_skips_landed_scan_for_unused_nonce() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault =
+            Arc::new(MockVaultService::new_success().with_nonce_used(false));
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "an unconsumed nonce must submit normally, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.find_minted_log_call_count(),
+            0,
+            "an unconsumed nonce must never trigger the lookback scan"
+        );
+        assert_eq!(vault.orchestrator_mint_preparation_call_count(), 1);
+    }
+
+    /// A consumed nonce with NO log at the pair parks the mint as the
+    /// inconclusive `NonceReplayUnresolved` — never submitted (the nonce
+    /// can only revert), never mislabeled as the proven mismatch. The mint
+    /// becomes stuck-visible, and recovery's widened reconciliation owns
+    /// the re-query (which resolves the fresh-landing case forward once the
+    /// reorg buffer moves past it).
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_consumed_nonce_without_log_parks_unresolved() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault =
+            Arc::new(MockVaultService::new_success().with_nonce_used(true));
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceReplayUnresolved,
+                    ..
+                }
+            ),
+            "a consumed nonce with an empty scan must park unresolved, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            vault.find_minted_log_call_count(),
+            1,
+            "the consumed nonce must trigger the landed-mint scan first"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be prepared or submitted for the parked mint"
+        );
+
+        let test =
+            "submit_mint_job_consumed_nonce_without_log_parks_unresolved";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "no Minted log was found at the pair", "parking"]
+        ));
+    }
+
+    /// A consumed nonce whose landing disagrees on amount parks the mint as
+    /// the PROVEN `NonceConsumedByOtherMint` — the pre-submit guard applies
+    /// the same two-outcome split as the confirm-side recheck.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_consumed_nonce_with_mismatch_parks_proven() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::repeat_byte(0xcc),
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: U256::from(1u8),
+                    block_number: 777,
+                }),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceConsumedByOtherMint,
+                    ..
+                }
+            ),
+            "a mismatching landing must park as the proven verdict, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be prepared or submitted for the parked mint"
+        );
+
+        let test = "submit_mint_job_consumed_nonce_with_mismatch_parks_proven";
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[test, "consumed by a different mint"]
+        ));
+    }
+
+    fn orchestrator_events_through_tx_intended(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> Vec<MintEvent> {
+        let mut events =
+            orchestrator_events_through_minting_authorized(issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: crate::vault::PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: Utc::now(),
+        });
+        events
+    }
+
+    /// The crash window after `MintTxIntended`: the prepared bytes may have
+    /// landed (consuming the nonce) before the crash, so the rebroadcast
+    /// path must run the same pre-submit guard as the `Minting` path and
+    /// recover the landing forward instead of blindly rebroadcasting a
+    /// consumed nonce into a `NonceReplayed` revert.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_tx_intended_replayed_nonce_recovers_landed_mint() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::repeat_byte(0xcc),
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: U256::from(100u64)
+                        * U256::from(10u64).pow(U256::from(18u64)),
+                    block_number: 777,
+                }),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(&mint, Mint::CallbackPending { .. }),
+            "the landed mint must be recovered forward, never rebroadcast, \
+             got: {mint:?}"
+        );
+        assert_eq!(
+            vault.find_minted_log_call_count(),
+            1,
+            "the consumed nonce must trigger the landed-mint scan before any \
+             rebroadcast"
+        );
+
+        let test =
+            "submit_mint_job_tx_intended_replayed_nonce_recovers_landed_mint";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Found landed orchestrator mint"]
+        ));
+    }
+
+    /// The same crash window when the pair's landing belongs to a different
+    /// mint: the rebroadcast path must park the typed verdict instead of
+    /// resubmitting into a `NonceReplayed` revert that records
+    /// `Unclassified`.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_tx_intended_consumed_nonce_mismatch_parks_proven()
+    {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_minted_log(OrchestratorMintedLog {
+                    tx_hash: B256::repeat_byte(0xcc),
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: U256::from(1u8),
+                    block_number: 777,
+                }),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                &mint,
+                Mint::MintingFailed {
+                    classification:
+                        MintFailureClassification::NonceConsumedByOtherMint,
+                    ..
+                }
+            ),
+            "a mismatching landing must park as the proven verdict rather \
+             than rebroadcast, got: {mint:?}"
+        );
+
+        let test =
+            "submit_mint_job_tx_intended_consumed_nonce_mismatch_parks_proven";
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[test, "consumed by a different mint"]
+        ));
+    }
+
+    /// The mint counterpart of the burn side's pre-submit halt deferral
+    /// (SPEC's `vaultLogicIsExpected()` check covers BOTH directions): a
+    /// halted orchestrator deterministically reverts `mint()`, so the submit
+    /// job defers — nothing signed, nothing submitted, no event, the mint
+    /// stays in `Minting` for the next recovery drive.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_halted_orchestrator_defers_from_minting() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_vault_logic_expected(false),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "a halted orchestrator must leave the mint in Minting, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be signed while the orchestrator is halted"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<ConfirmMintJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            0,
+            "the deferral must not hand off to the confirm job"
+        );
+
+        let test = "submit_mint_job_halted_orchestrator_defers_from_minting";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Orchestrator halted", "deferring"]
+        ));
+    }
+
+    /// The same halt deferral on the crash-recovery rebroadcast path: a
+    /// `MintTxIntended` mint whose orchestrator is halted keeps its prepared
+    /// identity and defers instead of rebroadcasting into a certain revert.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_halted_orchestrator_defers_from_tx_intended() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_vault_logic_expected(false),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxIntended { .. }),
+            "a halted orchestrator must preserve MintTxIntended, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            count_jobs(
+                &harness.pool,
+                type_name::<ConfirmMintJob>(),
+                &issuer_request_id.to_string(),
+            )
+            .await,
+            0,
+            "the deferral must not hand off to the confirm job"
+        );
+
+        let test =
+            "submit_mint_job_halted_orchestrator_defers_from_tx_intended";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Orchestrator halted", "deferring"]
+        ));
+    }
+
+    /// A failed health read proves nothing about the halt, so it defers
+    /// exactly like `false` rather than submitting blind.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_defers_when_health_read_fails() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault =
+            Arc::new(MockVaultService::new_success().with_vault_logic_error());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "a failed health read must defer in Minting, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be signed on a failed health read"
+        );
+
+        let test = "submit_mint_job_defers_when_health_read_fails";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Orchestrator health read failed"]
+        ));
+    }
+
+    /// A failed `nonceUsed` read proves nothing about the nonce, so the gate
+    /// defers: no state change, nothing signed, nothing submitted.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_defers_when_nonce_read_fails() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault =
+            Arc::new(MockVaultService::new_success().with_nonce_used_error());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "a failed consumed-nonce read must defer in Minting, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be signed on a failed consumed-nonce read"
+        );
+
+        let test = "submit_mint_job_defers_when_nonce_read_fails";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Consumed-nonce read failed"]
+        ));
+    }
+
+    /// A failed `Minted`-log lookup after a consumed nonce also defers — the
+    /// lookup proves nothing, so submitting blind is never an option.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_defers_when_landed_lookup_fails() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            orchestrator_events_through_minting_authorized(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_nonce_used(true)
+                .with_find_minted_log_error(),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "a failed landed-mint lookup must defer in Minting, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.orchestrator_mint_preparation_call_count(),
+            0,
+            "nothing may be signed on a failed landed-mint lookup"
+        );
+
+        let test = "submit_mint_job_defers_when_landed_lookup_fails";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Landed-mint lookup failed"]
+        ));
+    }
+
     /// Orchestrator confirmation records `OrchestratorTokensMinted` and never
     /// touches the receipt service — the orchestrator custodies the receipt.
     /// The failing receipt stub would log a warning if it were reached.
@@ -4877,7 +5884,14 @@ mod tests {
                     shares_minted: U256::from(100u64)
                         * U256::from(10u64).pow(U256::from(18u64)),
                     block_number: 777,
-                }),
+                })
+                // Bound to the fixture's exact orchestrator, recipient, and
+                // token: a lookup passing any wrong address must miss.
+                .with_minted_log_binding(
+                    ORCHESTRATOR,
+                    address!("0x1234567890abcdef1234567890abcdef12345678"),
+                    VAULT,
+                ),
         );
         let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1343,9 +1343,15 @@ impl Mint {
     }
 
     /// Records an orchestrator mint proven landed by the full-match
-    /// `Minted`-log lookup after a `NonceReplayed` revert. Pure — emits
-    /// `OrchestratorMintRecovered`. Idempotent: a no-op once the mint has
-    /// advanced past `TxSubmitted`.
+    /// `Minted`-log lookup — driven from `Minting` by the `SubmitMintJob`'s
+    /// pre-submit check (the double-mint guard) and from `TxSubmitted` by
+    /// the `ConfirmMintJob`'s `NonceReplayed` recovery. `TxIntended` and
+    /// `MintingFailed` have no driving caller; they are accepted purely as
+    /// concurrent-delivery defenses — a discovering job read its state
+    /// before a sibling job recorded an intent or a failure, and rejecting
+    /// the proven landing would discard it for a whole re-drive cycle.
+    /// Pure — emits `OrchestratorMintRecovered`. Idempotent: a no-op once
+    /// the mint has advanced to `CallbackPending`.
     fn handle_record_orchestrator_mint_recovered(
         &self,
         issuer_request_id: IssuerMintRequestId,
@@ -7594,6 +7600,54 @@ pub(crate) mod tests {
             ),
             "diverging shares must be rejected, got {error:?}"
         );
+    }
+
+    /// `TxIntended` and `MintingFailed` have no driving caller — the
+    /// recovery command reaches them only when a sibling job recorded an
+    /// intent or a failure after the discovering job loaded its state — but
+    /// the arms must still record the proven landing rather than discard it
+    /// for a whole re-drive cycle.
+    #[tokio::test]
+    async fn record_orchestrator_mint_recovered_accepts_race_states() {
+        let issuer_request_id = IssuerMintRequestId::random();
+
+        let mut intended_events =
+            orchestrator_events_through_minting_authorized(&issuer_request_id);
+        intended_events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: PreparedMintTx::valid_for_test(
+                1,
+                format!("mint-{issuer_request_id}"),
+            ),
+            intended_at: Utc::now(),
+        });
+        let failed_events = orchestrator_minting_failed_events(
+            &issuer_request_id,
+            orchestrator_events_through_tx_submitted(&issuer_request_id),
+            MintFailureClassification::NonceConsumedByOtherMint,
+        );
+
+        for events in [intended_events, failed_events] {
+            let emitted = TestHarness::<Mint>::with(())
+                .given(events)
+                .when(MintCommand::RecordOrchestratorMintRecovered {
+                    issuer_request_id: issuer_request_id.clone(),
+                    tx_hash: B256::ZERO,
+                    nonce: test_mint_authorization().nonce,
+                    shares_minted: uint!(100_000000000000000000_U256),
+                    block_number: 777,
+                })
+                .await
+                .events();
+            assert!(
+                matches!(
+                    emitted.as_slice(),
+                    [MintEvent::OrchestratorMintRecovered { .. }]
+                ),
+                "a race-state delivery must still record the landing, got \
+                 {emitted:?}"
+            );
+        }
     }
 
     /// A vault receipt is a vault-direct proof: the bot never custodies a

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -1046,16 +1046,26 @@ async fn recover_mint_until_automatic_budget_exhausted(
                     return RecoveryConclusion::Resolved;
                 }
                 reconcile_attempted = true;
-                if let Err(error) =
-                    reconcile_unresolved_replay(ctx, &mint, issuer_request_id)
-                        .await
+                match reconcile_unresolved_replay(ctx, &mint, issuer_request_id)
+                    .await
                 {
-                    debug!(target: "mint", issuer_request_id = %issuer_request_id,
-                        error = %error,
-                        "Unresolved-replay reconciliation failed; awaiting the next pass"
-                    );
+                    // The mint changed state — re-loop immediately so the
+                    // next iteration keeps driving it (the callback for a
+                    // recovery, the manual-only skip for an upgrade).
+                    Ok(ReconcileOutcome::Advanced) => {}
+                    // Unchanged (or unprovable): nothing more this pass can
+                    // do — the reconciler re-enqueues the next one.
+                    Ok(ReconcileOutcome::Parked) => {
+                        return RecoveryConclusion::Resolved;
+                    }
+                    Err(error) => {
+                        debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                            error = %error,
+                            "Unresolved-replay reconciliation failed; awaiting the next pass"
+                        );
+                        return RecoveryConclusion::Resolved;
+                    }
                 }
-                tokio::time::sleep(backoff).await;
             }
             AutomaticRetryDecision::Wait(wait) => {
                 let receipt_exists =
@@ -1475,6 +1485,17 @@ async fn drive_minting_failed_step(
 /// Authorization" -> "Nonce"). ~23 days on Base's 2s blocks.
 const UNRESOLVED_REPLAY_LOOKBACK_BLOCKS: u64 = 1_000_000;
 
+/// What one widened reconciliation attempt concluded, so the recovery loop
+/// can react immediately: an `Advanced` mint changed state (recovered
+/// forward, or upgraded to the proven mismatch) and the next iteration
+/// keeps driving it without waiting out a backoff; a `Parked` mint is
+/// unchanged until the reconciler's next pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReconcileOutcome {
+    Advanced,
+    Parked,
+}
+
 /// One reconciliation attempt for a `NonceReplayUnresolved` mint: re-runs
 /// the `Minted`-log full-match over [`UNRESOLVED_REPLAY_LOOKBACK_BLOCKS`].
 /// A `FullMatch` resolves the mint forward
@@ -1486,7 +1507,7 @@ async fn reconcile_unresolved_replay(
     ctx: &MintRecoveryContext,
     mint: &Mint,
     issuer_request_id: &IssuerMintRequestId,
-) -> Result<(), MintRecoveryStepError> {
+) -> Result<ReconcileOutcome, MintRecoveryStepError> {
     let Mint::MintingFailed {
         underlying,
         network,
@@ -1497,7 +1518,7 @@ async fn reconcile_unresolved_replay(
         ..
     } = mint
     else {
-        return Ok(());
+        return Ok(ReconcileOutcome::Parked);
     };
     let (
         VaultMode::Orchestrator { address: orchestrator },
@@ -1507,7 +1528,7 @@ async fn reconcile_unresolved_replay(
         // `NonceReplayUnresolved` is only ever recorded for an
         // orchestrator mint holding an authorization; anything else is an
         // impossible replay and there is nothing to reconcile.
-        return Ok(());
+        return Ok(ReconcileOutcome::Parked);
     };
 
     let vault = resolve_vault(ctx, underlying, *network).await?;
@@ -1522,7 +1543,7 @@ async fn reconcile_unresolved_replay(
                 error = %error,
                 "Unresolved-replay quantity cannot convert to on-chain units"
             );
-            return Ok(());
+            return Ok(ReconcileOutcome::Parked);
         }
     };
 
@@ -1557,6 +1578,7 @@ async fn reconcile_unresolved_replay(
                     },
                 )
                 .await?;
+            Ok(ReconcileOutcome::Advanced)
         }
         Ok(MintedLogScan::Mismatch) => {
             error!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -1580,6 +1602,7 @@ async fn reconcile_unresolved_replay(
                     },
                 )
                 .await?;
+            Ok(ReconcileOutcome::Advanced)
         }
         Ok(MintedLogScan::NotFound) => {
             debug!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -1587,6 +1610,7 @@ async fn reconcile_unresolved_replay(
                 "Widened reconciliation still found no Minted log at the \
                  pair; the mint stays parked for the next pass"
             );
+            Ok(ReconcileOutcome::Parked)
         }
         Err(error) => {
             warn!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -1594,10 +1618,9 @@ async fn reconcile_unresolved_replay(
                 "Unresolved-replay reconciliation lookup failed; the mint \
                  stays parked for the next pass"
             );
+            Ok(ReconcileOutcome::Parked)
         }
     }
-
-    Ok(())
 }
 
 /// `RetryMint` + enqueue `SubmitMintJob` — shared by free-prepare-safe and

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -905,7 +905,8 @@ impl MockVaultService {
     }
 
     /// Overrides the `nonce_used` consumed flag, e.g. `true` with no (or a
-    /// non-matching) `minted_log` exercises the consumed-but-unproven path.
+    /// non-matching) `minted_log` to exercise the consumed-by-another-mint
+    /// path through the pre-submit gate.
     #[cfg(test)]
     pub(crate) fn with_nonce_used(self, consumed: bool) -> Self {
         *self.orchestrator.nonce_used.lock().unwrap() = Some(consumed);
@@ -945,7 +946,9 @@ impl MockVaultService {
     /// Binds the configured `minted_log` to an exact
     /// `(orchestrator, to, token)`: a lookup passing any other address must
     /// miss (or mismatch, for `token`), mirroring the address half of the
-    /// real scan's four-field full-match.
+    /// real scan's four-field full-match — so a test can prove the
+    /// production query passes the right recipient and orchestrator, not
+    /// merely the right nonce and amount.
     #[cfg(test)]
     pub(crate) fn with_minted_log_binding(
         self,

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -295,10 +295,8 @@ pub(crate) trait VaultService: Send + Sync {
     /// `(token, to, amount, nonce)` from the authorization.
     async fn prepare_orchestrator_mint_tx(
         &self,
-        _params: &OrchestratorMintParams,
-    ) -> Result<PreparedMintTx, VaultError> {
-        Err(VaultError::InvalidReceipt)
-    }
+        params: &OrchestratorMintParams,
+    ) -> Result<PreparedMintTx, VaultError>;
 
     /// Confirms a previously submitted orchestrator mint, parsing the
     /// orchestrator's `Minted` event. A mined-but-reverted mint fails with
@@ -306,10 +304,8 @@ pub(crate) trait VaultService: Send + Sync {
     /// (`NonceReplayed`, `VaultLogicMismatch`, ...).
     async fn confirm_orchestrator_mint(
         &self,
-        _tx_id: &TxId,
-    ) -> Result<OrchestratorMintResult, VaultError> {
-        Err(VaultError::InvalidReceipt)
-    }
+        tx_id: &TxId,
+    ) -> Result<OrchestratorMintResult, VaultError>;
 
     /// Looks up a landed orchestrator mint by its `Minted` log and reports a
     /// three-way [`MintedLogScan`] verdict: `FullMatch` when a log at
@@ -320,13 +316,10 @@ pub(crate) trait VaultService: Send + Sync {
     /// nonce consumed, is an inconclusive chain view, never proof. Callers
     /// must never conflate the last two (SPEC "Recipient Authorization" ->
     /// "Nonce").
-    #[allow(dead_code)]
     async fn find_orchestrator_minted_log(
         &self,
-        _query: MintedLogQuery,
-    ) -> Result<MintedLogScan, VaultError> {
-        Err(VaultError::InvalidReceipt)
-    }
+        query: MintedLogQuery,
+    ) -> Result<MintedLogScan, VaultError>;
 
     /// Reads the orchestrator's `nonceUsed(to, nonce)` consumed flag — the
     /// single cheap read gating [`Self::find_orchestrator_minted_log`]'s
@@ -335,12 +328,10 @@ pub(crate) trait VaultService: Send + Sync {
     /// every ordinary first submission.
     async fn nonce_used(
         &self,
-        _orchestrator: Address,
-        _to: Address,
-        _nonce: B256,
-    ) -> Result<bool, VaultError> {
-        Err(VaultError::InvalidReceipt)
-    }
+        orchestrator: Address,
+        to: Address,
+        nonce: B256,
+    ) -> Result<bool, VaultError>;
 
     /// Validates a delivered recipient authorization before it is stored:
     /// the signature must recover to `query.to` over the orchestrator's own
@@ -356,11 +347,9 @@ pub(crate) trait VaultService: Send + Sync {
     /// will consume.
     async fn validate_mint_authorization(
         &self,
-        _query: MintedLogQuery,
-        _authorization: &MintAuthorization,
-    ) -> Result<(), VaultError> {
-        Err(VaultError::InvalidReceipt)
-    }
+        query: MintedLogQuery,
+        authorization: &MintAuthorization,
+    ) -> Result<(), VaultError>;
 }
 
 pub(crate) type WalletNonceGuard = Option<tokio::sync::OwnedMutexGuard<()>>;

--- a/tests/harness/mod.rs
+++ b/tests/harness/mod.rs
@@ -37,8 +37,13 @@ use st0x_issuance::test_utils::{
 };
 use st0x_issuance::{
     ANVIL_CHAIN_ID, AlpacaConfig, AuthConfig, ChainConfig, Config, Environment,
-    IpWhitelist, LogLevel, Network, SignerConfig, VaultModeConfig,
+    IpWhitelist, LogLevel, Network, SignerConfig, VaultMode, VaultModeConfig,
 };
+
+/// The internal API key every harness-built config and request header share:
+/// the config value and the `X-API-KEY` header must stay identical, or every
+/// authenticated assertion fails with a 401 that hides the real cause.
+pub const TEST_API_KEY: &str = "test-key-12345678901234567890123456";
 
 pub type TestProviderBuilder = ProviderBuilder<
     Identity,
@@ -297,10 +302,7 @@ pub async fn seed_tokenized_asset_with(
     let response = client
         .post("/tokenized-assets")
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
@@ -482,10 +484,7 @@ pub async fn setup_account(
     let register_response = client
         .post("/accounts")
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
@@ -502,10 +501,7 @@ pub async fn setup_account(
     let link_response = client
         .post("/accounts/connect")
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
@@ -525,10 +521,7 @@ pub async fn setup_account(
     let whitelist_response = client
         .post(format!("/accounts/{}/wallets", link_body.client_id))
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
@@ -611,9 +604,7 @@ pub fn create_config_with_db(
             backfill_start_block: 0,
             receipt_poll_interval: tokio::time::Duration::from_millis(500),
             auth: AuthConfig {
-                issuer_api_key: "test-key-12345678901234567890123456"
-                    .parse()
-                    .expect("Valid API key"),
+                issuer_api_key: TEST_API_KEY.parse().expect("Valid API key"),
                 alpaca_ip_ranges: IpWhitelist::single(
                     "127.0.0.1/32".parse().expect("Valid IP range"),
                 ),
@@ -715,18 +706,13 @@ pub async fn orchestrator_mint_to(
     orchestrator_address: Address,
     recipient_signer: &PrivateKeySigner,
     amount: U256,
-    nonce_seed: u8,
+    nonce: B256,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
-    let provider = create_provider()
-        .wallet(EthereumWallet::from(bot_signer))
-        .connect(&evm.endpoint)
-        .await?;
+    let provider = bot_provider(evm).await?;
     let orchestrator =
         IST0xOrchestratorV1::new(orchestrator_address, &provider);
 
     let recipient = recipient_signer.address();
-    let nonce = B256::with_last_byte(nonce_seed);
     let digest = orchestrator
         .mintAuthDigest(evm.vault_address, recipient, amount, nonce)
         .call()
@@ -753,11 +739,7 @@ pub async fn approve_orchestrator(
     evm: &LocalEvm,
     orchestrator_address: Address,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
-    let provider = create_provider()
-        .wallet(EthereumWallet::from(bot_signer))
-        .connect(&evm.endpoint)
-        .await?;
+    let provider = bot_provider(evm).await?;
     let vault =
         OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
 
@@ -840,32 +822,41 @@ pub async fn perform_mint_and_confirm_with(
     wallet: Address,
     request: MintFlowRequest<'_>,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let MintFlowRequest {
-        client_id,
-        tokenization_request_id,
-        quantity,
-        underlying,
-        token,
-        network,
-    } = request;
+    let issuer_request_id =
+        initiate_mint_request(client, wallet, &request).await?;
+    confirm_mint_journal(
+        client,
+        request.tokenization_request_id,
+        &issuer_request_id,
+    )
+    .await?;
+
+    Ok(issuer_request_id)
+}
+
+/// Drives `POST /inkind/issuance` alone, returning the issuer request id —
+/// orchestrator mint flows deliver the recipient authorization between this
+/// and [`confirm_mint_journal`].
+pub async fn initiate_mint_request(
+    client: &Client,
+    wallet: Address,
+    request: &MintFlowRequest<'_>,
+) -> Result<String, Box<dyn std::error::Error>> {
     let mint_response = client
         .post("/inkind/issuance")
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
         .body(
             json!({
-                "tokenization_request_id": tokenization_request_id,
-                "qty": quantity,
-                "underlying_symbol": underlying,
-                "token_symbol": token,
-                "network": network.as_str(),
-                "client_id": client_id,
+                "tokenization_request_id": request.tokenization_request_id,
+                "qty": request.quantity,
+                "underlying_symbol": request.underlying,
+                "token_symbol": request.token,
+                "network": request.network.as_str(),
+                "client_id": request.client_id,
                 "wallet_address": wallet
             })
             .to_string(),
@@ -878,22 +869,27 @@ pub async fn perform_mint_and_confirm_with(
         .into_json()
         .await
         .expect("mint response must contain valid JSON");
-    let issuer_request_id = mint_body.issuer_request_id.to_string();
 
+    Ok(mint_body.issuer_request_id.to_string())
+}
+
+/// Drives `POST /inkind/issuance/confirm` for an initiated mint.
+pub async fn confirm_mint_journal(
+    client: &Client,
+    tokenization_request_id: &str,
+    issuer_request_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let confirm_response = client
         .post("/inkind/issuance/confirm")
         .header(rocket::http::ContentType::JSON)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
         .remote(
             "127.0.0.1:8000".parse().expect("test client address must parse"),
         )
         .body(
             json!({
                 "tokenization_request_id": tokenization_request_id,
-                "issuer_request_id": mint_body.issuer_request_id,
+                "issuer_request_id": issuer_request_id,
                 "status": "completed"
             })
             .to_string(),
@@ -903,7 +899,7 @@ pub async fn perform_mint_and_confirm_with(
 
     assert_eq!(confirm_response.status(), rocket::http::Status::Ok);
 
-    Ok(issuer_request_id)
+    Ok(())
 }
 
 /// Seeds a `SchemaRegistry` event recording the last-known schema version for
@@ -1049,4 +1045,73 @@ pub fn create_provider() -> TestProviderBuilder {
         .filler(BlobGasFiller)
         .with_simple_nonce_management()
         .filler(ChainIdFiller::default())
+}
+
+/// `amount` whole tokens in 18-decimal share-wei.
+pub fn tokens(amount: u64) -> U256 {
+    U256::from(amount) * U256::from(10u64).pow(U256::from(18u64))
+}
+
+/// A `VaultModeConfig` putting one underlying in orchestrator mode over a
+/// vault-direct default — the single-asset-pilot shape.
+pub fn orchestrator_vault_modes(
+    underlying: &str,
+    orchestrator_address: Address,
+) -> VaultModeConfig {
+    VaultModeConfig::new(
+        HashMap::from([(
+            underlying.to_string(),
+            VaultMode::Orchestrator { address: orchestrator_address },
+        )]),
+        VaultMode::VaultDirect,
+    )
+}
+
+/// A provider signing with the bot wallet's key.
+pub async fn bot_provider(
+    evm: &LocalEvm,
+) -> Result<impl alloy::providers::Provider + Clone, Box<dyn std::error::Error>>
+{
+    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
+    Ok(create_provider()
+        .wallet(EthereumWallet::from(bot_signer))
+        .connect(&evm.endpoint)
+        .await?)
+}
+
+/// Dispatches an authenticated admin `GET`, failing loudly on a non-OK
+/// status or a non-JSON body so a broken endpoint can never read as a
+/// healthy/empty response.
+pub async fn authenticated_get_json(
+    client: &Client,
+    path: &str,
+) -> serde_json::Value {
+    let response = client
+        .get(path)
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
+        .dispatch()
+        .await;
+    assert_eq!(
+        response.status(),
+        rocket::http::Status::Ok,
+        "{path} must respond OK"
+    );
+    response
+        .into_json()
+        .await
+        .unwrap_or_else(|| panic!("{path} must return a JSON body"))
+}
+
+/// Fetches the current `GET /admin/stuck` entries, failing loudly on an
+/// endpoint error so a broken endpoint can never read as "nothing stuck".
+pub async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
+    let body = authenticated_get_json(client, "/admin/stuck").await;
+
+    body["stuck"]
+        .as_array()
+        .expect("/admin/stuck must contain a stuck array")
+        .clone()
 }

--- a/tests/orchestrator_mint.rs
+++ b/tests/orchestrator_mint.rs
@@ -1,0 +1,1229 @@
+//! End-to-end orchestrator-mode mint flows on Anvil.
+//!
+//! Assets whose configured `vault_mode` resolves to `Orchestrator` mint via a
+//! single `ST0xOrchestrator.mint()` gated on a recipient authorization — the
+//! liquidity bot (stood in for here by the recipient's key) signs the
+//! orchestrator's EIP-712 `MintAuthV1` digest and delivers it through the
+//! internal authorization endpoint before the mint can submit. These tests
+//! drive the full HTTP service through the public API, with the orchestrator
+//! deployed on Anvil and only Alpaca mocked.
+
+mod harness;
+
+use alloy::network::EthereumWallet;
+use alloy::primitives::{Address, B256, Bytes, U256, b256};
+use alloy::providers::Provider;
+use alloy::signers::SignerSync;
+use alloy::signers::local::PrivateKeySigner;
+use httpmock::prelude::*;
+use rocket::local::asynchronous::Client;
+use serde_json::json;
+use sqlx::sqlite::SqlitePoolOptions;
+use st0x_issuance::bindings::IST0xOrchestratorV1;
+use st0x_issuance::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Instance;
+use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::bindings::Receipt::ReceiptInstance;
+use st0x_issuance::test_utils::LocalEvm;
+use st0x_issuance::{Network, initialize_rocket};
+
+use crate::harness::{
+    MintFlowRequest, TEST_API_KEY, authenticated_get_json, bot_provider,
+    confirm_mint_journal, create_provider, fetch_stuck_entries,
+    initiate_mint_request, orchestrator_vault_modes, tokens,
+};
+
+const USER_PRIVATE_KEY: B256 =
+    b256!("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
+
+/// Signs the orchestrator's own `mintAuthDigest(token, to, amount, nonce)`
+/// with the recipient's key — exactly what the liquidity bot does before
+/// delivering the authorization.
+async fn signed_mint_authorization(
+    evm: &LocalEvm,
+    orchestrator_address: Address,
+    recipient_signer: &PrivateKeySigner,
+    amount: U256,
+    nonce: B256,
+) -> Result<Bytes, Box<dyn std::error::Error>> {
+    let reader = bot_provider(evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let digest = orchestrator
+        .mintAuthDigest(
+            evm.vault_address,
+            recipient_signer.address(),
+            amount,
+            nonce,
+        )
+        .call()
+        .await?;
+    let signature = recipient_signer.sign_hash_sync(&digest)?;
+    Ok(Bytes::from(signature.as_bytes().to_vec()))
+}
+
+/// Delivers the liquidity bot's authorization via
+/// `POST /internal/mints/<tokenization_request_id>/authorization`.
+async fn deliver_mint_authorization(
+    client: &Client,
+    tokenization_request_id: &str,
+    nonce: B256,
+    signature: &Bytes,
+) {
+    let status = deliver_mint_authorization_response(
+        client,
+        tokenization_request_id,
+        nonce,
+        signature,
+    )
+    .await;
+
+    assert_eq!(
+        status,
+        rocket::http::Status::Ok,
+        "the mint authorization delivery must be accepted"
+    );
+}
+
+/// The non-asserting delivery, for scenarios proving a rejection.
+async fn deliver_mint_authorization_response(
+    client: &Client,
+    tokenization_request_id: &str,
+    nonce: B256,
+    signature: &Bytes,
+) -> rocket::http::Status {
+    client
+        .post(format!(
+            "/internal/mints/{tokenization_request_id}/authorization"
+        ))
+        .header(rocket::http::ContentType::JSON)
+        .header(rocket::http::Header::new("X-API-KEY", TEST_API_KEY))
+        .remote(
+            "127.0.0.1:8000".parse().expect("test client address must parse"),
+        )
+        .body(json!({ "nonce": nonce, "signature": signature }).to_string())
+        .dispatch()
+        .await
+        .status()
+}
+
+/// Polls `GET /admin/stuck` until a `MintingFailed` entry appears.
+async fn wait_for_minting_failed_entry(
+    client: &Client,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let start = tokio::time::Instant::now();
+    let timeout = tokio::time::Duration::from_secs(15);
+
+    loop {
+        if let Some(entry) = fetch_stuck_entries(client)
+            .await
+            .into_iter()
+            .find(|entry| entry["state"] == "MintingFailed")
+        {
+            return Ok(entry);
+        }
+
+        if start.elapsed() >= timeout {
+            return Err(
+                "Timeout waiting for a MintingFailed stuck entry".into()
+            );
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    }
+}
+
+/// Seeds a mint's event history directly into the `events` table — the e2e
+/// setup exception: mid-flight states like `Minting`/`TxSubmitted` cannot be
+/// induced and then frozen through the public API alone.
+async fn seed_mint_events(
+    db_url: &str,
+    issuer_request_id: &str,
+    events: &[(&str, &str, serde_json::Value)],
+) -> Result<(), Box<dyn std::error::Error>> {
+    let pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+
+    for (sequence, (event_type, event_version, payload)) in
+        (1i64..).zip(events.iter())
+    {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, ?, ?, ?, ?, '{}')
+            ",
+        )
+        .bind(issuer_request_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(event_version)
+        .bind(payload.to_string())
+        .execute(&pool)
+        .await?;
+    }
+    pool.close().await;
+
+    Ok(())
+}
+
+/// The seeded history shared by the recovery scenarios: an orchestrator-mode
+/// mint that got its authorization and started minting before the "crash".
+/// Timestamps predate the stuck threshold so an unrecovered mint would be
+/// operator-visible.
+fn seeded_mint_history(
+    issuer_request_id: &str,
+    tokenization_request_id: &str,
+    orchestrator_address: Address,
+    user_wallet: Address,
+    nonce: B256,
+) -> Vec<(&'static str, &'static str, serde_json::Value)> {
+    let old = "2020-01-01T00:00:00Z";
+    let client_id = uuid::Uuid::new_v4();
+
+    vec![
+        (
+            "MintEvent::Initiated",
+            "1.0",
+            json!({
+                "Initiated": {
+                    "issuer_request_id": issuer_request_id,
+                    "tokenization_request_id": tokenization_request_id,
+                    "quantity": "50",
+                    "underlying": "AAPL",
+                    "token": "tAAPL",
+                    "network": "base",
+                    "client_id": client_id,
+                    "wallet": user_wallet,
+                    "initiated_at": old,
+                    "mint_mode": {
+                        "Orchestrator": { "address": orchestrator_address }
+                    }
+                }
+            }),
+        ),
+        (
+            "MintEvent::MintAuthorizationReceived",
+            "1.0",
+            json!({
+                "MintAuthorizationReceived": {
+                    "issuer_request_id": issuer_request_id,
+                    "mint_authorization": {
+                        "nonce": nonce,
+                        "signature": Bytes::from(vec![0x42u8; 65])
+                    },
+                    "received_at": old
+                }
+            }),
+        ),
+        (
+            "MintEvent::JournalConfirmed",
+            "1.0",
+            json!({
+                "JournalConfirmed": {
+                    "issuer_request_id": issuer_request_id,
+                    "confirmed_at": old
+                }
+            }),
+        ),
+        (
+            "MintEvent::MintingStarted",
+            "1.0",
+            json!({
+                "MintingStarted": {
+                    "issuer_request_id": issuer_request_id,
+                    "started_at": old
+                }
+            }),
+        ),
+    ]
+}
+
+/// Sends an orchestrator mint transaction that is doomed to revert (its
+/// nonce is already consumed) with explicit gas, so it skips estimation,
+/// mines, and reverts on-chain — reproducing the race where the nonce is
+/// consumed between broadcast and mining.
+async fn send_reverting_orchestrator_mint(
+    evm: &LocalEvm,
+    orchestrator_address: Address,
+    recipient_signer: &PrivateKeySigner,
+    amount: U256,
+    nonce: B256,
+) -> Result<B256, Box<dyn std::error::Error>> {
+    let signature = signed_mint_authorization(
+        evm,
+        orchestrator_address,
+        recipient_signer,
+        amount,
+        nonce,
+    )
+    .await?;
+
+    let provider = bot_provider(evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &provider);
+    let auth = IST0xOrchestratorV1::MintAuthV1 { nonce, signature };
+
+    let receipt = orchestrator
+        .mint(
+            evm.vault_address,
+            recipient_signer.address(),
+            amount,
+            auth,
+            Bytes::new(),
+        )
+        .gas(1_000_000)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    assert!(
+        !receipt.status(),
+        "the crafted collision transaction must revert on-chain"
+    );
+
+    Ok(receipt.transaction_hash)
+}
+
+/// The full orchestrator mint flow: Alpaca requests the mint, the recipient
+/// key signs the `MintAuthV1` digest and delivers it through the internal
+/// endpoint, the journal confirms, and the service mints through
+/// `orchestrator.mint()` — shares land in the recipient wallet, the
+/// orchestrator custodies the receipt, and the Alpaca callback fires.
+#[tokio::test]
+async fn orchestrator_mint_end_to_end() -> Result<(), Box<dyn std::error::Error>>
+{
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_e2e.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    let tokenization_request_id = "alp-orch-mint-1";
+    let issuer_request_id = initiate_mint_request(
+        &client,
+        user_wallet,
+        &MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id,
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+
+    let nonce = B256::with_last_byte(1);
+    let signature = signed_mint_authorization(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(50),
+        nonce,
+    )
+    .await?;
+    deliver_mint_authorization(
+        &client,
+        tokenization_request_id,
+        nonce,
+        &signature,
+    )
+    .await;
+
+    confirm_mint_journal(&client, tokenization_request_id, &issuer_request_id)
+        .await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+
+    let shares = harness::wait_for_shares(&vault, user_wallet).await?;
+    assert_eq!(
+        shares,
+        tokens(50),
+        "the recipient wallet must receive the full minted amount"
+    );
+
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(minted_logs.len(), 1, "exactly one Minted log must exist");
+    let (minted, _log) = &minted_logs[0];
+    assert_eq!(minted.token, evm.vault_address);
+    assert_eq!(minted.to, user_wallet);
+    assert_eq!(minted.amount, tokens(50));
+    assert_eq!(minted.nonce, nonce);
+
+    // The orchestrator — not the bot or the recipient — custodies the
+    // receipt backing the minted shares (a fresh vault's first deposit
+    // holds receipt id 1).
+    let receipt_address = Address::from(vault.receipt().call().await?.0);
+    let receipt_contract = ReceiptInstance::new(receipt_address, &reader);
+    assert_eq!(
+        receipt_contract
+            .balanceOf(orchestrator_address, U256::from(1u8))
+            .call()
+            .await?,
+        tokens(50),
+        "the orchestrator must custody the mint receipt"
+    );
+    assert_eq!(
+        receipt_contract.balanceOf(user_wallet, U256::from(1u8)).call().await?,
+        U256::ZERO,
+        "the recipient must hold shares only, never the receipt"
+    );
+
+    // The liquidity bot's cue for delivering an authorization: the public
+    // status endpoint reports the asset's live-config mode.
+    let status =
+        authenticated_get_json(&client, "/tokenized-assets/AAPL/status").await;
+    assert_eq!(
+        status["vault_mode"], "orchestrator",
+        "the status endpoint must report the orchestrator mode"
+    );
+
+    Ok(())
+}
+
+/// The recipient-authorization boundary on the live HTTP path: a signature
+/// by the wrong key over the mint's own digest is rejected at delivery
+/// (422), the mint stays waiting for its authorization even after the
+/// journal confirms, and nothing ever reaches the chain.
+#[tokio::test]
+async fn wrong_signer_authorization_is_rejected_and_nothing_mints()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_wrong_signer.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    let tokenization_request_id = "alp-orch-wrong-signer-1";
+    let issuer_request_id = initiate_mint_request(
+        &client,
+        user_wallet,
+        &MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id,
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+
+    // The wrong key signs the RIGHT digest — the orchestrator's own
+    // `mintAuthDigest` for this mint's recipient and amount — so the only
+    // thing wrong with the delivery is who signed it.
+    let wrong_signer = PrivateKeySigner::random();
+    let nonce = B256::with_last_byte(9);
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let digest = orchestrator
+        .mintAuthDigest(evm.vault_address, user_wallet, tokens(50), nonce)
+        .call()
+        .await?;
+    let wrong_signature =
+        Bytes::from(wrong_signer.sign_hash_sync(&digest)?.as_bytes().to_vec());
+
+    let status = deliver_mint_authorization_response(
+        &client,
+        tokenization_request_id,
+        nonce,
+        &wrong_signature,
+    )
+    .await;
+    assert_eq!(
+        status,
+        rocket::http::Status::UnprocessableEntity,
+        "a wrong-signer authorization must be rejected at delivery"
+    );
+
+    // Even with the journal confirmed, the unauthorized mint must defer —
+    // never fall back to vault-direct, never submit.
+    confirm_mint_journal(&client, tokenization_request_id, &issuer_request_id)
+        .await?;
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert!(
+        minted_logs.is_empty(),
+        "no Minted log may exist after a rejected authorization"
+    );
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    assert_eq!(
+        vault.balanceOf(user_wallet).call().await?,
+        U256::ZERO,
+        "the recipient must receive nothing from a rejected authorization"
+    );
+
+    Ok(())
+}
+
+/// Production ordering the happy path cannot prove: Alpaca confirms the
+/// journal on its own schedule, so the mint routinely reaches `Minting`
+/// before the liquidity bot delivers the recipient authorization. The submit
+/// job defers (never falls back to vault-direct), and the authorization's
+/// arrival wakes recovery — the mint must still complete end-to-end: exactly
+/// one `Minted` log and the Alpaca callback fired.
+#[tokio::test]
+async fn authorization_after_journal_confirmation_still_completes()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_deferred.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+
+    let tokenization_request_id = "alp-orch-deferred-1";
+    let issuer_request_id = initiate_mint_request(
+        &client,
+        user_wallet,
+        &MintFlowRequest {
+            client_id: &link_body.client_id.to_string(),
+            tokenization_request_id,
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+
+    // Journal first: the mint enters `Minting` with no authorization and the
+    // submit job's defer branch parks it — no event, no vault call.
+    confirm_mint_journal(&client, tokenization_request_id, &issuer_request_id)
+        .await?;
+
+    // The late delivery is the wake-up: the endpoint records the
+    // authorization and kicks recovery, which re-drives the deferred
+    // submission.
+    let nonce = B256::with_last_byte(2);
+    let signature = signed_mint_authorization(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(50),
+        nonce,
+    )
+    .await?;
+    deliver_mint_authorization(
+        &client,
+        tokenization_request_id,
+        nonce,
+        &signature,
+    )
+    .await;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let shares = harness::wait_for_shares(&vault, user_wallet).await?;
+    assert_eq!(
+        shares,
+        tokens(50),
+        "the deferred mint must complete once the authorization arrives"
+    );
+
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(
+        minted_logs.len(),
+        1,
+        "the resumed mint must submit exactly once"
+    );
+    let (minted, _log) = &minted_logs[0];
+    assert_eq!(minted.to, user_wallet);
+    assert_eq!(minted.amount, tokens(50));
+    assert_eq!(minted.nonce, nonce);
+
+    Ok(())
+}
+
+/// Kill-and-restart recovery of an orchestrator mint that already landed
+/// on-chain: the seeded mint crashed in `Minting` after its authorization
+/// arrived, while its transaction actually minted. Startup recovery
+/// full-matches the landed `Minted` log and completes the mint without ever
+/// submitting again — exactly one `Minted` log, the double-mint guard.
+#[tokio::test]
+async fn recovery_of_landed_orchestrator_mint_is_a_noop()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // The mint that "already landed before the crash": consumes
+    // (user, nonce 7) for exactly the seeded amount and token.
+    let nonce = B256::with_last_byte(7);
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(50),
+        nonce,
+    )
+    .await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_recovery.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let issuer_request_id = uuid::Uuid::new_v4().to_string();
+    seed_mint_events(
+        &db_url,
+        &issuer_request_id,
+        &seeded_mint_history(
+            &issuer_request_id,
+            "alp-orch-recovery-1",
+            orchestrator_address,
+            user_wallet,
+            nonce,
+        ),
+    )
+    .await?;
+
+    let reader = bot_provider(&evm).await?;
+    // Recovery's landed-log scan deliberately excludes the newest blocks as
+    // a reorg buffer; mine past it so the landing is inside the window, as
+    // it would be by the time real recovery re-drives a parked mint.
+    reader
+        .raw_request::<_, serde_json::Value>("anvil_mine".into(), (40u64,))
+        .await?;
+    // The bot's on-chain transaction count is the assertion that can
+    // actually fail on a resubmission: a second `mint()` with the consumed
+    // nonce would revert without emitting a log, so the Minted-log count
+    // below stays 1 no matter what the bot does — only the account nonce
+    // betrays a broadcast.
+    let bot_nonce_before =
+        reader.get_transaction_count(evm.wallet_address).await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    // Startup recovery completes the mint through the landed-log full match;
+    // the Alpaca callback is the completion signal.
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(
+        minted_logs.len(),
+        1,
+        "recovery must record the landed mint, never submit a second one"
+    );
+    assert_eq!(
+        reader.get_transaction_count(evm.wallet_address).await?,
+        bot_nonce_before,
+        "recovery must never broadcast anything — not even a doomed \
+         resubmission that would revert"
+    );
+
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &reader);
+    assert_eq!(
+        vault.balanceOf(user_wallet).call().await?,
+        tokens(50),
+        "the recipient balance must be exactly the single landed mint"
+    );
+
+    Ok(())
+}
+
+/// A `(to, nonce)` collision with a different amount must never falsely
+/// complete: the seeded mint's submitted transaction reverted with
+/// `NonceReplayed` because another mint consumed the pair for a smaller
+/// amount. Recovery full-matches the landed log, finds the amount differs,
+/// and fails the mint as `NonceConsumedByOtherMint` for manual
+/// reconciliation — visible in `/admin/stuck`, never auto-retried, no
+/// callback.
+#[tokio::test]
+async fn nonce_collision_fails_for_manual_reconciliation()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // A different mint consumes (user, nonce 9) first — for 10 tokens, not
+    // the 50 the seeded mint is for.
+    let nonce = B256::with_last_byte(9);
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(10),
+        nonce,
+    )
+    .await?;
+
+    // The seeded mint's own transaction: signed over 50 tokens with the now
+    // consumed nonce, sent with explicit gas so it mines and reverts
+    // on-chain (estimation would refuse to broadcast it).
+    let reverted_tx_hash = send_reverting_orchestrator_mint(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(50),
+        nonce,
+    )
+    .await?;
+
+    // Move the other mint's landing past the reorg-confirmation buffer so
+    // the confirm-side scan can SEE it — the proven-mismatch verdict
+    // requires the log; an in-buffer landing would (correctly) read as the
+    // inconclusive `NonceReplayUnresolved` instead.
+    bot_provider(&evm)
+        .await?
+        .raw_request::<_, serde_json::Value>("anvil_mine".into(), (40u64,))
+        .await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_collision.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let issuer_request_id = uuid::Uuid::new_v4().to_string();
+    let mut events = seeded_mint_history(
+        &issuer_request_id,
+        "alp-orch-collision-1",
+        orchestrator_address,
+        user_wallet,
+        nonce,
+    );
+    events.push((
+        "MintEvent::MintTxSubmitted",
+        "2.0",
+        json!({
+            "MintTxSubmitted": {
+                "issuer_request_id": issuer_request_id,
+                "external_tx_id": format!("mint-{issuer_request_id}"),
+                "tx_id": { "hash": reverted_tx_hash },
+                "submitted_at": "2020-01-01T00:00:00Z"
+            }
+        }),
+    ));
+    seed_mint_events(&db_url, &issuer_request_id, &events).await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let entry = wait_for_minting_failed_entry(&client).await?;
+    assert_eq!(entry["aggregate_id"], issuer_request_id.as_str());
+    let detail =
+        entry["detail"].as_str().expect("the stuck detail must be a string");
+    // The typed classification is the retry-exclusion signal — asserting it
+    // (not just the revert text) distinguishes the never-auto-retried park
+    // from a retryable `Unclassified` failure, which would pass the same
+    // stuck-state check while meaning the opposite.
+    assert!(
+        detail.contains("NonceConsumedByOtherMint"),
+        "the stuck detail must carry the typed classification, got: {detail}"
+    );
+    assert!(
+        detail.contains("NonceReplayed"),
+        "the stuck detail must carry the decoded revert, got: {detail}"
+    );
+
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(
+        minted_logs.len(),
+        1,
+        "the collision must never be completed or resubmitted"
+    );
+    let (minted, _log) = &minted_logs[0];
+    assert_eq!(
+        minted.amount,
+        tokens(10),
+        "the only landed mint must be the other mint's"
+    );
+
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &reader);
+    assert_eq!(
+        vault.balanceOf(user_wallet).call().await?,
+        tokens(10),
+        "the seeded mint's 50 tokens must never have minted"
+    );
+    assert_eq!(
+        mint_callback_mock.calls(),
+        0,
+        "a nonce-collision failure must never fire the Alpaca callback"
+    );
+
+    Ok(())
+}
+
+/// The inconclusive-replay lifecycle only e2e can prove, across a service
+/// restart: the mint's own landing sits INSIDE the reorg-confirmation
+/// buffer, so the pre-submit guard finds the nonce consumed with no visible
+/// log and parks the mint as `NonceReplayUnresolved` (stuck-visible, no
+/// callback, nothing broadcast). Once the chain moves past the buffer, the
+/// next service start's recovery reconciles with the widened window,
+/// full-matches the landing, and resolves the mint forward to its callback
+/// — still without ever broadcasting anything.
+#[tokio::test]
+async fn unresolved_replay_parks_then_reconciles_after_restart()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // The mint's OWN landing: consumes (user, nonce 7) for exactly the
+    // seeded amount and token, moments before the "crash" — so it is still
+    // inside the reorg-confirmation buffer when recovery first re-drives.
+    let nonce = B256::with_last_byte(7);
+    harness::orchestrator_mint_to(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(50),
+        nonce,
+    )
+    .await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_unresolved.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "AAPL",
+        "tAAPL",
+    )
+    .await?;
+
+    let issuer_request_id = uuid::Uuid::new_v4().to_string();
+    seed_mint_events(
+        &db_url,
+        &issuer_request_id,
+        &seeded_mint_history(
+            &issuer_request_id,
+            "alp-orch-unresolved-1",
+            orchestrator_address,
+            user_wallet,
+            nonce,
+        ),
+    )
+    .await?;
+
+    let reader = bot_provider(&evm).await?;
+    let bot_nonce_before =
+        reader.get_transaction_count(evm.wallet_address).await?;
+
+    // Phase 1: recovery re-drives the seeded mint; the guard finds the
+    // nonce consumed with no log inside the buffered window and parks the
+    // mint unresolved.
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let entry = wait_for_minting_failed_entry(&client).await?;
+    assert_eq!(entry["aggregate_id"], issuer_request_id.as_str());
+    let detail =
+        entry["detail"].as_str().expect("the stuck detail must be a string");
+    assert!(
+        detail.contains("NonceReplayUnresolved"),
+        "the parked mint must carry the inconclusive classification, got: \
+         {detail}"
+    );
+    assert_eq!(
+        mint_callback_mock.calls(),
+        0,
+        "an unresolved replay must not fire the Alpaca callback"
+    );
+
+    // "Crash" the first service, then let the chain move past the
+    // reorg-confirmation buffer — as it would within a minute on Base.
+    drop(client);
+    reader
+        .raw_request::<_, serde_json::Value>("anvil_mine".into(), (40u64,))
+        .await?;
+
+    // Phase 2: the restarted service's recovery reconciles with the widened
+    // window, full-matches the landing, and drives the mint to its
+    // callback.
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("AAPL", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let _client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(
+        minted_logs.len(),
+        1,
+        "reconciliation must resolve the landed mint, never submit again"
+    );
+    assert_eq!(
+        reader.get_transaction_count(evm.wallet_address).await?,
+        bot_nonce_before,
+        "neither phase may broadcast anything from the bot wallet"
+    );
+
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &reader);
+    assert_eq!(
+        vault.balanceOf(user_wallet).call().await?,
+        tokens(50),
+        "the recipient balance must be exactly the single landed mint"
+    );
+
+    Ok(())
+}
+
+/// Two assets in one deployment — one orchestrator-mode, one vault-direct —
+/// each mint takes its own path, side by side. This is the
+/// single-asset-pilot configuration.
+#[tokio::test]
+async fn mixed_mode_assets_each_take_their_own_mint_path()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_signer = PrivateKeySigner::from_bytes(&USER_PRIVATE_KEY)?;
+    let user_wallet = user_signer.address();
+
+    // Primary vault: RKLB, orchestrator mode.
+    evm.grant_certify_role(evm.wallet_address).await?;
+    evm.certify_vault(U256::MAX).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+
+    // Second vault: AAPL, vault-direct with the untouched mint flow.
+    let (vault2_address, vault2_authorizer) =
+        evm.deploy_additional_vault().await?;
+    harness::setup_roles_on_vault(
+        &evm,
+        vault2_authorizer,
+        vault2_address,
+        user_wallet,
+        bot_wallet,
+    )
+    .await?;
+
+    let mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir.path().join("orchestrator_mint_mixed.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+    harness::preseed_tokenized_asset(
+        &db_url,
+        evm.vault_address,
+        "RKLB",
+        "tRKLB",
+    )
+    .await?;
+    harness::preseed_tokenized_asset(&db_url, vault2_address, "AAPL", "tAAPL")
+        .await?;
+
+    let (config, _mock_subgraph) = harness::create_config_with_vault_modes(
+        &db_url,
+        &mock_alpaca,
+        &evm,
+        orchestrator_vault_modes("RKLB", orchestrator_address),
+    )?;
+    let rocket = initialize_rocket(config).await?;
+    let client = rocket::local::asynchronous::Client::tracked(rocket).await?;
+
+    let link_body = harness::setup_account(&client, user_wallet).await;
+    let client_id = link_body.client_id.to_string();
+
+    // Orchestrator-mode RKLB mint: initiate, deliver the authorization,
+    // confirm.
+    let rklb_tokenization_id = "alp-mint-rklb-mixed";
+    let rklb_issuer_id = initiate_mint_request(
+        &client,
+        user_wallet,
+        &MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: rklb_tokenization_id,
+            quantity: "25.0",
+            underlying: "RKLB",
+            token: "tRKLB",
+            network: Network::Base,
+        },
+    )
+    .await?;
+    let nonce = B256::with_last_byte(2);
+    let signature = signed_mint_authorization(
+        &evm,
+        orchestrator_address,
+        &user_signer,
+        tokens(25),
+        nonce,
+    )
+    .await?;
+    deliver_mint_authorization(
+        &client,
+        rklb_tokenization_id,
+        nonce,
+        &signature,
+    )
+    .await;
+    confirm_mint_journal(&client, rklb_tokenization_id, &rklb_issuer_id)
+        .await?;
+
+    // Vault-direct AAPL mint: the plain flow, no authorization anywhere.
+    harness::perform_mint_and_confirm_with(
+        &client,
+        user_wallet,
+        harness::MintFlowRequest {
+            client_id: &client_id,
+            tokenization_request_id: "alp-mint-aapl-mixed",
+            quantity: "50.0",
+            underlying: "AAPL",
+            token: "tAAPL",
+            network: Network::Base,
+        },
+    )
+    .await?;
+
+    let user_provider = create_provider()
+        .wallet(EthereumWallet::from(user_signer))
+        .connect(&evm.endpoint)
+        .await?;
+    let orchestrator_vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let direct_vault =
+        OffchainAssetReceiptVaultInstance::new(vault2_address, &user_provider);
+
+    assert_eq!(
+        harness::wait_for_shares(&orchestrator_vault, user_wallet).await?,
+        tokens(25),
+        "the orchestrator-mode mint must land its full amount"
+    );
+    assert_eq!(
+        harness::wait_for_shares(&direct_vault, user_wallet).await?,
+        tokens(50),
+        "the vault-direct mint must land its full amount"
+    );
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+
+    // Only the orchestrator-mode asset minted through the orchestrator; the
+    // vault-direct asset never touched it.
+    let reader = bot_provider(&evm).await?;
+    let orchestrator =
+        IST0xOrchestratorV1Instance::new(orchestrator_address, &reader);
+    let minted_logs =
+        orchestrator.Minted_filter().from_block(0).query().await?;
+    assert_eq!(
+        minted_logs.len(),
+        1,
+        "only the orchestrator asset may mint through the orchestrator"
+    );
+    let (minted, _log) = &minted_logs[0];
+    assert_eq!(
+        minted.token, evm.vault_address,
+        "the orchestrator mint must be for the orchestrator-mode asset"
+    );
+    assert_eq!(minted.amount, tokens(25));
+    assert_eq!(minted.to, user_wallet);
+
+    // Each asset's status endpoint reports its own mode — the liquidity
+    // bot's cue for which mints need an authorization.
+    let rklb_status =
+        authenticated_get_json(&client, "/tokenized-assets/RKLB/status").await;
+    assert_eq!(rklb_status["vault_mode"], "orchestrator");
+    let aapl_status =
+        authenticated_get_json(&client, "/tokenized-assets/AAPL/status").await;
+    assert_eq!(aapl_status["vault_mode"], "vault_direct");
+
+    Ok(())
+}

--- a/tests/orchestrator_redemption.rs
+++ b/tests/orchestrator_redemption.rs
@@ -17,84 +17,19 @@ use httpmock::prelude::*;
 use rocket::local::asynchronous::Client;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
-use std::collections::HashMap;
 
 use st0x_issuance::bindings::IST0xOrchestratorV1::IST0xOrchestratorV1Instance;
 use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::{Network, initialize_rocket};
-use st0x_issuance::{VaultMode, VaultModeConfig};
 
-use crate::harness::{MintFlowRequest, create_provider};
+use crate::harness::{
+    MintFlowRequest, authenticated_get_json, bot_provider, create_provider,
+    fetch_stuck_entries, orchestrator_vault_modes, tokens,
+};
 
 const USER_PRIVATE_KEY: B256 =
     b256!("0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d");
-
-fn tokens(amount: u64) -> U256 {
-    U256::from(amount) * U256::from(10u64).pow(U256::from(18u64))
-}
-
-fn orchestrator_vault_modes(
-    underlying: &str,
-    orchestrator_address: Address,
-) -> VaultModeConfig {
-    VaultModeConfig::new(
-        HashMap::from([(
-            underlying.to_string(),
-            VaultMode::Orchestrator { address: orchestrator_address },
-        )]),
-        VaultMode::VaultDirect,
-    )
-}
-
-async fn bot_provider(
-    evm: &LocalEvm,
-) -> Result<impl alloy::providers::Provider + Clone, Box<dyn std::error::Error>>
-{
-    let bot_signer = PrivateKeySigner::from_bytes(&evm.private_key)?;
-    Ok(create_provider()
-        .wallet(EthereumWallet::from(bot_signer))
-        .connect(&evm.endpoint)
-        .await?)
-}
-
-/// Dispatches an authenticated admin `GET`, failing loudly on a non-OK
-/// status or a non-JSON body so a broken endpoint can never read as a
-/// healthy/empty response.
-async fn authenticated_get_json(
-    client: &Client,
-    path: &str,
-) -> serde_json::Value {
-    let response = client
-        .get(path)
-        .header(rocket::http::Header::new(
-            "X-API-KEY",
-            "test-key-12345678901234567890123456",
-        ))
-        .remote("127.0.0.1:8000".parse().unwrap())
-        .dispatch()
-        .await;
-    assert_eq!(
-        response.status(),
-        rocket::http::Status::Ok,
-        "{path} must respond OK"
-    );
-    response
-        .into_json()
-        .await
-        .unwrap_or_else(|| panic!("{path} must return a JSON body"))
-}
-
-/// Fetches the current `GET /admin/stuck` entries, failing loudly on an
-/// endpoint error so a broken endpoint can never read as "nothing stuck".
-async fn fetch_stuck_entries(client: &Client) -> Vec<serde_json::Value> {
-    let body = authenticated_get_json(client, "/admin/stuck").await;
-
-    body["stuck"]
-        .as_array()
-        .expect("/admin/stuck must contain a stuck array")
-        .clone()
-}
 
 /// Polls `GET /admin/stuck` until a `BurnFailed` entry appears, returning it.
 async fn wait_for_burn_failed_entry(
@@ -261,7 +196,7 @@ async fn orchestrator_burn_walks_multiple_receipts()
             orchestrator_address,
             &user_signer,
             tokens(10),
-            nonce_seed,
+            B256::with_last_byte(nonce_seed),
         )
         .await?;
     }
@@ -359,7 +294,7 @@ async fn orchestrator_shortfall_is_classified_without_submission()
         orchestrator_address,
         &user_signer,
         tokens(10),
-        1,
+        B256::with_last_byte(1),
     )
     .await?;
     // ...but the user holds 30: 20 more minted with a receipt the user
@@ -463,7 +398,7 @@ async fn orchestrator_recovery_confirms_landed_burn_without_resubmitting()
         orchestrator_address,
         &bot_signer,
         tokens(10),
-        1,
+        B256::with_last_byte(1),
     )
     .await?;
     let provider = bot_provider(&evm).await?;
@@ -658,7 +593,7 @@ async fn orchestrator_crash_recovery_confirms_in_flight_burn_failed()
         orchestrator_address,
         &bot_signer,
         tokens(10),
-        1,
+        B256::with_last_byte(1),
     )
     .await?;
     let provider = bot_provider(&evm).await?;
@@ -880,7 +815,7 @@ async fn mixed_mode_assets_each_take_their_own_burn_path()
         orchestrator_address,
         &user_signer,
         tokens(10),
-        1,
+        B256::with_last_byte(1),
     )
     .await?;
 


### PR DESCRIPTION
## Motivation

Orchestrator-mode mints require a recipient authorization — the liquidity bot signs the orchestrator's EIP-712 `MintAuthV1` digest over `(token, to, amount, nonce)` and delivers it before the mint can proceed. Previously, the wire shape and correlation key for this internal call were left as implementation details to be resolved later. The `vault_mode` field was also absent from the tokenized asset status endpoint, leaving the liquidity bot without a way to know which assets require an authorization.

## Solution

The internal authorization endpoint is now settled as `POST /internal/mints/<tokenization_request_id>/authorization` with body `{ "nonce": <bytes32 hex>, "signature": <hex bytes> }`, correlated by `tokenization_request_id`. The endpoint validates the EIP-712 signer and queries `nonceUsed()` on-chain before recording the authorization. Response semantics are fully specified: `200` (idempotent re-delivery), `404` (unknown mint), `409` (conflicting authorization already recorded or mint already past intent), `422` (vault-direct asset, bad signer, or nonce already consumed), and `502` (retryable on-chain read failure).

The consumed nonce is the mint's idempotency key for recovery: startup recovery full-matches the orchestrator's `Minted` log against `(to, nonce, token, amount)` and completes without resubmitting. A nonce consumed by a different mint parks the mint as a classified failure for manual reconciliation rather than falsely completing it. The `vault_mode` field is now included in `GET /tokenized-assets/<underlying>/status` so the liquidity bot can determine which assets require an authorization.

End-to-end tests on Anvil cover the full orchestrator mint flow, kill-and-restart recovery of a mint that already landed on-chain (asserting exactly one `Minted` log and no resubmission), nonce collision parking as a `MintingFailed` stuck entry with no Alpaca callback, and a mixed-mode deployment where an orchestrator-mode asset and a vault-direct asset each take their own path concurrently.

Closes [RAI-1620](https://linear.app/makeitrain/issue/RAI-1620/orchestrator-mode-mint-path-with-recipient-authorization-and-e2e-tests)

Closes [RAI-1220](https://linear.app/makeitrain/issue/RAI-1220/5-mint-via-orchestratormint-with-recipient-authorization)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added per-asset vault-mode selection for direct and orchestrated minting.
  - Added authorization submission for orchestrated mints with nonce-based replay protection and idempotent handling.
  - Added recovery for previously completed or interrupted orchestrated mints.

- **Bug Fixes**
  - Prevented duplicate mint submissions after successful transactions.
  - Improved handling of nonce conflicts and temporary authorization lookup failures.

- **Documentation**
  - Documented vault modes, authorization flows, response outcomes, and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->