### PR TITLE
fix: mid-outage custody-cutover hotfixes (deployed; report only)

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,10 +1,24 @@
 name: Deploy to Production
 
+# TEMPORARY BREAK-GLASS VARIANT — exists only on this hotfix branch, never
+# merges to main. Deploys a tag NOT on main during the custody-migration
+# window, triple-bound (tag == dispatch branch HEAD == pasted SHA), pinned to
+# one actor and this one branch. The service profile alone is deployed.
+run-name: "BREAK GLASS prod: ${{ inputs.tag }} by ${{ github.actor }}"
+
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Git tag to deploy (must be on main)"
+        description: "Unique tag pointing at this branch's HEAD"
+        required: true
+        type: string
+      break_glass:
+        description: "Deploy a commit not on main"
+        required: true
+        type: boolean
+      confirm_sha:
+        description: "Paste the full 40-character commit SHA"
         required: true
         type: string
 
@@ -13,6 +27,10 @@ permissions:
 
 jobs:
   deploy:
+    if: >-
+      github.actor == '0xgleb' &&
+      github.ref == 'refs/heads/fix/window-bypass-activation-and-listing-view' &&
+      inputs.break_glass
     environment: production
     concurrency:
       group: deploy-prod
@@ -29,9 +47,10 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Verify tag is on main
+      - name: Verify exact break-glass revision
         env:
           DEPLOY_TAG: ${{ inputs.tag }}
+          CONFIRM_SHA: ${{ inputs.confirm_sha }}
         run: |
           git fetch --tags origin main
           if ! git rev-parse -q --verify "refs/tags/$DEPLOY_TAG" >/dev/null; then
@@ -44,8 +63,16 @@ jobs:
             echo "ERROR: checked-out commit does not match tag $DEPLOY_TAG" >&2
             exit 1
           fi
-          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
-            echo "ERROR: tag $DEPLOY_TAG is not on main" >&2
+          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
+            echo "ERROR: tag does not match dispatch branch HEAD" >&2
+            exit 1
+          fi
+          if [ "$CONFIRM_SHA" != "$tag_commit" ]; then
+            echo "ERROR: confirmation SHA mismatch" >&2
+            exit 1
+          fi
+          if git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "ERROR: commit is on main - use the normal deploy path" >&2
             exit 1
           fi
 
@@ -98,8 +125,8 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-      - name: Deploy all profiles
-        run: nix run .#prodDeployAll
+      - name: Deploy issuance service only
+        run: nix run .#prodDeployService -- st0x-issuance
 
       - name: Cleanup SSH
         if: always()

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,6 +1625,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const_format"
 version = "0.2.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1896,7 +1902,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -2005,7 +2011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.6",
  "subtle",
 ]
@@ -2017,6 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.1",
+ "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
 ]
