### PR TITLE
Add orchestrator onboarding CLI subcommands (preflight, approve, verify-signing)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1191,6 +1191,28 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
   with Turnkey without broadcasting it. `--smoke` additionally submits a
   zero-amount transfer through the full Fireblocks path. Temporary, like
   `migrate-receipts`.
+- `issuer orchestrator-preflight` — the on-chain read-only pre-cutover gate for
+  the orchestrator rollout: verifies the Turnkey bot wallet holds `MINT_ROLE`
+  and `BURN_ROLE` on the orchestrator, `vaultLogicIsExpected()` is healthy, the
+  orchestrator holds `DEPOSIT` and `WITHDRAW` on each vault's authorizer, and
+  each checked asset's one-time unlimited approval has been executed. Defaults
+  to the assets whose configured `vault_mode` resolves to orchestrator;
+  `--asset` narrows or widens the scope. Exits non-zero unless every check
+  passes, so runbook steps gate on it.
+- `issuer approve-orchestrator <UNDERLYING>` — executes the asset's one-time
+  unlimited ERC-20 approval (bot wallet → orchestrator, on the vault share
+  token) through the Turnkey signer, after verifying the configured address
+  answers as an orchestrator. Idempotent: an already-unlimited allowance sends
+  nothing.
+- `issuer verify-orchestrator-signing <UNDERLYING>` — signs, WITHOUT
+  broadcasting, one transaction per shape the Turnkey signing policy must allow
+  before cutover (`orchestrator.mint`, `orchestrator.burn`, `vault.approve`,
+  `receipt.safeBatchTransferFrom`), so a policy gap surfaces as a named signing
+  refusal instead of during the pilot's first live mint.
+
+The orchestrator onboarding subcommands take the orchestrator address from the
+TOML vault-mode config (`--config`) — never typed — and require the Turnkey
+signer configuration from the service's own environment.
 
 The custody subcommands are listing-scoped and therefore take `--network`, plus
 `--rpc-url` (the service's own `RPC_URL`) and `--chain-id` (cross-checked

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use alloy::providers::Provider;
 use clap::{Args, Parser};
 use st0x_issuance_dto::{UnderlyingSymbol, UnderlyingSymbolError};
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing::{Level, warn};
 use url::Url;
@@ -84,15 +84,32 @@ pub struct VaultModeConfig {
     per_asset: HashMap<String, VaultMode>,
     /// Fallback used for any asset not listed in `per_asset`.
     default: VaultMode,
+    /// `[orchestrator].address` as parsed from the TOML file, retained even
+    /// while every asset still resolves to vault-direct: the onboarding ops
+    /// tooling (role/allowance preflight, approval execution) needs the
+    /// address before the first asset's cutover, and the config file is its
+    /// single source of truth.
+    orchestrator_address: Option<Address>,
 }
 
 impl VaultModeConfig {
+    /// Programmatic constructor for tests and harnesses. Configs built this
+    /// way carry no `[orchestrator].address` (`orchestrator_address()` is
+    /// `None`); orchestrator addresses live inside the `VaultMode` variants.
     #[must_use]
     pub const fn new(
         per_asset: HashMap<String, VaultMode>,
         default: VaultMode,
     ) -> Self {
-        Self { per_asset, default }
+        Self { per_asset, default, orchestrator_address: None }
+    }
+
+    /// The `[orchestrator].address` from the TOML file, if one was configured.
+    /// Present as soon as the section carries an address — deliberately not
+    /// gated on any asset resolving to orchestrator mode.
+    #[must_use]
+    pub const fn orchestrator_address(&self) -> Option<Address> {
+        self.orchestrator_address
     }
 
     /// Returns the `VaultMode` for the given underlying asset symbol.
@@ -382,12 +399,7 @@ impl Env {
         let signer = self.signer.into_config()?;
         let hyperdx = self.hyperdx.into_config(log_level_tracing);
         let vault_mode_config = if let Some(config_path) = self.config {
-            let content =
-                std::fs::read_to_string(&config_path).map_err(|error| {
-                    ConfigError::ConfigFileRead { path: config_path, error }
-                })?;
-            let toml_file: TomlFile = toml::from_str(&content)?;
-            resolve_vault_modes(&toml_file)?
+            load_vault_mode_config(&config_path)?
         } else {
             VaultModeConfig::default()
         };
@@ -756,6 +768,26 @@ enum VaultModeStr {
     Orchestrator,
 }
 
+/// Reads and validates the TOML config file at `path` into a
+/// [`VaultModeConfig`]. The single loading path shared by server startup
+/// (`Env::into_config`) and the issuer CLI, so both apply identical strict
+/// parsing and validation.
+///
+/// # Errors
+///
+/// Returns an error if the file cannot be read, is not valid TOML for the
+/// strict schema (unknown keys are rejected), or fails the validation rules
+/// of [`resolve_vault_modes`].
+pub(crate) fn load_vault_mode_config(
+    path: &Path,
+) -> Result<VaultModeConfig, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|error| {
+        ConfigError::ConfigFileRead { path: path.to_path_buf(), error }
+    })?;
+    let toml_file: TomlFile = toml::from_str(&content)?;
+    resolve_vault_modes(&toml_file)
+}
+
 /// Converts the raw TOML file into a validated `VaultModeConfig`.
 ///
 /// Validation rules:
@@ -828,7 +860,7 @@ fn resolve_vault_modes(
         }
     }
 
-    Ok(VaultModeConfig { per_asset, default })
+    Ok(VaultModeConfig { per_asset, default, orchestrator_address })
 }
 
 /// RPC URL uses a scheme that cannot be mapped to HTTP.
