### PR TITLE
Add orchestrator onboarding CLI subcommands, SPEC docs, and runbook

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1202,17 +1202,14 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
 - `issuer approve-orchestrator <UNDERLYING>` — executes the asset's one-time
   unlimited ERC-20 approval (bot wallet → orchestrator, on the vault share
   token) through the Turnkey signer, after verifying the configured address
-  answers as an orchestrator. Idempotent: an already-unlimited allowance sends
-  nothing.
+  answers as an orchestrator. Idempotent — an already-unlimited allowance sends
+  nothing — and success is re-verified by an on-chain allowance read, never
+  inferred from the receipt.
 - `issuer verify-orchestrator-signing <UNDERLYING>` — signs, WITHOUT
   broadcasting, one transaction per shape the Turnkey signing policy must allow
   before cutover (`orchestrator.mint`, `orchestrator.burn`, `vault.approve`,
   `receipt.safeBatchTransferFrom`), so a policy gap surfaces as a named signing
   refusal instead of during the pilot's first live mint.
-
-The orchestrator onboarding subcommands take the orchestrator address from the
-TOML vault-mode config (`--config`) — never typed — and require the Turnkey
-signer configuration from the service's own environment.
 
 The custody subcommands are listing-scoped and therefore take `--network`, plus
 `--rpc-url` (the service's own `RPC_URL`) and `--chain-id` (cross-checked
@@ -1387,6 +1384,14 @@ addresses as free-form operator targets):**
 | Original mint recipient | `0xA9C16673F65AE808688cB18952AFE3d9658C808f`                         |
 | Receipt ID              | `7`                                                                  |
 | Shares                  | `0.750` (`750000000000000000` raw)                                   |
+
+The orchestrator onboarding subcommands (`orchestrator-preflight`,
+`approve-orchestrator`, `verify-orchestrator-signing`) take the same network
+flags plus `--config` (the TOML configuration file; its `[orchestrator].address`
+is the only source of the orchestrator address — never typed) and require the
+`TURNKEY_*` group: the readiness facts they verify or establish are keyed to the
+Turnkey bot wallet, so a local-key signer is refused. See
+`docs/runbooks/orchestrator-onboarding.md` for the ordered procedure.
 
 **No wallet address is ever an argument.** An ERC-1155 transfer to a wrong
 address is final — no counterparty, no recovery, and the receipts back tokens