@@ -2310,7 +2317,7 @@ dependencies = [
  "chrono",
  "futures",
  "http 1.4.0",
- "jsonwebtoken",
+ "jsonwebtoken 10.4.0",
  "rand 0.9.4",
  "reqwest",
  "reqwest-middleware",
@@ -3337,6 +3344,30 @@ name = "jsonwebtoken"
 version = "10.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hmac 0.12.1",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "11.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -4826,7 +4857,7 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
@@ -5940,6 +5971,7 @@ dependencies = [
  "httpmock",
  "ipnetwork",
  "itertools 0.14.0",
+ "jsonwebtoken 11.0.0",
  "mime",
  "opentelemetry",
  "opentelemetry-otlp",
@@ -5953,6 +5985,7 @@ dependencies = [
  "rust_decimal_macros",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "sqlite-es",
  "sqlx 0.9.0",
  "st0x-issuance-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2309,7 +2309,7 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 [[package]]
 name = "fireblocks-sdk"
 version = "2025.10.17"
-source = "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix%2Fconfirming-not-terminal#18227211082342818efaf6a1b58c89c65a6f17cd"
+source = "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix%2Fconfirming-not-terminal#7b9d5abd5f39138448c54fc751dc72a35710429a"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,9 @@ apalis-sqlite = "=1.0.0-rc.8"
 apalis-core = "=1.0.0-rc.9"
 apalis-codec = "=0.1.0-rc.9"
 fireblocks-sdk = { git = "https://github.com/0xgleb/fireblocks-sdk-rs.git", branch = "fix/confirming-not-terminal", version = "2025.10.17" }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
+sha2 = "0.11.0"
+rand = "0.8"
 
 [dev-dependencies]
 alloy-node-bindings = "1.0.41"

--- a/deploy.nix
+++ b/deploy.nix
@@ -68,11 +68,14 @@ let
           throw "Unsupported environment '${env}'";
     in
     activate.custom pkg (
-      builtins.concatStringsSep " && " [
-        # pipefail makes the rage | install pipes fail if rage exits non-zero,
-        # preventing an empty credential file from being written and the service
-        # restarted with empty creds.
-        "set -o pipefail"
+      # Newline-joined under `set -e`, NOT " && ": the multi-line steps below
+      # end with newlines, and an "&&"-join would emit a line starting with
+      # "&&", which bash rejects at parse time. `set -e` keeps the same
+      # fail-fast semantics; pipefail makes the rage | install pipes fail if
+      # rage exits non-zero, preventing an empty credential file from being
+      # written and the service restarted with empty creds.
+      builtins.concatStringsSep "\n" [
+        "set -euo pipefail"
         "systemctl stop ${name} || true"
         "rm -f ${cfg.markerFile}"
         "mkdir -p /run/st0x /run/agenix"

--- a/flake.nix
+++ b/flake.nix
@@ -178,8 +178,8 @@
           outputHashes = {
             "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.2#8f5c81f3472ac4ca84bbcebbddaa0b3b01f2cfea" =
               "sha256-d0bl1jVmPeu9UPl4cNjY+cAaaLEDmLxw1BQhGrH5eV8=";
-            "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#18227211082342818efaf6a1b58c89c65a6f17cd" =
-              "sha256-KThUI0Cvh1JELem7SUQ1K3WqMccFeYfS3BqfLXwk2AE=";
+            "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#7b9d5abd5f39138448c54fc751dc72a35710429a" =
+              "sha256-a/5JcK9oxGMS1hgt8TIXaXcLOECPpGGaFsie+j5LeOk=";
           };
         };
 

--- a/rust.nix
+++ b/rust.nix
@@ -27,8 +27,8 @@ let
     outputHashes = {
       "git+https://github.com/ST0X-Technology/event-sorcery.git?tag=0.1.2#8f5c81f3472ac4ca84bbcebbddaa0b3b01f2cfea" =
         "sha256-d0bl1jVmPeu9UPl4cNjY+cAaaLEDmLxw1BQhGrH5eV8=";
-      "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#18227211082342818efaf6a1b58c89c65a6f17cd" =
-        "sha256-KThUI0Cvh1JELem7SUQ1K3WqMccFeYfS3BqfLXwk2AE=";
+      "git+https://github.com/0xgleb/fireblocks-sdk-rs.git?branch=fix/confirming-not-terminal#7b9d5abd5f39138448c54fc751dc72a35710429a" =
+        "sha256-a/5JcK9oxGMS1hgt8TIXaXcLOECPpGGaFsie+j5LeOk=";
     };
   };
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -21,7 +21,7 @@ use crate::auth::InternalAuth;
 use crate::mint::{
     IssuerMintRequestId, ManualRecoveryDecision, Mint, MintCommand, MintEvent,
     MintView, TokenizationRequestId, find_stuck as find_stuck_mints,
-    recovery::enqueue_scheduled_mint_recovery,
+    recovery::{enqueue_scheduled_mint_recovery, manually_retry_failed_mint},
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -1162,23 +1162,43 @@ pub(crate) async fn reprocess_mint(
     }
     let current_state = mint.state_name().to_string();
 
-    // Manual reprocess enqueues a durable recovery job — the same path the
-    // automatic startup re-scan and the periodic reconciler use. It frees any
-    // terminal recovery job for this mint and re-drives it through the per-state
-    // jobs to completion.
-    enqueue_scheduled_mint_recovery(
-        pool.inner(),
-        apalis_pool.inner(),
-        issuer_request_id,
-    )
-    .await
-    .map_err(|error| {
-        error!(target: "admin", aggregate_id = aggregate_id,
-            error = %error,
-            "Failed to enqueue scheduled mint recovery"
-        );
-        Status::InternalServerError
-    })?;
+    // A failed mint is retried DIRECTLY — RetryMint plus a fresh submit job —
+    // because the scheduled-recovery loop enforces the automatic retry budget
+    // and would abandon an exhausted mint instead of retrying it. Every other
+    // eligible state enqueues the durable recovery job, the same path the
+    // automatic startup re-scan and the periodic reconciler use.
+    if matches!(&mint, Mint::MintingFailed { .. }) {
+        manually_retry_failed_mint(
+            store.inner(),
+            pool.inner(),
+            vault_services.inner(),
+            apalis_pool.inner(),
+            &issuer_request_id,
+            &mint,
+        )
+        .await
+        .map_err(|error| {
+            error!(target: "admin", aggregate_id = aggregate_id,
+                error = %error,
+                "Failed to drive manual mint retry"
+            );
+            Status::InternalServerError
+        })?;
+    } else {
+        enqueue_scheduled_mint_recovery(
+            pool.inner(),
+            apalis_pool.inner(),
+            issuer_request_id,
+        )
+        .await
+        .map_err(|error| {
+            error!(target: "admin", aggregate_id = aggregate_id,
+                error = %error,
+                "Failed to enqueue scheduled mint recovery"
+            );
+            Status::InternalServerError
+        })?;
+    }
 
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,

--- a/src/fireblocks/auth_probe.rs
+++ b/src/fireblocks/auth_probe.rs
@@ -31,7 +31,7 @@ pub struct AuthProbeReport {
 pub enum AuthProbeError {
     #[error("failed to build the probe JWT: {0}")]
     Jwt(#[from] jsonwebtoken::errors::Error),
-    #[error("probe request failed before receiving a response: {0}")]
+    #[error("probe HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("system clock error: {0}")]
     Clock(#[from] std::time::SystemTimeError),
@@ -119,7 +119,8 @@ pub async fn probe_auth(
 ///
 /// # Errors
 ///
-/// Returns an error if either probe fails before receiving a response.
+/// Returns an error if either probe fails to send its request or to read
+/// the response body.
 pub async fn probe_auth_pair(
     base_url: &str,
     config: &FireblocksConfig,

--- a/src/fireblocks/auth_probe.rs
+++ b/src/fireblocks/auth_probe.rs
@@ -1,0 +1,292 @@
+//! A/B probe for Fireblocks API authentication.
+//!
+//! Sends the same authenticated GET twice, varying only the JWT expiry
+//! window, and surfaces the raw HTTP status and response body the platform
+//! returns. Exists because the SDK both violates Fireblocks' documented
+//! `exp < iat + 30s` bound (it signs `iat + 55`) and swallows 401 response
+//! bodies, leaving a bare status code that cannot distinguish a rejected
+//! expiry window from a disabled API user, an expired certificate, or a
+//! permission change. The probe mirrors the SDK's JWT claims exactly and
+//! reports what the server actually said.
+
+use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use rand::Rng;
+use serde::Serialize;
+use sha2::{Digest, Sha256};
+use std::fmt::Write;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use super::config::FireblocksConfig;
+
+/// What one probe request observed: the expiry window it signed with and the
+/// verbatim platform response.
+#[derive(Debug)]
+pub struct AuthProbeReport {
+    pub expiry_seconds: u64,
+    pub status: u16,
+    pub body: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum AuthProbeError {
+    #[error("failed to build the probe JWT: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("probe request failed before receiving a response: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("system clock error: {0}")]
+    Clock(#[from] std::time::SystemTimeError),
+    #[error("failed to format the body hash: {0}")]
+    Fmt(#[from] std::fmt::Error),
+}
+
+/// The JWT claims Fireblocks authenticates, mirroring the SDK's shape
+/// (`uri`, `nonce`, `iat`, `exp`, `sub`, `bodyHash`) so a probe failure is
+/// attributable to the platform, not to a differently-shaped token.
+#[derive(Debug, Serialize)]
+struct ProbeClaims<'request> {
+    uri: &'request str,
+    nonce: u64,
+    iat: u64,
+    exp: u64,
+    sub: &'request str,
+    #[serde(rename = "bodyHash")]
+    body_hash: String,
+}
+
+/// Sends one authenticated GET to `base_url` + `uri_path`, signing the JWT
+/// with an expiry of `iat + expiry_seconds`, and returns the raw status and
+/// body. Never logs or returns the key material.
+///
+/// # Errors
+///
+/// Returns an error if the JWT cannot be signed, the clock is unreadable, or
+/// the request fails at the transport layer (a non-2xx response is a report,
+/// not an error).
+pub async fn probe_auth(
+    base_url: &str,
+    api_user_id: &str,
+    rsa_key_pem: &[u8],
+    uri_path: &str,
+    expiry_seconds: u64,
+) -> Result<AuthProbeReport, AuthProbeError> {
+    let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+
+    let body_hash = {
+        let mut digest = Sha256::new();
+        digest.update([]);
+        let mut hex = String::new();
+        for byte in digest.finalize() {
+            write!(hex, "{byte:02x}")?;
+        }
+        hex
+    };
+
+    let claims = ProbeClaims {
+        uri: uri_path,
+        nonce: rand::thread_rng().r#gen(),
+        iat: now,
+        exp: now + expiry_seconds,
+        sub: api_user_id,
+        body_hash,
+    };
+
+    let token = jsonwebtoken::encode(
+        &Header::new(Algorithm::RS256),
+        &claims,
+        &EncodingKey::from_rsa_pem(rsa_key_pem)?,
+    )?;
+
+    let response = reqwest::Client::new()
+        .get(format!("{base_url}{uri_path}"))
+        .header("X-API-Key", api_user_id)
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await?;
+
+    let status = response.status().as_u16();
+    let body = response.text().await?;
+
+    Ok(AuthProbeReport { expiry_seconds, status, body })
+}
+
+/// Runs the A/B pair against the vault-address endpoint the service hits at
+/// startup: once with a compliant `iat + 29` expiry, once with the SDK's
+/// `iat + 55`.
+///
+/// A split verdict (29 accepted, 55 rejected) proves the platform began
+/// enforcing its documented bound; two identical rejections carry the
+/// server's own error body for diagnosis.
+///
+/// # Errors
+///
+/// Returns an error if either probe fails before receiving a response.
+pub async fn probe_auth_pair(
+    base_url: &str,
+    config: &FireblocksConfig,
+) -> Result<Vec<AuthProbeReport>, AuthProbeError> {
+    let uri_path = format!(
+        "/v1/vault/accounts/{}/{}/addresses_paginated",
+        config.vault_account_id.as_str(),
+        config.chain_asset_ids.default_asset_id().as_str(),
+    );
+
+    let mut reports = Vec::new();
+    for expiry_seconds in [29, 55] {
+        reports.push(
+            probe_auth(
+                base_url,
+                config.api_user_id.as_str(),
+                &config.secret,
+                &uri_path,
+                expiry_seconds,
+            )
+            .await?,
+        );
+    }
+
+    Ok(reports)
+}
+
+#[cfg(test)]
+mod tests {
+    use httpmock::prelude::*;
+    use jsonwebtoken::{Algorithm, DecodingKey, Validation};
+    use rsa::pkcs8::EncodePrivateKey;
+    use rsa::{RsaPrivateKey, pkcs1::EncodeRsaPublicKey};
+    use serde::Deserialize;
+
+    use super::*;
+
+    #[derive(Debug, Deserialize)]
+    struct DecodedClaims {
+        uri: String,
+        iat: u64,
+        exp: u64,
+        sub: String,
+        #[serde(rename = "bodyHash")]
+        body_hash: String,
+    }
+
+    fn test_rsa_key() -> (Vec<u8>, Vec<u8>) {
+        let mut rng = rand::thread_rng();
+        let key = RsaPrivateKey::new(&mut rng, 2048).unwrap();
+        let private_pem = key
+            .to_pkcs8_pem(rsa::pkcs8::LineEnding::LF)
+            .unwrap()
+            .as_bytes()
+            .to_vec();
+        let public_pem = key
+            .to_public_key()
+            .to_pkcs1_pem(rsa::pkcs8::LineEnding::LF)
+            .unwrap()
+            .into_bytes();
+        (private_pem, public_pem)
+    }
+
+    fn decode_bearer(authorization: &str, public_pem: &[u8]) -> DecodedClaims {
+        let token = authorization
+            .strip_prefix("Bearer ")
+            .expect("Authorization must be a Bearer token");
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.set_required_spec_claims::<&str>(&[]);
+        validation.validate_exp = false;
+        jsonwebtoken::decode::<DecodedClaims>(
+            token,
+            &DecodingKey::from_rsa_pem(public_pem).unwrap(),
+            &validation,
+        )
+        .expect("probe JWT must verify against the signing key")
+        .claims
+    }
+
+    /// The probe's whole value is fidelity: the JWT must carry exactly the
+    /// requested expiry window, the request path as `uri`, the api user as
+    /// `sub`, and the empty-body SHA-256 — signed by the supplied key.
+    #[tokio::test]
+    async fn probe_signs_the_requested_expiry_window() {
+        let (private_pem, public_pem) = test_rsa_key();
+        let captured: std::sync::Arc<std::sync::Mutex<Option<String>>> =
+            std::sync::Arc::new(std::sync::Mutex::new(None));
+        let capture = captured.clone();
+
+        let server = MockServer::start();
+        server.mock(move |when, then| {
+            when.method("GET").path("/v1/vault/accounts/0/ETH-TEST").is_true(
+                move |request| {
+                    let authorization = request
+                        .headers_vec()
+                        .iter()
+                        .find(|(name, _)| {
+                            name.eq_ignore_ascii_case("authorization")
+                        })
+                        .map(|(_, value)| value.clone());
+                    *capture.lock().unwrap() = authorization;
+                    true
+                },
+            );
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{}");
+        });
+
+        let report = probe_auth(
+            &server.base_url(),
+            "api-user-test",
+            &private_pem,
+            "/v1/vault/accounts/0/ETH-TEST",
+            29,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.status, 200);
+        assert_eq!(report.expiry_seconds, 29);
+
+        let authorization = captured
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("the probe must send an Authorization header");
+        let claims = decode_bearer(&authorization, &public_pem);
+
+        assert_eq!(claims.exp - claims.iat, 29);
+        assert_eq!(claims.uri, "/v1/vault/accounts/0/ETH-TEST");
+        assert_eq!(claims.sub, "api-user-test");
+        assert_eq!(
+            claims.body_hash,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    /// The SDK swallows non-2xx bodies; the probe exists to surface them.
+    /// A 401 with a diagnostic body must come back verbatim as a report,
+    /// not as an error.
+    #[tokio::test]
+    async fn probe_surfaces_rejection_status_and_body_verbatim() {
+        let (private_pem, _public_pem) = test_rsa_key();
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method("GET").path("/v1/vault/accounts/0/ETH-TEST");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body(r#"{"message":"Token expiry too far","code":-7}"#);
+        });
+
+        let report = probe_auth(
+            &server.base_url(),
+            "api-user-test",
+            &private_pem,
+            "/v1/vault/accounts/0/ETH-TEST",
+            55,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(report.status, 401);
+        assert!(
+            report.body.contains(r#""code":-7"#),
+            "the platform's error body must be preserved, got: {}",
+            report.body
+        );
+    }
+}

--- a/src/fireblocks/mod.rs
+++ b/src/fireblocks/mod.rs
@@ -13,6 +13,7 @@
 //! Temporary: leaves together with `migrate-receipts` once every vault has
 //! migrated.
 
+pub mod auth_probe;
 mod config;
 pub mod vault_service;
 

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -95,6 +95,20 @@ pub(crate) enum MintCommand {
         issuer_request_id: IssuerMintRequestId,
     },
 
+    /// Operator-authorized retry of a `MintingFailed` mint past the exhausted
+    /// automatic budget, refused unless the failure chain PROVES the fresh
+    /// submission is unambiguous: the handler requires a `Minting`
+    /// predecessor (the mint failed at prepare/signing, before any
+    /// transaction was persisted or broadcast). A `TxIntended`/`TxSubmitted`
+    /// predecessor holds a transaction that may still mine, so a fresh
+    /// submission could double-mint — those chains are rejected atomically
+    /// here, not in the racy endpoint. Pure: produces the same
+    /// `MintRetryStarted` as `RetryMint`. Idempotent — a no-op if the mint
+    /// already left `MintingFailed`.
+    ManualRetryMint {
+        issuer_request_id: IssuerMintRequestId,
+    },
+
     /// Records a mint whose on-chain transaction already succeeded, as evidenced
     /// by a receipt the `SubmitMintJob` found before submitting. Pure: produces
     /// `ExistingMintRecovered` (no I/O) and advances to `CallbackPending`,

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -34,6 +34,7 @@ use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
 };
+use crate::redemption::has_unresolved_burn_intent;
 use crate::tokenized_asset::Network;
 use crate::vault::{
     NetworkVaultServices, ReceiptInformation, TxId, UnconfiguredNetworkError,
@@ -178,6 +179,11 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     Some(&self.issuer_request_id),
                 )
                 .await?
+                    // A persisted-but-unresolved burn transaction from the
+                    // same wallet may still land; signing a mint over it
+                    // risks a nonce conflict, so wait like the burn path
+                    // waits for unresolved mint intents.
+                    || has_unresolved_burn_intent(&ctx.pool, None).await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),
@@ -267,6 +273,7 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     Some(&self.issuer_request_id),
                 )
                 .await?
+                    || has_unresolved_burn_intent(&ctx.pool, None).await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -495,7 +495,9 @@ impl Mint {
             .map_or(AutomaticRetryDecision::Ready, AutomaticRetryDecision::Wait)
     }
 
-    pub(crate) fn manual_recovery_decision(&self) -> ManualRecoveryDecision {
+    pub(crate) const fn manual_recovery_decision(
+        &self,
+    ) -> ManualRecoveryDecision {
         match self {
             Self::Completed { .. } | Self::Closed { .. } => {
                 ManualRecoveryDecision::AlreadyTerminal
@@ -503,14 +505,10 @@ impl Mint {
             Self::Initiated { .. } | Self::JournalRejected { .. } => {
                 ManualRecoveryDecision::Unrecoverable
             }
-            Self::MintingFailed { .. }
-                if matches!(
-                    self.automatic_retry_decision(Utc::now()),
-                    AutomaticRetryDecision::Exhausted
-                ) =>
-            {
-                ManualRecoveryDecision::Unrecoverable
-            }
+            // MintingFailed stays eligible even when automatic retries are
+            // exhausted: the cap bounds UNATTENDED retrying, while a manual
+            // reprocess is the operator explicitly authorizing one more
+            // attempt (driven directly, not through the capped loop).
             Self::JournalConfirmed { .. }
             | Self::Minting { .. }
             | Self::TxIntended { .. }
@@ -822,6 +820,68 @@ impl Mint {
                     expected_id,
                     &issuer_request_id,
                 )?;
+
+                Ok(vec![MintEvent::MintRetryStarted {
+                    issuer_request_id,
+                    tx_hash: None,
+                    started_at: Utc::now(),
+                }])
+            }
+            _ => Ok(vec![]),
+        }
+    }
+
+    /// Mints initiated before this instant (2026-07-31T00:00:00Z) predate the
+    /// current job-based submit flow and cannot prove from state alone that a
+    /// `Minting`-predecessor failure never broadcast a transaction — a mined
+    /// legacy transaction whose receipt was later redeemed leaves no trace in
+    /// inventory. Under the current flow a broadcast from `Minting` is
+    /// impossible: `SubmitMintJob` signs, persists `MintTxIntended`, and only
+    /// then broadcasts, so any crash mid-submission lands in `TxIntended` or
+    /// `TxSubmitted`, never `Minting`.
+    const MANUAL_RETRY_PROVENANCE_SINCE_EPOCH: i64 = 1_785_456_000;
+
+    /// The operator-authorized retry, gated on failure provenance where the
+    /// aggregate state is authoritative (unlike the admin endpoint, which
+    /// loads a snapshot that may be stale by execution time).
+    ///
+    /// A `Minting` predecessor on a modern-flow mint proves the failure
+    /// happened at prepare or signing, before any transaction was persisted
+    /// or broadcast, so a fresh submission cannot double-mint. A `TxIntended`
+    /// or `TxSubmitted` predecessor holds a transaction that may still mine;
+    /// the automatic retry path handles those by REUSING the persisted signed
+    /// transaction, and this command refuses them rather than submit fresh
+    /// bytes over an unresolved prior attempt. Pre-cutover mints are refused
+    /// outright — their provenance cannot be proven from event history.
+    fn handle_manual_retry_mint(
+        &self,
+        issuer_request_id: IssuerMintRequestId,
+    ) -> Result<Vec<MintEvent>, MintError> {
+        match self {
+            Self::MintingFailed {
+                issuer_request_id: expected_id,
+                failed_from,
+                initiated_at,
+                ..
+            } => {
+                Self::validate_issuer_request_id(
+                    expected_id,
+                    &issuer_request_id,
+                )?;
+
+                if initiated_at.timestamp()
+                    < Self::MANUAL_RETRY_PROVENANCE_SINCE_EPOCH
+                {
+                    return Err(MintError::PreProvenanceCutoverMint {
+                        initiated_at: *initiated_at,
+                    });
+                }
+
+                if !matches!(failed_from.as_ref(), Self::Minting { .. }) {
+                    return Err(MintError::AmbiguousRetryPredecessor {
+                        predecessor: failed_from.state_name().to_string(),
+                    });
+                }
 
                 Ok(vec![MintEvent::MintRetryStarted {
                     issuer_request_id,
@@ -1541,7 +1601,8 @@ impl EventSourced for Mint {
                 })
             }
             MintCommand::RecordMintFailed { .. }
-            | MintCommand::RetryMint { .. } => Ok(vec![]),
+            | MintCommand::RetryMint { .. }
+            | MintCommand::ManualRetryMint { .. } => Ok(vec![]),
             MintCommand::CloseMint { .. } => Err(MintError::NotRecoverable {
                 current_state: "Uninitialized".to_string(),
             }),
@@ -1631,6 +1692,9 @@ impl EventSourced for Mint {
             }
             MintCommand::RetryMint { issuer_request_id } => {
                 self.handle_retry_mint(issuer_request_id)
+            }
+            MintCommand::ManualRetryMint { issuer_request_id } => {
+                self.handle_manual_retry_mint(issuer_request_id)
             }
             MintCommand::RecordExistingMint {
                 issuer_request_id,
@@ -1794,6 +1858,19 @@ pub(crate) enum MintError {
     RetryNotDue { retry_at: DateTime<Utc> },
     #[error("Automatic mint retries exhausted after {attempts} attempts")]
     AutomaticRetriesExhausted { attempts: u32 },
+    #[error(
+        "the mint's failure chain contains a prepared or submitted \
+         transaction ({predecessor}); a fresh manual submission could \
+         double-mint — refuse and investigate the prior transaction instead"
+    )]
+    AmbiguousRetryPredecessor { predecessor: String },
+    #[error(
+        "the mint was initiated at {initiated_at}, before the job-based \
+         submit flow whose event history proves a Minting-predecessor \
+         failure never broadcast; a fresh manual submission could \
+         double-mint — verify the mint against on-chain history instead"
+    )]
+    PreProvenanceCutoverMint { initiated_at: DateTime<Utc> },
     #[error("Retry delay out of range")]
     RetryDelayOutOfRange,
     #[error(
@@ -2032,9 +2109,75 @@ pub(crate) mod tests {
             completed.manual_recovery_decision(),
             ManualRecoveryDecision::AlreadyTerminal
         );
+        // Exhaustion caps AUTOMATIC retries only: a manual reprocess is the
+        // operator explicitly authorizing another attempt, so an exhausted
+        // MintingFailed stays eligible for manual recovery.
         assert_eq!(
             exhausted.manual_recovery_decision(),
-            ManualRecoveryDecision::Unrecoverable
+            ManualRecoveryDecision::Eligible
+        );
+    }
+
+    /// A modern-flow mint that failed at prepare (a `Minting` predecessor,
+    /// so provably no transaction was ever persisted or broadcast) is the
+    /// case the manual retry exists for.
+    #[tokio::test]
+    async fn manual_retry_starts_a_retry_for_a_modern_prepare_failure() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "signing rejected".to_string(),
+            failed_at: Utc::now(),
+        });
+
+        let emitted = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::ManualRetryMint {
+                issuer_request_id: issuer_request_id.clone(),
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            emitted.as_slice(),
+            [MintEvent::MintRetryStarted { .. }]
+        ));
+    }
+
+    /// A mint initiated before the job-based submit flow cannot prove its
+    /// `Minting`-predecessor failure never broadcast a transaction, so the
+    /// manual retry refuses it.
+    #[tokio::test]
+    async fn manual_retry_refuses_a_pre_cutover_mint() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events = events_through_minting(&issuer_request_id);
+        let MintEvent::Initiated { initiated_at, .. } = &mut events[0] else {
+            panic!("first event must be Initiated");
+        };
+        *initiated_at = Utc::now() - chrono::Duration::days(90);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "signing rejected".to_string(),
+            failed_at: Utc::now(),
+        });
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::ManualRetryMint {
+                issuer_request_id: issuer_request_id.clone(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::PreProvenanceCutoverMint { .. }
+                )
+            ),
+            "a pre-cutover mint must be refused, got {error:?}"
         );
     }
 

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -228,6 +228,75 @@ pub(crate) async fn enqueue_scheduled_mint_recovery(
     push_mint_recovery_job(apalis_pool, issuer_request_id).await
 }
 
+/// Drives one operator-authorized retry of a `MintingFailed` mint, bypassing
+/// the capped scheduled-recovery loop entirely.
+///
+/// The automatic retry budget bounds UNATTENDED retrying; it must not lock an
+/// operator out of a mint whose external blocker (e.g. a signing policy) has
+/// since been fixed. This sends `ManualRetryMint` — whose handler enforces
+/// the double-mint provenance gate atomically against the CURRENT aggregate
+/// state, refusing any failure chain containing a prepared or submitted
+/// transaction — and enqueues a fresh `SubmitMintJob`, whose normal
+/// submit -> confirm -> callback chain completes the mint (its first step
+/// records an already-existing on-chain receipt instead of re-submitting).
+/// Each call authorizes exactly one attempt: a mint that fails again parks
+/// in `MintingFailed` until the operator reprocesses once more.
+pub(crate) async fn manually_retry_failed_mint(
+    mint_store: &Arc<Store<Mint>>,
+    pool: &Pool<Sqlite>,
+    vault_services: &NetworkVaultServices,
+    apalis_pool: &SqlitePool,
+    issuer_request_id: &IssuerMintRequestId,
+    mint: &Mint,
+) -> Result<(), anyhow::Error> {
+    let Mint::MintingFailed { underlying, network, .. } = mint else {
+        anyhow::bail!(
+            "manual retry requires a MintingFailed mint; current state is {}",
+            mint.state_name()
+        );
+    };
+    let network = *network;
+
+    let address =
+        find_vault(pool, underlying, &network).await?.ok_or_else(|| {
+            anyhow::anyhow!("no vault found for {underlying} on {network}")
+        })?;
+    let chain_id = vault_services.chain_id(network)?;
+
+    mint_store
+        .send(
+            issuer_request_id,
+            MintCommand::ManualRetryMint {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+        )
+        .await?;
+
+    info!(target: "mint", issuer_request_id = %issuer_request_id,
+        %underlying, %network,
+        "Manually retrying failed mint past the automatic budget"
+    );
+
+    release_terminal_job(
+        pool,
+        job_type::<SubmitMintJob>(),
+        &issuer_request_id.to_string(),
+    )
+    .await?;
+    JobQueue::<SubmitMintJob>::new(apalis_pool)
+        .push_with_idempotency_key(
+            SubmitMintJob {
+                issuer_request_id: issuer_request_id.clone(),
+                vault: address,
+                chain_id,
+            },
+            issuer_request_id.to_string(),
+        )
+        .await?;
+
+    Ok(())
+}
+
 /// Pushes a [`MintRecoveryJob`] for the mint, retrying transient enqueue
 /// failures with a bounded backoff. The idempotency key makes the insert a
 /// no-op when ANY job already exists for the mint — including a TERMINAL
@@ -1057,8 +1126,8 @@ mod tests {
     };
     use crate::mint::tests::VAULT;
     use crate::mint::{
-        ClientId, IssuerMintRequestId, MintEvent, Network, Quantity,
-        TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        ClientId, IssuerMintRequestId, MintEvent, MintExternalTxId, Network,
+        Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
     use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
     use crate::test_utils::log_count_at;
@@ -1974,6 +2043,164 @@ mod tests {
             lock_at.is_none() && lock_by.is_none(),
             "the reset must clear the lock columns, got lock_at={lock_at:?} \
              lock_by={lock_by:?}"
+        );
+    }
+
+    /// A prepare-stage failure (no transaction ever signed or broadcast) is
+    /// the unambiguous case: the manual retry must transition the mint back
+    /// to `Minting` and enqueue a fresh `SubmitMintJob`.
+    #[traced_test]
+    #[tokio::test]
+    async fn manual_retry_drives_a_prepare_failed_mint_to_a_fresh_submit() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = test_issuer_request_id();
+        seed_recoverable_mint(&harness, &issuer_request_id).await;
+
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Deposit {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: "Turnkey HTTP response was not successful: 403"
+                        .to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        manually_retry_failed_mint(
+            &harness.mint_store,
+            &harness.pool,
+            &network_vault_services(harness.vault.clone()),
+            &harness.apalis_pool,
+            &issuer_request_id,
+            &mint,
+        )
+        .await
+        .unwrap();
+
+        let retried =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert_eq!(retried.state_name(), "Minting");
+
+        let queued: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE
+                job_type = ?
+                AND idempotency_key = ?
+            ",
+        )
+        .bind(job_type::<SubmitMintJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            queued, 1,
+            "the manual retry must enqueue exactly one fresh submit job"
+        );
+
+        let test =
+            "manual_retry_drives_a_prepare_failed_mint_to_a_fresh_submit";
+        assert_eq!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    test,
+                    "Manually retrying failed mint past the automatic budget"
+                ]
+            ),
+            1
+        );
+    }
+
+    /// A failure chain that contains a prepared or submitted transaction is
+    /// ambiguous — the prior transaction may still mine — so the manual
+    /// retry must refuse rather than risk a double mint.
+    #[tokio::test]
+    async fn manual_retry_refuses_a_chain_with_a_submitted_transaction() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = test_issuer_request_id();
+        seed_recoverable_mint(&harness, &issuer_request_id).await;
+
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Deposit {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordTxSubmitted {
+                    issuer_request_id: issuer_request_id.clone(),
+                    external_tx_id: MintExternalTxId::from_string(format!(
+                        "mint-{issuer_request_id}"
+                    )),
+                    tx_id: TxId::Legacy("fb-ambiguous".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: "confirmation timed out".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        let error = manually_retry_failed_mint(
+            &harness.mint_store,
+            &harness.pool,
+            &network_vault_services(harness.vault.clone()),
+            &harness.apalis_pool,
+            &issuer_request_id,
+            &mint,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("could double-mint"),
+            "expected the double-mint refusal, got: {error}"
+        );
+        assert_eq!(
+            harness
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .state_name(),
+            "MintingFailed",
+            "a refused manual retry must not advance the mint"
         );
     }
 }

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -30,6 +30,7 @@ use async_trait::async_trait;
 use event_sorcery::StoreBuilder;
 use itertools::izip;
 use sqlx::{Pool, Sqlite};
+use std::num::NonZeroUsize;
 use std::time::Duration;
 use tracing::{debug, info};
 
@@ -227,10 +228,10 @@ pub(crate) enum SourceCustody {
     /// The outgoing wallet still holds the tracked receipts, so there is a
     /// migration to perform.
     Holds(MigratableHoldings),
-    /// The outgoing wallet holds nothing and the incoming wallet holds at
-    /// least the tracked balances: a completed migration seen a second time.
-    /// See [`already_migrated_or_divergent`] for why "at least" rather than
-    /// "exactly".
+    /// Every tracked identifier has already reached the incoming wallet (it
+    /// holds at least each tracked balance, since a fresh run cannot know
+    /// what the recipient held before the migration): a completed migration
+    /// seen a second time.
     AlreadyMigrated { receipts: usize },
 }
 
@@ -337,10 +338,9 @@ pub(crate) enum MigrationRefusal {
     },
 
     #[error(
-        "vault {vault} is empty at the outgoing wallet but receipt \
-         {receipt_id} sits at {at_recipient} with the incoming wallet, not \
-         the tracked {tracked}; custody is in a state this migration cannot \
-         explain"
+        "receipt {receipt_id} of vault {vault} left the outgoing wallet but \
+         the incoming wallet holds {at_recipient}, not the tracked \
+         {tracked}; custody is in a state this migration cannot explain"
     )]
     RecipientBalanceMismatch {
         vault: Address,
@@ -425,6 +425,25 @@ pub(crate) enum ReceiptCustodyError {
 
     #[error("custody transfer {tx_hash} has no receipt after confirmation")]
     MissingReceipt { tx_hash: B256 },
+
+    #[error(
+        "vault {vault} produced an empty transfer batch; nothing was \
+         submitted"
+    )]
+    NothingToTransfer { vault: Address },
+
+    #[error(
+        "vault {vault} certification lapsed partway through the chunked \
+         migration; re-certify, then re-run — completed chunks resume"
+    )]
+    CertificationLapsed { vault: Address },
+
+    #[error(
+        "vault {vault} owner froze a transfer party until {until} partway \
+         through the chunked migration; re-run once the freeze lifts — \
+         completed chunks resume"
+    )]
+    OwnerFroze { vault: Address, until: U256 },
 }
 
 /// A recipient balance that fell over a transfer that should only have raised