@@ -937,6 +969,7 @@ pub fn setup_tracing(log_level: &LogLevel) {
 mod tests {
     use alloy::primitives::address;
     use ipnetwork::IpNetwork;
+    use tempfile::NamedTempFile;
 
     use super::*;
     use crate::auth::IpWhitelist;
@@ -1437,6 +1470,7 @@ mod tests {
         let cfg = VaultModeConfig::default();
         assert_eq!(cfg.default, VaultMode::VaultDirect);
         assert!(cfg.per_asset.is_empty());
+        assert_eq!(cfg.orchestrator_address(), None);
     }
 
     // Pins the committed per-environment deploy configs (baked into the
@@ -1474,6 +1508,7 @@ mod tests {
             Some(VaultMode::Orchestrator { address: orch_address() })
         );
         assert_eq!(cfg.default, VaultMode::VaultDirect);
+        assert_eq!(cfg.orchestrator_address(), Some(orch_address()));
     }
 
     #[test]
@@ -1549,6 +1584,7 @@ mod tests {
 
         assert_eq!(cfg.default, VaultMode::VaultDirect);
         assert!(cfg.per_asset.is_empty());
+        assert_eq!(cfg.orchestrator_address(), None);
     }
 
     #[test]
@@ -1649,6 +1685,74 @@ mod tests {
             cfg.mode_for(&UnderlyingSymbol::new("TSLA").unwrap()),
             VaultMode::VaultDirect
         );
+    }
+
+    // The address must survive resolution even while no asset resolves to
+    // orchestrator mode: the onboarding ops tooling (preflight, approvals)
+    // runs against exactly this dark configuration, before the first cutover.
+    #[test]
+    fn orchestrator_address_exposed_while_all_assets_vault_direct() {
+        let toml = TomlFile {
+            orchestrator: Some(OrchestratorSection {
+                address: Some(ORCH_ADDR.to_string()),
+                default_vault_mode: None,
+            }),
+            assets: HashMap::new(),
+        };
+
+        let cfg = resolve_vault_modes(&toml).unwrap();
+
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+        assert!(cfg.per_asset.is_empty());
+        assert_eq!(cfg.orchestrator_address(), Some(orch_address()));
+    }
+
+    #[test]
+    fn programmatic_config_carries_no_orchestrator_address() {
+        let cfg = VaultModeConfig::new(
+            HashMap::from([(
+                "AAPL".to_string(),
+                VaultMode::Orchestrator { address: orch_address() },
+            )]),
+            VaultMode::VaultDirect,
+        );
+
+        assert_eq!(cfg.orchestrator_address(), None);
+    }
+
+    #[test]
+    fn load_vault_mode_config_reads_and_resolves_file() {
+        let file = NamedTempFile::new().unwrap();
+        std::fs::write(
+            file.path(),
+            r#"
+            [orchestrator]
+            address = "0x1234567890abcdef1234567890abcdef12345678"
+
+            [assets.RKLB]
+            vault_mode = "orchestrator"
+            "#,
+        )
+        .unwrap();
+
+        let cfg = load_vault_mode_config(file.path()).unwrap();
+
+        assert_eq!(
+            cfg.per_asset.get("RKLB").copied(),
+            Some(VaultMode::Orchestrator { address: orch_address() })
+        );
+        assert_eq!(cfg.default, VaultMode::VaultDirect);
+        assert_eq!(cfg.orchestrator_address(), Some(orch_address()));
+    }
+
+    #[test]
+    fn load_vault_mode_config_missing_file_is_read_error() {
+        let missing = PathBuf::from("/nonexistent/issuance-config.toml");
+
+        assert!(matches!(
+            load_vault_mode_config(&missing),
+            Err(ConfigError::ConfigFileRead { path, .. }) if path == missing
+        ));
     }
 
     #[test]

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -7,13 +7,15 @@ use event_sorcery::{
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 use sqlx::{Pool, Sqlite};
 use std::io::{self, Write};
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 use url::Url;
 
 use super::view::{
-    TokenizedAssetViewError, find_vault, underlying_has_listing,
+    TokenizedAssetViewError, find_vault, list_enabled_assets,
+    underlying_has_listing,
 };
 use super::{TokenizedAsset, UnderlyingSymbol};
 use crate::Network;
@@ -23,7 +25,7 @@ use crate::burn_excess::cli::{
 };
 use crate::config::{
     DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, LogLevel,
-    setup_tracing,
+    VaultMode, VaultModeConfig, load_vault_mode_config, setup_tracing,
 };
 use crate::fireblocks::auth_probe::probe_auth_pair;
 use crate::fireblocks::{
@@ -45,6 +47,10 @@ use crate::redemption::force_complete::{
 use crate::underlying::{
     AssetStatus, Underlying, UnderlyingCommand, UnderlyingViewError,
     load_freeze_status,
+};
+use crate::vault::onboarding::{
+    ApprovalOutcome, check_orchestrator_readiness, ensure_unlimited_approval,
+    prove_signing_shapes,
 };
 use crate::wallet::turnkey::{TurnkeyConfig, resolve_turnkey_signer};
 use crate::wallet::{SignerConfig, SignerEnv};
@@ -163,6 +169,38 @@ enum IssuerCommand {
     /// Default is dry-run inspection; pass `--execute` to mutate.
     #[command(subcommand)]
     BurnExcess(Box<BurnExcessCliCommand>),
+    /// On-chain read-only pre-cutover gate for the orchestrator rollout:
+    /// verifies via on-chain reads that the Turnkey bot wallet holds
+    /// MINT_ROLE and BURN_ROLE on the orchestrator, that
+    /// vaultLogicIsExpected() reports healthy, that the orchestrator holds
+    /// DEPOSIT and WITHDRAW on each vault's authorizer, and that each
+    /// checked asset's one-time unlimited ERC-20 approval to the
+    /// orchestrator has been executed. The orchestrator address comes from
+    /// the TOML config file — never typed. Exits non-zero unless every check
+    /// passes, so runbook steps can gate on it. Submits nothing and signs
+    /// nothing on-chain; locally it does touch the operator's database —
+    /// connecting runs any pending migrations and projection catch-up before
+    /// the asset lookup.
+    OrchestratorPreflight(Box<OrchestratorPreflightArgs>),
+    /// Executes one asset's one-time unlimited ERC-20 approval (Turnkey bot
+    /// wallet -> orchestrator, on the vault share token) through the Turnkey
+    /// signer. Idempotent: an already-unlimited allowance sends nothing, so
+    /// re-runs and per-asset batches are safe. Approvals are inert until the
+    /// asset's vault_mode flips to orchestrator, and approving through
+    /// Turnkey is itself the live proof that the Turnkey signing policy
+    /// allows `approve` on this token. The orchestrator address comes from
+    /// the TOML config file — never typed.
+    ApproveOrchestrator(Box<ApproveOrchestratorArgs>),
+    /// Signs — WITHOUT broadcasting — one transaction per shape the Turnkey
+    /// signing policy must allow before an asset's cutover: mint and burn on
+    /// the orchestrator, approve on the vault share token, and ERC-1155
+    /// safeBatchTransferFrom to the orchestrator (the receipt-migration step
+    /// needs it). A policy gap surfaces here as a named signing refusal
+    /// instead of during the pilot's first live mint. On-chain read-only:
+    /// nothing is submitted and no chain state changes. Locally it does
+    /// touch the operator's database — connecting runs any pending
+    /// migrations and projection catch-up before the vault lookup.
+    VerifyOrchestratorSigning(Box<VerifyOrchestratorSigningArgs>),
 }
 
 #[derive(Args)]
@@ -820,6 +858,144 @@ struct ConfirmCustodyArgs {
 }
 
 #[derive(Args)]
+struct OrchestratorPreflightArgs {
+    /// TOML config file whose `[orchestrator].address` names the orchestrator
+    /// to check — the config file is the single source of truth for the
+    /// address, matching what the deployed service resolves.
+    #[arg(long, env = "CONFIG")]
+    config: PathBuf,
+
+    /// Network whose asset listings to check.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// Restrict the per-asset allowance checks to these underlyings
+    /// (repeatable). Defaults to the enabled assets whose configured
+    /// `vault_mode` resolves to orchestrator — the assets actually cutting
+    /// over; pass `--asset` to check one ahead of its cutover.
+    /// Upper-cased like [`AssetArgs`].
+    #[arg(long = "asset", value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    assets: Vec<UnderlyingSymbol>,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
+struct ApproveOrchestratorArgs {
+    /// Underlying symbol, e.g. RKLB. Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// TOML config file whose `[orchestrator].address` names the approval's
+    /// spender — the config file is the single source of truth for the
+    /// address, matching what the deployed service resolves.
+    #[arg(long, env = "CONFIG")]
+    config: PathBuf,
+
+    /// Network whose vault to approve on.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
+struct VerifyOrchestratorSigningArgs {
+    /// Underlying symbol whose vault the token-scoped shapes (approve,
+    /// receipt transfer) are built against, e.g. RKLB. Upper-cased like
+    /// [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// TOML config file whose `[orchestrator].address` names the orchestrator
+    /// the shapes target — the config file is the single source of truth for
+    /// the address, matching what the deployed service resolves.
+    #[arg(long, env = "CONFIG")]
+    config: PathBuf,
+
+    /// Network whose vault the shapes are built against.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
 struct AssetArgs {
     /// Underlying symbol, e.g. SGOV. Upper-cased so `"sgov"` resolves to the
     /// stored `SGOV` (assets are keyed by their upper-case symbol). Whitespace
@@ -874,6 +1050,15 @@ impl IssuerCli {
             }
             IssuerCommand::BurnExcess(command) => {
                 run_burn_excess_cli(*command, prompt_confirm).await
+            }
+            IssuerCommand::OrchestratorPreflight(args) => {
+                run_orchestrator_preflight(*args).await
+            }
+            IssuerCommand::ApproveOrchestrator(args) => {
+                run_approve_orchestrator(*args, prompt_confirm).await
+            }
+            IssuerCommand::VerifyOrchestratorSigning(args) => {
+                run_verify_orchestrator_signing(*args).await
             }
         }
     }
@@ -1165,6 +1350,316 @@ struct SmokeTarget {
     receipt_contract: Address,
     fireblocks_wallet: Address,
     turnkey: Address,
+}
+
+/// The read-only pre-cutover readiness gate: resolves the orchestrator from
+/// the TOML config, the bot wallet from the Turnkey configuration, and the
+/// vaults from the listing view, then reads roles, orchestrator health, and
+/// per-asset allowances on-chain. Prints the report and fails unless every
+/// check passes, so the cutover runbook can gate on the exit code. No prompt:
+/// nothing is signed or submitted.
+async fn run_orchestrator_preflight(
+    args: OrchestratorPreflightArgs,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    let vault_modes = load_vault_mode_config(&args.config)?;
+    let orchestrator = orchestrator_address_from(&vault_modes, &args.config)?;
+
+    // Only the wallet address is used — the readiness facts (roles,
+    // approvals) are keyed to the Turnkey bot wallet, and requiring the full
+    // Turnkey configuration keeps that address sourced from the service's own
+    // environment instead of an operator-typed value.
+    let SignerConfig::Turnkey(turnkey_config) = args.signer.into_config()?
+    else {
+        anyhow::bail!(
+            "orchestrator-preflight requires the Turnkey signer configuration"
+        );
+    };
+    let bot = turnkey_config.settings.address;
+
+    println!("Using database: {}", args.database_url);
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let assets =
+        preflight_assets(&admin.pool, args.network, &args.assets, &vault_modes)
+            .await?;
+
+    verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+    let report =
+        check_orchestrator_readiness(&provider, orchestrator, bot, &assets)
+            .await?;
+
+    println!("{report}");
+
+    if !report.is_ready() {
+        anyhow::bail!("orchestrator preflight FAILED — see the report above");
+    }
+
+    Ok(())
+}
+
+/// Executes one asset's one-time unlimited approval through the Turnkey
+/// signer, after an explicit confirmation naming the asset, vault,
+/// orchestrator, and wallet. The mutation itself is idempotent
+/// ([`ensure_unlimited_approval`]), so a re-run after a completed approval
+/// reports "already unlimited" instead of sending again.
+async fn run_approve_orchestrator(
+    args: ApproveOrchestratorArgs,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    let orchestrator = required_orchestrator_address(&args.config)?;
+
+    let SignerConfig::Turnkey(turnkey_config) = args.signer.into_config()?
+    else {
+        anyhow::bail!(
+            "approve-orchestrator requires the Turnkey signer configuration"
+        );
+    };
+    let bot = turnkey_config.settings.address;
+
+    println!("Using database: {}", args.database_url);
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    if !confirm(&format!(
+        "Approve UNLIMITED spending of {} vault {vault} shares by \
+         orchestrator {orchestrator}, from Turnkey wallet {bot}?",
+        args.underlying
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let resolved = resolve_turnkey_signer(&turnkey_config, chain_id)?;
+    let provider = ProviderBuilder::new()
+        .with_chain_id(chain_id)
+        .wallet(resolved.wallet)
+        .connect(args.rpc_url.as_str())
+        .await?;
+
+    // The spender is about to receive an UNLIMITED allowance from the
+    // production bot wallet, so prove the configured address actually IS an
+    // orchestrator before approving: these reads only answer on a contract
+    // implementing the orchestrator interface (a typo'd or stale TOML entry
+    // fails them), and a false version lock means the address is a stale
+    // deployment nothing should be approved for.
+    let readiness =
+        check_orchestrator_readiness(&provider, orchestrator, bot, &[])
+            .await
+            .map_err(|error| {
+            anyhow::anyhow!(
+                "refusing to approve: {orchestrator} cannot be verified \
+                     as an orchestrator (readiness reads failed: {error})"
+            )
+        })?;
+    if !readiness.vault_logic_expected {
+        anyhow::bail!(
+            "refusing to approve: {orchestrator} reports \
+             vaultLogicIsExpected() = false — the configured address is a \
+             stale or mismatched orchestrator deployment"
+        );
+    }
+
+    match ensure_unlimited_approval(&provider, vault, orchestrator, bot).await?
+    {
+        ApprovalOutcome::AlreadyUnlimited => println!(
+            "Already unlimited: {} vault {vault} needs no approval \
+             transaction.",
+            args.underlying
+        ),
+        ApprovalOutcome::Approved { tx_hash } => println!(
+            "Approved: unlimited allowance for orchestrator {orchestrator} \
+             on {} vault {vault} in {tx_hash}.",
+            args.underlying
+        ),
+    }
+    println!("Run orchestrator-preflight to verify overall readiness.");
+
+    Ok(())
+}
+
+/// Signs the pre-cutover policy-proof shapes with Turnkey — never
+/// broadcasting — and reports each signed shape. A Turnkey signing-policy
+/// denial fails here, naming the refused shape, which is the entire point:
+/// the alternative discovery site is the pilot's first live transaction. No
+/// prompt: nothing is submitted and no state changes.
+async fn run_verify_orchestrator_signing(
+    args: VerifyOrchestratorSigningArgs,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    let orchestrator = required_orchestrator_address(&args.config)?;
+
+    let SignerConfig::Turnkey(turnkey_config) = args.signer.into_config()?
+    else {
+        anyhow::bail!(
+            "verify-orchestrator-signing requires the Turnkey signer \
+             configuration — proving a local key's signing capability says \
+             nothing about the Turnkey policy"
+        );
+    };
+    let bot = turnkey_config.settings.address;
+
+    println!("Using database: {}", args.database_url);
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let resolved = resolve_turnkey_signer(&turnkey_config, chain_id)?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+
+    let proofs = prove_signing_shapes(
+        &provider,
+        &resolved.wallet,
+        orchestrator,
+        vault,
+        bot,
+    )
+    .await?;
+
+    for proof in &proofs {
+        println!(
+            "Signed (not broadcast): {} -> {} as {}",
+            proof.label, proof.to, proof.tx_hash
+        );
+    }
+    println!(
+        "Turnkey policy allows all {} orchestrator shapes for {} from {bot}.",
+        proofs.len(),
+        args.underlying
+    );
+
+    Ok(())
+}
+
+/// Resolves the orchestrator address from the TOML config file — the single
+/// source the onboarding subcommands accept, never a typed argument. A
+/// missing section is an actionable error rather than a default, and a zero
+/// address is refused: the config may stay dark (no asset needs
+/// `vault_mode = "orchestrator"`) and still carry the address these commands
+/// work against.
+fn required_orchestrator_address(config: &Path) -> anyhow::Result<Address> {
+    let vault_modes = load_vault_mode_config(config)?;
+    orchestrator_address_from(&vault_modes, config)
+}
+
+fn orchestrator_address_from(
+    vault_modes: &VaultModeConfig,
+    config: &Path,
+) -> anyhow::Result<Address> {
+    let Some(orchestrator) = vault_modes.orchestrator_address() else {
+        anyhow::bail!(
+            "{} has no [orchestrator].address; add the section — the config \
+             may stay dark (no asset needs vault_mode = \"orchestrator\")",
+            config.display()
+        );
+    };
+
+    // No zero-address guard here: `load_vault_mode_config` already refuses a
+    // zero `[orchestrator].address` at parse time, for the service and these
+    // commands alike.
+    Ok(orchestrator)
+}
+
+/// Resolves which assets the preflight checks. `--asset` narrows to the
+/// named symbols; without it the scope defaults to the enabled listings
+/// whose configured `vault_mode` resolves to orchestrator — the assets the
+/// rollout is actually cutting over — so the incremental one-asset-at-a-time
+/// cutover never demands approvals for assets that stay vault-direct. A
+/// filter symbol with no enabled listing on the network is an error rather
+/// than silently skipped — a typo'd symbol must not produce a READY verdict
+/// that never checked the intended asset.
+async fn preflight_assets(
+    pool: &Pool<Sqlite>,
+    network: Network,
+    filter: &[UnderlyingSymbol],
+    vault_modes: &VaultModeConfig,
+) -> anyhow::Result<Vec<(UnderlyingSymbol, Address)>> {
+    let listed: Vec<(UnderlyingSymbol, Address)> = list_enabled_assets(pool)
+        .await?
+        .into_iter()
+        .filter(|asset| asset.network == network)
+        .map(|asset| (asset.underlying, asset.vault))
+        .collect();
+
+    if filter.is_empty() {
+        if listed.is_empty() {
+            anyhow::bail!("no enabled assets listed on {network}");
+        }
+        let orchestrator_scoped: Vec<(UnderlyingSymbol, Address)> = listed
+            .into_iter()
+            .filter(|(underlying, _)| {
+                matches!(
+                    vault_modes.mode_for(underlying),
+                    VaultMode::Orchestrator { .. }
+                )
+            })
+            .collect();
+        if orchestrator_scoped.is_empty() {
+            anyhow::bail!(
+                "no enabled asset on {network} is configured for \
+                 orchestrator mode; pass --asset to check an asset ahead of \
+                 its cutover"
+            );
+        }
+        return Ok(orchestrator_scoped);
+    }
+
+    let missing = filter
+        .iter()
+        .filter(|wanted| {
+            listed.iter().all(|(underlying, _)| underlying != *wanted)
+        })
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    if !missing.is_empty() {
+        anyhow::bail!("not enabled on {network}: {}", missing.join(", "));
+    }
+
+    Ok(listed
+        .into_iter()
+        .filter(|(underlying, _)| filter.contains(underlying))
+        .collect())
 }
 
 /// Submits a zero-amount `safeTransferFrom` of the first tracked receipt
@@ -1960,7 +2455,9 @@ fn parse_confirmation(input: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use alloy::network::EthereumWallet;
     use alloy::primitives::{U256, address, b256};
+    use alloy::signers::local::PrivateKeySigner;
     use chrono::Utc;
     use cqrs_es::DomainEvent;
     use rust_decimal::Decimal;
@@ -1972,7 +2469,7 @@ mod tests {
     use crate::redemption::{
         BurnFailureClassification, BurnRecord, RedemptionEvent,
     };
-    use crate::test_utils::logs_contain_at;
+    use crate::test_utils::{LocalEvm, logs_contain_at};
     use crate::tokenized_asset::{
         AssetKey, Network, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
         TokenizedAssetEvent,
@@ -2917,6 +3414,569 @@ mod tests {
         assert!(
             error.to_string().contains("--chain-id"),
             "the parse failure must name the missing --chain-id, got {error}"
+        );
+    }
+
+    /// Mirrors [`seed_listing_at`] but at a caller-chosen vault, so the
+    /// preflight end-to-end test can list the vault Anvil actually deployed.
+    async fn seed_listing_at_vault(
+        database_url: &str,
+        underlying: &str,
+        vault: Address,
+    ) {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(database_url)
+            .await
+            .expect("Failed to open database");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("Failed to run migrations");
+
+        let (listing_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .expect("Failed to build tokenized asset store");
+
+        let underlying = UnderlyingSymbol::new(underlying).unwrap();
+        listing_store
+            .send(
+                &AssetKey::new(underlying.clone(), Network::Base),
+                TokenizedAssetCommand::Add {
+                    underlying: underlying.clone(),
+                    token: TokenSymbol::new(format!("t{underlying}")),
+                    network: Network::Base,
+                    vault,
+                },
+            )
+            .await
+            .expect("Failed to add asset");
+        pool.close().await;
+    }
+
+    #[test]
+    fn orchestrator_preflight_parses_and_uppercases_asset_filters() {
+        let cli = IssuerCli::try_parse_from([
+            "issuer",
+            "orchestrator-preflight",
+            "--config",
+            "issuance-config.toml",
+            "--network",
+            "base",
+            "--asset",
+            "rklb",
+            "--asset",
+            "SGOV",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--turnkey-org-id",
+            "org-id",
+            "--turnkey-api-private-key",
+            "api-key",
+            "--turnkey-address",
+            "0x00000000000000000000000000000000000000cc",
+            "--database-url",
+            "sqlite::memory:",
+        ])
+        .expect("arguments parse");
+
+        let IssuerCommand::OrchestratorPreflight(args) = cli.command else {
+            panic!("expected the orchestrator-preflight subcommand")
+        };
+
+        assert_eq!(args.config, PathBuf::from("issuance-config.toml"));
+        assert_eq!(args.network, Network::Base);
+        assert_eq!(
+            args.assets,
+            vec![
+                UnderlyingSymbol::new("RKLB").unwrap(),
+                UnderlyingSymbol::new("SGOV").unwrap()
+            ]
+        );
+    }
+
+    #[test]
+    fn orchestrator_preflight_requires_a_config_file() {
+        let Err(error) = IssuerCli::try_parse_from([
+            "issuer",
+            "orchestrator-preflight",
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--turnkey-org-id",
+            "org-id",
+            "--turnkey-api-private-key",
+            "api-key",
+            "--turnkey-address",
+            "0x00000000000000000000000000000000000000cc",
+            "--database-url",
+            "sqlite::memory:",
+        ]) else {
+            panic!(
+                "omitting --config must fail at parse time — the orchestrator \
+                 address has no other source"
+            )
+        };
+
+        assert!(
+            error.to_string().contains("--config"),
+            "the parse failure must name the missing --config, got {error}"
+        );
+    }
+
+    /// A vault-modes config resolving every asset to orchestrator mode, so
+    /// the default preflight scope covers all listings.
+    fn all_orchestrator_modes() -> VaultModeConfig {
+        VaultModeConfig::new(
+            std::collections::HashMap::new(),
+            VaultMode::Orchestrator { address: Address::repeat_byte(0xdd) },
+        )
+    }
+
+    #[tokio::test]
+    async fn preflight_assets_lists_only_the_requested_network() {
+        let admin =
+            admin_with_asset("SGOV", &[Network::Base, Network::Ethereum]).await;
+
+        let assets = preflight_assets(
+            &admin.pool,
+            Network::Base,
+            &[],
+            &all_orchestrator_modes(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            assets,
+            vec![(UnderlyingSymbol::new("SGOV").unwrap(), TEST_VAULT)]
+        );
+    }
+
+    /// The default scope is the assets configured for orchestrator mode —
+    /// the incremental cutover must not demand approvals for assets staying
+    /// vault-direct, and a scope that matches nothing is an error, never a
+    /// vacuous READY.
+    #[tokio::test]
+    async fn preflight_assets_default_scope_is_orchestrator_configured() {
+        let admin =
+            admin_with_asset("SGOV", &[Network::Base, Network::Ethereum]).await;
+
+        let sgov_only = VaultModeConfig::new(
+            std::collections::HashMap::from([(
+                "SGOV".to_string(),
+                VaultMode::Orchestrator { address: Address::repeat_byte(0xdd) },
+            )]),
+            VaultMode::VaultDirect,
+        );
+        let assets =
+            preflight_assets(&admin.pool, Network::Base, &[], &sgov_only)
+                .await
+                .unwrap();
+        assert_eq!(
+            assets,
+            vec![(UnderlyingSymbol::new("SGOV").unwrap(), TEST_VAULT)]
+        );
+
+        let all_vault_direct = VaultModeConfig::new(
+            std::collections::HashMap::new(),
+            VaultMode::VaultDirect,
+        );
+        let error = preflight_assets(
+            &admin.pool,
+            Network::Base,
+            &[],
+            &all_vault_direct,
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("no enabled asset on base is configured"),
+            "an all-vault-direct config must refuse the default scope, got \
+             {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_assets_filter_narrows_and_rejects_unknown_symbols() {
+        let admin = admin_with_asset("SGOV", &[Network::Base]).await;
+        let rklb_vault = address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+        let (listing_store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(admin.pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        let rklb = UnderlyingSymbol::new("RKLB").unwrap();
+        listing_store
+            .send(
+                &AssetKey::new(rklb.clone(), Network::Base),
+                TokenizedAssetCommand::Add {
+                    underlying: rklb.clone(),
+                    token: TokenSymbol::new("tRKLB".to_string()),
+                    network: Network::Base,
+                    vault: rklb_vault,
+                },
+            )
+            .await
+            .unwrap();
+
+        let narrowed = preflight_assets(
+            &admin.pool,
+            Network::Base,
+            std::slice::from_ref(&rklb),
+            &all_orchestrator_modes(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(narrowed, vec![(rklb, rklb_vault)]);
+
+        let error = preflight_assets(
+            &admin.pool,
+            Network::Base,
+            &[UnderlyingSymbol::new("TSLA").unwrap()],
+            &all_orchestrator_modes(),
+        )
+        .await
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("TSLA"),
+            "the error must name the unknown symbol, got {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn preflight_assets_errors_when_nothing_is_listed_on_the_network() {
+        let admin = admin_with_asset("SGOV", &[Network::Ethereum]).await;
+
+        let error = preflight_assets(
+            &admin.pool,
+            Network::Base,
+            &[],
+            &all_orchestrator_modes(),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("no enabled assets"),
+            "an empty listing must be an error, got {error}"
+        );
+    }
+
+    /// The full preflight glue against a real orchestrator on Anvil: NOT
+    /// READY (non-zero exit) while the approval is missing, READY after it is
+    /// executed. Turnkey credentials are parse-only stand-ins — the preflight
+    /// reads the wallet address from the configuration and never signs.
+    #[tokio::test]
+    async fn orchestrator_preflight_end_to_end_gates_on_readiness() {
+        let evm = LocalEvm::with_chain_id(8453).await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("preflight.db").display()
+        );
+        seed_listing_at_vault(&database_url, "RKLB", evm.vault_address).await;
+
+        let config_path = directory.path().join("issuance-config.toml");
+        // RKLB is configured for orchestrator mode so the default scope —
+        // the assets actually cutting over — covers it.
+        std::fs::write(
+            &config_path,
+            format!(
+                "[orchestrator]\naddress = \"{orchestrator}\"\n\n\
+                 [assets.RKLB]\nvault_mode = \"orchestrator\"\n"
+            ),
+        )
+        .unwrap();
+
+        let parse_args = |database_url: &str| {
+            let cli = IssuerCli::try_parse_from([
+                "issuer",
+                "orchestrator-preflight",
+                "--config",
+                config_path.to_str().unwrap(),
+                "--network",
+                "base",
+                "--chain-id",
+                "8453",
+                "--rpc-url",
+                &evm.endpoint,
+                "--turnkey-org-id",
+                "org-id",
+                "--turnkey-api-private-key",
+                "api-key",
+                "--turnkey-address",
+                &evm.wallet_address.to_string(),
+                "--database-url",
+                database_url,
+            ])
+            .expect("arguments parse");
+            let IssuerCommand::OrchestratorPreflight(args) = cli.command else {
+                panic!("expected the orchestrator-preflight subcommand")
+            };
+            *args
+        };
+
+        let error = run_orchestrator_preflight(parse_args(&database_url))
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("preflight FAILED"),
+            "a missing approval must fail the preflight, got {error}"
+        );
+
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        OffchainAssetReceiptVault::new(evm.vault_address, &provider)
+            .approve(orchestrator, U256::MAX)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        run_orchestrator_preflight(parse_args(&database_url))
+            .await
+            .expect("preflight must pass once the approval is unlimited");
+    }
+
+    fn approve_orchestrator_args(
+        config_path: &str,
+        database_url: &str,
+        signer_flags: &[&str],
+    ) -> ApproveOrchestratorArgs {
+        let mut command_line = vec![
+            "issuer",
+            "approve-orchestrator",
+            "rklb",
+            "--config",
+            config_path,
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            database_url,
+        ];
+        command_line.extend_from_slice(signer_flags);
+
+        let cli =
+            IssuerCli::try_parse_from(command_line).expect("arguments parse");
+        let IssuerCommand::ApproveOrchestrator(args) = cli.command else {
+            panic!("expected the approve-orchestrator subcommand")
+        };
+        *args
+    }
+
+    const TURNKEY_FLAGS: [&str; 6] = [
+        "--turnkey-org-id",
+        "org-id",
+        "--turnkey-api-private-key",
+        "api-key",
+        "--turnkey-address",
+        "0x00000000000000000000000000000000000000cc",
+    ];
+
+    fn write_orchestrator_config(directory: &std::path::Path) -> PathBuf {
+        let config_path = directory.join("issuance-config.toml");
+        std::fs::write(
+            &config_path,
+            "[orchestrator]\n\
+             address = \"0x1234567890abcdef1234567890abcdef12345678\"\n",
+        )
+        .unwrap();
+        config_path
+    }
+
+    #[test]
+    fn approve_orchestrator_parses_and_uppercases_the_underlying() {
+        let args = approve_orchestrator_args(
+            "issuance-config.toml",
+            "sqlite::memory:",
+            &TURNKEY_FLAGS,
+        );
+
+        assert_eq!(args.underlying, UnderlyingSymbol::new("RKLB").unwrap());
+        assert_eq!(args.network, Network::Base);
+        assert_eq!(args.config, PathBuf::from("issuance-config.toml"));
+    }
+
+    /// A declined confirmation must abort before any network call. The
+    /// unreachable `--rpc-url` is the assertion: if the prompt were bypassed,
+    /// or the chain-id round-trip ran first, this would fail on the endpoint
+    /// rather than on the operator's decision.
+    #[tokio::test]
+    async fn approve_orchestrator_aborts_without_touching_the_chain_when_declined()
+     {
+        let directory = tempfile::tempdir().unwrap();
+        let database_url = format!(
+            "sqlite:{}?mode=rwc",
+            directory.path().join("approve-decline.db").display()
+        );
+        seed_listing_at(&database_url, "RKLB").await;
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = approve_orchestrator_args(
+            config_path.to_str().unwrap(),
+            &database_url,
+            &TURNKEY_FLAGS,
+        );
+
+        let error =
+            run_approve_orchestrator(args, |_| Ok(false)).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("aborted by operator"),
+            "a declined confirmation must abort before any RPC, got {error}"
+        );
+    }
+
+    /// The approval must come from the Turnkey bot wallet — the wallet whose
+    /// allowance production burns will spend — so a local key is refused
+    /// outright instead of approving from an address production never uses.
+    #[tokio::test]
+    async fn approve_orchestrator_refuses_a_non_turnkey_signer() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = approve_orchestrator_args(
+            config_path.to_str().unwrap(),
+            "sqlite::memory:",
+            &["--evm-private-key", TEST_SIGNER_KEY],
+        );
+
+        let error = run_approve_orchestrator(args, |_| {
+            panic!("must refuse the signer before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("Turnkey signer configuration"),
+            "the refusal must name the Turnkey requirement, got {error}"
+        );
+    }
+
+    fn verify_signing_args(
+        config_path: &str,
+        signer_flags: &[&str],
+    ) -> VerifyOrchestratorSigningArgs {
+        let mut command_line = vec![
+            "issuer",
+            "verify-orchestrator-signing",
+            "rklb",
+            "--config",
+            config_path,
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            "sqlite::memory:",
+        ];
+        command_line.extend_from_slice(signer_flags);
+
+        let cli =
+            IssuerCli::try_parse_from(command_line).expect("arguments parse");
+        let IssuerCommand::VerifyOrchestratorSigning(args) = cli.command else {
+            panic!("expected the verify-orchestrator-signing subcommand")
+        };
+        *args
+    }
+
+    #[test]
+    fn verify_orchestrator_signing_parses_and_uppercases_the_underlying() {
+        let args = verify_signing_args("issuance-config.toml", &TURNKEY_FLAGS);
+
+        assert_eq!(args.underlying, UnderlyingSymbol::new("RKLB").unwrap());
+        assert_eq!(args.network, Network::Base);
+        assert_eq!(args.config, PathBuf::from("issuance-config.toml"));
+    }
+
+    /// Signing with a local key would trivially succeed and prove nothing
+    /// about the Turnkey policy — the command must refuse rather than report
+    /// a hollow pass.
+    #[tokio::test]
+    async fn verify_orchestrator_signing_refuses_a_non_turnkey_signer() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = verify_signing_args(
+            config_path.to_str().unwrap(),
+            &["--evm-private-key", TEST_SIGNER_KEY],
+        );
+
+        let error = run_verify_orchestrator_signing(args).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("Turnkey signer"),
+            "the refusal must name the Turnkey requirement, got {error}"
+        );
+    }
+
+    #[test]
+    fn required_orchestrator_address_refuses_missing_and_zero() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let dark = directory.path().join("dark.toml");
+        std::fs::write(&dark, "# dark: no [orchestrator] section\n").unwrap();
+        let error = required_orchestrator_address(&dark).unwrap_err();
+        assert!(
+            error.to_string().contains("[orchestrator].address"),
+            "the refusal must name the missing key, got {error}"
+        );
+
+        // The zero address is refused by the config loader itself (before
+        // this helper's own checks), with the same strict parse the service
+        // applies — pinned here so it can never reach these commands.
+        let zeroed = directory.path().join("zero.toml");
+        std::fs::write(
+            &zeroed,
+            format!("[orchestrator]\naddress = \"{}\"\n", Address::ZERO),
+        )
+        .unwrap();
+        let error = required_orchestrator_address(&zeroed).unwrap_err();
+        assert!(
+            error.to_string().contains("not a valid EVM address"),
+            "a zero address must be refused by the config loader, got {error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn verify_orchestrator_signing_requires_an_orchestrator_address() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = directory.path().join("dark-config.toml");
+        std::fs::write(&config_path, "# dark: no [orchestrator] section\n")
+            .unwrap();
+
+        let args =
+            verify_signing_args(config_path.to_str().unwrap(), &TURNKEY_FLAGS);
+
+        let error = run_verify_orchestrator_signing(args).await.unwrap_err();
+
+        assert!(
+            error.to_string().contains("[orchestrator].address"),
+            "the refusal must name the missing address, got {error}"
         );
     }
 }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -29,6 +29,7 @@ use crate::vault::orchestrator::BurnProofKind;
 
 pub(crate) mod mock;
 pub(crate) mod network_services;
+pub(crate) mod onboarding;
 pub(crate) mod orchestrator;
 pub(crate) mod rain_meta;
 pub(crate) mod service;

--- a/src/vault/onboarding.rs
+++ b/src/vault/onboarding.rs
@@ -1,0 +1,1007 @@
+//! Pre-cutover orchestrator onboarding checks.
+//!
+//! Before an asset's `vault_mode` may flip to orchestrator, the ops checklist
+//! requires — verified by on-chain reads — that the bot wallet holds
+//! `MINT_ROLE` + `BURN_ROLE` on the orchestrator, that the orchestrator's
+//! vault-logic version lock is healthy, that the orchestrator holds
+//! `DEPOSIT` + `WITHDRAW` on each vault's authorizer, and that each asset's
+//! one-time unlimited ERC-20 approval (bot → orchestrator, on the vault
+//! share token) has been executed. This module is that verification:
+//! read-only, generic over the provider, consumed by the issuer CLI's
+//! preflight subcommand.
+
+use alloy::network::{
+    Ethereum, EthereumWallet, TransactionBuilder, TransactionBuilderError,
+};
+use alloy::primitives::{Address, B256, Bytes, U256, keccak256};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionRequest;
+use alloy::sol_types::SolCall;
+use std::fmt::{self, Display, Formatter};
+use tracing::{debug, info};
+
+use crate::bindings::{
+    IST0xOrchestratorV1, OffchainAssetReceiptVault,
+    OffchainAssetReceiptVaultAuthorizerV1, Receipt, ST0xOrchestrator,
+};
+use crate::mint::UnderlyingSymbol;
+
+/// Everything the pre-cutover gate checks, in one report. The role and
+/// vault-logic facts are orchestrator-wide; approvals are per asset.
+///
+/// The three booleans are independent on-chain facts (each combination is a
+/// real, reportable state), not one status split across flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OrchestratorReadiness {
+    pub(crate) orchestrator: Address,
+    pub(crate) bot: Address,
+    pub(crate) mint_role_granted: bool,
+    pub(crate) burn_role_granted: bool,
+    pub(crate) vault_logic_expected: bool,
+    pub(crate) assets: Vec<AssetApprovalReadiness>,
+}
+
+/// One asset's ERC-20 allowance from the bot wallet to the orchestrator, read
+/// from the vault contract (the vault IS the share token — the approval's
+/// target contract is the vault, the spender is the orchestrator).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AssetApprovalReadiness {
+    pub(crate) underlying: UnderlyingSymbol,
+    pub(crate) vault: Address,
+    pub(crate) allowance: U256,
+    /// Whether the ORCHESTRATOR holds `DEPOSIT` on this vault's authorizer —
+    /// without it the vault reverts the orchestrator's deposit inside
+    /// `mint()`, a hard prerequisite no orchestrator-side read covers
+    /// (`vaultLogicIsExpected()` is the implementation version lock, not an
+    /// authorization check).
+    pub(crate) deposit_role_granted: bool,
+    /// Whether the orchestrator holds `WITHDRAW` on this vault's authorizer
+    /// — the burn-side counterpart of `deposit_role_granted`.
+    pub(crate) withdraw_role_granted: bool,
+}
+
+impl OrchestratorReadiness {
+    /// The pre-cutover gate: both bot roles granted, vault logic healthy,
+    /// and every checked asset approved unlimited with the orchestrator
+    /// authorized on its vault's authorizer.
+    pub(crate) fn is_ready(&self) -> bool {
+        self.mint_role_granted
+            && self.burn_role_granted
+            && self.vault_logic_expected
+            && self.assets.iter().all(AssetApprovalReadiness::is_ready)
+    }
+}
+
+impl AssetApprovalReadiness {
+    /// The approval strategy is a one-time UNLIMITED approval per token
+    /// (SPEC Decision 5), so the pass criterion is exactly `U256::MAX` — a
+    /// finite allowance means the one-time approval step has not run for
+    /// this asset. Fail direction is safe: should an allowance ever read
+    /// below `U256::MAX`, this reports NOT READY and the (idempotent)
+    /// approval step is simply re-run; burns are additionally protected by
+    /// their own per-burn allowance gate in
+    /// [`super::VaultService::check_orchestrator_burn_readiness`].
+    pub(crate) fn is_unlimited(&self) -> bool {
+        self.allowance == U256::MAX
+    }
+
+    /// This asset is cutover-ready: approval unlimited and the orchestrator
+    /// authorized for both vault operations on this vault's authorizer.
+    pub(crate) fn is_ready(&self) -> bool {
+        self.is_unlimited()
+            && self.deposit_role_granted
+            && self.withdraw_role_granted
+    }
+}
+
+impl Display for OrchestratorReadiness {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        writeln!(formatter, "Orchestrator onboarding readiness")?;
+        writeln!(formatter, "  orchestrator: {}", self.orchestrator)?;
+        writeln!(formatter, "  bot wallet:   {}", self.bot)?;
+        writeln!(
+            formatter,
+            "  [{}] MINT_ROLE granted to bot wallet",
+            pass_fail(self.mint_role_granted)
+        )?;
+        writeln!(
+            formatter,
+            "  [{}] BURN_ROLE granted to bot wallet",
+            pass_fail(self.burn_role_granted)
+        )?;
+        writeln!(
+            formatter,
+            "  [{}] vaultLogicIsExpected()",
+            pass_fail(self.vault_logic_expected)
+        )?;
+        for asset in &self.assets {
+            writeln!(
+                formatter,
+                "  [{}] {} (vault {}): allowance {}",
+                pass_fail(asset.is_unlimited()),
+                asset.underlying,
+                asset.vault,
+                if asset.is_unlimited() {
+                    "unlimited".to_string()
+                } else {
+                    asset.allowance.to_string()
+                }
+            )?;
+            writeln!(
+                formatter,
+                "  [{}] {} authorizer: DEPOSIT granted to orchestrator",
+                pass_fail(asset.deposit_role_granted),
+                asset.underlying,
+            )?;
+            writeln!(
+                formatter,
+                "  [{}] {} authorizer: WITHDRAW granted to orchestrator",
+                pass_fail(asset.withdraw_role_granted),
+                asset.underlying,
+            )?;
+        }
+        write!(
+            formatter,
+            "Overall: {}",
+            if self.is_ready() { "READY" } else { "NOT READY" }
+        )
+    }
+}
+
+/// Result of the idempotent per-asset approval step.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApprovalOutcome {
+    /// The allowance was already unlimited; no transaction was sent.
+    AlreadyUnlimited,
+    /// An `approve(orchestrator, U256::MAX)` landed and the re-read
+    /// allowance is unlimited.
+    Approved { tx_hash: B256 },
+}
+
+/// One transaction shape the Turnkey signing policy must allow. Target and
+/// calldata are fixed at build time, so tests can decode exactly what would
+/// be signed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SigningShape {
+    pub(crate) label: &'static str,
+    pub(crate) to: Address,
+    pub(crate) calldata: Bytes,
+}
+
+/// Proof that one shape was signed — never broadcast.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct SigningShapeProof {
+    pub(crate) label: &'static str,
+    pub(crate) to: Address,
+    /// Hash of the signed, unbroadcast transaction.
+    pub(crate) tx_hash: B256,
+}
+
+/// Errors from the on-chain readiness reads, the approval step, and the
+/// sign-only policy proof.
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum OnboardingError {
+    #[error(transparent)]
+    Contract(#[from] alloy::contract::Error),
+    #[error(transparent)]
+    PendingTransaction(#[from] alloy::providers::PendingTransactionError),
+    #[error(transparent)]
+    Transport(#[from] alloy::transports::TransportError),
+    #[error("approve transaction {tx_hash} reverted on-chain")]
+    ApprovalReverted { tx_hash: B256 },
+    #[error(
+        "approve transaction {tx_hash} succeeded but the re-read allowance \
+         is {allowance}, not unlimited"
+    )]
+    ApprovalNotEffective { tx_hash: B256, allowance: U256 },
+    #[error(
+        "failed to sign the {label} shape — a Turnkey signing-policy denial \
+         surfaces here"
+    )]
+    SigningRejected {
+        label: &'static str,
+        #[source]
+        source: Box<TransactionBuilderError<Ethereum>>,
+    },
+}
+
+/// Reads the full pre-cutover readiness state: `hasRole(MINT_ROLE, bot)`,
+/// `hasRole(BURN_ROLE, bot)`, `vaultLogicIsExpected()`, and per asset
+/// `allowance(bot, orchestrator)` on the vault share token. Read-only — never
+/// signs or submits anything.
+///
+/// # Errors
+///
+/// Returns an error if any on-chain read fails; a partially-checked state is
+/// never reported as a result.
+pub(crate) async fn check_orchestrator_readiness<P: Provider>(
+    provider: &P,
+    orchestrator: Address,
+    bot: Address,
+    assets: &[(UnderlyingSymbol, Address)],
+) -> Result<OrchestratorReadiness, OnboardingError> {
+    let orchestrator_contract = ST0xOrchestrator::new(orchestrator, provider);
+    let mint_role = orchestrator_contract.MINT_ROLE().call().await?;
+    let burn_role = orchestrator_contract.BURN_ROLE().call().await?;
+    let mint_role_granted =
+        orchestrator_contract.hasRole(mint_role, bot).call().await?;
+    let burn_role_granted =
+        orchestrator_contract.hasRole(burn_role, bot).call().await?;
+    let vault_logic_expected =
+        orchestrator_contract.vaultLogicIsExpected().call().await?;
+
+    let mut asset_readiness = Vec::with_capacity(assets.len());
+    for (underlying, vault) in assets {
+        let vault_contract = OffchainAssetReceiptVault::new(*vault, provider);
+        let allowance =
+            vault_contract.allowance(bot, orchestrator).call().await?;
+        // The vault authorizes deposits/withdrawals through its authorizer
+        // contract, resolved on-chain — the orchestrator must hold both
+        // roles there or the vault reverts its calls at the first live
+        // mint/burn. `vaultLogicIsExpected()` above cannot detect this: it
+        // is the implementation version lock, not an authorization check.
+        let authorizer = vault_contract.authorizer().call().await?;
+        let authorizer_contract = OffchainAssetReceiptVaultAuthorizerV1::new(
+            Address::from(authorizer.0),
+            provider,
+        );
+        let deposit_role_granted = authorizer_contract
+            .hasRole(keccak256(b"DEPOSIT"), orchestrator)
+            .call()
+            .await?;
+        let withdraw_role_granted = authorizer_contract
+            .hasRole(keccak256(b"WITHDRAW"), orchestrator)
+            .call()
+            .await?;
+        debug!(
+            target: "vault",
+            underlying = %underlying,
+            vault = %vault,
+            %allowance,
+            deposit_role_granted,
+            withdraw_role_granted,
+            "Checked orchestrator allowance and authorizer grants"
+        );
+        asset_readiness.push(AssetApprovalReadiness {
+            underlying: underlying.clone(),
+            vault: *vault,
+            allowance,
+            deposit_role_granted,
+            withdraw_role_granted,
+        });
+    }
+
+    let readiness = OrchestratorReadiness {
+        orchestrator,
+        bot,
+        mint_role_granted,
+        burn_role_granted,
+        vault_logic_expected,
+        assets: asset_readiness,
+    };
+    info!(
+        target: "vault",
+        orchestrator = %orchestrator,
+        bot = %bot,
+        ready = readiness.is_ready(),
+        asset_count = readiness.assets.len(),
+        "Orchestrator readiness checked"
+    );
+
+    Ok(readiness)
+}
+
+/// Executes the one-time unlimited approval (SPEC Decision 5) of the vault
+/// share token for the orchestrator, idempotently: an already-unlimited
+/// allowance sends nothing, so re-runs and batch scripts are safe.
+///
+/// `signing_provider` must sign as `bot` — the allowance is read and
+/// re-verified for `bot`, so a mismatched signer cannot silently approve from
+/// the wrong wallet: the post-send re-read would still see a non-unlimited
+/// allowance for `bot` and fail with [`OnboardingError::ApprovalNotEffective`].
+/// Success is never inferred from the receipt alone; the allowance the burns
+/// will rely on is re-read from the chain.
+///
+/// # Errors
+///
+/// Returns an error if any read or the send fails, if the approve
+/// transaction reverts, or if the re-read allowance is not unlimited.
+pub(crate) async fn ensure_unlimited_approval<P: Provider>(
+    signing_provider: &P,
+    vault: Address,
+    orchestrator: Address,
+    bot: Address,
+) -> Result<ApprovalOutcome, OnboardingError> {
+    let vault_contract =
+        OffchainAssetReceiptVault::new(vault, signing_provider);
+    let current = vault_contract.allowance(bot, orchestrator).call().await?;
+    if current == U256::MAX {
+        info!(
+            target: "vault",
+            %vault,
+            %orchestrator,
+            bot = %bot,
+            "Orchestrator allowance already unlimited; nothing to send"
+        );
+        return Ok(ApprovalOutcome::AlreadyUnlimited);
+    }
+
+    let receipt = vault_contract
+        .approve(orchestrator, U256::MAX)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let tx_hash = receipt.transaction_hash;
+    if !receipt.status() {
+        return Err(OnboardingError::ApprovalReverted { tx_hash });
+    }
+
+    let allowance = vault_contract.allowance(bot, orchestrator).call().await?;
+    if allowance != U256::MAX {
+        return Err(OnboardingError::ApprovalNotEffective {
+            tx_hash,
+            allowance,
+        });
+    }
+
+    info!(
+        target: "vault",
+        %vault,
+        %orchestrator,
+        bot = %bot,
+        %tx_hash,
+        "Approved unlimited orchestrator allowance"
+    );
+
+    Ok(ApprovalOutcome::Approved { tx_hash })
+}
+
+/// Signs — without ever broadcasting — one transaction per shape the Turnkey
+/// policy must allow before an asset's cutover: `mint` and `burn` on the
+/// orchestrator, `approve` on the vault share token, and ERC-1155
+/// `safeBatchTransferFrom` to the orchestrator on the vault's receipt
+/// contract — the batch selector, because that is the shape every
+/// Turnkey-signed receipt move in the migration tooling submits. A policy gap
+/// found here costs nothing; found during the pilot's first live mint it
+/// stalls a real customer flow.
+///
+/// The receipt contract is resolved on-chain from the vault, mirroring the
+/// migration tooling — never typed.
+///
+/// # Errors
+///
+/// Returns an error if an on-chain read fails or a shape fails to sign;
+/// [`OnboardingError::SigningRejected`] names the shape, so a policy denial
+/// is attributable to the exact allowance that is missing.
+pub(crate) async fn prove_signing_shapes<P: Provider>(
+    provider: &P,
+    wallet: &EthereumWallet,
+    orchestrator: Address,
+    vault: Address,
+    bot: Address,
+) -> Result<Vec<SigningShapeProof>, OnboardingError> {
+    let receipt_contract = Address::from(
+        OffchainAssetReceiptVault::new(vault, provider)
+            .receipt()
+            .call()
+            .await?
+            .0,
+    );
+    let chain_id = provider.get_chain_id().await?;
+    // Deliberately unreachable nonces, descending from the top of the
+    // EIP-2681 range: the proofs must stay sign-only, so even a leaked
+    // signed envelope is non-broadcastable by construction — u64::MAX is
+    // itself invalid to execute, and the values below it would require
+    // ~2^64 prior transactions from the bot wallet. Live account nonces
+    // would instead produce immediately broadcastable transactions.
+    let mut nonce = u64::MAX;
+
+    let shapes =
+        build_signing_shapes(orchestrator, vault, receipt_contract, bot);
+    let mut proofs = Vec::with_capacity(shapes.len());
+    for shape in shapes {
+        let request = TransactionRequest::default()
+            .with_from(bot)
+            .with_to(shape.to)
+            .with_input(shape.calldata)
+            .with_chain_id(chain_id)
+            .with_nonce(nonce)
+            .with_gas_limit(SIGNING_PROOF_GAS_LIMIT)
+            .with_max_fee_per_gas(SIGNING_PROOF_MAX_FEE_PER_GAS)
+            .with_max_priority_fee_per_gas(SIGNING_PROOF_MAX_PRIORITY_FEE);
+        nonce = nonce.saturating_sub(1);
+
+        // Signing only: built and signed, never submitted. The Turnkey signer
+        // verifies the recovered signature matches its address before
+        // returning, so success proves control, not just an HTTP 200.
+        let envelope = request.build(wallet).await.map_err(|source| {
+            OnboardingError::SigningRejected {
+                label: shape.label,
+                source: Box::new(source),
+            }
+        })?;
+        debug!(
+            target: "vault",
+            label = shape.label,
+            to = %shape.to,
+            tx_hash = %envelope.tx_hash(),
+            "Signed policy-proof shape without broadcasting"
+        );
+        proofs.push(SigningShapeProof {
+            label: shape.label,
+            to: shape.to,
+            tx_hash: *envelope.tx_hash(),
+        });
+    }
+
+    info!(
+        target: "vault",
+        %orchestrator,
+        %vault,
+        shapes = proofs.len(),
+        "Signed every policy-proof shape without broadcasting"
+    );
+
+    Ok(proofs)
+}
+
+/// The four transaction shapes, with harmless placeholder values (one wei,
+/// zero nonce, empty signature/data): a signing policy evaluates the target
+/// contract and calldata shape, the transactions are never broadcast, and gas
+/// is fixed by the caller so nothing is ever estimated (estimating the
+/// dummy-auth mint would revert).
+fn build_signing_shapes(
+    orchestrator: Address,
+    vault: Address,
+    receipt_contract: Address,
+    bot: Address,
+) -> Vec<SigningShape> {
+    vec![
+        SigningShape {
+            label: "orchestrator.mint",
+            to: orchestrator,
+            calldata: IST0xOrchestratorV1::mintCall {
+                token: vault,
+                to: bot,
+                amount: U256::ONE,
+                auth: IST0xOrchestratorV1::MintAuthV1 {
+                    nonce: B256::ZERO,
+                    signature: Bytes::new(),
+                },
+                receiptInformation: Bytes::new(),
+            }
+            .abi_encode()
+            .into(),
+        },
+        SigningShape {
+            label: "orchestrator.burn",
+            to: orchestrator,
+            calldata: IST0xOrchestratorV1::burnCall {
+                token: vault,
+                amount: U256::ONE,
+                burnInfo: Bytes::new(),
+            }
+            .abi_encode()
+            .into(),
+        },
+        SigningShape {
+            label: "vault.approve",
+            to: vault,
+            calldata: OffchainAssetReceiptVault::approveCall {
+                spender: orchestrator,
+                amount: U256::MAX,
+            }
+            .abi_encode()
+            .into(),
+        },
+        // The BATCH form, not `safeTransferFrom`: every Turnkey-signed
+        // receipt move in this repo is `safeBatchTransferFrom` (the custody
+        // migration's rollback leg and `verify_rollback_signing` both build
+        // it), and a Turnkey policy grants contract + selector — proving the
+        // singular selector would pass while the real cutover migration is
+        // denied.
+        SigningShape {
+            label: "receipt.safeBatchTransferFrom",
+            to: receipt_contract,
+            calldata: Receipt::safeBatchTransferFromCall {
+                from: bot,
+                to: orchestrator,
+                ids: vec![U256::ONE],
+                amounts: vec![U256::ONE],
+                data: Bytes::new(),
+            }
+            .abi_encode()
+            .into(),
+        },
+    ]
+}
+
+/// Deliberately generous and fixed rather than estimated: a signature's
+/// validity does not depend on gas or fee values, the transactions are never
+/// broadcast, and estimation would `eth_call` the dummy-auth mint and revert.
+const SIGNING_PROOF_GAS_LIMIT: u64 = 1_000_000;
+const SIGNING_PROOF_MAX_FEE_PER_GAS: u128 = 100_000_000_000;
+const SIGNING_PROOF_MAX_PRIORITY_FEE: u128 = 1_000_000_000;
+
+const fn pass_fail(passed: bool) -> &'static str {
+    if passed { "PASS" } else { "FAIL" }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::providers::ProviderBuilder;
+    use alloy::signers::local::PrivateKeySigner;
+    use httpmock::MockServer;
+    use tracing::Level;
+    use tracing_test::traced_test;
+
+    use super::*;
+    use crate::test_utils::{LocalEvm, logs_contain_at};
+    use crate::wallet::turnkey::test_wallet_against;
+
+    fn rklb() -> UnderlyingSymbol {
+        UnderlyingSymbol::new("RKLB").unwrap()
+    }
+
+    async fn approve(evm: &LocalEvm, orchestrator: Address, amount: U256) {
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+
+        OffchainAssetReceiptVault::new(evm.vault_address, &provider)
+            .approve(orchestrator, amount)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+    }
+
+    async fn revoke_authorizer_role(
+        evm: &LocalEvm,
+        role_name: &[u8],
+        from: Address,
+    ) {
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+
+        OffchainAssetReceiptVaultAuthorizerV1::new(
+            evm.authorizer_address,
+            &provider,
+        )
+        .revokeRole(keccak256(role_name), from)
+        .send()
+        .await
+        .unwrap()
+        .get_receipt()
+        .await
+        .unwrap();
+    }
+
+    async fn readiness(
+        evm: &LocalEvm,
+        orchestrator: Address,
+        bot: Address,
+    ) -> OrchestratorReadiness {
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        check_orchestrator_readiness(
+            &provider,
+            orchestrator,
+            bot,
+            &[(rklb(), evm.vault_address)],
+        )
+        .await
+        .unwrap()
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn deployer_with_roles_but_no_approval_is_not_ready() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+
+        assert!(report.mint_role_granted);
+        assert!(report.burn_role_granted);
+        assert!(report.vault_logic_expected);
+        assert_eq!(report.assets.len(), 1);
+        assert_eq!(report.assets[0].allowance, U256::ZERO);
+        assert!(!report.is_ready());
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Orchestrator readiness checked", "ready=false"]
+        ));
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Checked orchestrator allowance", "RKLB"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn unlimited_approval_makes_deployer_ready() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        approve(&evm, orchestrator, U256::MAX).await;
+
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+
+        assert!(report.assets[0].is_unlimited());
+        assert!(report.assets[0].deposit_role_granted);
+        assert!(report.assets[0].withdraw_role_granted);
+        assert!(report.is_ready());
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Orchestrator readiness checked", "ready=true"]
+        ));
+    }
+
+    /// The authorizer grants are a hard prerequisite nothing
+    /// orchestrator-side covers (`vaultLogicIsExpected()` is the version
+    /// lock, not an authorization check): with WITHDRAW revoked from the
+    /// orchestrator, the bot roles, vault logic, and allowance all pass
+    /// while the report refuses READY — the state that would otherwise
+    /// revert the first live burn inside the vault.
+    #[traced_test]
+    #[tokio::test]
+    async fn revoked_authorizer_grant_is_not_ready() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        approve(&evm, orchestrator, U256::MAX).await;
+        revoke_authorizer_role(&evm, b"WITHDRAW", orchestrator).await;
+
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+
+        assert!(report.mint_role_granted);
+        assert!(report.burn_role_granted);
+        assert!(report.vault_logic_expected);
+        assert!(report.assets[0].is_unlimited());
+        assert!(report.assets[0].deposit_role_granted);
+        assert!(
+            !report.assets[0].withdraw_role_granted,
+            "the revoked grant must be reported"
+        );
+        assert!(
+            !report.is_ready(),
+            "a missing authorizer grant must refuse READY"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Orchestrator readiness checked", "ready=false"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn foreign_wallet_has_no_roles() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+
+        let report = readiness(&evm, orchestrator, Address::random()).await;
+
+        assert!(!report.mint_role_granted);
+        assert!(!report.burn_role_granted);
+        assert!(!report.is_ready());
+    }
+
+    #[tokio::test]
+    async fn finite_allowance_is_not_unlimited() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        approve(&evm, orchestrator, U256::from(10).pow(U256::from(18))).await;
+
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+
+        assert!(!report.assets[0].is_unlimited());
+        assert!(!report.is_ready());
+    }
+
+    async fn signing_provider(evm: &LocalEvm) -> impl Provider + use<> {
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap()
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn first_approval_sends_verifies_and_reports_the_tx() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        let provider = signing_provider(&evm).await;
+
+        let outcome = ensure_unlimited_approval(
+            &provider,
+            evm.vault_address,
+            orchestrator,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(outcome, ApprovalOutcome::Approved { .. }));
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+        assert!(report.assets[0].is_unlimited());
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Approved unlimited orchestrator allowance", "tx_hash"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn repeated_approval_is_a_no_op_without_a_transaction() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        let provider = signing_provider(&evm).await;
+
+        ensure_unlimited_approval(
+            &provider,
+            evm.vault_address,
+            orchestrator,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap();
+        let nonce_after_first =
+            provider.get_transaction_count(evm.wallet_address).await.unwrap();
+
+        let outcome = ensure_unlimited_approval(
+            &provider,
+            evm.vault_address,
+            orchestrator,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ApprovalOutcome::AlreadyUnlimited);
+        assert_eq!(
+            provider.get_transaction_count(evm.wallet_address).await.unwrap(),
+            nonce_after_first,
+            "an already-unlimited allowance must not send a transaction"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["already unlimited", "nothing to send"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn finite_allowance_upgrades_to_unlimited() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        approve(&evm, orchestrator, U256::from(10).pow(U256::from(18))).await;
+        let provider = signing_provider(&evm).await;
+
+        let outcome = ensure_unlimited_approval(
+            &provider,
+            evm.vault_address,
+            orchestrator,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(outcome, ApprovalOutcome::Approved { .. }));
+        let report = readiness(&evm, orchestrator, evm.wallet_address).await;
+        assert!(report.assets[0].is_unlimited());
+    }
+
+    #[test]
+    fn signing_shapes_target_the_right_contracts_with_decodable_calldata() {
+        let orchestrator = Address::repeat_byte(0x11);
+        let vault = Address::repeat_byte(0x22);
+        let receipt_contract = Address::repeat_byte(0x33);
+        let bot = Address::repeat_byte(0x44);
+
+        let shapes =
+            build_signing_shapes(orchestrator, vault, receipt_contract, bot);
+        let labels: Vec<&str> =
+            shapes.iter().map(|shape| shape.label).collect();
+        assert_eq!(
+            labels,
+            [
+                "orchestrator.mint",
+                "orchestrator.burn",
+                "vault.approve",
+                "receipt.safeBatchTransferFrom"
+            ]
+        );
+
+        let mint =
+            IST0xOrchestratorV1::mintCall::abi_decode(&shapes[0].calldata)
+                .unwrap();
+        assert_eq!(shapes[0].to, orchestrator);
+        assert_eq!(mint.token, vault);
+        assert_eq!(mint.to, bot);
+        assert!(
+            mint.auth.signature.is_empty(),
+            "the placeholder auth must stay opaque and empty"
+        );
+
+        let burn =
+            IST0xOrchestratorV1::burnCall::abi_decode(&shapes[1].calldata)
+                .unwrap();
+        assert_eq!(shapes[1].to, orchestrator);
+        assert_eq!(burn.token, vault);
+
+        let approve = OffchainAssetReceiptVault::approveCall::abi_decode(
+            &shapes[2].calldata,
+        )
+        .unwrap();
+        assert_eq!(shapes[2].to, vault);
+        assert_eq!(approve.spender, orchestrator);
+        assert_eq!(approve.amount, U256::MAX);
+
+        // The batch selector — the shape the migration tooling actually
+        // submits; the singular `safeTransferFrom` is a different selector
+        // and therefore a different Turnkey policy grant.
+        let transfer =
+            Receipt::safeBatchTransferFromCall::abi_decode(&shapes[3].calldata)
+                .unwrap();
+        assert_eq!(shapes[3].to, receipt_contract);
+        assert_eq!(transfer.from, bot);
+        assert_eq!(transfer.to, orchestrator);
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn prove_signing_shapes_signs_everything_and_broadcasts_nothing() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let wallet = EthereumWallet::from(signer);
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let block_before = provider.get_block_number().await.unwrap();
+        let nonce_before =
+            provider.get_transaction_count(evm.wallet_address).await.unwrap();
+
+        let proofs = prove_signing_shapes(
+            &provider,
+            &wallet,
+            orchestrator,
+            evm.vault_address,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(proofs.len(), 4);
+        assert!(
+            proofs
+                .iter()
+                .any(|proof| proof.label == "receipt.safeBatchTransferFrom"
+                    && proof.to != evm.vault_address
+                    && proof.to != orchestrator),
+            "the transfer shape must target the resolved receipt contract"
+        );
+
+        assert_eq!(
+            provider.get_block_number().await.unwrap(),
+            block_before,
+            "signing must not broadcast anything"
+        );
+        assert_eq!(
+            provider.get_transaction_count(evm.wallet_address).await.unwrap(),
+            nonce_before,
+            "signing must not consume a nonce on-chain"
+        );
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &["Signed every policy-proof shape", "shapes=4"]
+        ));
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Signed policy-proof shape", "orchestrator.mint"]
+        ));
+    }
+
+    /// A Turnkey-side refusal (mocked as the policy-denial case: the API
+    /// rejects the sign request) must surface as `SigningRejected` naming the
+    /// first refused shape — attribution is the whole point of the proof.
+    #[tokio::test]
+    async fn turnkey_refusal_names_the_rejected_shape() {
+        let evm = LocalEvm::new().await.unwrap();
+        let orchestrator = evm.deploy_orchestrator().await.unwrap();
+
+        let server = MockServer::start();
+        server.mock(|when, then| {
+            when.method("POST").path("/public/v1/submit/sign_transaction");
+            then.status(403)
+                .header("Content-Type", "application/json")
+                .json_body(serde_json::json!({
+                    "message": "request denied by policy"
+                }));
+        });
+        let wallet = test_wallet_against(
+            server.base_url(),
+            evm.wallet_address,
+            evm.chain_id,
+        );
+        let provider =
+            ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+        let error = prove_signing_shapes(
+            &provider,
+            &wallet,
+            orchestrator,
+            evm.vault_address,
+            evm.wallet_address,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                OnboardingError::SigningRejected {
+                    label: "orchestrator.mint",
+                    ..
+                }
+            ),
+            "the first shape's denial must be attributed to it, got {error}"
+        );
+    }
+
+    #[test]
+    fn display_reports_each_check_and_overall_verdict() {
+        let not_ready = OrchestratorReadiness {
+            orchestrator: Address::repeat_byte(0x11),
+            bot: Address::repeat_byte(0x22),
+            mint_role_granted: true,
+            burn_role_granted: false,
+            vault_logic_expected: true,
+            assets: vec![AssetApprovalReadiness {
+                underlying: rklb(),
+                vault: Address::repeat_byte(0x33),
+                allowance: U256::from(7),
+                deposit_role_granted: true,
+                withdraw_role_granted: false,
+            }],
+        };
+
+        let rendered = not_ready.to_string();
+        assert!(rendered.contains("[PASS] MINT_ROLE granted to bot wallet"));
+        assert!(rendered.contains("[FAIL] BURN_ROLE granted to bot wallet"));
+        assert!(rendered.contains("[PASS] vaultLogicIsExpected()"));
+        assert!(rendered.contains("RKLB"));
+        assert!(rendered.contains("allowance 7"));
+        assert!(rendered.contains(
+            "[PASS] RKLB authorizer: DEPOSIT granted to orchestrator"
+        ));
+        assert!(rendered.contains(
+            "[FAIL] RKLB authorizer: WITHDRAW granted to orchestrator"
+        ));
+        assert!(rendered.contains("Overall: NOT READY"));
+
+        let ready = OrchestratorReadiness {
+            burn_role_granted: true,
+            assets: vec![AssetApprovalReadiness {
+                allowance: U256::MAX,
+                withdraw_role_granted: true,
+                ..not_ready.assets[0].clone()
+            }],
+            ..not_ready
+        };
+
+        let rendered = ready.to_string();
+        assert!(rendered.contains("allowance unlimited"));
+        assert!(rendered.contains("Overall: READY"));
+    }
+}