--- a/docs/runbooks/orchestrator-onboarding.md
+++ b/docs/runbooks/orchestrator-onboarding.md
@@ -1,0 +1,186 @@
+# Orchestrator onboarding: Turnkey policy, role grants, approvals (RAI-1221)
+
+The ops procedure that must be complete for an asset **before** that asset's
+`vault_mode` flips to `"orchestrator"` (the per-asset cutover itself is
+RAI-1222's runbook; this one establishes its preconditions). Roles and the
+Turnkey policy are orchestrator-wide — done once, before the pilot. Approvals
+are per asset — RKLB's before the pilot cutover, each remaining asset's before
+its own.
+
+There is no testnet or staging chain for this: every step below runs against
+prod (Base mainnet) and is verified by on-chain reads. The first live end-to-end
+mint/burn through Turnkey is the RKLB pilot's manual exercise, which everything
+here must fully precede.
+
+## Prerequisites
+
+- Turnkey is the live signer (RAI-1123 done, Fireblocks retired): the service
+  runs with the `TURNKEY_*` env group, and the bot wallet is `TURNKEY_ADDRESS`.
+- The orchestrator is deployed by st0x.deploy (PR #222/#223) and its address is
+  known; the permissions scripts have run.
+- The liquidity-bot counterpart (RAI-1243) is tracked separately — it gates the
+  RAI-1222 cutover, not this procedure.
+
+All `issuer` subcommands below run on the issuer host (over SSH) with the
+service's own environment; they refuse a local-key signer because every fact
+they verify or establish is keyed to the Turnkey bot wallet. None of them takes
+an address argument — the orchestrator address comes from the TOML config file,
+the bot wallet from `TURNKEY_ADDRESS`, and vault/receipt addresses from the
+listing view and on-chain resolution.
+
+## 1. Ship the orchestrator address in the config (stays dark)
+
+Add to `config.prod.toml`:
+
+```toml
+[orchestrator]
+address = "0x…"   # from st0x.deploy
+```
+
+Do **not** add any `[assets.<SYM>]` section — with no `vault_mode` overrides
+every asset stays vault-direct, so this deploys dark. Parsing is strict (unknown
+keys and a malformed or zero address are startup errors, even while dark).
+Verify locally with `cargo run --bin validate-config`, then deploy. The config
+file is baked into the systemd unit (`CONFIG=<nix store path>`, see
+`nix/upgradeable-services.nix`). Every command below passes `--config "$CONFIG"`
+— the unit's own value — so the CLI provably validates and approves against the
+exact file the running service resolves, never a stray local copy.
+
+## 2. On-chain roles (st0x.deploy coordination)
+
+Confirm with the st0x.deploy owners that the bot's Turnkey wallet is granted
+`MINT_ROLE` + `BURN_ROLE` on the orchestrator. This is the only role fact the
+issuance bot needs — it never calls the emergency/admin functions. Separately,
+the orchestrator itself must hold `DEPOSIT` and `WITHDRAW` on each vault's
+authorizer (a deploy-side grant, per vault); step 6's preflight verifies these
+alongside the bot's roles. `EMERGENCY_ROLE` / `DEFAULT_ADMIN_ROLE` holders are
+st0x.deploy's governance call; record who holds `EMERGENCY_ROLE` in the table
+below, because the shortfall escalation (last section) pages them.
+
+Verification is step 6's preflight (`hasRole` reads) — no trust in the
+deploy-side report is required.
+
+## 3. Turnkey signing policy
+
+Create (or extend) the Turnkey policy for the issuer wallet to allow:
+
+| Allowance                               | Target contract               | Why                                                                                                                                                     |
+| --------------------------------------- | ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mint(...)`                             | orchestrator                  | orchestrator-mode mints                                                                                                                                 |
+| `burn(...)`                             | orchestrator                  | orchestrator-mode burns                                                                                                                                 |
+| `approve(...)`                          | each vault share token        | the one-time approval (step 5)                                                                                                                          |
+| `safeBatchTransferFrom(...)` (ERC-1155) | each vault's receipt contract | receipt migration during cutover (RAI-1222) — the BATCH selector: every Turnkey-signed receipt move submits it, and a policy grants contract + selector |
+
+These allowances replace the retired per-vault Fireblocks whitelist/TAP entries;
+note they span three target kinds — the orchestrator (`mint`/`burn`), each vault
+share token (`approve`), and each vault's receipt contract (the batch transfer)
+— and they are **additions**: do not remove or narrow the policy shapes the
+vault-direct path already signs under Turnkey (Fireblocks stays retired). During
+the per-asset rollout BOTH mint/burn paths run in production simultaneously,
+until RAI-1223 retires vault-direct mode.
+
+Record the policy name(s) in the table below.
+
+## 4. Prove the policy by signing (nothing broadcast)
+
+```
+issuer verify-orchestrator-signing RKLB \
+  --config "$CONFIG" \
+  --network base --chain-id 8453 --rpc-url "$RPC_URL"
+```
+
+Signs one transaction per shape in the table above — never broadcasting — and
+fails naming the refused shape if the policy denies one. Run it per asset as
+each asset approaches cutover (the approve/transfer shapes are token-scoped). A
+policy gap surfaces here as a named refusal instead of during the pilot's first
+live mint.
+
+## 5. Execute the approval (per asset, staged with the rollout)
+
+```
+issuer approve-orchestrator RKLB \
+  --config "$CONFIG" \
+  --network base --chain-id 8453 --rpc-url "$RPC_URL"
+```
+
+One-time unlimited ERC-20 approval, bot wallet → orchestrator, on the asset's
+vault share token, signed by Turnkey after an explicit confirmation. Before
+sending, the command verifies the configured address answers as an orchestrator
+(interface reads plus a healthy `vaultLogicIsExpected()`), so a typo'd or stale
+`[orchestrator].address` is refused rather than granted an unlimited allowance.
+Idempotent: a re-run reports "already unlimited" and sends nothing, so batching
+every asset's approval early is safe — approvals are inert until the asset's
+`vault_mode` flips. Success is re-verified by an on-chain allowance read. When
+this step actually submits, the transaction is also live proof that the policy's
+`approve` allowance works; the idempotent no-op path proves nothing new — step
+4's signing proof covers `approve` in that case.
+
+Record each executed approval in the table below.
+
+## 6. Final gate: preflight must print READY
+
+```
+issuer orchestrator-preflight \
+  --config "$CONFIG" \
+  --network base --chain-id 8453 --rpc-url "$RPC_URL" \
+  --asset RKLB
+```
+
+On-chain read-only (locally it runs any pending database migrations and
+projection catch-up before the asset lookup). Checks `hasRole(MINT_ROLE, bot)`,
+`hasRole(BURN_ROLE, bot)`, `vaultLogicIsExpected()`, and per asset
+`allowance(bot, orchestrator)` plus the orchestrator's `DEPOSIT`/`WITHDRAW`
+grants on the vault's authorizer. The two scopes serve different moments:
+`--asset <SYM>` is the explicit per-asset cutover gate — it works while the
+asset is still vault-direct in config, which is exactly when the RAI-1222
+pre-check runs; omitting `--asset` is the aggregate sweep over the assets whose
+configured `vault_mode` already resolves to orchestrator (a standing health
+re-check, not a cutover gate). The gate is the **exit status**: zero only when
+every check passes, so the RAI-1222 pre-checks gate on the exit code for the
+asset being cut over; `Overall: READY` is the human-readable rendering of the
+same verdict.
+
+## Record of prod facts
+
+Fill in as the steps execute; this table is the standing record the acceptance
+criteria ask for.
+
+| Fact                                                                | Value | Date | Verified by                   |
+| ------------------------------------------------------------------- | ----- | ---- | ----------------------------- |
+| Orchestrator address                                                |       |      | config.prod.toml + deploy     |
+| `MINT_ROLE` grant tx / holder check                                 |       |      | `orchestrator-preflight`      |
+| `BURN_ROLE` grant tx / holder check                                 |       |      | `orchestrator-preflight`      |
+| `DEPOSIT`/`WITHDRAW` grants (orchestrator on each vault authorizer) |       |      | `orchestrator-preflight`      |
+| `EMERGENCY_ROLE` holder (for escalation)                            |       |      | st0x.deploy                   |
+| Turnkey policy name(s)                                              |       |      | `verify-orchestrator-signing` |
+
+Per-asset approvals:
+
+| Asset | Approval tx hash | Date | Operator |
+| ----- | ---------------- | ---- | -------- |
+| RKLB  |                  |      |          |
+
+## Shortfall escalation (InsufficientReceipts)
+
+An orchestrator burn that reverts `InsufficientReceipts(token, shortfall)` puts
+the redemption in a failed, manual-recovery-only state — the bot never
+auto-retries through it and never mints to cover a shortfall (see SPEC "Failure
+States"). Escalation:
+
+1. Page the `EMERGENCY_ROLE` holder (recorded above) — recovery is an on-chain
+   emergency action: transfer the missing receipts into the orchestrator (or
+   adjust the burn pointer; see SPEC "Contract Summary" on `EMERGENCY_ROLE`),
+   owned by st0x.deploy governance.
+2. Once receipts are in place, re-drive the redemption via the existing admin
+   recovery surface — `POST /admin/recover/redemption/<id>`, which issues
+   `ResumeBurn`; the failure classification blocks only _automatic_ retries, not
+   the manual re-drive.
+
+A pre-submit `VaultLogicMismatch` halt is different — the orchestrator is
+version-locked against upgraded vault beacons, no redemption has failed, and the
+bot defers until `vaultLogicIsExpected()` reads true again (visible in
+`GET /admin/orchestrator-health` and the preflight). When the mismatch instead
+races a transaction that was already submitted, the redemption records a
+classified `BurningFailed` (`VaultLogicMismatch`/`ReceiptLogicMismatch`) that is
+never auto-retried; once the health check reads true again, re-drive it via the
+manual `ResumeBurn` admin recovery — same as the shortfall's step 2.


### PR DESCRIPTION
## Motivation

The orchestrator rollout requires a defined, verifiable onboarding procedure before any asset's `vault_mode` can flip to `"orchestrator"`. Previously, there was no documented runbook or CLI tooling to establish and confirm the preconditions (role grants, Turnkey signing policy, per-asset ERC-20 approvals) in a way that gates the cutover deterministically.

## Solution

Three new `issuer` subcommands are introduced and documented in `SPEC.md`:

- `issuer orchestrator-preflight` — read-only gate that verifies `MINT_ROLE` + `BURN_ROLE` on the orchestrator for the Turnkey bot wallet, checks `vaultLogicIsExpected()`, and confirms each asset's unlimited ERC-20 approval to the orchestrator is in place. Exits non-zero unless every check passes, so runbook steps can gate on it.
- `issuer approve-orchestrator <UNDERLYING>` — executes the one-time unlimited ERC-20 approval (bot wallet → orchestrator) through the Turnkey signer. Idempotent against an already-unlimited allowance, and success is confirmed by an on-chain allowance read rather than inferred from the receipt.
- `issuer verify-orchestrator-signing <UNDERLYING>` — signs one transaction per required shape (`mint`, `burn`, `approve`, ERC-1155 `safeTransferFrom`) without broadcasting, surfacing any Turnkey policy denial by name before the pilot's first live mint.

All three subcommands require the `TURNKEY_*` env group and derive the orchestrator address exclusively from the TOML config file — no address arguments are accepted.

A new runbook (`docs/runbooks/orchestrator-onboarding.md`) provides the ordered procedure: shipping the orchestrator address dark in config, coordinating role grants with st0x.deploy, configuring and proving the Turnkey signing policy, executing per-asset approvals, and running the final preflight gate. It includes a record table for prod facts (orchestrator address, role grant transactions, `EMERGENCY_ROLE` holder, policy names, per-asset approval hashes) and an escalation path for `InsufficientReceipts` and `VaultLogicMismatch` failure states.

The `SPEC.md` prose for the existing `force-complete-redemption` section was also reflowed for readability with no semantic changes.

Closes [RAI-1221](https://linear.app/makeitrain/issue/RAI-1221/6-ops-turnkey-policy-role-grants-approvals)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added issuer CLI commands for onboarding preflight checks, per-asset ERC-20 approvals, and signing-policy verification.
  * Added support for network and configuration options, idempotent execution, and clear failure handling.

* **Documentation**
  * Added a production orchestrator onboarding runbook covering prerequisites, deployment, verification, approvals, readiness checks, and escalation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->