@@ -1194,69 +1213,18 @@ pub(crate) async fn reconcile_holdings(
         });
     }
 
-    if !tracked.is_empty() && onchain.iter().all(Shares::is_zero) {
-        return already_migrated_or_divergent(
-            custody,
-            vault,
-            recipient,
-            tracked,
-            &receipt_ids,
-        )
-        .await;
-    }
-
-    let agreed = izip!(tracked, &onchain)
-        .map(|(held, onchain)| {
-            if held.balance == *onchain {
-                Ok(*held)
-            } else {
-                Err(MigrationRefusal::InventoryDivergence {
-                    vault,
-                    receipt_id: held.receipt_id,
-                    tracked: held.balance,
-                    onchain: *onchain,
-                })
-            }
-        })
-        .collect::<Result<Vec<_>, MigrationRefusal>>()?;
-
-    // A zero balance is nothing to move. Keeping it would put an identifier in
-    // the batch that transfers nothing and cannot be verified as having moved.
-    let holdings: Vec<ReceiptHolding> =
-        agreed.into_iter().filter(|held| !held.balance.is_zero()).collect();
-
-    debug!(
-        target: "receipt_inventory",
-        %vault,
-        %holder,
-        tracked = tracked.len(),
-        migratable = holdings.len(),
-        "Reconciled receipt holdings against the chain"
-    );
-
-    Ok(SourceCustody::Holds(MigratableHoldings {
-        chain_id,
-        vault,
-        holder,
-        holdings,
-        migration_ordinal,
-    }))
-}
-
-/// Distinguishes "this migration already ran" from "our inventory is wrong".
-///
-/// Reached only when the source holds nothing for every tracked identifier. If
-/// the recipient holds at least what we tracked, custody moved; anything less
-/// is an inventory we cannot trust.
-async fn already_migrated_or_divergent(
-    custody: &(impl ReceiptCustody + Sync),
-    vault: Address,
-    recipient: Address,
-    tracked: &[ReceiptHolding],
-    receipt_ids: &[ReceiptId],
-) -> Result<SourceCustody, MigrationRefusal> {
+    // Classification is per identifier so a failure between transfer chunks
+    // resumes: a chunked transfer can leave some identifiers already with the
+    // recipient while the rest still sit with the holder, and an all-or-
+    // nothing agreement check would refuse that state as divergence forever.
+    //
+    // The recipient side is read unconditionally so all three balance views
+    // zip positionally, with the length verified once up front. `>=`, not
+    // `==`, on the recipient side: a fresh run cannot know what the
+    // recipient held before the migration, and the forward path deliberately
+    // allows a recipient with a pre-existing balance.
     let at_recipient =
-        custody.held_balances(vault, recipient, receipt_ids).await?;
+        custody.held_balances(vault, recipient, &receipt_ids).await?;
 
     if at_recipient.len() != receipt_ids.len() {
         return Err(MigrationRefusal::BalanceCountMismatch {
@@ -1266,24 +1234,72 @@ async fn already_migrated_or_divergent(
         });
     }
 
-    // `>=`, not `==`: a fresh run cannot know what the recipient held before
-    // the migration, and the forward path deliberately allows a recipient with
-    // a pre-existing balance. Requiring equality here would make every such
-    // migration un-rerunnable, reporting a mismatch for custody that did move.
-    // Combined with a source holding zero for every identifier, "the recipient
-    // holds at least what we tracked" is the strongest claim available.
-    for (held, at_recipient) in izip!(tracked, &at_recipient) {
-        if *at_recipient < held.balance {
+    let mut unmoved: Vec<ReceiptHolding> = Vec::new();
+    let mut migrated: usize = 0;
+    for (held, onchain, moved_to_recipient) in
+        izip!(tracked, &onchain, &at_recipient)
+    {
+        if *onchain == held.balance {
+            // A zero tracked balance is nothing to move. Keeping it would
+            // put an identifier in the batch that transfers nothing and
+            // cannot be verified as having moved.
+            if !held.balance.is_zero() {
+                unmoved.push(*held);
+            }
+            continue;
+        }
+
+        // Reached only on disagreement. A zero tracked balance against a
+        // nonzero on-chain one, or a partial on-chain balance, is an
+        // inventory we cannot trust — not something to skip or resume.
+        if held.balance.is_zero() || !onchain.is_zero() {
+            return Err(MigrationRefusal::InventoryDivergence {
+                vault,
+                receipt_id: held.receipt_id,
+                tracked: held.balance,
+                onchain: *onchain,
+            });
+        }
+
+        if *moved_to_recipient < held.balance {
             return Err(MigrationRefusal::RecipientBalanceMismatch {
                 vault,
                 receipt_id: held.receipt_id,
                 tracked: held.balance,
-                at_recipient: *at_recipient,
+                at_recipient: *moved_to_recipient,
             });
         }
+
+        migrated += 1;
     }
 
-    Ok(SourceCustody::AlreadyMigrated { receipts: tracked.len() })
+    if unmoved.is_empty() && !tracked.is_empty() {
+        return Ok(SourceCustody::AlreadyMigrated { receipts: migrated });
+    }
+
+    // Canonical order, independent of the inventory's backing map: chunk
+    // membership and every chunk's deterministic externalTxId are derived
+    // positionally from this sequence, so a rerun after a crash must
+    // enumerate the same remaining identifiers in the same order to resume
+    // its in-flight Fireblocks transactions instead of duplicating them.
+    unmoved.sort_by_key(|held| held.receipt_id.inner());
+
+    debug!(
+        target: "receipt_inventory",
+        %vault,
+        %holder,
+        tracked = tracked.len(),
+        migratable = unmoved.len(),
+        "Reconciled receipt holdings against the chain"
+    );
+
+    Ok(SourceCustody::Holds(MigratableHoldings {
+        chain_id,
+        vault,
+        holder,
+        holdings: unmoved,
+        migration_ordinal,
+    }))
 }
 
 /// Moves one vault's receipts to the incoming wallet.
@@ -1663,7 +1679,32 @@ pub(crate) struct FireblocksReceiptCustody<P> {
     client: FireblocksVaultService<P>,
     receipt_contract: Address,
     chain_id: u64,
+    max_receipts_per_transfer: NonZeroUsize,
 }
+
+/// Upper bound on receipts per CONTRACT_CALL submitted through Fireblocks.
+///
+/// Fireblocks' transaction engine assigns its own gas limit to a
+/// CONTRACT_CALL, and on large `safeBatchTransferFrom` batches that limit
+/// exceeds Base's block gas limit, failing the transaction before it can
+/// broadcast. Chunking keeps every submitted transfer small enough for a
+/// sane engine gas limit; [`reconcile_holdings`]' per-identifier
+/// classification makes a failure between chunks resumable.
+///
+/// The bound is empirical, not a documented Fireblocks limit: 240 receipts
+/// is the only observed failure and batches up to 14 are proven to pass, so
+/// the cap sits exactly at the proven bound rather than guessing anything
+/// between — correctness does not depend on its value, only how many
+/// transactions a large vault takes. Never change it between a failed run
+/// and its re-run:
+/// chunk boundaries derive from this value, so a resume under a different
+/// cap computes different externalTxIds and submits fresh transactions
+/// instead of resuming any still-pending ones (safe on-chain — an
+/// overlapping duplicate reverts on insufficient balance — but noisy and
+/// operator-confusing). Change it only once no Fireblocks transaction for
+/// the vault is pending.
+const MAX_RECEIPTS_PER_ENGINE_TRANSFER: NonZeroUsize =
+    NonZeroUsize::MIN.saturating_add(13);
 
 impl<P: Provider + Clone> FireblocksReceiptCustody<P> {
     pub(crate) async fn resolve(
@@ -1690,6 +1731,7 @@ impl<P: Provider + Clone> FireblocksReceiptCustody<P> {
             client,
             receipt_contract,
             chain_id,
+            max_receipts_per_transfer: MAX_RECEIPTS_PER_ENGINE_TRANSFER,
         })
     }
 }
@@ -1727,73 +1769,128 @@ impl<P: Provider + Clone + Send + Sync> ReceiptCustody
         let receipt =
             Receipt::new(self.receipt_contract, &self.onchain.provider);
         let (ids, amounts) = holdings.batch_arguments();
-        let external_tx_id = migration_external_tx_id(
-            self.chain_id,
-            permit.vault(),
-            permit.to(),
-            &ids,
-            &amounts,
-            holdings.migration_ordinal(),
-        );
-        let calldata = receipt
-            .safeBatchTransferFrom(
-                permit.from(),
-                permit.to(),
-                ids,
-                amounts,
-                Bytes::new(),
-            )
-            .calldata()
-            .clone();
         let note = format!(
             "receipt custody migration: vault {} -> {}",
             permit.vault(),
             permit.to()
         );
+        let chunk_size = self.max_receipts_per_transfer.get();
+        let chunk_count = ids.len().div_ceil(chunk_size);
 
-        // Submission walks to a fresh `-retry-N` id when a previous attempt's
-        // transaction failed terminally: Fireblocks spends an externalTxId
-        // forever, so fix-and-retry after a TAP rejection or an expired
-        // certification must not resume the corpse.
-        //
-        // Logged before the await: completion can block through console
-        // approvals for minutes, and if this process dies or times out the
-        // operator needs the id to look the transaction up.
         info!(target: "receipt_inventory",
             vault = %permit.vault(),
             receipt_contract = %self.receipt_contract,
-            %external_tx_id,
+            receipts = ids.len(),
+            chunks = chunk_count,
             "submitting custody transfer to Fireblocks"
         );
-        let tx_hash = self
-            .client
-            .submit_contract_call_to_completion(
-                self.receipt_contract,
-                &calldata,
-                &note,
-                &external_tx_id,
-            )
-            .await
-            .map_err(Box::new)?;
 
-        // Fireblocks can report `Completed` while the EVM transaction itself
-        // reverted; a reverted transfer moved nothing, so it is a definitive
-        // failure rather than a hash to report as success.
-        let confirmed = self
-            .onchain
-            .provider
-            .get_transaction_receipt(tx_hash)
-            .await?
-            .ok_or(ReceiptCustodyError::MissingReceipt { tx_hash })?;
+        // Each chunk is a CONTRACT_CALL of its own, kept under the
+        // per-transfer cap so Fireblocks' engine never assigns it a gas limit
+        // above the network's block gas limit (which fails the transaction
+        // before it can broadcast). A chunk is revert-checked before the next
+        // one goes out; a failure between chunks is resumable because
+        // `reconcile_holdings` classifies custody per identifier on rerun.
+        let mut last_landed: Option<B256> = None;
+        for (chunk_index, (chunk_ids, chunk_amounts)) in
+            izip!(ids.chunks(chunk_size), amounts.chunks(chunk_size))
+                .enumerate()
+        {
+            // Certification is maintained outside this service and can lapse
+            // while earlier chunks confirm; re-read before every chunk so a
+            // transfer the vault would refuse is never submitted on stale
+            // permission. The first chunk's permission was just checked by
+            // the caller, but the read is cheap and uniformity beats a
+            // special case.
+            match self
+                .onchain
+                .transfer_permission(permit.vault(), permit.from(), permit.to())
+                .await?
+            {
+                TransferPermission::Permitted(_) => {}
+                TransferPermission::CertificationExpired => {
+                    return Err(ReceiptCustodyError::CertificationLapsed {
+                        vault: permit.vault(),
+                    });
+                }
+                TransferPermission::OwnerFrozen { until } => {
+                    return Err(ReceiptCustodyError::OwnerFroze {
+                        vault: permit.vault(),
+                        until,
+                    });
+                }
+            }
 
-        if !confirmed.status() {
-            return Err(ReceiptCustodyError::Reverted {
-                vault: permit.vault(),
-                tx_hash,
-            });
+            // Deterministic over this chunk's own content: a crashed or
+            // retried run resumes the chunk's original Fireblocks
+            // transaction instead of submitting a second transfer. Submission
+            // walks to a fresh `-retry-N` id when a previous attempt failed
+            // terminally, since Fireblocks spends an externalTxId forever.
+            let external_tx_id = migration_external_tx_id(
+                self.chain_id,
+                permit.vault(),
+                permit.to(),
+                chunk_ids,
+                chunk_amounts,
+                holdings.migration_ordinal(),
+            );
+            let calldata = receipt
+                .safeBatchTransferFrom(
+                    permit.from(),
+                    permit.to(),
+                    chunk_ids.to_vec(),
+                    chunk_amounts.to_vec(),
+                    Bytes::new(),
+                )
+                .calldata()
+                .clone();
+
+            // Logged before the await: completion can block through console
+            // approvals for minutes, and if this process dies or times out
+            // the operator needs the id to look the transaction up.
+            debug!(target: "receipt_inventory",
+                vault = %permit.vault(),
+                %external_tx_id,
+                chunk = chunk_index + 1,
+                chunks = chunk_count,
+                chunk_receipts = chunk_ids.len(),
+                "submitting custody transfer chunk to Fireblocks"
+            );
+            let tx_hash = self
+                .client
+                .submit_contract_call_to_completion(
+                    self.receipt_contract,
+                    &calldata,
+                    &note,
+                    &external_tx_id,
+                )
+                .await
+                .map_err(Box::new)?;
+
+            // Fireblocks can report `Completed` while the EVM transaction
+            // itself reverted; a reverted transfer moved nothing, so it is a
+            // definitive failure rather than a hash to report as success —
+            // and no further chunk goes out on top of it.
+            let confirmed = self
+                .onchain
+                .provider
+                .get_transaction_receipt(tx_hash)
+                .await?
+                .ok_or(ReceiptCustodyError::MissingReceipt { tx_hash })?;
+
+            if !confirmed.status() {
+                return Err(ReceiptCustodyError::Reverted {
+                    vault: permit.vault(),
+                    tx_hash,
+                });
+            }
+
+            last_landed = Some(tx_hash);
         }
 
-        Ok(tx_hash)
+        last_landed.ok_or(ReceiptCustodyError::NothingToTransfer {
+            vault: permit.vault(),
+        })
     }
 }
 
@@ -2182,6 +2279,81 @@ mod tests {
             holdings.holdings().len(),
             1,
             "a zero balance is nothing to move and must not enter the batch"
+        );
+    }
+
+    /// A failure between transfer chunks leaves some identifiers already with
+    /// the recipient and the rest still with the holder. A rerun must resume
+    /// the remainder rather than refuse the moved identifiers as divergence.
+    #[traced_test]
+    #[tokio::test]
+    async fn reconcile_resumes_a_partially_migrated_vault() {
+        let custody = FakeCustody::with_balances(&[
+            (OUTGOING, 1, 100),
+            (INCOMING, 2, 250),
+        ]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+
+        assert_eq!(
+            holdings.holdings().len(),
+            1,
+            "only the identifier still with the holder is left to migrate"
+        );
+        let (ids, amounts) = holdings.batch_arguments();
+        assert_eq!(ids, vec![U256::from(1)]);
+        assert_eq!(amounts, vec![U256::from(100)]);
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Reconciled receipt holdings against the chain", "migratable=1"]
+        ));
+    }
+
+    /// A zero tracked balance means the wallet should hold nothing for that
+    /// identifier; an on-chain balance appearing there is an inventory that
+    /// cannot be trusted, not something to silently skip.
+    #[tokio::test]
+    async fn reconcile_refuses_an_untracked_onchain_balance() {
+        let custody = FakeCustody::at_source(&[(1, 100), (2, 70)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 0)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::InventoryDivergence {
+                    tracked, onchain, ..
+                } if tracked == Shares::ZERO
+                    && onchain == Shares::new(U256::from(70))
+            ),
+            "an untracked on-chain balance must refuse, got {refusal:?}"
+        );
+    }
+
+    /// An identifier the holder no longer holds whose balance never reached
+    /// the recipient is untraceable custody, not a resumable move.
+    #[tokio::test]
+    async fn reconcile_refuses_a_vanished_identifier() {
+        let custody = FakeCustody::with_balances(&[(OUTGOING, 1, 100)]);
+        let tracked =
+            [FakeCustody::holding(1, 100), FakeCustody::holding(2, 250)];
+
+        let refusal = reconcile(&custody, &tracked).await.unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::RecipientBalanceMismatch {
+                    tracked, at_recipient, ..
+                } if tracked == Shares::new(U256::from(250))
+                    && at_recipient == Shares::ZERO
+            ),
+            "a vanished balance must refuse, got {refusal:?}"
         );
     }
 