--- a/src/wallet/turnkey.rs
+++ b/src/wallet/turnkey.rs
@@ -640,6 +640,31 @@ impl TxSigner<Signature> for TracingTurnkeySigner {
     }
 }
 
+/// Builds an `EthereumWallet` whose Turnkey signer talks to `base_url`
+/// instead of the real API, with a throwaway P-256 key. For tests outside
+/// this module that need a Turnkey-shaped signing refusal (e.g. a
+/// signing-policy denial) without exposing the private client machinery.
+#[cfg(test)]
+pub(crate) fn test_wallet_against(
+    base_url: String,
+    address: Address,
+    chain_id: u64,
+) -> EthereumWallet {
+    let client = TracingTurnkeyClient::for_base_url(
+        base_url,
+        TurnkeyP256ApiKey::generate(),
+    )
+    .expect("mock Turnkey client must build");
+
+    TurnkeyWallet::from_client(
+        client,
+        TurnkeyOrganizationId::new("org-test".to_string()),
+        address,
+        chain_id,
+    )
+    .wallet
+}
+
 #[cfg(test)]
 mod tests {
     use alloy::consensus::{Signed, TxEip1559, TxLegacy};


### PR DESCRIPTION
## Motivation

Before an asset's `vault_mode` can flip to orchestrator, the ops runbook requires several pre-cutover checks: the Turnkey bot wallet must hold `MINT_ROLE` and `BURN_ROLE` on the orchestrator, the orchestrator's `vaultLogicIsExpected()` must report healthy, and each asset must have its one-time unlimited ERC-20 approval (bot → orchestrator on the vault share token) executed. Previously there was no tooling to verify or execute these steps before cutover, meaning gaps would only surface during a live customer flow.

Additionally, the orchestrator address was not retained in `VaultModeConfig` when no asset had yet flipped to orchestrator mode, making it unavailable to onboarding tooling that needs it before the first cutover.

## Solution

`VaultModeConfig` now stores the `[orchestrator].address` from the TOML file independently of whether any asset resolves to orchestrator mode, exposed via `orchestrator_address()`. The file-loading logic is extracted into a public `load_vault_mode_config` function shared by server startup and the new CLI subcommands.

Three new issuer CLI subcommands are added:

- **`orchestrator-preflight`**: Read-only gate that checks roles, `vaultLogicIsExpected()`, and per-asset allowances on-chain, printing a structured report and exiting non-zero unless every check passes. The orchestrator address is always sourced from the TOML config file, never typed.
- **`approve-orchestrator`**: Executes the one-time unlimited ERC-20 approval for a single asset through the Turnkey signer. Idempotent — an already-unlimited allowance sends nothing. Requires an explicit confirmation naming the asset, vault, orchestrator, and wallet before any network call.
- **`verify-orchestrator-signing`**: Signs (without broadcasting) one transaction per shape the Turnkey signing policy must allow before cutover: `mint` and `burn` on the orchestrator, `approve` on the vault share token, and ERC-1155 `safeTransferFrom` on the receipt contract. A policy gap surfaces here as a named `SigningRejected` error rather than during a live mint.

The underlying on-chain logic lives in a new `vault/onboarding.rs` module (`check_orchestrator_readiness`, `ensure_unlimited_approval`, `prove_signing_shapes`), generic over the provider and independently testable. A `test_wallet_against` helper is added to `wallet/turnkey.rs` to allow tests outside that module to simulate Turnkey signing-policy denials via a mock server.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [ ] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added orchestrator onboarding commands for readiness checks, token approvals, and signing-policy verification.
  * Added validation for contract roles, vault status, asset allowances, network settings, and required credentials.
  * Added support for configuring and loading an orchestrator address from configuration files.
* **Improvements**
  * Existing unlimited approvals are detected and skipped safely.
  * Signing checks run without broadcasting transactions, improving onboarding safety.
  * Readiness results and failures now provide clearer status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->