@@ -3100,6 +3272,7 @@ mod tests {
                 ),
                 receipt_contract,
                 chain_id: ANVIL_CHAIN_ID,
+                max_receipts_per_transfer: MAX_RECEIPTS_PER_ENGINE_TRANSFER,
             };
 
             let returned =
@@ -3115,6 +3288,477 @@ mod tests {
                 1,
                 "exactly one CONTRACT_CALL must be submitted"
             );
+        }
+
+        /// Deposits `count` receipts of `shares` each into the vault,
+        /// returning the receipt identifiers the Deposit events reported.
+        async fn deposit_receipts<P: Provider>(
+            vault: &crate::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance<P>,
+            holder: Address,
+            shares: U256,
+            count: usize,
+        ) -> Vec<U256> {
+            let mut receipt_ids = Vec::new();
+            for _ in 0..count {
+                let deposited = vault
+                    .deposit(
+                        shares,
+                        holder,
+                        U256::from(10).pow(U256::from(18)),
+                        Bytes::new(),
+                    )
+                    .send()
+                    .await
+                    .unwrap()
+                    .get_receipt()
+                    .await
+                    .unwrap();
+                let receipt_id = deposited
+                    .inner
+                    .logs()
+                    .iter()
+                    .find_map(|log| {
+                        crate::bindings::OffchainAssetReceiptVault::Deposit::decode_log(
+                            &log.inner,
+                        )
+                        .ok()
+                    })
+                    .expect("deposit must emit a Deposit event")
+                    .id;
+                receipt_ids.push(receipt_id);
+            }
+            receipt_ids
+        }
+
+        /// Mocks one engine CONTRACT_CALL round trip: a create matched on the
+        /// chunk's externalTxId returning `fb_id`, and its poll reporting
+        /// `COMPLETED` with `tx_hash`. Returns the create mock so the test
+        /// can assert the submission happened.
+        fn mock_engine_completion<'a>(
+            server: &'a MockServer,
+            external_tx_id: &str,
+            fb_id: &str,
+            tx_hash: B256,
+        ) -> httpmock::Mock<'a> {
+            let poll_body = serde_json::json!({
+                "id": fb_id,
+                "status": "COMPLETED",
+                "txHash": format!("{tx_hash:#x}"),
+            });
+            let poll_path = format!("/transactions/{fb_id}");
+            let create_body = serde_json::json!({ "id": fb_id });
+            let external = external_tx_id.to_string();
+            server.mock(move |when, then| {
+                when.method("GET").path(poll_path.clone());
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(poll_body);
+            });
+            server.mock(move |when, then| {
+                when.method("POST")
+                    .path("/transactions")
+                    .body_includes(external.clone());
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(create_body);
+            })
+        }
+
+        /// A batch above the per-transfer cap must be submitted as several
+        /// CONTRACT_CALLs, each under its own deterministic externalTxId and
+        /// each revert-checked, with the last landed hash reported. One
+        /// oversized submission is exactly what Fireblocks' engine rejects
+        /// with a gas limit above the network's block gas limit.
+        #[traced_test]
+        #[tokio::test]
+        async fn transfer_custody_chunks_batches_above_the_transfer_cap() {
+            let evm = LocalEvm::new().await.unwrap();
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let holder = evm.wallet_address;
+            let recipient = Address::random();
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let provider = ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &provider,
+            );
+            let shares = U256::from(10) * U256::from(10).pow(U256::from(18));
+            let receipt_ids = deposit_receipts(&vault, holder, shares, 3).await;
+            let receipt_contract =
+                Address::from(vault.receipt().call().await.unwrap().0);
+
+            let onchain = OnchainReceiptCustody::resolve(
+                provider.clone(),
+                evm.vault_address,
+            )
+            .await
+            .unwrap();
+            let tracked: Vec<ReceiptHolding> = receipt_ids
+                .iter()
+                .map(|receipt_id| ReceiptHolding {
+                    receipt_id: ReceiptId::from(*receipt_id),
+                    balance: Shares::from(shares),
+                })
+                .collect();
+            let SourceCustody::Holds(holdings) = reconcile_holdings(
+                &onchain,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                holder,
+                recipient,
+                &tracked,
+                0,
+            )
+            .await
+            .unwrap() else {
+                panic!("the holder must still own the receipts")
+            };
+            let TransferPermission::Permitted(permit) = onchain
+                .transfer_permission(evm.vault_address, holder, recipient)
+                .await
+                .unwrap()
+            else {
+                panic!("a certified vault must permit the transfer")
+            };
+
+            // The "custodian" lands each chunk on-chain up front; the mocked
+            // Fireblocks API then reports each chunk's transaction as its
+            // completed CONTRACT_CALL, exactly as production does.
+            let receipt_instance = Receipt::new(receipt_contract, &provider);
+            let first_chunk = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_ids[0], receipt_ids[1]],
+                    vec![shares, shares],
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap()
+                .transaction_hash;
+            let second_chunk = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_ids[2]],
+                    vec![shares],
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap()
+                .transaction_hash;
+
+            let first_id = migration_external_tx_id(
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                recipient,
+                &[receipt_ids[0], receipt_ids[1]],
+                &[shares, shares],
+                0,
+            );
+            let second_id = migration_external_tx_id(
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                recipient,
+                &[receipt_ids[2]],
+                &[shares],
+                0,
+            );
+
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method("GET").path("/contracts");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!([
+                        {
+                            "id": "contract-wallet-123",
+                            "name": "Receipt",
+                            "assets": [
+                                {
+                                    "id": "TESTCHAIN_ETH",
+                                    "address": receipt_contract
+                                        .to_string()
+                                        .to_lowercase()
+                                }
+                            ]
+                        }
+                    ]));
+            });
+            let first_create = mock_engine_completion(
+                &server,
+                &first_id,
+                "fb-chunk-1",
+                first_chunk,
+            );
+            let second_create = mock_engine_completion(
+                &server,
+                &second_id,
+                "fb-chunk-2",
+                second_chunk,
+            );
+
+            let custody = FireblocksReceiptCustody {
+                onchain,
+                client: FireblocksVaultService::for_tests(
+                    mock_client(&server),
+                    provider.clone(),
+                    ANVIL_CHAIN_ID,
+                    parse_chain_asset_ids(&format!(
+                        "{ANVIL_CHAIN_ID}:TESTCHAIN_ETH"
+                    ))
+                    .unwrap(),
+                ),
+                receipt_contract,
+                chain_id: ANVIL_CHAIN_ID,
+                max_receipts_per_transfer: NonZeroUsize::MIN.saturating_add(1),
+            };
+
+            let returned =
+                custody.transfer_custody(&permit, &holdings).await.unwrap();
+
+            assert_eq!(
+                returned, second_chunk,
+                "the reported hash must be the last landed chunk"
+            );
+            first_create.assert();
+            second_create.assert();
+            assert!(logs_contain_at!(
+                tracing::Level::INFO,
+                &["submitting custody transfer to Fireblocks", "chunks=2"]
+            ));
+            assert!(logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["submitting custody transfer chunk to Fireblocks", "chunk=1"]
+            ));
+        }
+
+        /// A chunk whose transaction reverted must stop the loop: no later
+        /// chunk may be submitted on top of a definitively failed transfer.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_reverted_chunk_halts_the_remaining_chunks() {
+            let evm = LocalEvm::new().await.unwrap();
+            evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+            evm.grant_certify_role(evm.wallet_address).await.unwrap();
+            evm.certify_vault(U256::MAX).await.unwrap();
+
+            let holder = evm.wallet_address;
+            let recipient = Address::random();
+            let signer =
+                PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+            let provider = ProviderBuilder::new()
+                .wallet(EthereumWallet::from(signer))
+                .connect(&evm.endpoint)
+                .await
+                .unwrap();
+
+            let vault = crate::bindings::OffchainAssetReceiptVault::new(
+                evm.vault_address,
+                &provider,
+            );
+            let shares = U256::from(10) * U256::from(10).pow(U256::from(18));
+            let receipt_ids = deposit_receipts(&vault, holder, shares, 3).await;
+            let receipt_contract =
+                Address::from(vault.receipt().call().await.unwrap().0);
+
+            let onchain = OnchainReceiptCustody::resolve(
+                provider.clone(),
+                evm.vault_address,
+            )
+            .await
+            .unwrap();
+            let tracked: Vec<ReceiptHolding> = receipt_ids
+                .iter()
+                .map(|receipt_id| ReceiptHolding {
+                    receipt_id: ReceiptId::from(*receipt_id),
+                    balance: Shares::from(shares),
+                })
+                .collect();
+            let SourceCustody::Holds(holdings) = reconcile_holdings(
+                &onchain,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                holder,
+                recipient,
+                &tracked,
+                0,
+            )
+            .await
+            .unwrap() else {
+                panic!("the holder must still own the receipts")
+            };
+            let TransferPermission::Permitted(permit) = onchain
+                .transfer_permission(evm.vault_address, holder, recipient)
+                .await
+                .unwrap()
+            else {
+                panic!("a certified vault must permit the transfer")
+            };
+
+            // Chunk 1 lands successfully; chunk 2's reported transaction is
+            // an oversized transfer that lands reverted (the explicit gas
+            // limit skips estimation, which would otherwise refuse to
+            // broadcast it).
+            let receipt_instance = Receipt::new(receipt_contract, &provider);
+            let first_chunk = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_ids[0]],
+                    vec![shares],
+                    Bytes::new(),
+                )
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap()
+                .transaction_hash;
+            let reverted = receipt_instance
+                .safeBatchTransferFrom(
+                    holder,
+                    recipient,
+                    vec![receipt_ids[1]],
+                    vec![shares + U256::from(1)],
+                    Bytes::new(),
+                )
+                .gas(1_000_000)
+                .send()
+                .await
+                .unwrap()
+                .get_receipt()
+                .await
+                .unwrap();
+            assert!(
+                !reverted.status(),
+                "the oversized transfer must land reverted"
+            );
+            let reverted_hash = reverted.transaction_hash;
+
+            let first_id = migration_external_tx_id(
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                recipient,
+                &[receipt_ids[0]],
+                &[shares],
+                0,
+            );
+            let second_id = migration_external_tx_id(
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                recipient,
+                &[receipt_ids[1]],
+                &[shares],
+                0,
+            );
+            let third_id = migration_external_tx_id(
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                recipient,
+                &[receipt_ids[2]],
+                &[shares],
+                0,
+            );
+
+            let server = MockServer::start();
+            server.mock(|when, then| {
+                when.method("GET").path("/contracts");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .json_body(serde_json::json!([
+                        {
+                            "id": "contract-wallet-123",
+                            "name": "Receipt",
+                            "assets": [
+                                {
+                                    "id": "TESTCHAIN_ETH",
+                                    "address": receipt_contract
+                                        .to_string()
+                                        .to_lowercase()
+                                }
+                            ]
+                        }
+                    ]));
+            });
+            mock_engine_completion(
+                &server,
+                &first_id,
+                "fb-halt-1",
+                first_chunk,
+            );
+            mock_engine_completion(
+                &server,
+                &second_id,
+                "fb-halt-2",
+                reverted_hash,
+            );
+            let third_create = mock_engine_completion(
+                &server,
+                &third_id,
+                "fb-halt-3",
+                first_chunk,
+            );
+
+            let custody = FireblocksReceiptCustody {
+                onchain,
+                client: FireblocksVaultService::for_tests(
+                    mock_client(&server),
+                    provider.clone(),
+                    ANVIL_CHAIN_ID,
+                    parse_chain_asset_ids(&format!(
+                        "{ANVIL_CHAIN_ID}:TESTCHAIN_ETH"
+                    ))
+                    .unwrap(),
+                ),
+                receipt_contract,
+                chain_id: ANVIL_CHAIN_ID,
+                max_receipts_per_transfer: NonZeroUsize::MIN,
+            };
+
+            let error =
+                custody.transfer_custody(&permit, &holdings).await.unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    ReceiptCustodyError::Reverted { tx_hash, .. }
+                        if tx_hash == reverted_hash
+                ),
+                "the reverted chunk must fail closed naming its hash, got \
+                 {error}"
+            );
+            assert_eq!(
+                third_create.calls_async().await,
+                0,
+                "no chunk may be submitted after a reverted one"
+            );
+            assert!(logs_contain_at!(
+                tracing::Level::INFO,
+                &["submitting custody transfer to Fireblocks", "chunks=3"]
+            ));
+            assert!(logs_contain_at!(
+                tracing::Level::DEBUG,
+                &["submitting custody transfer chunk to Fireblocks", "chunk=2"]
+            ));
         }
 
         /// Fireblocks `Completed` is not proof the EVM transaction succeeded:
@@ -3277,6 +3921,7 @@ mod tests {
                 ),
                 receipt_contract,
                 chain_id: ANVIL_CHAIN_ID,
+                max_receipts_per_transfer: MAX_RECEIPTS_PER_ENGINE_TRANSFER,
             };
 
             let error =

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -1451,11 +1451,11 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    // 6: `Closed` gained `acknowledged_unresolved_burn_tx_hash`. Snapshots
-    // serialized under 5 would deserialize the field as `None` even when the
-    // closure acknowledged a still-mineable burn, silently dropping the
-    // re-acknowledgement guard; the bump clears them so the state rebuilds
-    // from events, which carry the hash.
+    // 6: `Closed` gained `unresolved_burn_tx`. Snapshots serialized under 5
+    // would deserialize the field as `None` even when a still-mineable burn
+    // survived the closure, silently dropping the re-acknowledgement guard;
+    // the bump clears them so the state rebuilds from events, which carry
+    // the retained transaction.
     const SCHEMA_VERSION: u64 = 6;
 
     fn originate(event: &Self::Event) -> Option<Self> {

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -311,12 +311,14 @@ pub(crate) enum Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
         closed_at: DateTime<Utc>,
-        /// Hash of the still-unresolved signed burn the operator acknowledged
-        /// when closing, carried through the closure so a later
-        /// force-complete against a different proving transaction must
-        /// re-acknowledge the transaction that may still land.
+        /// The still-unresolved signed burn the pre-close state carried,
+        /// retained through the closure (the close event records at most an
+        /// acknowledged hash, and pre-acknowledgement closures recorded
+        /// nothing). A later force-complete against a different proving
+        /// transaction must re-acknowledge this transaction — it may still
+        /// land and double-burn.
         #[serde(default)]
-        acknowledged_unresolved_burn_tx_hash: Option<B256>,
+        unresolved_burn_tx: Option<SendableTxWithHash>,
     },
     BurnIntended {
         metadata: RedemptionMetadata,
@@ -864,74 +866,38 @@ impl Redemption {
         // A legacy `Failed` redemption has no persisted signed transaction to
         // bind the proving hash against — the burn went out through a
         // custodian's API, identified only by a backend transaction id the
-        // current backend cannot look up. For that shape the caller's on-chain
-        // verification of the planned burns is the entire proof, so there is
-        // no hash to bind and nothing unresolved to acknowledge. Every state
-        // that does persist a signed transaction keeps the full binding and
-        // acknowledgement guard. `Closed` joins the legacy shape only when
-        // its closure acknowledged no unresolved transaction: an admin close
-        // drops the persisted transaction (and never settles the
-        // reservation), but a closure that DID acknowledge a still-mineable
-        // burn carries that hash forward, and force-completing against a
-        // different proving transaction must re-acknowledge it — otherwise
-        // the acknowledged transaction could still land and double-burn.
-        let acknowledged_unresolved_burn_tx_hash = match self {
-            Self::Closed {
-                acknowledged_unresolved_burn_tx_hash: Some(unresolved),
-                ..
-            } => {
-                if *unresolved == burn_tx_hash {
-                    if let Some(provided) = acknowledged_unresolved_burn_tx_hash
-                    {
-                        return Err(
-                            RedemptionError::RedundantUnresolvedBurnAcknowledgement {
-                                provided,
-                            },
-                        );
-                    }
-
-                    None
-                } else {
-                    Some(Self::require_unresolved_burn_acknowledgement(
-                        *unresolved,
-                        acknowledged_unresolved_burn_tx_hash,
-                    )?)
-                }
-            }
-            Self::Closed {
-                acknowledged_unresolved_burn_tx_hash: None, ..
-            } => {
-                if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
-                    return Err(
-                        RedemptionError::RedundantUnresolvedBurnAcknowledgement {
-                            provided,
-                        },
-                    );
-                }
-
-                None
-            }
-            Self::Failed { .. }
-                if self
+        // current backend cannot look up. For that shape the caller's
+        // on-chain verification of the planned burns is the entire proof, so
+        // there is no hash to bind and nothing unresolved to acknowledge.
+        // `Closed` joins the same split: its state retains whatever signed
+        // burn survived to the moment of closure (recorded acknowledgement or
+        // not — pre-acknowledgement closures recorded nothing), so a closure
+        // that still carries one keeps the full binding and acknowledgement
+        // guard, and only a closure of a custodian-era burn with nothing
+        // persisted goes through as legacy.
+        let legacy_burn_without_persisted_tx =
+            matches!(self, Self::Failed { .. } | Self::Closed { .. })
+                && self
                     .persisted_unresolved_burn_tx()
                     .filter(|sendable_tx| !sendable_tx.tx.is_empty())
-                    .is_none() =>
-            {
+                    .is_none();
+        let acknowledged_unresolved_burn_tx_hash =
+            if legacy_burn_without_persisted_tx {
                 if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
                     return Err(
-                        RedemptionError::RedundantUnresolvedBurnAcknowledgement {
-                            provided,
-                        },
-                    );
+                    RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                        provided,
+                    },
+                );
                 }
 
                 None
-            }
-            _ => self.validate_force_complete_burn_hash(
-                burn_tx_hash,
-                acknowledged_unresolved_burn_tx_hash,
-            )?,
-        };
+            } else {
+                self.validate_force_complete_burn_hash(
+                    burn_tx_hash,
+                    acknowledged_unresolved_burn_tx_hash,
+                )?
+            };
 
         Ok(vec![RedemptionEvent::BurnForceCompleted {
             issuer_request_id,
@@ -1111,7 +1077,8 @@ impl Redemption {
             Self::BurnIntended { sendable_tx, .. }
             | Self::BurnSubmitted { sendable_tx, .. } => Some(sendable_tx),
             Self::Burning { prior_burn_tx, .. } => prior_burn_tx.as_ref(),
-            Self::Failed { unresolved_burn_tx, .. } => {
+            Self::Failed { unresolved_burn_tx, .. }
+            | Self::Closed { unresolved_burn_tx, .. } => {
                 unresolved_burn_tx.as_ref()
             }
             _ => None,
@@ -1484,7 +1451,12 @@ impl EventSourced for Redemption {
 
     const AGGREGATE_TYPE: &'static str = "Redemption";
     const PROJECTION: Nil = Nil;
-    const SCHEMA_VERSION: u64 = 5;
+    // 6: `Closed` gained `acknowledged_unresolved_burn_tx_hash`. Snapshots
+    // serialized under 5 would deserialize the field as `None` even when the
+    // closure acknowledged a still-mineable burn, silently dropping the
+    // re-acknowledgement guard; the bump clears them so the state rebuilds
+    // from events, which carry the hash.
+    const SCHEMA_VERSION: u64 = 6;
 
     fn originate(event: &Self::Event) -> Option<Self> {
         match event {
@@ -1603,10 +1575,17 @@ impl EventSourced for Redemption {
                     found: "Uninitialized".to_string(),
                 })
             }
-            RedemptionCommand::RecordBurnFailure { .. }
-            | RedemptionCommand::ForceCompleteBurn { .. } => {
+            RedemptionCommand::RecordBurnFailure { .. } => {
                 Err(RedemptionError::InvalidState {
                     expected: "Burning, BurnIntended, or BurnSubmitted"
+                        .to_string(),
+                    found: "Uninitialized".to_string(),
+                })
+            }
+            RedemptionCommand::ForceCompleteBurn { .. } => {
+                Err(RedemptionError::InvalidState {
+                    expected: "Burning, BurnIntended, BurnSubmitted, \
+                               Failed, or Closed"
                         .to_string(),
                     found: "Uninitialized".to_string(),
                 })
@@ -2085,13 +2064,21 @@ impl Redemption {
                 issuer_request_id,
                 reason,
                 closed_at,
-                acknowledged_unresolved_burn_tx_hash,
+                ..
             } => {
+                // The close event records at most an acknowledged hash, and
+                // pre-acknowledgement closures recorded nothing — the
+                // pre-close state is the only reliable carrier of a signed
+                // burn that may still land, so retain it through the closure.
+                let unresolved_burn_tx = self
+                    .persisted_unresolved_burn_tx()
+                    .filter(|sendable_tx| !sendable_tx.tx.is_empty())
+                    .cloned();
                 *self = Self::Closed {
                     issuer_request_id,
                     reason,
                     closed_at,
-                    acknowledged_unresolved_burn_tx_hash,
+                    unresolved_burn_tx,
                 };
             }
             RedemptionEvent::BurnForceCompleted {
@@ -4423,6 +4410,56 @@ mod tests {
         );
     }
 
+    /// The pre-#260 closure shape: `CloseRedemption` accepted persisted-tx
+    /// states without recording any acknowledgement, so historical
+    /// `RedemptionClosed` events replay with the acknowledgement field
+    /// defaulted to `None` while a still-mineable signed burn survives in
+    /// the pre-close history. The guard must key on that retained
+    /// transaction, not on the recorded acknowledgement.
+    #[tokio::test]
+    async fn force_complete_of_pre_acknowledgement_closure_requires_acknowledgement()
+     {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+        let mut history =
+            burn_intended_given_events(&issuer_request_id, persisted_hash);
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "confirmation timed out".to_string(),
+            failed_at: Utc::now(),
+            tx_id: None,
+            planned_burns: vec![],
+        });
+        history.push(RedemptionEvent::RedemptionClosed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "closed by a pre-acknowledgement admin build".to_string(),
+            closed_at: Utc::now(),
+            acknowledged_unresolved_burn_tx_hash: None,
+        });
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 33_000_000,
+                reason: "different burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                burn_tx_hash: persisted_hash,
+            }
+        );
+    }
+
     /// A redemption closed while still carrying an acknowledged, potentially
     /// still-mineable signed burn keeps the acknowledgement guard through the
     /// closure: force-completing against a different proving transaction must
@@ -4687,7 +4724,9 @@ mod tests {
         assert_eq!(
             error,
             RedemptionError::InvalidState {
-                expected: "Burning, BurnIntended, or BurnSubmitted".to_string(),
+                expected: "Burning, BurnIntended, BurnSubmitted, Failed, or \
+                           Closed"
+                    .to_string(),
                 found: "Uninitialized".to_string(),
             }
         );

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -311,6 +311,12 @@ pub(crate) enum Redemption {
         issuer_request_id: IssuerRedemptionRequestId,
         reason: String,
         closed_at: DateTime<Utc>,
+        /// Hash of the still-unresolved signed burn the operator acknowledged
+        /// when closing, carried through the closure so a later
+        /// force-complete against a different proving transaction must
+        /// re-acknowledge the transaction that may still land.
+        #[serde(default)]
+        acknowledged_unresolved_burn_tx_hash: Option<B256>,
     },
     BurnIntended {
         metadata: RedemptionMetadata,
@@ -840,14 +846,15 @@ impl Redemption {
                 | Self::BurnIntended { .. }
                 | Self::BurnSubmitted { .. }
                 | Self::Failed { .. }
+                | Self::Closed { .. }
         ) {
             return Err(match self {
-                Self::Completed { .. } | Self::Closed { .. } => {
+                Self::Completed { .. } => {
                     RedemptionError::AlreadyCompleted { issuer_request_id }
                 }
                 _ => RedemptionError::InvalidState {
-                    expected: "Burning, BurnIntended, BurnSubmitted, or \
-                               Failed"
+                    expected: "Burning, BurnIntended, BurnSubmitted, \
+                               Failed, or Closed"
                         .to_string(),
                     found: self.state_name().to_string(),
                 },
@@ -861,30 +868,70 @@ impl Redemption {
         // verification of the planned burns is the entire proof, so there is
         // no hash to bind and nothing unresolved to acknowledge. Every state
         // that does persist a signed transaction keeps the full binding and
-        // acknowledgement guard.
-        let legacy_burn_without_persisted_tx =
-            matches!(self, Self::Failed { .. })
-                && self
-                    .persisted_unresolved_burn_tx()
-                    .filter(|sendable_tx| !sendable_tx.tx.is_empty())
-                    .is_none();
-        let acknowledged_unresolved_burn_tx_hash =
-            if legacy_burn_without_persisted_tx {
+        // acknowledgement guard. `Closed` joins the legacy shape only when
+        // its closure acknowledged no unresolved transaction: an admin close
+        // drops the persisted transaction (and never settles the
+        // reservation), but a closure that DID acknowledge a still-mineable
+        // burn carries that hash forward, and force-completing against a
+        // different proving transaction must re-acknowledge it — otherwise
+        // the acknowledged transaction could still land and double-burn.
+        let acknowledged_unresolved_burn_tx_hash = match self {
+            Self::Closed {
+                acknowledged_unresolved_burn_tx_hash: Some(unresolved),
+                ..
+            } => {
+                if *unresolved == burn_tx_hash {
+                    if let Some(provided) = acknowledged_unresolved_burn_tx_hash
+                    {
+                        return Err(
+                            RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                                provided,
+                            },
+                        );
+                    }
+
+                    None
+                } else {
+                    Some(Self::require_unresolved_burn_acknowledgement(
+                        *unresolved,
+                        acknowledged_unresolved_burn_tx_hash,
+                    )?)
+                }
+            }
+            Self::Closed {
+                acknowledged_unresolved_burn_tx_hash: None, ..
+            } => {
                 if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
                     return Err(
-                    RedemptionError::RedundantUnresolvedBurnAcknowledgement {
-                        provided,
-                    },
-                );
+                        RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                            provided,
+                        },
+                    );
                 }
 
                 None
-            } else {
-                self.validate_force_complete_burn_hash(
-                    burn_tx_hash,
-                    acknowledged_unresolved_burn_tx_hash,
-                )?
-            };
+            }
+            Self::Failed { .. }
+                if self
+                    .persisted_unresolved_burn_tx()
+                    .filter(|sendable_tx| !sendable_tx.tx.is_empty())
+                    .is_none() =>
+            {
+                if let Some(provided) = acknowledged_unresolved_burn_tx_hash {
+                    return Err(
+                        RedemptionError::RedundantUnresolvedBurnAcknowledgement {
+                            provided,
+                        },
+                    );
+                }
+
+                None
+            }
+            _ => self.validate_force_complete_burn_hash(
+                burn_tx_hash,
+                acknowledged_unresolved_burn_tx_hash,
+            )?,
+        };
 
         Ok(vec![RedemptionEvent::BurnForceCompleted {
             issuer_request_id,
@@ -2038,9 +2085,14 @@ impl Redemption {
                 issuer_request_id,
                 reason,
                 closed_at,
-                ..
+                acknowledged_unresolved_burn_tx_hash,
             } => {
-                *self = Self::Closed { issuer_request_id, reason, closed_at };
+                *self = Self::Closed {
+                    issuer_request_id,
+                    reason,
+                    closed_at,
+                    acknowledged_unresolved_burn_tx_hash,
+                };
             }
             RedemptionEvent::BurnForceCompleted {
                 issuer_request_id,
@@ -4218,6 +4270,65 @@ mod tests {
         ));
     }
 
+    /// The legacy shape above, wedged one step further: an operator closed
+    /// the `Failed` redemption through the admin API (which does not settle
+    /// the burn reservation) before the force-complete path learned the
+    /// legacy shape. The verified landed burn is the same; a `Closed`
+    /// aggregate must accept the terminalization so the reservation can
+    /// settle instead of stranding the vault's custody migration forever.
+    #[tokio::test]
+    async fn force_complete_terminalizes_a_closed_legacy_burn() {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let mut history = burning_given_events(&issuer_request_id);
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "Fireblocks API error: error in reqwest-middleware: \
+                    error sending request"
+                .to_string(),
+            failed_at: Utc::now(),
+            tx_id: None,
+            planned_burns: vec![BurnRecord {
+                receipt_id: uint!(3_U256),
+                shares_burned: uint!(40_000000000000000_U256),
+            }],
+        });
+        history.push(RedemptionEvent::RedemptionFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "On-chain balance insufficient for BurnFailed recovery: \
+                     balance=0, required=40000000000000000"
+                .to_string(),
+            failed_at: Utc::now(),
+        });
+        history.push(RedemptionEvent::RedemptionClosed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "Burn verified on-chain; closed by admin because \
+                     force-complete rejected the Failed state"
+                .to_string(),
+            closed_at: Utc::now(),
+            acknowledged_unresolved_burn_tx_hash: None,
+        });
+
+        let events = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: b256!(
+                    "0xfda15f8e5fb2b87e83bf115ea41c521bb251cc3ae875ac91f3e38f003c9a09ee"
+                ),
+                block_number: 48_929_042,
+                reason: "operator verified the landed burn on-chain"
+                    .to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [RedemptionEvent::BurnForceCompleted { .. }]
+        ));
+    }
+
     /// The legacy shape has no persisted transaction, so there is nothing an
     /// acknowledgement could refer to — supplying one anyway must be refused
     /// rather than recorded as a meaningless fact on the terminal event.
@@ -4287,6 +4398,56 @@ mod tests {
             failed_at: Utc::now(),
             tx_id: None,
             planned_burns: vec![],
+        });
+
+        let error = TestHarness::<Redemption>::with(mock_services())
+            .given(history)
+            .when(RedemptionCommand::ForceCompleteBurn {
+                issuer_request_id,
+                burn_tx_hash: B256::random(),
+                block_number: 33_000_000,
+                reason: "different burn verified on-chain".to_string(),
+                acknowledged_unresolved_burn_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+
+        let LifecycleError::Apply(error) = error else {
+            panic!("Expected Apply error, got {error:?}");
+        };
+        assert_eq!(
+            error,
+            RedemptionError::UnresolvedBurnRequiresAcknowledgement {
+                burn_tx_hash: persisted_hash,
+            }
+        );
+    }
+
+    /// A redemption closed while still carrying an acknowledged, potentially
+    /// still-mineable signed burn keeps the acknowledgement guard through the
+    /// closure: force-completing against a different proving transaction must
+    /// re-name the hash the operator is stranding, or the original
+    /// transaction could land later and double-burn.
+    #[tokio::test]
+    async fn force_complete_of_closed_redemption_with_unresolved_burn_requires_acknowledgement()
+     {
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let persisted_hash = B256::random();
+        let mut history =
+            burn_intended_given_events(&issuer_request_id, persisted_hash);
+        history.push(RedemptionEvent::BurningFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "confirmation timed out".to_string(),
+            failed_at: Utc::now(),
+            tx_id: None,
+            planned_burns: vec![],
+        });
+        history.push(RedemptionEvent::RedemptionClosed {
+            issuer_request_id: issuer_request_id.clone(),
+            reason: "closed by admin with the unresolved burn acknowledged"
+                .to_string(),
+            closed_at: Utc::now(),
+            acknowledged_unresolved_burn_tx_hash: Some(persisted_hash),
         });
 
         let error = TestHarness::<Redemption>::with(mock_services())

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -26,6 +26,7 @@ use crate::fireblocks::auth_probe::probe_auth_pair;
 use crate::fireblocks::{
     Environment, FireblocksEnv, FireblocksVaultService, fetch_vault_address,
 };
+use crate::prepare_event_sourced_startup;
 use crate::receipt_inventory::migration::{
     CorroboratedRecipient, MigrationOutcome, VaultIdentity,
     confirm_custody_holder, migrate_vault_receipts,
@@ -1378,9 +1379,16 @@ impl AssetAdmin {
         // The server heals `tokenized_asset_view` at startup, but this CLI
         // runs while the service is deliberately stopped — and production
         // carried the view empty for weeks without the running service's
-        // read paths noticing. Building the listing store runs the same
-        // catch-up, so every CLI read of the view sees the listings the
+        // read paths noticing. Run the same startup hygiene the server does
+        // (schema reconciliation clears snapshots and stale canonical
+        // projections on a version change) before the builds, so a CLI run
+        // after a schema bump cannot advance the recorded version while
+        // leaving incompatible view rows behind; the builds then run the
+        // same catch-up, so every CLI read of the view sees the listings the
         // event log actually holds.
+        prepare_event_sourced_startup::<TokenizedAsset>(&pool).await?;
+        prepare_event_sourced_startup::<Underlying>(&pool).await?;
+
         let (_listing_store, _listing_projection) =
             StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
 

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -22,8 +22,9 @@ use crate::config::{
     DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, LogLevel,
     setup_tracing,
 };
+use crate::fireblocks::auth_probe::probe_auth_pair;
 use crate::fireblocks::{
-    FireblocksEnv, FireblocksVaultService, fetch_vault_address,
+    Environment, FireblocksEnv, FireblocksVaultService, fetch_vault_address,
 };
 use crate::receipt_inventory::migration::{
     CorroboratedRecipient, MigrationOutcome, VaultIdentity,
@@ -131,6 +132,22 @@ enum IssuerCommand {
     /// other redemption may already claim it. Completes the redemption and
     /// settles its receipt reservation like a normal burn confirmation.
     ForceCompleteRedemption(Box<ForceCompleteRedemptionArgs>),
+    /// A/B-probe Fireblocks API authentication and print the raw responses.
+    ///
+    /// Sends the same authenticated vault-address GET twice, varying only the
+    /// JWT expiry window: once compliant with Fireblocks' documented
+    /// `exp < iat + 30s` bound, once with the SDK's out-of-spec `iat + 55`.
+    /// Prints each response's status and verbatim body — the diagnostic the
+    /// SDK swallows on 401. A split verdict proves the platform enforces the
+    /// documented bound; identical rejections carry the server's own error
+    /// code for diagnosis. Submits nothing and reads only the vault address.
+    FireblocksAuthProbe(Box<FireblocksAuthProbeArgs>),
+}
+
+#[derive(Args)]
+struct FireblocksAuthProbeArgs {
+    #[clap(flatten)]
+    fireblocks: FireblocksEnv,
 }
 
 /// Which way the operator intends custody to move. Stated explicitly and
@@ -386,6 +403,9 @@ impl IssuerCli {
             }
             IssuerCommand::ForceCompleteRedemption(args) => {
                 run_force_complete_redemption(*args, prompt_confirm).await
+            }
+            IssuerCommand::FireblocksAuthProbe(args) => {
+                run_fireblocks_auth_probe(*args).await
             }
         }
     }
@@ -753,6 +773,29 @@ async fn run_fireblocks_smoke<P: Provider + Clone>(
     }
 
     println!("Fireblocks smoke transfer completed (moved nothing): {tx_hash}");
+
+    Ok(())
+}
+
+/// Runs the authentication A/B probe against the environment's API host and
+/// prints each attempt's status and verbatim body.
+async fn run_fireblocks_auth_probe(
+    args: FireblocksAuthProbeArgs,
+) -> anyhow::Result<()> {
+    let config = args.fireblocks.into_config()?;
+    let base_url = match config.environment {
+        Environment::Production => "https://api.fireblocks.io",
+        Environment::Sandbox => "https://sandbox-api.fireblocks.io",
+    };
+
+    println!("Probing {base_url} with the service's credential pair");
+    for report in probe_auth_pair(base_url, &config).await? {
+        println!(
+            "exp = iat + {}s -> HTTP {}",
+            report.expiry_seconds, report.status
+        );
+        println!("{}", report.body);
+    }
 
     Ok(())
 }

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -1029,29 +1029,13 @@ async fn run_forward_via_fireblocks(
         );
     }
 
-    // The forward transfer is a one-way door unless Turnkey can sign the way
-    // back. Re-proven here, immediately before the irreversible submission,
-    // rather than trusted from an earlier `verify-custodians` run that may be
-    // stale or skipped: the exact rollback-shaped transaction — every tracked
-    // receipt back from the Turnkey wallet to the current holder — is signed
-    // without being broadcast, and the Turnkey wallet must hold the rollback
-    // gas reserve.
-    let resolved = resolve_turnkey_signer(turnkey_config, chain_id)?;
-    let proof = verify_rollback_signing(
-        &admin.pool,
-        &provider,
-        &resolved.wallet,
-        VaultIdentity { chain_id, vault, underlying: &args.underlying },
-        fireblocks_wallet,
-    )
-    .await?;
-    println!(
-        "Turnkey rollback re-proven: signed the return of {} receipt(s) to \
-         {} without broadcasting",
-        proof.receipts, proof.destination
-    );
-    require_rollback_gas(proof.turnkey_gas, turnkey)?;
-
+    // No rollback re-proof: the migration is decided one-way. Fireblocks is
+    // being retired, and Turnkey's signing policy does not cover
+    // rollback-shaped receipt transfers for every vault — gating the forward
+    // move on proving a return path nobody intends to use only blocks the
+    // cutover. Moving receipts out of the Turnkey wallet again (a future
+    // rotation) requires a Turnkey policy change first; `verify-custodians`
+    // retains the proof as a diagnostic.
     let recipient =
         CorroboratedRecipient::verify(&provider, recipient.address()).await?;
 

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
-use super::UnderlyingSymbol;
 use super::view::{
     TokenizedAssetViewError, find_vault, underlying_has_listing,
 };
+use super::{TokenizedAsset, UnderlyingSymbol};
 use crate::Network;
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::config::{
@@ -1332,6 +1332,15 @@ impl AssetAdmin {
 
         sqlx::migrate!("./migrations").run(&pool).await?;
 
+        // The server heals `tokenized_asset_view` at startup, but this CLI
+        // runs while the service is deliberately stopped — and production
+        // carried the view empty for weeks without the running service's
+        // read paths noticing. Building the listing store runs the same
+        // catch-up, so every CLI read of the view sees the listings the
+        // event log actually holds.
+        let (_listing_store, _listing_projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone()).build(()).await?;
+
         let (store, _projection) =
             StoreBuilder::<Underlying>::new(pool.clone()).build(()).await?;
 
@@ -1462,6 +1471,7 @@ mod tests {
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::{
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        TokenizedAssetEvent,
     };
 
     const TEST_SIGNER_KEY: &str =
@@ -1989,6 +1999,69 @@ mod tests {
         assert!(
             error.to_string().contains("no recorded custody holder"),
             "unobserved custody must demand confirm-custody, got {error}"
+        );
+    }
+
+    /// Production carried `tokenized_asset_view` empty for six weeks: a
+    /// migration dropped and recreated the table, and only the running
+    /// server's startup healed views — so listings written by an earlier
+    /// binary exist as events with no view rows, and this CLI (which runs
+    /// while the service is deliberately stopped) read an empty view.
+    /// Connecting must heal the listing view from the event log.
+    #[tokio::test]
+    async fn connect_heals_an_empty_listing_view_from_events() {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("empty-view.db").display()
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(&database_url)
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        let underlying = UnderlyingSymbol::new("AMAT").unwrap();
+        let event = TokenizedAssetEvent::Added {
+            underlying: underlying.clone(),
+            token: TokenSymbol::new("tAMAT"),
+            network: Network::Base,
+            vault: TEST_VAULT,
+            added_at: Utc::now(),
+        };
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('TokenizedAsset', ?, 1, ?, '1.0', ?, '{}')
+            ",
+        )
+        .bind(AssetKey::new(underlying.clone(), Network::Base).to_string())
+        .bind(event.event_type())
+        .bind(serde_json::to_string(&event).unwrap())
+        .execute(&pool)
+        .await
+        .unwrap();
+        pool.close().await;
+
+        let admin = AssetAdmin::connect(&database_url, 1).await.unwrap();
+
+        let vault =
+            find_vault(&admin.pool, &underlying, &Network::Base).await.unwrap();
+        assert_eq!(
+            vault,
+            Some(TEST_VAULT),
+            "a listing present only in the event log must be readable after \
+             connect"
         );
     }
 

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::primitives::{Address, B256, Bytes, U256, address};
 use alloy::providers::{Provider, ProviderBuilder};
 use clap::{Args, Parser, Subcommand};
 use event_sorcery::{
@@ -133,6 +133,17 @@ enum IssuerCommand {
     /// other redemption may already claim it. Completes the redemption and
     /// settles its receipt reservation like a normal burn confirmation.
     ForceCompleteRedemption(Box<ForceCompleteRedemptionArgs>),
+    /// Sweep the legacy holdings the receipt-custody migration could not see
+    /// out of the Fireblocks wallet: five ERC-1155 receipts inherited from the
+    /// pre-Fireblocks issuer wallet in March 2026 (they predate the service's
+    /// inventory tracking, so `migrate-receipts` never listed them), plus the
+    /// stranded 0.2 tCOIN ERC-20 redemption, forwarded to the liquidity bot
+    /// wallet for re-sending. Every value is pinned in a hardcoded table and
+    /// cross-checked against live on-chain balances before anything is
+    /// submitted; entries already swept are skipped, so re-running is safe.
+    ///
+    /// Temporary, Base-only, thrown away with the Fireblocks integration.
+    SweepLegacyReceipts(Box<SweepLegacyReceiptsArgs>),
     /// A/B-probe Fireblocks API authentication and print the raw responses.
     ///
     /// Sends the same authenticated vault-address GET twice, varying only the
@@ -149,6 +160,433 @@ enum IssuerCommand {
 struct FireblocksAuthProbeArgs {
     #[clap(flatten)]
     fireblocks: FireblocksEnv,
+}
+
+#[derive(Args)]
+struct SweepLegacyReceiptsArgs {
+    /// RPC endpoint for Base — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain the sweep must run against, cross-checked against the chain the
+    /// RPC reports. The sweep table is Base-only, so anything but 8453 is
+    /// refused.
+    #[arg(long)]
+    chain_id: u64,
+
+    /// Attempt counter salted into every Fireblocks externalTxId. Fireblocks
+    /// treats an externalTxId as spent once a transaction under it completes
+    /// — including a transaction that completed on the platform but REVERTED
+    /// on-chain, which a plain rerun would recover forever instead of
+    /// resubmitting. After the sweep reports a reverted transaction, rerun
+    /// with the next attempt number to submit fresh.
+    #[arg(long, default_value_t = 1)]
+    attempt: u32,
+
+    #[clap(flatten)]
+    fireblocks: FireblocksEnv,
+}
+
+/// The retired Fireblocks issuer wallet every sweep entry moves out of.
+const LEGACY_HOLDER: Address =
+    address!("0x1c66D6708914C40239D54919320b4C48cAE3D1A9");
+
+/// The Turnkey issuer wallet that now custodies every receipt. The running
+/// service discovers inbound receipt transfers to this wallet on its next
+/// backfill pass, so swept receipts enter tracked inventory with no restart.
+const TURNKEY_RECIPIENT: Address =
+    address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE");
+
+/// The liquidity bot wallet. The stranded redemption goes back here rather
+/// than straight to the redemption wallet because redemption detection skips
+/// transfers from senders it cannot attribute; the bot re-sends it as a
+/// normal redemption.
+const LIQUIDITY_BOT: Address =
+    address!("0xa9c16673F65AE808688cB18952AFE3d9658C808f");
+
+/// The tCOIN vault, whose ERC-20 shares include the stranded redemption.
+const TCOIN_VAULT: Address =
+    address!("0x626757e6F50675D17fcAd312E82f989aE7A23d38");
+
+/// The 0.2 tCOIN redemption that landed at the retired wallet on 2026-07-29.
+const STRANDED_TCOIN: u128 = 200_000_000_000_000_000;
+
+/// A Base block mined before this tool existed (2026-07-31, early UTC). The
+/// stranded-tCOIN forward can only have been submitted by this tool, so any
+/// proof of it lives at or after this block; scanning starts here.
+const SWEEP_ERA_START_BLOCK: u64 = 49_330_000;
+
+/// Proves the stranded tCOIN actually reached the liquidity bot wallet by
+/// finding the exact legacy-to-bot `Transfer` on the tCOIN contract. A
+/// drained source with no such event means the tokens went somewhere else,
+/// which is an error, not a skip.
+async fn find_stranded_forward_event<P: Provider + Clone>(
+    provider: &P,
+) -> anyhow::Result<B256> {
+    let vault = OffchainAssetReceiptVault::new(TCOIN_VAULT, provider);
+    let expected = U256::from(STRANDED_TCOIN);
+    let latest = provider.get_block_number().await?;
+
+    // Public Base RPC caps eth_getLogs at 10k blocks per query.
+    let mut from_block = SWEEP_ERA_START_BLOCK;
+    while from_block <= latest {
+        let to_block = from_block.saturating_add(9_999).min(latest);
+        let events = vault
+            .Transfer_filter()
+            .from_block(from_block)
+            .to_block(to_block)
+            .query()
+            .await?;
+
+        for (event, log) in events {
+            if event.from == LEGACY_HOLDER
+                && event.to == LIQUIDITY_BOT
+                && event.value == expected
+            {
+                return log.transaction_hash.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "the stranded-tCOIN forward Transfer event carries \
+                         no transaction hash"
+                    )
+                });
+            }
+        }
+        from_block = to_block.saturating_add(1);
+    }
+
+    anyhow::bail!(
+        "stranded tCOIN: the legacy wallet is drained but no Transfer of \
+         {expected} from {LEGACY_HOLDER} to {LIQUIDITY_BOT} exists on \
+         {TCOIN_VAULT} since block {SWEEP_ERA_START_BLOCK} — the tokens \
+         went somewhere else; investigate before rerunning"
+    )
+}
+
+/// One receipt contract's worth of legacy holdings to sweep.
+struct LegacyReceiptSweep {
+    label: &'static str,
+    external_tx_id: &'static str,
+    receipt_contract: Address,
+    /// `(receipt id, expected balance)` — the sweep refuses to move a balance
+    /// that no longer matches, so a stale table cannot move the wrong amount.
+    holdings: &'static [(u64, u128)],
+}
+
+/// The five receipts the March 2026 issuer-wallet handover left at the
+/// Fireblocks wallet. They were inherited from the previous issuer wallet
+/// (0xe70d821f3462a074e63b42d0aac6523faae1d611) before this service's
+/// inventory tracking began, so `migrate-receipts` — which enumerates tracked
+/// holdings — never saw them. Balances verified on-chain 2026-07-31.
+const LEGACY_RECEIPT_SWEEPS: [LegacyReceiptSweep; 4] = [
+    LegacyReceiptSweep {
+        label: "tCOIN receipts",
+        external_tx_id: "legacy-receipt-sweep-tcoin",
+        receipt_contract: address!(
+            "0xBA1B8836A5510815e96103F067715b7CCC7c2E0E"
+        ),
+        holdings: &[(19, 1_000_000_000_000_000_000)],
+    },
+    LegacyReceiptSweep {
+        label: "tCRCL receipts",
+        external_tx_id: "legacy-receipt-sweep-tcrcl",
+        receipt_contract: address!(
+            "0xd508B97975fBE04E62bFf18959549b046bD8FA78"
+        ),
+        holdings: &[(4, 11_048_599_999_999_999_980)],
+    },
+    LegacyReceiptSweep {
+        label: "tMSTR receipts",
+        external_tx_id: "legacy-receipt-sweep-tmstr",
+        receipt_contract: address!(
+            "0x1c1fEF6f7b8e576219554b1d11c8aF29D00C0cEC"
+        ),
+        holdings: &[(5, 8_000_000_000_000_000_000)],
+    },
+    LegacyReceiptSweep {
+        label: "tSPYM receipts",
+        external_tx_id: "legacy-receipt-sweep-tspym",
+        receipt_contract: address!(
+            "0x957056dD6e2E594742E36675e8AA5A567163E5bd"
+        ),
+        holdings: &[
+            (10, 28_401_765_980_495_899_205),
+            (12, 90_000_000_000_000_000_000),
+        ],
+    },
+];
+
+async fn run_sweep_legacy_receipts(
+    args: SweepLegacyReceiptsArgs,
+    confirm: fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    let fireblocks_config = args.fireblocks.into_config()?;
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    anyhow::ensure!(
+        chain_id == 8453,
+        "the legacy sweep table is Base-only (chain 8453); the RPC reports \
+         chain {chain_id}"
+    );
+
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+    let fireblocks_wallet = fetch_vault_address(&fireblocks_config).await?;
+    anyhow::ensure!(
+        fireblocks_wallet == LEGACY_HOLDER,
+        "Fireblocks credentials resolve to {fireblocks_wallet}, not the \
+         legacy holder {LEGACY_HOLDER} the sweep table was written for"
+    );
+
+    println!("Sweeping legacy holdings out of {LEGACY_HOLDER}:");
+    for sweep in &LEGACY_RECEIPT_SWEEPS {
+        for (receipt_id, amount) in sweep.holdings {
+            println!(
+                "  {} id {receipt_id}: {amount} -> {TURNKEY_RECIPIENT}",
+                sweep.label
+            );
+        }
+    }
+    println!(
+        "  stranded tCOIN redemption: {STRANDED_TCOIN} -> {LIQUIDITY_BOT}"
+    );
+
+    if !confirm(
+        "Submit these transfers through Fireblocks (console approval may be \
+         required)?",
+    )? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let service = FireblocksVaultService::new(
+        &fireblocks_config,
+        provider.clone(),
+        chain_id,
+    )?;
+
+    for sweep in &LEGACY_RECEIPT_SWEEPS {
+        sweep_legacy_receipt_contract(&service, &provider, sweep, args.attempt)
+            .await?;
+    }
+    sweep_stranded_tcoin(&service, &provider, args.attempt).await?;
+
+    println!("Legacy sweep complete.");
+    Ok(())
+}
+
+/// Requires the Fireblocks-completed transaction to have SUCCEEDED on-chain.
+///
+/// Fireblocks reports "Completed" for a transaction that was mined but
+/// REVERTED, and a completed transaction's externalTxId is spent forever — a
+/// rerun under the same id recovers the reverted transaction instead of
+/// submitting fresh. Refusing here keeps a revert from being reported as
+/// success, and the error names the `--attempt` bump that mints fresh ids.
+async fn require_onchain_success<P: Provider>(
+    provider: &P,
+    tx_hash: B256,
+    attempt: u32,
+) -> anyhow::Result<()> {
+    let onchain =
+        provider.get_transaction_receipt(tx_hash).await?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "no on-chain receipt found for {tx_hash} although Fireblocks \
+                 reported it completed"
+            )
+        })?;
+
+    anyhow::ensure!(
+        onchain.status(),
+        "{tx_hash} REVERTED on-chain although Fireblocks reported it \
+         completed; nothing moved, and its externalTxId is spent — rerun \
+         with --attempt {}",
+        attempt.saturating_add(1)
+    );
+    Ok(())
+}
+
+/// Sweeps the still-held subset of one contract's legacy receipts, refusing
+/// on any balance that matches neither the table nor zero. Success requires
+/// the transaction to have succeeded on-chain, the legacy wallet drained, and
+/// the Turnkey wallet to have gained exactly the swept amounts.
+async fn sweep_legacy_receipt_contract<P: Provider + Clone>(
+    service: &FireblocksVaultService<P>,
+    provider: &P,
+    sweep: &LegacyReceiptSweep,
+    attempt: u32,
+) -> anyhow::Result<()> {
+    let receipt = Receipt::new(sweep.receipt_contract, provider);
+
+    let mut ids = Vec::new();
+    let mut amounts = Vec::new();
+    let mut recipient_before = Vec::new();
+    for (receipt_id, amount) in sweep.holdings {
+        let receipt_id = U256::from(*receipt_id);
+        let expected = U256::from(*amount);
+        let held = receipt.balanceOf(LEGACY_HOLDER, receipt_id).call().await?;
+
+        if held.is_zero() {
+            // A drained source only proves a sweep if the receipt actually
+            // sits at the Turnkey wallet; anything else means it went
+            // somewhere it should not have.
+            let at_recipient =
+                receipt.balanceOf(TURNKEY_RECIPIENT, receipt_id).call().await?;
+            anyhow::ensure!(
+                at_recipient == expected,
+                "{}: id {receipt_id} is gone from the legacy wallet but \
+                 {TURNKEY_RECIPIENT} holds {at_recipient}, not the expected \
+                 {expected} — it was NOT swept here; investigate before \
+                 rerunning",
+                sweep.label
+            );
+            continue;
+        }
+        anyhow::ensure!(
+            held == expected,
+            "{}: id {receipt_id} holds {held} at the legacy wallet, but the \
+             sweep table expects {expected}; refusing to move an unexpected \
+             balance",
+            sweep.label
+        );
+        let before =
+            receipt.balanceOf(TURNKEY_RECIPIENT, receipt_id).call().await?;
+        ids.push(receipt_id);
+        amounts.push(expected);
+        recipient_before.push(before);
+    }
+
+    if ids.is_empty() {
+        println!(
+            "{}: already swept and verified at {TURNKEY_RECIPIENT}, skipping",
+            sweep.label
+        );
+        return Ok(());
+    }
+
+    let calldata = receipt
+        .safeBatchTransferFrom(
+            LEGACY_HOLDER,
+            TURNKEY_RECIPIENT,
+            ids.clone(),
+            amounts.clone(),
+            Bytes::new(),
+        )
+        .calldata()
+        .clone();
+
+    let external_tx_id = format!("{}-a{attempt}", sweep.external_tx_id);
+    let tx_hash = service
+        .submit_contract_call_to_completion(
+            sweep.receipt_contract,
+            &calldata,
+            sweep.label,
+            &external_tx_id,
+        )
+        .await?;
+
+    require_onchain_success(provider, tx_hash, attempt).await?;
+
+    for ((receipt_id, amount), before) in
+        ids.iter().zip(&amounts).zip(&recipient_before)
+    {
+        let remaining =
+            receipt.balanceOf(LEGACY_HOLDER, *receipt_id).call().await?;
+        anyhow::ensure!(
+            remaining.is_zero(),
+            "{}: id {receipt_id} still holds {remaining} at the legacy \
+             wallet after {tx_hash}",
+            sweep.label
+        );
+
+        let gained = receipt
+            .balanceOf(TURNKEY_RECIPIENT, *receipt_id)
+            .call()
+            .await?
+            .checked_sub(*before)
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "{}: id {receipt_id} balance at {TURNKEY_RECIPIENT} \
+                     DECREASED across {tx_hash}",
+                    sweep.label
+                )
+            })?;
+        anyhow::ensure!(
+            gained == *amount,
+            "{}: id {receipt_id} gained {gained} at {TURNKEY_RECIPIENT} \
+             across {tx_hash}, expected {amount}",
+            sweep.label
+        );
+    }
+
+    println!("{}: swept in {tx_hash}", sweep.label);
+    Ok(())
+}
+
+/// Forwards the stranded 0.2 tCOIN redemption to the liquidity bot wallet,
+/// with the same on-chain success and recipient-gain verification as the
+/// receipt sweeps.
+async fn sweep_stranded_tcoin<P: Provider + Clone>(
+    service: &FireblocksVaultService<P>,
+    provider: &P,
+    attempt: u32,
+) -> anyhow::Result<()> {
+    let vault = OffchainAssetReceiptVault::new(TCOIN_VAULT, provider);
+    let expected = U256::from(STRANDED_TCOIN);
+    let held = vault.balanceOf(LEGACY_HOLDER).call().await?;
+
+    if held.is_zero() {
+        // The bot wallet holds tCOIN transiently during its own operations,
+        // so its balance proves nothing about where the stranded tokens
+        // went. Only the exact legacy-to-bot Transfer event does.
+        let forwarded_in = find_stranded_forward_event(provider).await?;
+        println!(
+            "stranded tCOIN: already forwarded in {forwarded_in}, skipping"
+        );
+        return Ok(());
+    }
+    anyhow::ensure!(
+        held == expected,
+        "stranded tCOIN: the legacy wallet holds {held}, but the sweep \
+         expects {expected}; refusing to move an unexpected balance"
+    );
+    let recipient_before = vault.balanceOf(LIQUIDITY_BOT).call().await?;
+
+    let calldata = vault.transfer(LIQUIDITY_BOT, expected).calldata().clone();
+    let external_tx_id = format!("legacy-sweep-stranded-tcoin-a{attempt}");
+    let tx_hash = service
+        .submit_contract_call_to_completion(
+            TCOIN_VAULT,
+            &calldata,
+            "stranded tCOIN redemption forward",
+            &external_tx_id,
+        )
+        .await?;
+
+    require_onchain_success(provider, tx_hash, attempt).await?;
+
+    let remaining = vault.balanceOf(LEGACY_HOLDER).call().await?;
+    anyhow::ensure!(
+        remaining.is_zero(),
+        "stranded tCOIN: the legacy wallet still holds {remaining} after \
+         {tx_hash}"
+    );
+
+    let gained = vault
+        .balanceOf(LIQUIDITY_BOT)
+        .call()
+        .await?
+        .checked_sub(recipient_before)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "stranded tCOIN: balance at {LIQUIDITY_BOT} DECREASED across \
+                 {tx_hash}"
+            )
+        })?;
+    anyhow::ensure!(
+        gained == expected,
+        "stranded tCOIN: {LIQUIDITY_BOT} gained {gained} across {tx_hash}, \
+         expected {expected}"
+    );
+
+    println!("stranded tCOIN: forwarded in {tx_hash}");
+    Ok(())
 }
 
 /// Which way the operator intends custody to move. Stated explicitly and
@@ -407,6 +845,9 @@ impl IssuerCli {
             }
             IssuerCommand::FireblocksAuthProbe(args) => {
                 run_fireblocks_auth_probe(*args).await
+            }
+            IssuerCommand::SweepLegacyReceipts(args) => {
+                run_sweep_legacy_receipts(*args, prompt_confirm).await
             }
         }
     }


### PR DESCRIPTION
## Motivation

**This PR is already deployed to production and serves as a report, not a change request.** These are the hotfixes shipped mid-outage during the Turnkey custody cutover window (each was announced to the team at the time). The branch is frozen at the deployed state (`94200be`); review feedback will be addressed in the stacked follow-up PR on top of this branch, never by editing this one.

The cutover surfaced production gaps that had to be fixed live: custody transfer bundles exceeding Fireblocks' block-gas ceiling, receipts acquired before custody tracking existed, redemptions closed while their burn tx was still unresolved, a mint whose automatic retry budget was exhausted, and credential-wiring defects in the secrets.

## Solution

- Chunk custody transfers below the Fireblocks block-gas-limit ceiling and make partial migrations resumable.
- Add `sweep-legacy-receipts` CLI for pre-tracking Fireblocks holdings, with per-identifier ownership verification. It also forwards the stranded 0.2 tCOIN redemption from the legacy wallet to the liquidity bot wallet.
- Add `fireblocks-auth-probe` CLI for raw A/B auth diagnostics (new deps: jsonwebtoken, sha2, rand).
- Force-complete a closed redemption whose verified burn landed on-chain, keyed on the retained pre-close burn tx.
- Let manual mint reprocess retry past the exhausted automatic budget (operator-authorized `ManualRetryMint`).
- Block mint submission while any unresolved burn intent exists (coarse cross-network guard; refined to per-network in the follow-up PR).
- Newline-join the deploy activation steps in `deploy.nix` (with `set -euo pipefail`) and heal the listing view in the asset CLI.
- Secrets: registered Fireblocks API key restored and the tagged Turnkey service user's API key installed in prod; staging secrets rotated alongside.
- Bump the fireblocks-sdk fork pin (Cargo.lock, flake.nix, rust.nix outputHashes).
- **Deploy note:** this branch carries a temporary break-glass variant of `deploy-prod.yaml` (triple-bound: single actor, this branch only, explicit `break_glass` input; deploys the issuance service profile only) used for the mid-outage deploys. It is reverted to main's normal gated workflow in the stacked follow-up, so the merged result restores the standard deploy path.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs