### PR TITLE
feat: serialize signer intents per nonce domain and restore the gated prod deploy

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -1,24 +1,10 @@
 name: Deploy to Production
 
-# TEMPORARY BREAK-GLASS VARIANT — exists only on this hotfix branch, never
-# merges to main. Deploys a tag NOT on main during the custody-migration
-# window, triple-bound (tag == dispatch branch HEAD == pasted SHA), pinned to
-# one actor and this one branch. The service profile alone is deployed.
-run-name: "BREAK GLASS prod: ${{ inputs.tag }} by ${{ github.actor }}"
-
 on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Unique tag pointing at this branch's HEAD"
-        required: true
-        type: string
-      break_glass:
-        description: "Deploy a commit not on main"
-        required: true
-        type: boolean
-      confirm_sha:
-        description: "Paste the full 40-character commit SHA"
+        description: "Git tag to deploy (must be on main)"
         required: true
         type: string
 
@@ -27,10 +13,6 @@ permissions:
 
 jobs:
   deploy:
-    if: >-
-      github.actor == '0xgleb' &&
-      github.ref == 'refs/heads/fix/window-bypass-activation-and-listing-view' &&
-      inputs.break_glass
     environment: production
     concurrency:
       group: deploy-prod
@@ -47,12 +29,11 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Verify exact break-glass revision
+      - name: Verify tag is on main
         env:
           DEPLOY_TAG: ${{ inputs.tag }}
-          CONFIRM_SHA: ${{ inputs.confirm_sha }}
         run: |
-          git fetch --tags origin main
+          git fetch --tags origin '+refs/heads/main:refs/remotes/origin/main'
           if ! git rev-parse -q --verify "refs/tags/$DEPLOY_TAG" >/dev/null; then
             echo "ERROR: '$DEPLOY_TAG' is not an existing tag" >&2
             exit 1
@@ -63,16 +44,8 @@ jobs:
             echo "ERROR: checked-out commit does not match tag $DEPLOY_TAG" >&2
             exit 1
           fi
-          if [ "$tag_commit" != "$GITHUB_SHA" ]; then
-            echo "ERROR: tag does not match dispatch branch HEAD" >&2
-            exit 1
-          fi
-          if [ "$CONFIRM_SHA" != "$tag_commit" ]; then
-            echo "ERROR: confirmation SHA mismatch" >&2
-            exit 1
-          fi
-          if git merge-base --is-ancestor "$tag_commit" origin/main; then
-            echo "ERROR: commit is on main - use the normal deploy path" >&2
+          if ! git merge-base --is-ancestor "$tag_commit" origin/main; then
+            echo "ERROR: tag $DEPLOY_TAG is not on main" >&2
             exit 1
           fi
 
@@ -125,8 +98,8 @@ jobs:
           printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
-      - name: Deploy issuance service only
-        run: nix run .#prodDeployService -- st0x-issuance
+      - name: Deploy all profiles
+        run: nix run .#prodDeployAll
 
       - name: Cleanup SSH
         if: always()

--- a/SPEC.md
+++ b/SPEC.md
@@ -220,6 +220,16 @@ initial request through journal confirmation to on-chain minting and callback.
   automatic retry cap so an operator can retry after fixing the underlying
   cause. This prevents double-minting after crashes while ensuring terminal
   failures can be retried with new `externalTxId`s
+- `ManualRetryMint { issuer_request_id, manual_retry_id }` - Operator-authorized
+  retry of a `MintingFailed` mint past the exhausted automatic budget, gated on
+  the aggregate's own failure provenance (not a snapshot that may be stale by
+  execution time). Refused unless the failure chain proves a fresh submission is
+  unambiguous: only a `Minting` predecessor with no transaction provenance
+  qualifies, since a `MintIntended`/`TxSubmitted` predecessor's transaction may
+  still land, and a fresh submission over it could double-mint. Mints initiated
+  before the job-based submit flow are refused outright — their provenance
+  cannot be proven from event history. Produces the same `MintRetryStarted`
+  event as automatic retry
 - `RecoverWalletStep { issuer_request_id, mode }` - Internal recovery variant
   used only while the wallet lock is held. It performs the same recoverable
   on-chain steps as `Recover`, but becomes a no-op if a concurrent transition
@@ -250,7 +260,11 @@ initial request through journal confirmation to on-chain minting and callback.
 - `MintCompleted` - Alpaca callback sent, mint fully completed (terminal)
 - `ExistingMintRecovered` - Existing on-chain mint discovered during recovery
   (carries tx details)
-- `MintRetryStarted` - Mint retry started during recovery
+- `MintRetryStarted` - Mint retry started during recovery, either automatic or
+  operator-authorized. An operator-authorized retry carries a `manual_retry_id`
+  correlating the command with the event it commits, so queue dispatch can
+  distinguish a successful transition from an idempotent no-op against
+  already-advanced state
 
 Newly persisted transaction IDs use an explicitly tagged `hash` or `legacy`
 representation so replay preserves the original `TxId` variant, including a
@@ -295,14 +309,37 @@ critical section. Startup mint recovery processes its persisted intents in nonce
 order before mint states that may prepare a new transaction. Mint and redemption
 recovery run concurrently so persisted transactions from either domain can fill
 lower nonce gaps while higher transactions await confirmation. Live mint and
-burn preparation query the authoritative event log and are blocked while any
-other wallet intent remains unresolved; this safety check does not depend on a
-fallible read-model projection. Together these rules prevent two aggregate
-commands from signing the same wallet nonce without relying on in-memory nonce
-state that would be lost on restart. Each live burn attempt waits at most 30
-seconds behind an earlier unresolved wallet intent. On timeout it prepares and
-broadcasts nothing, leaves the redemption recoverable, and defers the burn to
-recovery rather than occupying the live flow indefinitely.
+burn preparation consult the trigger-maintained signer-intent reservation and
+are blocked while any other wallet intent remains unresolved; this safety check
+does not depend on a fallible read-model projection. Together these rules
+prevent two aggregate commands from signing the same wallet nonce without
+relying on in-memory nonce state that would be lost on restart. Each live burn
+attempt waits at most 30 seconds behind an earlier unresolved wallet intent. On
+timeout it prepares and broadcasts nothing, leaves the redemption recoverable,
+and defers the burn to recovery rather than occupying the live flow
+indefinitely.
+
+**Cross-instance signer-intent guard.** The pre-check above is an
+application-level read; it cannot by itself stop two separate processes from
+independently signing the same nonce during the brief overlap between the old
+process terminating and its replacement starting. `active_signer_intents` is the
+durable, cross-process backstop for that window: one row per network (a signer's
+nonce domain), reserved by a trigger in the same transaction that appends
+`MintTxIntended` or `BurnIntended`, and released by a trigger on that
+aggregate's own definitively-resolved terminal event. The reservation key is
+`network` alone, so it is shared between `Mint` and `Redemption` — only one
+signer intent per nonce domain can be outstanding at a time, regardless of which
+aggregate holds it. This makes the event append itself the durable arbitration
+point: a second instance's competing intent is rejected by SQLite before it can
+commit, rather than relying on an in-memory lock or a fallible read-model
+projection. When the pre-append check finds the network occupied, a mint job
+returns `MintJobError::UnresolvedWalletIntent` and refuses to submit rather than
+risk a nonce collision, leaving the job to retry once the guard clears. When the
+race is lost between that check and the append, the trigger aborts the append
+with an explicit signer-reservation error — worded distinctly from a
+same-aggregate concurrency conflict so an operator reading the failure is
+pointed at the nonce-domain guard, not at a phantom concurrent modification of
+the aggregate.
 
 The issuer is a single-writer service: exactly one process may own a given
 SQLite event store and signing wallet at a time. Horizontal replicas sharing a

--- a/migrations/20260801095000_enforce_active_signer_intents.sql
+++ b/migrations/20260801095000_enforce_active_signer_intents.sql
@@ -1,0 +1,362 @@
+-- Serialize persisted transaction intentions per signer nonce domain.
+--
+-- The in-process wallet mutex prevents two jobs in one service process from
+-- signing concurrently, but it cannot coordinate two service instances during
+-- a rollout or operator overlap. SQLite serializes writers, so maintaining this
+-- unique row in the SAME transaction that appends an intent event makes the
+-- event append the durable arbitration point: a competing signed-but-unbroadcast
+-- transaction is rejected before its intent can commit or its caller can submit
+-- it.
+CREATE TABLE active_signer_intents (
+    network TEXT NOT NULL PRIMARY KEY
+        CHECK (network IN ('base', 'ethereum', 'hyperevm')),
+    aggregate_type TEXT NOT NULL
+        CHECK (aggregate_type IN ('Mint', 'Redemption')),
+    aggregate_id TEXT NOT NULL,
+    UNIQUE (aggregate_type, aggregate_id)
+);
+
+-- Rebuild the derived guard from existing unresolved event streams. Missing
+-- origin metadata and unknown network values intentionally violate the table's
+-- constraints so startup fails closed instead of silently assigning an
+-- ambiguous signer domain. Redemption explicitly supports pre-network Detected
+-- events as Base; Mint has no such wire compatibility, so a missing mint
+-- network is malformed and remains NULL to trip the NOT NULL constraint.
+WITH unresolved_mints AS (
+    SELECT DISTINCT
+        CASE
+            -- Exactly one Initiated event, matching the live validation
+            -- trigger: zero OR duplicates leave the network NULL so the
+            -- NOT NULL constraint aborts the backfill instead of guessing
+            -- which origin is authoritative.
+            WHEN (
+                SELECT COUNT(*)
+                FROM events AS initiated
+                WHERE initiated.aggregate_type = intent.aggregate_type
+                  AND initiated.aggregate_id = intent.aggregate_id
+                  AND initiated.event_type = 'MintEvent::Initiated'
+            ) = 1
+            THEN (
+                SELECT json_extract(
+                    initiated.payload,
+                    '$.Initiated.network'
+                )
+                FROM events AS initiated
+                WHERE initiated.aggregate_type = intent.aggregate_type
+                  AND initiated.aggregate_id = intent.aggregate_id
+                  AND initiated.event_type = 'MintEvent::Initiated'
+                ORDER BY initiated.sequence
+                LIMIT 1
+            )
+        END AS network,
+        'Mint' AS aggregate_type,
+        intent.aggregate_id
+    FROM events AS intent
+    WHERE intent.aggregate_type = 'Mint'
+      AND intent.event_type = 'MintEvent::MintTxIntended'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM events AS later
+          WHERE later.aggregate_type = intent.aggregate_type
+            AND later.aggregate_id = intent.aggregate_id
+            AND later.sequence > intent.sequence
+            AND later.event_type IN (
+                'MintEvent::MintTxSubmitted',
+                'MintEvent::TokensMinted',
+                'MintEvent::ExistingMintRecovered',
+                'MintEvent::MintClosed'
+            )
+      )
+),
+unresolved_burns AS (
+    SELECT DISTINCT
+        CASE
+            -- Exactly one Detected event, matching the live validation
+            -- trigger: zero or duplicates fail the backfill closed via the
+            -- NOT NULL constraint rather than guessing an origin.
+            WHEN (
+                SELECT COUNT(*)
+                FROM events AS detected
+                WHERE detected.aggregate_type = intent.aggregate_type
+                  AND detected.aggregate_id = intent.aggregate_id
+                  AND detected.event_type = 'RedemptionEvent::Detected'
+            ) = 1
+            THEN COALESCE((
+                SELECT json_extract(detected.payload, '$.Detected.network')
+                FROM events AS detected
+                WHERE detected.aggregate_type = intent.aggregate_type
+                  AND detected.aggregate_id = intent.aggregate_id
+                  AND detected.event_type = 'RedemptionEvent::Detected'
+                ORDER BY detected.sequence
+                LIMIT 1
+            ), 'base')
+        END AS network,
+        'Redemption' AS aggregate_type,
+        intent.aggregate_id
+    FROM events AS intent
+    WHERE intent.aggregate_type = 'Redemption'
+      AND intent.event_type = 'RedemptionEvent::BurnIntended'
+      AND NOT EXISTS (
+          SELECT 1
+          FROM events AS later
+          WHERE later.aggregate_type = intent.aggregate_type
+            AND later.aggregate_id = intent.aggregate_id
+            AND later.sequence > intent.sequence
+            AND later.event_type NOT IN (
+                'RedemptionEvent::BurnIntended',
+                'RedemptionEvent::BurnRecoveryAttempted',
+                'RedemptionEvent::BurnPreparationRecoveryAttempted',
+                'RedemptionEvent::BurnRecoveryExhausted',
+                'RedemptionEvent::BurnPreparationRecoveryExhausted',
+                'RedemptionEvent::BurningFailed',
+                'RedemptionEvent::RedemptionFailed',
+                'RedemptionEvent::BurnResumed',
+                'RedemptionEvent::Reprocessed',
+                'RedemptionEvent::AlpacaCalled',
+                'RedemptionEvent::AlpacaCallFailed',
+                'RedemptionEvent::AlpacaJournalCompleted'
+            )
+      )
+)
+-- A PRIMARY KEY violation here means the history already contains TWO
+-- unresolved signed intents on the same network — the exact double-signing
+-- hazard this table exists to prevent, produced before the guard existed.
+-- The migration aborting is the correct outcome: do NOT weaken this insert
+-- to pick a winner. Remediate by resolving the older intent's aggregate
+-- first (recover or close it through the admin endpoints so its stream
+-- gains a releasing event), then re-run the migration. Run the
+-- verify-migrations binary against a prod snapshot before deploying to
+-- surface such conflicts ahead of the rollout restart.
+INSERT INTO active_signer_intents (network, aggregate_type, aggregate_id)
+SELECT network, aggregate_type, aggregate_id FROM unresolved_mints
+UNION ALL
+SELECT network, aggregate_type, aggregate_id FROM unresolved_burns;
+
+CREATE TRIGGER validate_mint_signer_intent_origin
+BEFORE INSERT ON events
+WHEN NEW.aggregate_type = 'Mint'
+ AND NEW.event_type = 'MintEvent::MintTxIntended'
+BEGIN
+    SELECT CASE
+        WHEN (
+            SELECT COUNT(*)
+            FROM events AS initiated
+            WHERE initiated.aggregate_type = NEW.aggregate_type
+              AND initiated.aggregate_id = NEW.aggregate_id
+              AND initiated.event_type = 'MintEvent::Initiated'
+        ) != 1
+        THEN RAISE(ABORT, 'mint signer intent requires one Initiated event')
+        WHEN (
+            SELECT json_extract(initiated.payload, '$.Initiated.network')
+            FROM events AS initiated
+            WHERE initiated.aggregate_type = NEW.aggregate_type
+              AND initiated.aggregate_id = NEW.aggregate_id
+              AND initiated.event_type = 'MintEvent::Initiated'
+            LIMIT 1
+        ) IS NULL
+        THEN RAISE(ABORT, 'mint signer intent requires network metadata')
+        WHEN (
+            SELECT json_extract(initiated.payload, '$.Initiated.network')
+            FROM events AS initiated
+            WHERE initiated.aggregate_type = NEW.aggregate_type
+              AND initiated.aggregate_id = NEW.aggregate_id
+              AND initiated.event_type = 'MintEvent::Initiated'
+            LIMIT 1
+        ) NOT IN ('base', 'ethereum', 'hyperevm')
+        THEN RAISE(ABORT, 'mint signer intent has an unknown network')
+    END;
+END;
+
+CREATE TRIGGER reserve_mint_signer_intent
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'Mint'
+ AND NEW.event_type = 'MintEvent::MintTxIntended'
+BEGIN
+    -- Explicit RAISE for the cross-instance case. Letting the PRIMARY KEY
+    -- violation surface instead would be misclassified upstream: the event
+    -- store treats any unique violation as a same-aggregate optimistic-lock
+    -- conflict ("aggregate conflict"), pointing an operator at the wrong
+    -- root cause during exactly the rollout-overlap incident this guard
+    -- exists for.
+    SELECT RAISE(
+        ABORT,
+        'signer network already reserved by another unresolved intent'
+    )
+    WHERE EXISTS (
+        SELECT 1
+        FROM active_signer_intents
+        WHERE network = (
+            SELECT json_extract(initiated.payload, '$.Initiated.network')
+            FROM events AS initiated
+            WHERE initiated.aggregate_type = NEW.aggregate_type
+              AND initiated.aggregate_id = NEW.aggregate_id
+              AND initiated.event_type = 'MintEvent::Initiated'
+            LIMIT 1
+        )
+          AND NOT (
+              aggregate_type = NEW.aggregate_type
+              AND aggregate_id = NEW.aggregate_id
+          )
+    );
+
+    INSERT INTO active_signer_intents (
+        network,
+        aggregate_type,
+        aggregate_id
+    )
+    VALUES (
+        (
+            SELECT json_extract(initiated.payload, '$.Initiated.network')
+            FROM events AS initiated
+            WHERE initiated.aggregate_type = NEW.aggregate_type
+              AND initiated.aggregate_id = NEW.aggregate_id
+              AND initiated.event_type = 'MintEvent::Initiated'
+            LIMIT 1
+        ),
+        NEW.aggregate_type,
+        NEW.aggregate_id
+    )
+    ON CONFLICT (aggregate_type, aggregate_id)
+    DO UPDATE SET network = excluded.network;
+END;
+
+-- MintClosed releases too: the admin close command is valid from any
+-- non-terminal state, including TxIntended. Without it in this list a
+-- routine operator close would strand the network's reservation forever
+-- (the row is keyed by network, so every later mint AND burn on that
+-- network would be rejected with no self-healing path).
+CREATE TRIGGER release_mint_signer_intent
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'Mint'
+ AND NEW.event_type IN (
+     'MintEvent::MintTxSubmitted',
+     'MintEvent::TokensMinted',
+     'MintEvent::ExistingMintRecovered',
+     'MintEvent::MintClosed'
+ )
+BEGIN
+    DELETE FROM active_signer_intents
+    WHERE aggregate_type = NEW.aggregate_type
+      AND aggregate_id = NEW.aggregate_id;
+END;
+
+CREATE TRIGGER validate_burn_signer_intent_origin
+BEFORE INSERT ON events
+WHEN NEW.aggregate_type = 'Redemption'
+ AND NEW.event_type = 'RedemptionEvent::BurnIntended'
+BEGIN
+    SELECT CASE
+        WHEN (
+            SELECT COUNT(*)
+            FROM events AS detected
+            WHERE detected.aggregate_type = NEW.aggregate_type
+              AND detected.aggregate_id = NEW.aggregate_id
+              AND detected.event_type = 'RedemptionEvent::Detected'
+        ) != 1
+        THEN RAISE(ABORT, 'burn signer intent requires one Detected event')
+        WHEN COALESCE((
+            SELECT json_extract(detected.payload, '$.Detected.network')
+            FROM events AS detected
+            WHERE detected.aggregate_type = NEW.aggregate_type
+              AND detected.aggregate_id = NEW.aggregate_id
+              AND detected.event_type = 'RedemptionEvent::Detected'
+            LIMIT 1
+        ), 'base') NOT IN ('base', 'ethereum', 'hyperevm')
+        THEN RAISE(ABORT, 'burn signer intent has an unknown network')
+    END;
+END;
+
+CREATE TRIGGER reserve_burn_signer_intent
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'Redemption'
+ AND NEW.event_type = 'RedemptionEvent::BurnIntended'
+BEGIN
+    -- Explicit RAISE for the cross-instance case, mirroring the mint
+    -- reserve trigger: an implicit PRIMARY KEY violation would be
+    -- misreported upstream as a same-aggregate optimistic-lock conflict.
+    SELECT RAISE(
+        ABORT,
+        'signer network already reserved by another unresolved intent'
+    )
+    WHERE EXISTS (
+        SELECT 1
+        FROM active_signer_intents
+        WHERE network = COALESCE((
+            SELECT json_extract(detected.payload, '$.Detected.network')
+            FROM events AS detected
+            WHERE detected.aggregate_type = NEW.aggregate_type
+              AND detected.aggregate_id = NEW.aggregate_id
+              AND detected.event_type = 'RedemptionEvent::Detected'
+            LIMIT 1
+        ), 'base')
+          AND NOT (
+              aggregate_type = NEW.aggregate_type
+              AND aggregate_id = NEW.aggregate_id
+          )
+    );
+
+    INSERT INTO active_signer_intents (
+        network,
+        aggregate_type,
+        aggregate_id
+    )
+    VALUES (
+        COALESCE((
+            SELECT json_extract(detected.payload, '$.Detected.network')
+            FROM events AS detected
+            WHERE detected.aggregate_type = NEW.aggregate_type
+              AND detected.aggregate_id = NEW.aggregate_id
+              AND detected.event_type = 'RedemptionEvent::Detected'
+            LIMIT 1
+        ), 'base'),
+        NEW.aggregate_type,
+        NEW.aggregate_id
+    )
+    ON CONFLICT (aggregate_type, aggregate_id)
+    DO UPDATE SET network = excluded.network;
+END;
+
+-- Recovery bookkeeping does not release the nonce domain, while any other
+-- later redemption event does. BurningFailed and RedemptionFailed are in the
+-- exclusion set for the same reason MintingFailed never releases on the mint
+-- side: a failed submit may still have broadcast the signed transaction, and
+-- the ambiguous recover_single_burn_failed path emits BurningFailed then
+-- RedemptionFailed while deliberately keeping the reservation — a release on
+-- the second event would undo the first's retention. BurnResumed is excluded
+-- too: it moves a Failed redemption back into Burning before the replacement
+-- BurnIntended re-reserves, and the prior signed transaction's on-chain fate
+-- is still unknown in that window. Reprocessed is excluded for the same
+-- ambiguous-broadcast reason: it is valid from Failed while
+-- unresolved_burn_tx is still retained, so releasing on reprocess would free
+-- the nonce domain before the prior signed transaction's fate is known.
+-- After Reprocessed, apply_reprocessed returns the aggregate to Detected, so
+-- the next events are AlpacaCalled / AlpacaCallFailed / AlpacaJournalCompleted
+-- — those must stay excluded too, or the reservation would drop one event
+-- after reprocess while the prior signed burn may still be unknown on-chain.
+-- Real terminal outcomes (TokensBurned, RedemptionClosed) release by falling
+-- outside this list. This list must stay in lockstep with the
+-- unresolved_burns backfill CTE above; the application-side guard reads the
+-- active_signer_intents table itself, so the triggers and backfill are the
+-- only two places encoding it.
+CREATE TRIGGER release_burn_signer_intent
+AFTER INSERT ON events
+WHEN NEW.aggregate_type = 'Redemption'
+ AND NEW.event_type NOT IN (
+     'RedemptionEvent::BurnIntended',
+     'RedemptionEvent::BurnRecoveryAttempted',
+     'RedemptionEvent::BurnPreparationRecoveryAttempted',
+     'RedemptionEvent::BurnRecoveryExhausted',
+     'RedemptionEvent::BurnPreparationRecoveryExhausted',
+     'RedemptionEvent::BurningFailed',
+     'RedemptionEvent::RedemptionFailed',
+     'RedemptionEvent::BurnResumed',
+     'RedemptionEvent::Reprocessed',
+     'RedemptionEvent::AlpacaCalled',
+     'RedemptionEvent::AlpacaCallFailed',
+     'RedemptionEvent::AlpacaJournalCompleted'
+ )
+BEGIN
+    DELETE FROM active_signer_intents
+    WHERE aggregate_type = NEW.aggregate_type
+      AND aggregate_id = NEW.aggregate_id;
+END;

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -21,7 +21,10 @@ use crate::auth::InternalAuth;
 use crate::mint::{
     IssuerMintRequestId, ManualRecoveryDecision, Mint, MintCommand, MintEvent,
     MintView, TokenizationRequestId, find_stuck as find_stuck_mints,
-    recovery::{enqueue_scheduled_mint_recovery, manually_retry_failed_mint},
+    recovery::{
+        ManualRetryOutcome, enqueue_scheduled_mint_recovery,
+        manually_retry_failed_mint,
+    },
 };
 use crate::redemption::Redemption;
 use crate::redemption::burn_manager::{
@@ -1167,8 +1170,8 @@ pub(crate) async fn reprocess_mint(
     // and would abandon an exhausted mint instead of retrying it. Every other
     // eligible state enqueues the durable recovery job, the same path the
     // automatic startup re-scan and the periodic reconciler use.
-    if matches!(&mint, Mint::MintingFailed { .. }) {
-        manually_retry_failed_mint(
+    let message = if matches!(&mint, Mint::MintingFailed { .. }) {
+        match manually_retry_failed_mint(
             store.inner(),
             pool.inner(),
             vault_services.inner(),
@@ -1183,7 +1186,17 @@ pub(crate) async fn reprocess_mint(
                 "Failed to drive manual mint retry"
             );
             Status::InternalServerError
-        })?;
+        })? {
+            ManualRetryOutcome::Enqueued => "Recovery initiated",
+            ManualRetryOutcome::AlreadyHandled => "Recovery already initiated",
+            ManualRetryOutcome::DeferredToRecovery { error } => {
+                warn!(target: "admin", aggregate_id = aggregate_id,
+                    error,
+                    "Manual mint retry committed; queue dispatch deferred"
+                );
+                "Recovery authorized; queue dispatch deferred to reconciler"
+            }
+        }
     } else {
         enqueue_scheduled_mint_recovery(
             pool.inner(),
@@ -1198,18 +1211,23 @@ pub(crate) async fn reprocess_mint(
             );
             Status::InternalServerError
         })?;
-    }
+        "Recovery initiated"
+    };
 
+    // `message` already distinguishes enqueued / already-handled / deferred;
+    // logging it keeps this line truthful for the outcomes where nothing was
+    // enqueued.
     info!(target: "admin", aggregate_id = aggregate_id,
         previous_state = %current_state,
-        "Mint reprocess enqueued successfully"
+        outcome = message,
+        "Mint reprocess request completed"
     );
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Mint,
         aggregate_id: aggregate_id.to_string(),
         previous_state: current_state,
-        message: "Recovery initiated".to_string(),
+        message: message.to_string(),
     }))
 }
 

--- a/src/fireblocks/auth_probe.rs
+++ b/src/fireblocks/auth_probe.rs
@@ -14,7 +14,7 @@ use rand::Rng;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::fmt::Write;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, SystemTimeError, UNIX_EPOCH};
 
 use super::config::FireblocksConfig;
 
@@ -27,6 +27,7 @@ pub struct AuthProbeReport {
     pub body: String,
 }
 
+/// Errors produced while constructing or executing an authentication probe.
 #[derive(Debug, thiserror::Error)]
 pub enum AuthProbeError {
     #[error("failed to build the probe JWT: {0}")]
@@ -34,9 +35,36 @@ pub enum AuthProbeError {
     #[error("probe HTTP error: {0}")]
     Http(#[from] reqwest::Error),
     #[error("system clock error: {0}")]
-    Clock(#[from] std::time::SystemTimeError),
+    SystemTime(#[from] SystemTimeError),
+    #[error("probe JWT expiry must be positive, got {expiry_seconds}")]
+    InvalidExpiry { expiry_seconds: u64 },
+    #[error(
+        "probe JWT expiry overflows: iat {issued_at} + {expiry_seconds} seconds"
+    )]
+    ExpiryOverflow { issued_at: u64, expiry_seconds: u64 },
     #[error("failed to format the body hash: {0}")]
     Fmt(#[from] std::fmt::Error),
+}
+
+/// Probe JWT expiry window in seconds, positive by construction: existence
+/// of a value proves the zero case was already rejected, so `probe_auth`
+/// cannot be handed a token that expires at issuance.
+#[derive(Debug, Clone, Copy)]
+pub struct PositiveExpirySeconds(u64);
+
+impl PositiveExpirySeconds {
+    /// # Errors
+    ///
+    /// Returns [`AuthProbeError::InvalidExpiry`] for a zero expiry — a token
+    /// that expires at issuance can never authenticate.
+    pub const fn new(seconds: u64) -> Result<Self, AuthProbeError> {
+        if seconds == 0 {
+            return Err(AuthProbeError::InvalidExpiry {
+                expiry_seconds: seconds,
+            });
+        }
+        Ok(Self(seconds))
+    }
 }
 
 /// The JWT claims Fireblocks authenticates, mirroring the SDK's shape
@@ -67,9 +95,13 @@ pub async fn probe_auth(
     api_user_id: &str,
     rsa_key_pem: &[u8],
     uri_path: &str,
-    expiry_seconds: u64,
+    expiry_seconds: PositiveExpirySeconds,
 ) -> Result<AuthProbeReport, AuthProbeError> {
+    let PositiveExpirySeconds(expiry_seconds) = expiry_seconds;
     let now = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs();
+    let expires_at = now.checked_add(expiry_seconds).ok_or(
+        AuthProbeError::ExpiryOverflow { issued_at: now, expiry_seconds },
+    )?;
 
     let body_hash = {
         let mut digest = Sha256::new();
@@ -85,7 +117,7 @@ pub async fn probe_auth(
         uri: uri_path,
         nonce: rand::thread_rng().r#gen(),
         iat: now,
-        exp: now + expiry_seconds,
+        exp: expires_at,
         sub: api_user_id,
         body_hash,
     };
@@ -139,7 +171,7 @@ pub async fn probe_auth_pair(
                 config.api_user_id.as_str(),
                 &config.secret,
                 &uri_path,
-                expiry_seconds,
+                PositiveExpirySeconds::new(expiry_seconds)?,
             )
             .await?,
         );
@@ -235,7 +267,7 @@ mod tests {
             "api-user-test",
             &private_pem,
             "/v1/vault/accounts/0/ETH-TEST",
-            29,
+            PositiveExpirySeconds::new(29).unwrap(),
         )
         .await
         .unwrap();
@@ -259,6 +291,29 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn probe_rejects_invalid_expiry_without_signing_or_sending() {
+        let zero = PositiveExpirySeconds::new(0).unwrap_err();
+        assert!(matches!(
+            zero,
+            AuthProbeError::InvalidExpiry { expiry_seconds: 0 }
+        ));
+
+        let overflow = probe_auth(
+            "http://127.0.0.1:1",
+            "api-user-test",
+            b"not-a-key",
+            "/v1/probe",
+            PositiveExpirySeconds::new(u64::MAX).unwrap(),
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            overflow,
+            AuthProbeError::ExpiryOverflow { expiry_seconds: u64::MAX, .. }
+        ));
+    }
+
     /// The SDK swallows non-2xx bodies; the probe exists to surface them.
     /// A 401 with a diagnostic body must come back verbatim as a report,
     /// not as an error.
@@ -278,7 +333,7 @@ mod tests {
             "api-user-test",
             &private_pem,
             "/v1/vault/accounts/0/ETH-TEST",
-            55,
+            PositiveExpirySeconds::new(55).unwrap(),
         )
         .await
         .unwrap();

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -1,5 +1,6 @@
 use alloy::primitives::{Address, B256, U256};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use super::{
     ClientId, IssuerMintRequestId, MintExternalTxId, Network, Quantity,
@@ -107,6 +108,10 @@ pub(crate) enum MintCommand {
     /// already left `MintingFailed`.
     ManualRetryMint {
         issuer_request_id: IssuerMintRequestId,
+        /// Correlates this operator command with the event it commits so queue
+        /// dispatch can distinguish a successful transition from an idempotent
+        /// no-op against already-advanced state.
+        manual_retry_id: Uuid,
     },
 
     /// Records a mint whose on-chain transaction already succeeded, as evidenced

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -2,6 +2,7 @@ use alloy::primitives::{Address, B256, TxHash, U256};
 use chrono::{DateTime, Utc};
 use cqrs_es::DomainEvent;
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::vault::{PreparedMintTx, TxId};
 
@@ -97,6 +98,10 @@ pub(crate) enum MintEvent {
         /// when triggered by startup auto-recovery (which may retry the mint).
         #[serde(default)]
         tx_hash: Option<TxHash>,
+        /// Present only for operator-authorized retries. Older and automatic
+        /// retry events default to `None` during replay.
+        #[serde(default)]
+        manual_retry_id: Option<Uuid>,
         started_at: DateTime<Utc>,
     },
 }

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -27,14 +27,13 @@ use tracing::{info, warn};
 
 use super::recovery::enqueue_scheduled_mint_recovery;
 use super::{
-    IssuerMintRequestId, Mint, MintCommand, has_unresolved_mint_intent,
+    IssuerMintRequestId, Mint, MintCommand, has_unresolved_signer_intent,
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
 };
-use crate::redemption::has_unresolved_burn_intent;
 use crate::tokenized_asset::Network;
 use crate::vault::{
     NetworkVaultServices, ReceiptInformation, TxId, UnconfiguredNetworkError,
@@ -174,16 +173,18 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     .map(super::MintExternalTxId::into_string);
 
                 let wallet_guard = vault.lock_wallet().await;
-                if has_unresolved_mint_intent(
+                // The reservation is keyed by network alone, so this single
+                // check also blocks behind an unresolved burn on the same
+                // signer: a persisted-but-unbroadcast burn transaction may
+                // still land, and signing a mint over it risks a nonce
+                // conflict. Intents on other networks use independent nonce
+                // domains and must not block this one.
+                if has_unresolved_signer_intent(
                     &ctx.pool,
+                    *network,
                     Some(&self.issuer_request_id),
                 )
                 .await?
-                    // A persisted-but-unresolved burn transaction from the
-                    // same wallet may still land; signing a mint over it
-                    // risks a nonce conflict, so wait like the burn path
-                    // waits for unresolved mint intents.
-                    || has_unresolved_burn_intent(&ctx.pool, None).await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),
@@ -268,12 +269,14 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     return Ok(());
                 };
                 let wallet_guard = vault.lock_wallet().await;
-                if has_unresolved_mint_intent(
+                // Network-keyed reservation: one check covers competing mint
+                // AND burn intents on this signer's nonce domain.
+                if has_unresolved_signer_intent(
                     &ctx.pool,
+                    *network,
                     Some(&self.issuer_request_id),
                 )
                 .await?
-                    || has_unresolved_burn_intent(&ctx.pool, None).await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),
@@ -1207,6 +1210,7 @@ mod tests {
         events.push(MintEvent::MintRetryStarted {
             issuer_request_id: issuer_request_id.clone(),
             tx_hash: None,
+            manual_retry_id: None,
             started_at: chrono::Utc::now(),
         });
         seed_mint_events(&harness.pool, &issuer_request_id, events).await;

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -27,36 +27,38 @@ pub(crate) use cmd::MintCommand;
 pub(crate) use event::MintEvent;
 pub(crate) use view::{MintView, find_all_recoverable_mints, find_stuck};
 
-/// Returns whether another mint has a prepared transaction whose terminal
-/// submission outcome has not yet been persisted.
-pub(crate) async fn has_unresolved_mint_intent(
+/// Returns whether any signed transaction on the same signer network — a
+/// mint or a burn — is still awaiting its terminal outcome, excluding at
+/// most this mint's own reservation.
+///
+/// Reads the trigger-maintained `active_signer_intents` table rather than
+/// re-deriving the answer from event streams: the triggers update the table
+/// in the same transaction that appends the intent event, so the table is
+/// the single source of truth and cannot drift from the reserve/release
+/// rules the migration encodes. Because the table is keyed by network, an
+/// outstanding Redemption burn intent blocks a mint on the same nonce
+/// domain too — which is exactly right, both flows sign with the same key.
+pub(crate) async fn has_unresolved_signer_intent(
     pool: &Pool<Sqlite>,
+    network: Network,
     excluding: Option<&IssuerMintRequestId>,
 ) -> Result<bool, sqlx::Error> {
+    // `None` collapses to "" rather than a NULL bind: `aggregate_id = NULL`
+    // is NULL in SQL, `NOT NULL` is NULL, and a NULL predicate silently
+    // excludes EVERY row — the empty string matches no aggregate_id, which
+    // is the intended "exclude nothing".
     let excluding = excluding.map(ToString::to_string).unwrap_or_default();
     let exists = sqlx::query_scalar::<_, bool>(
         "
         SELECT EXISTS (
             SELECT 1
-            FROM events AS intent
-            WHERE intent.aggregate_type = 'Mint'
-              AND intent.event_type = 'MintEvent::MintTxIntended'
-              AND intent.aggregate_id != ?
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM events AS later
-                  WHERE later.aggregate_type = intent.aggregate_type
-                    AND later.aggregate_id = intent.aggregate_id
-                    AND later.sequence > intent.sequence
-                    AND later.event_type IN (
-                        'MintEvent::MintTxSubmitted',
-                        'MintEvent::TokensMinted',
-                        'MintEvent::ExistingMintRecovered'
-                    )
-              )
+            FROM active_signer_intents
+            WHERE network = ?
+              AND NOT (aggregate_type = 'Mint' AND aggregate_id = ?)
         )
         ",
     )
+    .bind(network.as_str())
     .bind(excluding)
     .fetch_one(pool)
     .await?;
@@ -324,6 +326,12 @@ struct ConfirmedMint {
 pub(crate) struct MintRetryContext {
     attempts: u32,
     failed_from: Box<Mint>,
+    /// Legacy receipt-triggered retries could carry an on-chain transaction
+    /// hash even though replay moved the aggregate back to `Minting`. Preserve
+    /// it so a later manual retry cannot mistake that state for a transaction-
+    /// free prepare failure.
+    #[serde(default)]
+    tx_hash: Option<B256>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -824,6 +832,7 @@ impl Mint {
                 Ok(vec![MintEvent::MintRetryStarted {
                     issuer_request_id,
                     tx_hash: None,
+                    manual_retry_id: None,
                     started_at: Utc::now(),
                 }])
             }
@@ -856,6 +865,7 @@ impl Mint {
     fn handle_manual_retry_mint(
         &self,
         issuer_request_id: IssuerMintRequestId,
+        manual_retry_id: Uuid,
     ) -> Result<Vec<MintEvent>, MintError> {
         match self {
             Self::MintingFailed {
@@ -877,7 +887,9 @@ impl Mint {
                     });
                 }
 
-                if !matches!(failed_from.as_ref(), Self::Minting { .. }) {
+                if !matches!(failed_from.as_ref(), Self::Minting { .. })
+                    || failed_from.has_transaction_provenance()
+                {
                     return Err(MintError::AmbiguousRetryPredecessor {
                         predecessor: failed_from.state_name().to_string(),
                     });
@@ -886,6 +898,7 @@ impl Mint {
                 Ok(vec![MintEvent::MintRetryStarted {
                     issuer_request_id,
                     tx_hash: None,
+                    manual_retry_id: Some(manual_retry_id),
                     started_at: Utc::now(),
                 }])
             }
@@ -1242,7 +1255,11 @@ impl Mint {
                 Box::new(self.clone()),
             ),
             Self::Minting { retry: Some(context), .. } => {
-                (context.attempts + 1, context.failed_from.clone())
+                // Keep the retry wrapper, not only its older predecessor: the
+                // wrapper may carry transaction-hash provenance that a manual
+                // retry must never flatten away. `non_failed_predecessor`
+                // already traverses this chain for automatic retry identity.
+                (context.attempts + 1, Box::new(self.clone()))
             }
             _ => (1, Box::new(self.clone())),
         };
@@ -1436,7 +1453,32 @@ impl Mint {
         };
     }
 
-    fn apply_mint_retry_started(&mut self, started_at: DateTime<Utc>) {
+    fn has_transaction_provenance(&self) -> bool {
+        match self {
+            Self::TxIntended { .. }
+            | Self::TxSubmitted { .. }
+            | Self::CallbackPending { .. }
+            | Self::Completed { .. } => true,
+            Self::Minting { retry: Some(retry), .. } => {
+                retry.tx_hash.is_some()
+                    || retry.failed_from.has_transaction_provenance()
+            }
+            Self::MintingFailed { failed_from, .. } => {
+                failed_from.has_transaction_provenance()
+            }
+            Self::Initiated { .. }
+            | Self::JournalConfirmed { .. }
+            | Self::JournalRejected { .. }
+            | Self::Minting { retry: None, .. }
+            | Self::Closed { .. } => false,
+        }
+    }
+
+    fn apply_mint_retry_started(
+        &mut self,
+        tx_hash: Option<B256>,
+        started_at: DateTime<Utc>,
+    ) {
         let Self::MintingFailed {
             issuer_request_id,
             tokenization_request_id,
@@ -1468,7 +1510,7 @@ impl Mint {
             initiated_at,
             journal_confirmed_at,
             minting_started_at: started_at,
-            retry: Some(MintRetryContext { attempts, failed_from }),
+            retry: Some(MintRetryContext { attempts, failed_from, tx_hash }),
         };
     }
     fn handle_close_mint(
@@ -1693,9 +1735,11 @@ impl EventSourced for Mint {
             MintCommand::RetryMint { issuer_request_id } => {
                 self.handle_retry_mint(issuer_request_id)
             }
-            MintCommand::ManualRetryMint { issuer_request_id } => {
-                self.handle_manual_retry_mint(issuer_request_id)
-            }
+            MintCommand::ManualRetryMint {
+                issuer_request_id,
+                manual_retry_id,
+            } => self
+                .handle_manual_retry_mint(issuer_request_id, manual_retry_id),
             MintCommand::RecordExistingMint {
                 issuer_request_id,
                 tx_hash,
@@ -1807,10 +1851,11 @@ impl Mint {
             }
             MintEvent::MintRetryStarted {
                 issuer_request_id: _,
+                tx_hash,
                 started_at,
                 ..
             } => {
-                self.apply_mint_retry_started(started_at);
+                self.apply_mint_retry_started(tx_hash, started_at);
             }
             MintEvent::MintClosed { issuer_request_id, reason, closed_at } => {
                 *self = Self::Closed { issuer_request_id, reason, closed_at };
@@ -1921,7 +1966,7 @@ impl From<UnconfiguredNetworkError> for MintError {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use alloy::primitives::{Address, address, b256, uint};
+    use alloy::primitives::{Address, B256, address, b256, uint};
     use chrono::{DateTime, Utc};
     use event_sorcery::{LifecycleError, StoreBuilder, TestHarness, replay};
     use proptest::prelude::*;
@@ -1936,6 +1981,7 @@ pub(crate) mod tests {
         ClientId, IssuerMintRequestId, ManualRecoveryDecision, Mint,
         MintCommand, MintError, MintEvent, MintExternalTxId, Network, Quantity,
         TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
+        has_unresolved_signer_intent,
     };
     use crate::prepare_event_sourced_startup;
     use crate::test_utils::logs_contain_at;
@@ -1949,6 +1995,602 @@ pub(crate) mod tests {
 
     pub(super) const BOT: Address =
         address!("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+    async fn insert_raw_event(
+        pool: &Pool<Sqlite>,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (?, ?, ?, ?, '1.0', ?, '{}')
+            ",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unresolved_mint_intents_only_block_the_same_signer_network() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+        let aggregate_id = IssuerMintRequestId::random().to_string();
+
+        for (sequence, event_type, payload) in [
+            (1, "MintEvent::Initiated", r#"{"Initiated":{"network":"base"}}"#),
+            (2, "MintEvent::MintTxIntended", "{}"),
+        ] {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Mint', ?, ?, ?, '1.0', ?, '{}')
+                ",
+            )
+            .bind(&aggregate_id)
+            .bind(sequence)
+            .bind(event_type)
+            .bind(payload)
+            .execute(&pool)
+            .await
+            .expect("test event should insert");
+        }
+
+        assert!(
+            has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "an unresolved intent must keep the same network's gate closed"
+        );
+        assert!(
+            !has_unresolved_signer_intent(&pool, Network::Ethereum, None)
+                .await
+                .expect("intent query should succeed"),
+            "a Base intent must not block an independent Ethereum signer"
+        );
+
+        let orphaned = sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Mint',
+                'orphaned-intent',
+                1,
+                'MintEvent::MintTxIntended',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(&pool)
+        .await;
+
+        let orphaned_error = orphaned
+            .expect_err(
+                "an intent with no origin metadata must be rejected atomically",
+            )
+            .to_string();
+        assert!(
+            orphaned_error.contains("requires one Initiated event"),
+            "the validation trigger must name the missing origin, got: \
+             {orphaned_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn signer_intent_migration_backfills_and_rejects_ambiguous_history() {
+        const INIT: &str =
+            include_str!("../../migrations/20251016210348_init.sql");
+        const GUARD: &str = include_str!(
+            "../../migrations/20260801095000_enforce_active_signer_intents.sql"
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::raw_sql(INIT).execute(&pool).await.unwrap();
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "existing-mint",
+            1,
+            "MintEvent::Initiated",
+            r#"{"Initiated":{"network":"base"}}"#,
+        )
+        .await
+        .unwrap();
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "existing-mint",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .unwrap();
+
+        sqlx::raw_sql(GUARD).execute(&pool).await.unwrap();
+        let active: (String, String, String) = sqlx::query_as(
+            "SELECT network, aggregate_type, aggregate_id \
+             FROM active_signer_intents",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            active,
+            (
+                "base".to_string(),
+                "Mint".to_string(),
+                "existing-mint".to_string(),
+            )
+        );
+
+        let malformed = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::raw_sql(INIT).execute(&malformed).await.unwrap();
+        insert_raw_event(
+            &malformed,
+            "Mint",
+            "missing-network",
+            1,
+            "MintEvent::Initiated",
+            r#"{"Initiated":{}}"#,
+        )
+        .await
+        .unwrap();
+        insert_raw_event(
+            &malformed,
+            "Mint",
+            "missing-network",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .unwrap();
+
+        let malformed_error = sqlx::raw_sql(GUARD)
+            .execute(&malformed)
+            .await
+            .expect_err(
+                "migration must fail closed when an active intent has no \
+                 signer domain",
+            )
+            .to_string();
+        assert!(
+            malformed_error.contains("NOT NULL constraint failed"),
+            "the malformed origin must abort on the NOT NULL network \
+             constraint specifically, got: {malformed_error}"
+        );
+
+        // The core double-signing hazard the table exists to prevent: TWO
+        // historical aggregates left unresolved intents on the same network.
+        // The backfill must abort on the PRIMARY KEY rather than pick a
+        // winner — remediation is resolving one aggregate, never guessing.
+        let conflicted = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::raw_sql(INIT).execute(&conflicted).await.unwrap();
+        for aggregate_id in ["first-unresolved", "second-unresolved"] {
+            insert_raw_event(
+                &conflicted,
+                "Mint",
+                aggregate_id,
+                1,
+                "MintEvent::Initiated",
+                r#"{"Initiated":{"network":"base"}}"#,
+            )
+            .await
+            .unwrap();
+            insert_raw_event(
+                &conflicted,
+                "Mint",
+                aggregate_id,
+                2,
+                "MintEvent::MintTxIntended",
+                "{}",
+            )
+            .await
+            .unwrap();
+        }
+        let conflicted_error = sqlx::raw_sql(GUARD)
+            .execute(&conflicted)
+            .await
+            .expect_err(
+                "migration must abort on two unresolved intents sharing a \
+                 network instead of silently choosing one",
+            )
+            .to_string();
+        assert!(
+            conflicted_error.contains("UNIQUE constraint failed"),
+            "the historical conflict must abort on the network PRIMARY KEY \
+             specifically, got: {conflicted_error}"
+        );
+
+        // Duplicate origin events make the signer domain ambiguous; the
+        // backfill must fail closed exactly like the live validation trigger
+        // instead of trusting whichever duplicate a LIMIT picks.
+        let duplicated = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::raw_sql(INIT).execute(&duplicated).await.unwrap();
+        for (sequence, event_type, payload) in [
+            (1, "MintEvent::Initiated", r#"{"Initiated":{"network":"base"}}"#),
+            (
+                2,
+                "MintEvent::Initiated",
+                r#"{"Initiated":{"network":"ethereum"}}"#,
+            ),
+            (3, "MintEvent::MintTxIntended", "{}"),
+        ] {
+            insert_raw_event(
+                &duplicated,
+                "Mint",
+                "duplicated-origin",
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .unwrap();
+        }
+        let duplicated_error = sqlx::raw_sql(GUARD)
+            .execute(&duplicated)
+            .await
+            .expect_err(
+                "migration must fail closed on duplicate origin events \
+                 instead of guessing which network is authoritative",
+            )
+            .to_string();
+        assert!(
+            duplicated_error.contains("NOT NULL constraint failed"),
+            "duplicate origins must abort on the NOT NULL network constraint \
+             specifically, got: {duplicated_error}"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_store_atomically_rejects_a_second_same_network_intent() {
+        // A single connection: each pooled connection to ":memory:" opens
+        // its OWN empty database, so a second connection would see neither
+        // the schema nor the seeded events.
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+
+        for (aggregate_id, sequence, event_type, payload) in [
+            (
+                "mint-a",
+                1,
+                "MintEvent::Initiated",
+                r#"{"Initiated":{"network":"base"}}"#,
+            ),
+            ("mint-a", 2, "MintEvent::MintTxIntended", "{}"),
+            (
+                "mint-b",
+                1,
+                "MintEvent::Initiated",
+                r#"{"Initiated":{"network":"base"}}"#,
+            ),
+        ] {
+            insert_raw_event(
+                &pool,
+                "Mint",
+                aggregate_id,
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("test history should insert");
+        }
+
+        let competing = insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-b",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await;
+        let competing_error = competing
+            .expect_err(
+                "the intent append must atomically reject a competing signer \
+                 nonce",
+            )
+            .to_string();
+        assert!(
+            competing_error.contains("signer network already reserved"),
+            "the cross-instance rejection must carry the explicit \
+             reservation message, not an implicit unique violation that \
+             upstream layers misreport as a same-aggregate conflict; got: \
+             {competing_error}"
+        );
+
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-missing-network",
+            1,
+            "MintEvent::Initiated",
+            r#"{"Initiated":{}}"#,
+        )
+        .await
+        .expect("malformed origin should seed for boundary testing");
+        let missing_error = insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-missing-network",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .expect_err(
+            "missing mint network metadata must fail closed before intent \
+             commit",
+        )
+        .to_string();
+        assert!(
+            missing_error.contains("requires network metadata"),
+            "the validation trigger must name the missing metadata, got: \
+             {missing_error}"
+        );
+
+        for (sequence, event_type, payload) in [
+            (
+                1,
+                "MintEvent::Initiated",
+                r#"{"Initiated":{"network":"ethereum"}}"#,
+            ),
+            (2, "MintEvent::MintTxIntended", "{}"),
+        ] {
+            insert_raw_event(
+                &pool,
+                "Mint",
+                "mint-ethereum",
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("an independent signer network must remain available");
+        }
+
+        insert_raw_event(
+            &pool,
+            "Redemption",
+            "redemption-base",
+            1,
+            "RedemptionEvent::Detected",
+            r#"{"Detected":{"network":"base"}}"#,
+        )
+        .await
+        .expect("redemption origin should insert");
+        let competing_burn = insert_raw_event(
+            &pool,
+            "Redemption",
+            "redemption-base",
+            2,
+            "RedemptionEvent::BurnIntended",
+            "{}",
+        )
+        .await;
+        let competing_burn_error = competing_burn
+            .expect_err(
+                "mint and burn intents must share one per-network nonce domain",
+            )
+            .to_string();
+        assert!(
+            competing_burn_error.contains("signer network already reserved"),
+            "a burn competing with an unresolved mint must carry the explicit \
+             reservation message, got: {competing_burn_error}"
+        );
+
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-a",
+            3,
+            "MintEvent::MintTxSubmitted",
+            "{}",
+        )
+        .await
+        .expect("terminal submission should release the signer domain");
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-b",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .expect("a resolved intent must release the next same-network append");
+    }
+
+    /// An operator close is valid from any non-terminal state, including
+    /// TxIntended. It must release the network's signer reservation — a
+    /// close that left the row behind would permanently reject every later
+    /// mint and burn on that network with no self-healing path.
+    #[tokio::test]
+    async fn admin_close_releases_the_signer_reservation() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+
+        for (sequence, event_type, payload) in [
+            (1, "MintEvent::Initiated", r#"{"Initiated":{"network":"base"}}"#),
+            (2, "MintEvent::MintTxIntended", "{}"),
+        ] {
+            insert_raw_event(
+                &pool,
+                "Mint",
+                "mint-closed",
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("test history should insert");
+        }
+        assert!(
+            has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "the intent must reserve the network before the close"
+        );
+
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-closed",
+            3,
+            "MintEvent::MintClosed",
+            "{}",
+        )
+        .await
+        .expect("the admin close event should insert");
+
+        assert!(
+            !has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "an admin close must release the network's signer reservation"
+        );
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-after-close",
+            1,
+            "MintEvent::Initiated",
+            r#"{"Initiated":{"network":"base"}}"#,
+        )
+        .await
+        .expect("successor origin should insert");
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-after-close",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .expect("a closed mint must not block the next same-network intent");
+    }
+
+    /// The validation trigger's third branch: a network value outside the
+    /// known set must abort the intent append, not reserve an ambiguous
+    /// signer domain.
+    #[tokio::test]
+    async fn unknown_network_metadata_rejects_the_intent_append() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+
+        insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-unknown-network",
+            1,
+            "MintEvent::Initiated",
+            r#"{"Initiated":{"network":"solana"}}"#,
+        )
+        .await
+        .expect("unknown-network origin should seed for boundary testing");
+
+        let unknown_error = insert_raw_event(
+            &pool,
+            "Mint",
+            "mint-unknown-network",
+            2,
+            "MintEvent::MintTxIntended",
+            "{}",
+        )
+        .await
+        .expect_err(
+            "an unknown mint network must fail closed before intent commit",
+        )
+        .to_string();
+        assert!(
+            unknown_error.contains("has an unknown network"),
+            "the validation trigger must name the unknown-network branch, \
+             got: {unknown_error}"
+        );
+    }
 
     fn minting_events_for_retry(
         issuer_request_id: &IssuerMintRequestId,
@@ -2135,6 +2777,7 @@ pub(crate) mod tests {
             .given(events)
             .when(MintCommand::ManualRetryMint {
                 issuer_request_id: issuer_request_id.clone(),
+                manual_retry_id: Uuid::new_v4(),
             })
             .await
             .events();
@@ -2143,6 +2786,51 @@ pub(crate) mod tests {
             emitted.as_slice(),
             [MintEvent::MintRetryStarted { .. }]
         ));
+    }
+
+    /// A replayed legacy retry can carry a transaction hash while its enum
+    /// state is `Minting`; a later prepare-looking failure must retain and
+    /// reject that provenance instead of authorizing another mint transaction.
+    #[tokio::test]
+    async fn manual_retry_refuses_transaction_provenance_hidden_by_retry_state()
+    {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "first attempt failed".to_string(),
+            failed_at: Utc::now(),
+        });
+        events.push(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: Some(B256::random()),
+            manual_retry_id: None,
+            started_at: Utc::now(),
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "retry failed".to_string(),
+            failed_at: Utc::now(),
+        });
+
+        let error = TestHarness::<Mint>::with(())
+            .given(events)
+            .when(MintCommand::ManualRetryMint {
+                issuer_request_id: issuer_request_id.clone(),
+                manual_retry_id: Uuid::new_v4(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::AmbiguousRetryPredecessor { .. }
+                )
+            ),
+            "transaction-bearing retry provenance must block a fresh mint, got {error:?}"
+        );
     }
 
     /// A mint initiated before the job-based submit flow cannot prove its
@@ -2166,6 +2854,7 @@ pub(crate) mod tests {
             .given(events)
             .when(MintCommand::ManualRetryMint {
                 issuer_request_id: issuer_request_id.clone(),
+                manual_retry_id: Uuid::new_v4(),
             })
             .await
             .then_expect_error();
@@ -2443,6 +3132,7 @@ pub(crate) mod tests {
         mint.apply_event(MintEvent::MintRetryStarted {
             issuer_request_id: issuer_request_id.clone(),
             tx_hash: None,
+            manual_retry_id: None,
             started_at: now,
         });
 
@@ -2475,8 +3165,13 @@ pub(crate) mod tests {
             "the attempt counter must survive the retry transition"
         );
         assert!(
-            matches!(failed_from.as_ref(), Mint::TxSubmitted { .. }),
-            "the predecessor chain must survive a failed retry"
+            matches!(failed_from.as_ref(), Mint::Minting { .. })
+                && matches!(
+                    failed_from.non_failed_predecessor(),
+                    Mint::TxSubmitted { .. }
+                ),
+            "the retry wrapper and its predecessor chain must both survive a \
+             failed retry"
         );
     }
 
@@ -2494,6 +3189,7 @@ pub(crate) mod tests {
         mint.apply_event(MintEvent::MintRetryStarted {
             issuer_request_id: issuer_request_id.clone(),
             tx_hash: None,
+            manual_retry_id: None,
             started_at: now,
         });
         mint.apply_event(MintEvent::MintTxIntended {
@@ -3511,7 +4207,7 @@ pub(crate) mod tests {
     /// calls `load_with_context`, which deserializes into `Lifecycle<Mint>`.
     #[traced_test]
     #[tokio::test]
-    async fn pre_lifecycle_snapshot_cleared_before_projection_catch_up() {
+    async fn mint_pre_lifecycle_snapshot_cleared_before_projection_catch_up() {
         let pool = SqlitePoolOptions::new()
             .max_connections(1)
             .connect(":memory:")

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -228,6 +228,20 @@ pub(crate) async fn enqueue_scheduled_mint_recovery(
     push_mint_recovery_job(apalis_pool, issuer_request_id).await
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ManualRetryOutcome {
+    Enqueued,
+    /// Another caller already moved the aggregate out of `MintingFailed`; this
+    /// command emitted no event, so this caller must not mutate queue state.
+    AlreadyHandled,
+    /// The domain transition committed, but immediate queue dispatch failed.
+    /// The periodic mint reconciler will discover the recoverable `Minting`
+    /// state and retry dispatch without another operator command.
+    DeferredToRecovery {
+        error: String,
+    },
+}
+
 /// Drives one operator-authorized retry of a `MintingFailed` mint, bypassing
 /// the capped scheduled-recovery loop entirely.
 ///
@@ -248,7 +262,7 @@ pub(crate) async fn manually_retry_failed_mint(
     apalis_pool: &SqlitePool,
     issuer_request_id: &IssuerMintRequestId,
     mint: &Mint,
-) -> Result<(), anyhow::Error> {
+) -> Result<ManualRetryOutcome, anyhow::Error> {
     let Mint::MintingFailed { underlying, network, .. } = mint else {
         anyhow::bail!(
             "manual retry requires a MintingFailed mint; current state is {}",
@@ -263,38 +277,88 @@ pub(crate) async fn manually_retry_failed_mint(
         })?;
     let chain_id = vault_services.chain_id(network)?;
 
+    let manual_retry_id = Uuid::new_v4();
     mint_store
         .send(
             issuer_request_id,
             MintCommand::ManualRetryMint {
                 issuer_request_id: issuer_request_id.clone(),
+                manual_retry_id,
             },
         )
         .await?;
+
+    let retry_committed = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM events
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+              AND event_type = 'MintEvent::MintRetryStarted'
+              AND json_extract(
+                  payload,
+                  '$.MintRetryStarted.manual_retry_id'
+              ) = ?
+        )
+        ",
+    )
+    .bind(issuer_request_id.to_string())
+    .bind(manual_retry_id.to_string())
+    .fetch_one(pool)
+    .await?;
+    if !retry_committed {
+        info!(target: "mint", issuer_request_id = %issuer_request_id,
+            %manual_retry_id,
+            "Manual retry was already handled; leaving queue state unchanged"
+        );
+        return Ok(ManualRetryOutcome::AlreadyHandled);
+    }
 
     info!(target: "mint", issuer_request_id = %issuer_request_id,
         %underlying, %network,
         "Manually retrying failed mint past the automatic budget"
     );
 
-    release_terminal_job(
-        pool,
-        job_type::<SubmitMintJob>(),
-        &issuer_request_id.to_string(),
-    )
-    .await?;
-    JobQueue::<SubmitMintJob>::new(apalis_pool)
-        .push_with_idempotency_key(
-            SubmitMintJob {
-                issuer_request_id: issuer_request_id.clone(),
-                vault: address,
-                chain_id,
-            },
-            issuer_request_id.to_string(),
+    let dispatch = async {
+        release_terminal_job(
+            pool,
+            job_type::<SubmitMintJob>(),
+            &issuer_request_id.to_string(),
         )
         .await?;
+        JobQueue::<SubmitMintJob>::new(apalis_pool)
+            .push_with_idempotency_key(
+                SubmitMintJob {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault: address,
+                    chain_id,
+                },
+                issuer_request_id.to_string(),
+            )
+            .await?;
 
-    Ok(())
+        Ok::<(), anyhow::Error>(())
+    }
+    .await;
+
+    match dispatch {
+        Ok(()) => Ok(ManualRetryOutcome::Enqueued),
+        Err(error) => {
+            // ManualRetryMint has already committed. Reporting a hard failure
+            // would invite the operator to repeat a command whose effect was
+            // accepted. Surface partial success instead; the periodic
+            // reconciler re-drives every recoverable Minting state and its
+            // enqueue path releases terminal submit-job keys before pushing.
+            warn!(target: "mint", issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Manual retry committed; deferring queue dispatch to reconciler"
+            );
+            Ok(ManualRetryOutcome::DeferredToRecovery {
+                error: error.to_string(),
+            })
+        }
+    }
 }
 
 /// Pushes a [`MintRecoveryJob`] for the mint, retrying transient enqueue
@@ -2081,7 +2145,7 @@ mod tests {
 
         let mint =
             harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
-        manually_retry_failed_mint(
+        let outcome = manually_retry_failed_mint(
             &harness.mint_store,
             &harness.pool,
             &network_vault_services(harness.vault.clone()),
@@ -2092,6 +2156,7 @@ mod tests {
         .await
         .unwrap();
 
+        assert_eq!(outcome, ManualRetryOutcome::Enqueued);
         let retried =
             harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
         assert_eq!(retried.state_name(), "Minting");
@@ -2126,6 +2191,194 @@ mod tests {
                 ]
             ),
             1
+        );
+    }
+
+    /// Once `ManualRetryMint` commits, an immediate queue failure is partial
+    /// success rather than a failed operator command: the durable state is now
+    /// recoverable and the periodic reconciler owns retrying its dispatch.
+    #[traced_test]
+    #[tokio::test]
+    async fn manual_retry_reports_deferred_dispatch_after_the_transition_commits()
+     {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = test_issuer_request_id();
+        seed_recoverable_mint(&harness, &issuer_request_id).await;
+
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Deposit {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: "prepare failed".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+
+        sqlx::query("DROP TABLE Jobs").execute(&harness.pool).await.unwrap();
+
+        let outcome = manually_retry_failed_mint(
+            &harness.mint_store,
+            &harness.pool,
+            &network_vault_services(harness.vault.clone()),
+            &harness.apalis_pool,
+            &issuer_request_id,
+            &mint,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(
+                outcome,
+                ManualRetryOutcome::DeferredToRecovery { ref error }
+                    if error.contains("Jobs")
+            ),
+            "the committed retry must expose deferred dispatch, got {outcome:?}"
+        );
+        assert_eq!(
+            harness
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .state_name(),
+            "Minting",
+            "the operator command committed before queue dispatch failed"
+        );
+
+        let test = "manual_retry_reports_deferred_dispatch_after_the_transition_commits";
+        assert!(
+            log_count_at!(
+                Level::WARN,
+                &[
+                    test,
+                    "Manual retry committed; deferring queue dispatch to \
+                     reconciler"
+                ]
+            ) >= 1,
+            "a committed retry whose dispatch fails must log the deferral \
+             for operators"
+        );
+    }
+
+    /// A stale endpoint snapshot must not release and recreate queue state when
+    /// another request already committed the manual retry transition.
+    #[traced_test]
+    #[tokio::test]
+    async fn stale_manual_retry_does_not_resurrect_a_terminal_submit_job() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = test_issuer_request_id();
+        seed_recoverable_mint(&harness, &issuer_request_id).await;
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::Deposit {
+                    issuer_request_id: issuer_request_id.clone(),
+                },
+            )
+            .await
+            .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::RecordMintFailed {
+                    issuer_request_id: issuer_request_id.clone(),
+                    error: "prepare failed".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        let stale =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+
+        JobQueue::<SubmitMintJob>::new(&harness.apalis_pool)
+            .push_with_idempotency_key(
+                SubmitMintJob {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault: VAULT,
+                    chain_id: Network::Base.chain_id(),
+                },
+                issuer_request_id.to_string(),
+            )
+            .await
+            .unwrap();
+        sqlx::query(
+            "UPDATE Jobs SET status = 'Done' WHERE job_type = ? \
+             AND idempotency_key = ?",
+        )
+        .bind(job_type::<SubmitMintJob>())
+        .bind(issuer_request_id.to_string())
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+        harness
+            .mint_store
+            .send(
+                &issuer_request_id,
+                MintCommand::ManualRetryMint {
+                    issuer_request_id: issuer_request_id.clone(),
+                    manual_retry_id: Uuid::new_v4(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let outcome = manually_retry_failed_mint(
+            &harness.mint_store,
+            &harness.pool,
+            &network_vault_services(harness.vault.clone()),
+            &harness.apalis_pool,
+            &issuer_request_id,
+            &stale,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(outcome, ManualRetryOutcome::AlreadyHandled);
+        let status: String = sqlx::query_scalar(
+            "SELECT status FROM Jobs WHERE job_type = ? AND idempotency_key = ?",
+        )
+        .bind(job_type::<SubmitMintJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            status, "Done",
+            "a no-op retry command must not resurrect terminal queue state"
+        );
+
+        let test =
+            "stale_manual_retry_does_not_resurrect_a_terminal_submit_job";
+        assert!(
+            log_count_at!(
+                Level::INFO,
+                &[
+                    test,
+                    "Manual retry was already handled; leaving queue state \
+                     unchanged"
+                ]
+            ) >= 1,
+            "a stale retry that lost the commit race must log the no-op \
+             outcome for operators"
         );
     }
 

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -30,6 +30,7 @@ use async_trait::async_trait;
 use event_sorcery::StoreBuilder;
 use itertools::izip;
 use sqlx::{Pool, Sqlite};
+use std::fmt;
 use std::num::NonZeroUsize;
 use std::time::Duration;
 use tracing::{debug, info};
@@ -411,6 +412,27 @@ pub(crate) enum ReceiptCustodyError {
     )]
     PermitHolderMismatch { permitted: Address, holdings: Address },
 
+    #[error(
+        "wallet {holder} has pending transactions (latest nonce {latest_nonce}, \
+         pending nonce {pending_nonce}); refusing a custody transfer until \
+         they settle or drop"
+    )]
+    PendingWalletTransactions {
+        holder: Address,
+        latest_nonce: LatestNonce,
+        pending_nonce: PendingNonce,
+    },
+
+    #[error(
+        "wallet {holder} returned pending nonce {pending_nonce} below latest \
+         nonce {latest_nonce}"
+    )]
+    InvalidNonceOrder {
+        holder: Address,
+        latest_nonce: LatestNonce,
+        pending_nonce: PendingNonce,
+    },
+
     #[error("custody transfer {tx_hash} reverted on vault {vault}")]
     Reverted { vault: Address, tx_hash: B256 },
 
@@ -444,6 +466,30 @@ pub(crate) enum ReceiptCustodyError {
          completed chunks resume"
     )]
     OwnerFroze { vault: Address, until: U256 },
+}
+
+/// A wallet's nonce per `eth_getTransactionCount(holder, "latest")` — the
+/// highest mined nonce. Kept distinct from [`PendingNonce`] so the two nonce
+/// views can't be swapped at a call site without a type error.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct LatestNonce(u64);
+
+impl fmt::Display for LatestNonce {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
+}
+
+/// A wallet's nonce per `eth_getTransactionCount(holder, "pending")` — mined
+/// plus mempool-visible. Kept distinct from [`LatestNonce`] so the two nonce
+/// views can't be swapped at a call site without a type error.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct PendingNonce(u64);
+
+impl fmt::Display for PendingNonce {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, formatter)
+    }
 }
 
 /// A recipient balance that fell over a transfer that should only have raised
@@ -1273,7 +1319,11 @@ pub(crate) async fn reconcile_holdings(
         migrated += 1;
     }
 
-    if unmoved.is_empty() && !tracked.is_empty() {
+    // Only positive tracked balances corroborated at the recipient prove a
+    // completed migration. An inventory containing only zero balances has
+    // nothing to move, but it is not evidence that any custody transfer ever
+    // happened and must not record a false migration history entry.
+    if unmoved.is_empty() && migrated > 0 {
         return Ok(SourceCustody::AlreadyMigrated { receipts: migrated });
     }
 
@@ -1313,6 +1363,9 @@ pub(crate) async fn migrate_vault_custody(
     recipient: Address,
 ) -> Result<MigrationOutcome, MigrationRefusal> {
     let vault = holdings.vault();
+    if holdings.holdings().is_empty() {
+        return Err(ReceiptCustodyError::NothingToTransfer { vault }.into());
+    }
 
     let permit = match custody
         .transfer_permission(vault, holdings.holder(), recipient)
@@ -1457,6 +1510,57 @@ async fn verify_custody_moved(
             expected,
         })
         .into());
+    }
+
+    Ok(())
+}
+
+/// Reads both nonce views for `holder` and rejects a non-quiescent wallet —
+/// the single entry point for the read+check pair, so every submission path
+/// (custody transfers, chunked Fireblocks calls, the legacy-receipt sweeps)
+/// applies the identical guard.
+///
+/// Relies on `eth_getTransactionCount(holder, "pending")` reflecting the
+/// node's actual mempool contents for `holder` — i.e. that it is >= the
+/// `"latest"` count, with equality meaning no in-flight transaction. This has
+/// not been confirmed against Base's, Ethereum's, or HyperEVM's RPC providers
+/// specifically. If a provider instead aliases `"pending"` to `"latest"` (or
+/// otherwise ignores mempool contents), the two views always agree and this
+/// guard silently never blocks, even with a genuinely in-flight transaction
+/// from `holder` — allowing the double-submission this guard exists to
+/// prevent.
+pub(crate) async fn ensure_holder_quiescent<HolderProvider: Provider>(
+    provider: &HolderProvider,
+    holder: Address,
+) -> Result<(), ReceiptCustodyError> {
+    let (latest_count, pending_count) = tokio::try_join!(
+        provider.get_transaction_count(holder).latest(),
+        provider.get_transaction_count(holder).pending(),
+    )?;
+    let latest_nonce = LatestNonce(latest_count);
+    let pending_nonce = PendingNonce(pending_count);
+    ensure_wallet_nonce_quiescent(holder, latest_nonce, pending_nonce)
+}
+
+/// Rejects a wallet whose `pending` and `latest` nonce views disagree.
+const fn ensure_wallet_nonce_quiescent(
+    holder: Address,
+    latest_nonce: LatestNonce,
+    pending_nonce: PendingNonce,
+) -> Result<(), ReceiptCustodyError> {
+    if pending_nonce.0 < latest_nonce.0 {
+        return Err(ReceiptCustodyError::InvalidNonceOrder {
+            holder,
+            latest_nonce,
+            pending_nonce,
+        });
+    }
+    if pending_nonce.0 > latest_nonce.0 {
+        return Err(ReceiptCustodyError::PendingWalletTransactions {
+            holder,
+            latest_nonce,
+            pending_nonce,
+        });
     }
 
     Ok(())
@@ -1624,6 +1728,14 @@ impl<P: Provider + Clone + Send + Sync> ReceiptCustody
     ) -> Result<B256, ReceiptCustodyError> {
         self.check_vault(permit.vault())?;
         ensure_permit_covers(permit, holdings)?;
+
+        // A previous rollback may have been broadcast just before this CLI
+        // crashed. While its transaction remains pending, re-submitting would
+        // create a second attempt without knowing the first one's outcome.
+        // Once it drops, both nonce views converge and retrying the identical
+        // transfer is safe; once it mines, the next reconciliation observes
+        // moved custody and never reaches this submission path.
+        ensure_holder_quiescent(&self.provider, permit.from()).await?;
 
         let receipt = Receipt::new(self.receipt_contract, &self.provider);
         let (ids, amounts) = holdings.batch_arguments();
@@ -1796,6 +1908,15 @@ impl<P: Provider + Clone + Send + Sync> ReceiptCustody
             izip!(ids.chunks(chunk_size), amounts.chunks(chunk_size))
                 .enumerate()
         {
+            // The retiring Fireblocks wallet may be used outside this process.
+            // Re-read both nonce views immediately before EVERY chunk: an
+            // interleaved pending transaction means this migration no longer
+            // owns a quiescent nonce domain and must stop before asking
+            // Fireblocks for another CONTRACT_CALL. Exact retries remain
+            // resumable through the deterministic externalTxId below.
+            ensure_holder_quiescent(&self.onchain.provider, permit.from())
+                .await?;
+
             // Certification is maintained outside this service and can lapse
             // while earlier chunks confirm; re-read before every chunk so a
             // transfer the vault would refuse is never submitted on stale
@@ -2282,6 +2403,25 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn zero_only_inventory_is_not_reported_as_already_migrated() {
+        let custody =
+            FakeCustody::with_balances(&[(OUTGOING, 1, 0), (INCOMING, 1, 0)]);
+        let tracked = [FakeCustody::holding(1, 0)];
+
+        let source = reconcile(&custody, &tracked).await.unwrap();
+        let SourceCustody::Holds(holdings) = source else {
+            panic!(
+                "zero balances cannot prove a completed migration, got {source:?}"
+            );
+        };
+
+        assert!(
+            holdings.holdings().is_empty(),
+            "zero balances must not enter a transfer batch"
+        );
+    }
+
     /// A failure between transfer chunks leaves some identifiers already with
     /// the recipient and the rest still with the holder. A rerun must resume
     /// the remainder rather than refuse the moved identifiers as divergence.
@@ -2594,6 +2734,44 @@ mod tests {
             "the refusal must name the recipient balance it actually read, \
              got {refusal:?}"
         );
+    }
+
+    #[test]
+    fn a_pending_wallet_transaction_blocks_a_second_custody_submission() {
+        let error = ensure_wallet_nonce_quiescent(
+            OUTGOING,
+            LatestNonce(7),
+            PendingNonce(8),
+        )
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            ReceiptCustodyError::PendingWalletTransactions {
+                holder: OUTGOING,
+                latest_nonce: LatestNonce(7),
+                pending_nonce: PendingNonce(8),
+            }
+        ));
+        ensure_wallet_nonce_quiescent(
+            OUTGOING,
+            LatestNonce(8),
+            PendingNonce(8),
+        )
+        .unwrap();
+        assert!(matches!(
+            ensure_wallet_nonce_quiescent(
+                OUTGOING,
+                LatestNonce(9),
+                PendingNonce(8)
+            )
+            .unwrap_err(),
+            ReceiptCustodyError::InvalidNonceOrder {
+                holder: OUTGOING,
+                latest_nonce: LatestNonce(9),
+                pending_nonce: PendingNonce(8),
+            }
+        ));
     }
 
     #[tokio::test]
@@ -3392,7 +3570,9 @@ mod tests {
                 &provider,
             );
             let shares = U256::from(10) * U256::from(10).pow(U256::from(18));
-            let receipt_ids = deposit_receipts(&vault, holder, shares, 3).await;
+            let mut receipt_ids =
+                deposit_receipts(&vault, holder, shares, 3).await;
+            receipt_ids.sort_unstable();
             let receipt_contract =
                 Address::from(vault.receipt().call().await.unwrap().0);
 
@@ -3402,8 +3582,12 @@ mod tests {
             )
             .await
             .unwrap();
+            // Deliberately oppose canonical receipt-id order: the chunks and
+            // their deterministic externalTxIds must follow reconciliation's
+            // sort, not the inventory fixture's iteration order.
             let tracked: Vec<ReceiptHolding> = receipt_ids
                 .iter()
+                .rev()
                 .map(|receipt_id| ReceiptHolding {
                     receipt_id: ReceiptId::from(*receipt_id),
                     balance: Shares::from(shares),
@@ -3538,8 +3722,8 @@ mod tests {
                 returned, second_chunk,
                 "the reported hash must be the last landed chunk"
             );
-            first_create.assert();
-            second_create.assert();
+            first_create.assert_calls(1);
+            second_create.assert_calls(1);
             assert!(logs_contain_at!(
                 tracing::Level::INFO,
                 &["submitting custody transfer to Fireblocks", "chunks=2"]
@@ -3575,7 +3759,9 @@ mod tests {
                 &provider,
             );
             let shares = U256::from(10) * U256::from(10).pow(U256::from(18));
-            let receipt_ids = deposit_receipts(&vault, holder, shares, 3).await;
+            let mut receipt_ids =
+                deposit_receipts(&vault, holder, shares, 3).await;
+            receipt_ids.sort_unstable();
             let receipt_contract =
                 Address::from(vault.receipt().call().await.unwrap().0);
 
@@ -3587,6 +3773,7 @@ mod tests {
             .unwrap();
             let tracked: Vec<ReceiptHolding> = receipt_ids
                 .iter()
+                .rev()
                 .map(|receipt_id| ReceiptHolding {
                     receipt_id: ReceiptId::from(*receipt_id),
                     balance: Shares::from(shares),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -15,13 +15,13 @@ use super::{
     Redemption, RedemptionCommand, RedemptionError, RedemptionEvent,
     next_burn_retry_external_tx_id_from_history,
 };
-use crate::mint::{QuantityConversionError, has_unresolved_mint_intent};
+use crate::mint::QuantityConversionError;
 use crate::receipt_inventory::{
     BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
     Shares,
 };
 use crate::redemption::{
-    BurnRecord, RedemptionMetadata, has_unresolved_burn_intent,
+    BurnRecord, RedemptionMetadata, has_unresolved_signer_intent,
 };
 use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
 use crate::tokenized_asset::{Network, UnderlyingSymbol};
@@ -952,14 +952,16 @@ impl BurnManager {
             network: metadata.network,
         })?;
         if status == BurnTxStatus::ProvablyDead {
-            let unresolved_mint =
-                has_unresolved_mint_intent(&self.view_pool, None).await?;
-            let unresolved_burn = has_unresolved_burn_intent(
+            // Network-keyed reservation: one check covers competing burn AND
+            // mint intents on this signer's nonce domain, excluding only this
+            // redemption's own reservation.
+            let unresolved_intent = has_unresolved_signer_intent(
                 &self.view_pool,
+                metadata.network,
                 Some(issuer_request_id),
             )
             .await?;
-            if unresolved_mint || unresolved_burn {
+            if unresolved_intent {
                 drop(wallet_guard);
                 debug!(target: "redemption",
                     issuer_request_id = %issuer_request_id,
@@ -1622,20 +1624,36 @@ impl BurnManager {
     ) -> Result<(), BurnManagerError> {
         let execution =
             BurnExecutionPlan::new(network, vault, &plan, external_tx_id);
+        // Bounded to the 30 seconds SPEC promises: a live burn defers to
+        // recovery rather than occupying the flow indefinitely behind an
+        // intent that is not resolving.
+        const MAX_WALLET_INTENT_WAIT_ATTEMPTS: u32 = 30;
+        let mut wait_attempts = 0;
         let wallet_guard = loop {
             let wallet_guard = self.vault_for(network)?.lock_wallet().await;
-            let unresolved_mint =
-                has_unresolved_mint_intent(&self.view_pool, None).await?;
-            let unresolved_burn = has_unresolved_burn_intent(
+            let unresolved_intent = has_unresolved_signer_intent(
                 &self.view_pool,
+                network,
                 Some(issuer_request_id),
             )
             .await?;
-            if !unresolved_mint && !unresolved_burn {
+            if !unresolved_intent {
                 break wallet_guard;
             }
 
             drop(wallet_guard);
+            wait_attempts += 1;
+            if wait_attempts >= MAX_WALLET_INTENT_WAIT_ATTEMPTS {
+                warn!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    attempts = wait_attempts,
+                    "Earlier wallet intent did not resolve within the wait \
+                     budget; deferring this burn to recovery"
+                );
+                return Err(BurnManagerError::WalletIntentWaitExhausted {
+                    issuer_request_id: issuer_request_id.clone(),
+                });
+            }
             debug!(target: "redemption",
                 issuer_request_id = %issuer_request_id,
                 "Waiting for an earlier wallet intent before preparing burn"
@@ -1771,7 +1789,41 @@ impl BurnManager {
                     RedemptionError::PreparingBurnTxFailed { message },
                 ))
             }
-            Err(error) => Err(error.into()),
+            Err(error) => {
+                // The append failed before anything reached the chain (the
+                // event store rolls the write back atomically, including a
+                // signer-intent trigger rejection), so the receipt
+                // reservation must not outlive the attempt — a stranded
+                // reservation blocks every later burn on the vault.
+                warn!(target: "redemption",
+                    issuer_request_id = %issuer_request_id,
+                    network = %execution.network,
+                    error = %error,
+                    "Burn intent append failed; releasing the receipt \
+                     reservation before propagating"
+                );
+                match self.chain_id_for(execution.network) {
+                    Ok(chain_id) => {
+                        self.release_reserved_burn(
+                            chain_id,
+                            execution.vault,
+                            issuer_request_id,
+                        )
+                        .await;
+                    }
+                    Err(chain_id_error) => {
+                        warn!(target: "redemption",
+                            issuer_request_id = %issuer_request_id,
+                            network = %execution.network,
+                            append_error = %error,
+                            chain_id_error = %chain_id_error,
+                            "Burn intent append failed and the receipt \
+                             reservation could not be released"
+                        );
+                    }
+                }
+                Err(error.into())
+            }
         }
     }
 
@@ -2220,6 +2272,11 @@ pub(crate) enum BurnManagerError {
     ReceiptRegistration(#[from] ReceiptRegistrationError),
     #[error("Burn recovery attempt counter overflowed for {issuer_request_id}")]
     RecoveryAttemptOverflow { issuer_request_id: IssuerRedemptionRequestId },
+    #[error(
+        "earlier wallet intent did not resolve within the wait budget for \
+         {issuer_request_id}; deferred to recovery"
+    )]
+    WalletIntentWaitExhausted { issuer_request_id: IssuerRedemptionRequestId },
 }
 
 #[cfg(test)]
@@ -2270,6 +2327,39 @@ mod tests {
 
     fn transaction_failed() -> VaultError {
         VaultError::Reverted { tx_hash: B256::random() }
+    }
+
+    async fn insert_raw_event(
+        pool: &SqlitePool,
+        aggregate_type: &str,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (?, ?, ?, ?, '1.0', ?, '{}')
+            ",
+        )
+        .bind(aggregate_type)
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await?;
+
+        Ok(())
     }
 
     #[test]
@@ -5251,31 +5341,41 @@ mod tests {
             .await
             .expect("burn intent should persist");
 
-        sqlx::query(
+        // The durable uniqueness guard prevents this overlap now. Remove the
+        // derived row for the current burn to model a historical pre-guard
+        // database and retain coverage for the query-level defence in depth.
+        let removed = sqlx::query(
             "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES (
-                'Mint',
-                'blocking-mint',
-                1,
-                'MintEvent::MintTxIntended',
-                '1.0',
-                '{}',
-                '{}'
-            )
+            DELETE FROM active_signer_intents
+            WHERE aggregate_type = 'Redemption' AND aggregate_id = ?
             ",
         )
+        .bind(issuer_request_id.to_string())
         .execute(pool)
         .await
-        .expect("blocking mint intent should seed");
+        .expect("test should remove the derived guard row");
+        assert_eq!(
+            removed.rows_affected(),
+            1,
+            "the reserve trigger must have created exactly the guard row this \
+             test removes; a zero-row delete would silently stop modeling the \
+             pre-guard database"
+        );
+        for (sequence, event_type, payload) in [
+            (1, "MintEvent::Initiated", r#"{"Initiated":{"network":"base"}}"#),
+            (2, "MintEvent::MintTxIntended", "{}"),
+        ] {
+            insert_raw_event(
+                pool,
+                "Mint",
+                "blocking-mint",
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("blocking mint intent should seed");
+        }
 
         let manager = BurnManager::new_for_tests(
             vault_mock.clone(),
@@ -5316,57 +5416,36 @@ mod tests {
             ]
         ));
 
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES (
-                'Mint',
-                'blocking-mint',
-                2,
-                'MintEvent::MintTxSubmitted',
-                '1.0',
-                '{}',
-                '{}'
-            )
-            ",
+        insert_raw_event(
+            pool,
+            "Mint",
+            "blocking-mint",
+            3,
+            "MintEvent::MintTxSubmitted",
+            "{}",
         )
-        .execute(pool)
         .await
         .expect("blocking mint intent should resolve");
 
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
+        for (sequence, event_type, payload) in [
+            (
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+        ] {
+            insert_raw_event(
+                pool,
+                "Redemption",
+                "blocking-redemption",
                 sequence,
                 event_type,
-                event_version,
                 payload,
-                metadata
             )
-            VALUES (
-                'Redemption',
-                'blocking-redemption',
-                1,
-                'RedemptionEvent::BurnIntended',
-                '1.0',
-                '{}',
-                '{}'
-            )
-            ",
-        )
-        .execute(pool)
-        .await
-        .expect("blocking burn intent should seed");
+            .await
+            .expect("blocking burn intent should seed");
+        }
         assert!(matches!(
             manager.recover_single_burning(&issuer_request_id).await,
             Ok(RecoveryOutcome::SkippedManualIntervention)
@@ -5374,29 +5453,14 @@ mod tests {
         assert_eq!(vault_mock.replacement_preparation_call_count(), 0);
         assert!(vault_mock.submitted_burn_txs().is_empty());
 
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES (
-                'Redemption',
-                'blocking-redemption',
-                2,
-                'RedemptionEvent::BurnTxSubmitted',
-                '1.0',
-                '{}',
-                '{}'
-            )
-            ",
+        insert_raw_event(
+            pool,
+            "Redemption",
+            "blocking-redemption",
+            3,
+            "RedemptionEvent::BurnTxSubmitted",
+            "{}",
         )
-        .execute(pool)
         .await
         .expect("blocking burn intent should resolve");
         vault_mock.set_prepared_tx(replacement_tx.clone());

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -27,35 +27,38 @@ use crate::redemption::burn_manager::{
     extract_tx_hash, is_pending_burn_confirmation, should_release_reserved_burn,
 };
 
-pub(crate) async fn has_unresolved_burn_intent(
+/// Returns whether any signed transaction on the same signer network — a
+/// burn or a mint — is still awaiting its terminal outcome, excluding at
+/// most this redemption's own reservation.
+///
+/// Reads the trigger-maintained `active_signer_intents` table rather than
+/// re-deriving the answer from event streams: the triggers update the table
+/// in the same transaction that appends the intent event, so the table is
+/// the single source of truth and cannot drift from the reserve/release
+/// rules the migration encodes. Because the table is keyed by network, an
+/// outstanding Mint intent blocks a burn on the same nonce domain too —
+/// both flows sign with the same key.
+pub(crate) async fn has_unresolved_signer_intent(
     pool: &Pool<Sqlite>,
+    network: Network,
     excluding: Option<&IssuerRedemptionRequestId>,
 ) -> Result<bool, sqlx::Error> {
+    // `None` collapses to "" rather than a NULL bind: `aggregate_id = NULL`
+    // is NULL in SQL, `NOT NULL` is NULL, and a NULL predicate silently
+    // excludes EVERY row — the empty string matches no aggregate_id, which
+    // is the intended "exclude nothing".
     let excluding = excluding.map(ToString::to_string).unwrap_or_default();
     let exists = sqlx::query_scalar::<_, bool>(
         "
         SELECT EXISTS (
             SELECT 1
-            FROM events AS intent
-            WHERE intent.aggregate_type = 'Redemption'
-              AND intent.event_type = 'RedemptionEvent::BurnIntended'
-              AND intent.aggregate_id != ?
-              AND NOT EXISTS (
-                  SELECT 1
-                  FROM events AS later
-                  WHERE later.aggregate_type = intent.aggregate_type
-                    AND later.aggregate_id = intent.aggregate_id
-                    AND later.sequence > intent.sequence
-                    AND later.event_type NOT IN (
-                        'RedemptionEvent::BurnRecoveryAttempted',
-                        'RedemptionEvent::BurnPreparationRecoveryAttempted',
-                        'RedemptionEvent::BurnRecoveryExhausted',
-                        'RedemptionEvent::BurnPreparationRecoveryExhausted'
-                    )
-              )
+            FROM active_signer_intents
+            WHERE network = ?
+              AND NOT (aggregate_type = 'Redemption' AND aggregate_id = ?)
         )
         ",
     )
+    .bind(network.as_str())
     .bind(excluding)
     .fetch_one(pool)
     .await?;
@@ -2199,7 +2202,7 @@ mod tests {
         BurnExternalTxId, BurnRecord, BurnRecoveryAction,
         IssuerRedemptionRequestId, Redemption, RedemptionCommand,
         RedemptionError, RedemptionEvent, RedemptionMetadata,
-        RedemptionServices, TokensBurnedData, has_unresolved_burn_intent,
+        RedemptionServices, TokensBurnedData, has_unresolved_signer_intent,
         next_burn_retry_external_tx_id_from_history,
     };
     use crate::mint::{Quantity, TokenizationRequestId};
@@ -2231,10 +2234,15 @@ mod tests {
             .expect("migrations should run");
         let aggregate_id = IssuerRedemptionRequestId::random().to_string();
 
-        for (sequence, event_type) in [
-            (1, "RedemptionEvent::BurnIntended"),
-            (2, "RedemptionEvent::BurnRecoveryAttempted"),
-            (3, "RedemptionEvent::BurnRecoveryExhausted"),
+        for (sequence, event_type, payload) in [
+            (
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+            (3, "RedemptionEvent::BurnRecoveryAttempted", "{}"),
+            (4, "RedemptionEvent::BurnRecoveryExhausted", "{}"),
         ] {
             sqlx::query(
                 "
@@ -2247,22 +2255,338 @@ mod tests {
                     payload,
                     metadata
                 )
-                VALUES ('Redemption', ?, ?, ?, '1.0', '{}', '{}')
+                VALUES ('Redemption', ?, ?, ?, '1.0', ?, '{}')
                 ",
             )
             .bind(&aggregate_id)
             .bind(sequence)
             .bind(event_type)
+            .bind(payload)
             .execute(&pool)
             .await
             .expect("test event should insert");
         }
 
         assert!(
-            has_unresolved_burn_intent(&pool, None)
+            has_unresolved_signer_intent(&pool, Network::Base, None)
                 .await
                 .expect("intent query should succeed"),
-            "recovery bookkeeping must not permit another wallet transaction"
+            "recovery bookkeeping must keep the same network's gate closed"
+        );
+        assert!(
+            !has_unresolved_signer_intent(&pool, Network::Ethereum, None)
+                .await
+                .expect("intent query should succeed"),
+            "an intent on Base must not block an independent Ethereum signer"
+        );
+
+        let orphaned = sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                'orphaned-intent',
+                1,
+                'RedemptionEvent::BurnIntended',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .execute(&pool)
+        .await;
+
+        let orphaned_error = orphaned
+            .expect_err(
+                "an intent with no origin metadata must be rejected atomically",
+            )
+            .to_string();
+        assert!(
+            orphaned_error.contains("requires one Detected event"),
+            "the validation trigger must name the missing origin, got: \
+             {orphaned_error}"
+        );
+    }
+
+    async fn insert_redemption_event(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        aggregate_id: &str,
+        sequence: i64,
+        event_type: &str,
+        payload: &str,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Redemption', ?, ?, ?, '1.0', ?, '{}')
+            ",
+        )
+        .bind(aggregate_id)
+        .bind(sequence)
+        .bind(event_type)
+        .bind(payload)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+
+    /// A failed burn submission may still have broadcast the signed
+    /// transaction, so BurningFailed must keep the network's reservation —
+    /// mirroring the mint side, where MintingFailed never releases. The same
+    /// holds for RedemptionFailed, Reprocessed (operator requeue without a
+    /// terminal on-chain outcome), the post-reprocess Alpaca* events that
+    /// follow once the aggregate returns to Detected, and BurnResumed, which
+    /// re-enters Burning before the replacement intent re-reserves. Only a
+    /// real terminal outcome (TokensBurned or RedemptionClosed) frees the
+    /// nonce domain.
+    #[tokio::test]
+    async fn failed_and_resumed_burns_keep_the_signer_reservation() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+        let aggregate_id = IssuerRedemptionRequestId::random().to_string();
+
+        for (sequence, event_type, payload) in [
+            (
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+            // The ambiguous recover_single_burn_failed path emits
+            // BurningFailed then RedemptionFailed; neither may release.
+            (3, "RedemptionEvent::BurningFailed", "{}"),
+            (4, "RedemptionEvent::RedemptionFailed", "{}"),
+            // Reprocessed requeues without a terminal on-chain outcome;
+            // apply_reprocessed returns the aggregate to Detected, so the
+            // next event is AlpacaCalled (or sibling Alpaca*).
+            (5, "RedemptionEvent::Reprocessed", "{}"),
+            (6, "RedemptionEvent::AlpacaCalled", "{}"),
+            (7, "RedemptionEvent::BurnResumed", "{}"),
+        ] {
+            insert_redemption_event(
+                &pool,
+                &aggregate_id,
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("test event should insert");
+        }
+
+        assert!(
+            has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "a failed/reprocessed/AlpacaCalled/resumed burn may have \
+             broadcast its tx and must keep the gate closed"
+        );
+
+        insert_redemption_event(
+            &pool,
+            &aggregate_id,
+            8,
+            "RedemptionEvent::RedemptionClosed",
+            "{}",
+        )
+        .await
+        .expect("the close event should insert");
+
+        assert!(
+            !has_unresolved_signer_intent(&pool, Network::Base, None)
+                .await
+                .expect("intent query should succeed"),
+            "closing the redemption must release the signer reservation"
+        );
+    }
+
+    /// The burn reserve trigger must reject a competing same-network intent
+    /// with the explicit reservation message — mirroring the mint-side
+    /// regression test, so a burn-trigger-only regression back to the
+    /// implicit PK violation (misreported upstream as a same-aggregate
+    /// conflict) cannot slip through.
+    #[tokio::test]
+    async fn competing_burn_intent_raises_the_explicit_reservation_error() {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::migrate!("./migrations")
+            .run(&pool)
+            .await
+            .expect("migrations should run");
+
+        for (aggregate_id, sequence, event_type, payload) in [
+            (
+                "burn-first",
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            ("burn-first", 2, "RedemptionEvent::BurnIntended", "{}"),
+            (
+                "burn-second",
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+        ] {
+            insert_redemption_event(
+                &pool,
+                aggregate_id,
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("test history should insert");
+        }
+
+        let competing_error = insert_redemption_event(
+            &pool,
+            "burn-second",
+            2,
+            "RedemptionEvent::BurnIntended",
+            "{}",
+        )
+        .await
+        .expect_err("a competing same-network burn intent must be rejected")
+        .to_string();
+        assert!(
+            competing_error.contains("signer network already reserved"),
+            "the burn-side rejection must carry the explicit reservation \
+             message, got: {competing_error}"
+        );
+    }
+
+    /// The migration backfill must reconstruct a reservation for an
+    /// unresolved historical burn, defaulting pre-network Detected events to
+    /// Base for wire compatibility.
+    #[tokio::test]
+    async fn signer_intent_migration_backfills_unresolved_burns() {
+        const INIT: &str =
+            include_str!("../../migrations/20251016210348_init.sql");
+        const GUARD: &str = include_str!(
+            "../../migrations/20260801095000_enforce_active_signer_intents.sql"
+        );
+
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::raw_sql(INIT).execute(&pool).await.expect("init schema");
+
+        for (sequence, event_type, payload) in [
+            (1, "RedemptionEvent::Detected", r#"{"Detected":{}}"#),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+            (3, "RedemptionEvent::BurningFailed", "{}"),
+        ] {
+            insert_redemption_event(
+                &pool,
+                "legacy-burn",
+                sequence,
+                event_type,
+                payload,
+            )
+            .await
+            .expect("historical event should insert");
+        }
+
+        sqlx::raw_sql(GUARD).execute(&pool).await.expect("backfill");
+
+        let active: (String, String, String) = sqlx::query_as(
+            "SELECT network, aggregate_type, aggregate_id \
+             FROM active_signer_intents",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("the unresolved burn must be backfilled");
+        assert_eq!(
+            active,
+            (
+                "base".to_string(),
+                "Redemption".to_string(),
+                "legacy-burn".to_string(),
+            )
+        );
+    }
+
+    /// The core double-signing hazard the table exists to prevent: TWO
+    /// historical aggregates left unresolved burns on the same network. The
+    /// backfill must abort on the PRIMARY KEY rather than pick a winner —
+    /// remediation is resolving one aggregate, never guessing.
+    #[tokio::test]
+    async fn signer_intent_migration_aborts_on_conflicting_unresolved_burns() {
+        const INIT: &str =
+            include_str!("../../migrations/20251016210348_init.sql");
+        const GUARD: &str = include_str!(
+            "../../migrations/20260801095000_enforce_active_signer_intents.sql"
+        );
+
+        let conflicted = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect(":memory:")
+            .await
+            .expect("in-memory database should connect");
+        sqlx::raw_sql(INIT).execute(&conflicted).await.expect("init schema");
+        for aggregate_id in ["first-unresolved", "second-unresolved"] {
+            insert_redemption_event(
+                &conflicted,
+                aggregate_id,
+                1,
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            )
+            .await
+            .expect("historical Detected should insert");
+            insert_redemption_event(
+                &conflicted,
+                aggregate_id,
+                2,
+                "RedemptionEvent::BurnIntended",
+                "{}",
+            )
+            .await
+            .expect("historical BurnIntended should insert");
+        }
+        let conflicted_error = sqlx::raw_sql(GUARD)
+            .execute(&conflicted)
+            .await
+            .expect_err(
+                "migration must abort on two unresolved burns sharing a \
+                 network instead of silently choosing one",
+            )
+            .to_string();
+        assert!(
+            conflicted_error.contains("UNIQUE constraint failed"),
+            "the historical conflict must abort on the network PRIMARY KEY \
+             specifically, got: {conflicted_error}"
         );
     }
 

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -29,7 +29,7 @@ use crate::fireblocks::{
 use crate::prepare_event_sourced_startup;
 use crate::receipt_inventory::migration::{
     CorroboratedRecipient, MigrationOutcome, VaultIdentity,
-    confirm_custody_holder, migrate_vault_receipts,
+    confirm_custody_holder, ensure_holder_quiescent, migrate_vault_receipts,
     migrate_vault_receipts_via_fireblocks, recorded_custody_holder,
     recorded_migration_origin, rollback_gas_reserve, verify_rollback_signing,
 };
@@ -428,12 +428,15 @@ async fn sweep_legacy_receipt_contract<P: Provider + Clone>(
             // somewhere it should not have.
             let at_recipient =
                 receipt.balanceOf(TURNKEY_RECIPIENT, receipt_id).call().await?;
+            // The destination may have held this receipt before the sweep.
+            // Drained source custody is corroborated when it holds at least the
+            // swept amount, matching the migration path's rerun semantics.
             anyhow::ensure!(
-                at_recipient == expected,
+                at_recipient >= expected,
                 "{}: id {receipt_id} is gone from the legacy wallet but \
-                 {TURNKEY_RECIPIENT} holds {at_recipient}, not the expected \
-                 {expected} — it was NOT swept here; investigate before \
-                 rerunning",
+                 {TURNKEY_RECIPIENT} holds {at_recipient}, less than the \
+                 expected swept amount {expected} — it was NOT fully swept \
+                 here; investigate before rerunning",
                 sweep.label
             );
             continue;
@@ -470,6 +473,12 @@ async fn sweep_legacy_receipt_contract<P: Provider + Clone>(
         )
         .calldata()
         .clone();
+
+    // The retiring wallet may have a broadcast-but-unmined transaction from
+    // an earlier attempt or another process; submitting over it would create
+    // a second in-flight transfer without knowing the first one's outcome.
+    // Same guard as every custody-transfer submission path.
+    ensure_holder_quiescent(provider, LEGACY_HOLDER).await?;
 
     let external_tx_id = format!("{}-a{attempt}", sweep.external_tx_id);
     let tx_hash = service
@@ -549,6 +558,11 @@ async fn sweep_stranded_tcoin<P: Provider + Clone>(
     let recipient_before = vault.balanceOf(LIQUIDITY_BOT).call().await?;
 
     let calldata = vault.transfer(LIQUIDITY_BOT, expected).calldata().clone();
+
+    // Same guard as the receipt sweeps: never submit over an in-flight
+    // transaction from the retiring wallet.
+    ensure_holder_quiescent(provider, LEGACY_HOLDER).await?;
+
     let external_tx_id = format!("legacy-sweep-stranded-tcoin-a{attempt}");
     let tx_hash = service
         .submit_contract_call_to_completion(


### PR DESCRIPTION
## Motivation

Stacked on #305 (the frozen, already-deployed mid-outage hotfix report). All review feedback on #305 and all follow-up hardening lands here, never in #305 itself. The multichain (`CHAIN_ETHEREUM_*`) secret env additions for the Ethereum activation are included (prod env secret + recipient rekey).

## Solution

- **Cross-instance signer-intent serialization**: new `active_signer_intents` table maintained by SQLite triggers in the same transaction that appends `MintTxIntended`/`BurnIntended`, keyed per network (nonce domain, shared between Mint and Redemption). Backfill rebuilds the guard from unresolved event streams, failing closed on malformed, duplicated, or conflicting origins.
- Cross-instance rejection RAISEs an explicit 'signer network already reserved' abort — an implicit PK violation would be misclassified upstream as a same-aggregate optimistic-lock conflict.
- Release rules: `MintClosed` releases (an admin close must not strand the network); `BurningFailed`/`RedemptionFailed`/`BurnResumed` do NOT release (a failed submit may still have broadcast the signed tx). App-side guards (`has_unresolved_signer_intent`) read the trigger-maintained table, so the trigger + backfill lists are the single encoding.
- Mint jobs refuse submission while any wallet intent on the network is unresolved (`UnresolvedWalletIntent`, replacing #305's coarse cross-network check); the burn manager defers dead-burn replacement the same way; a rejected intent append releases the receipt reservation with a WARN.
- The burn wallet-intent wait is bounded to 30 one-second attempts, then defers to recovery (matches SPEC's stated bound).
- The legacy-receipt and stranded-tCOIN sweeps apply the same nonce-quiescence guard as every custody submission (shared `ensure_holder_quiescent`; `LatestNonce`/`PendingNonce` newtypes prevent transposition).
- **Sweep corroboration relaxed from exact-balance to at-least-swept-amount** (`>=`): the recipient is the live issuer wallet and may hold pre-existing balance on a rerun; the post-sweep check still asserts the exact per-identifier gain.
- Already-migrated verdicts require at least one verified migrated identifier instead of merely nothing-left-to-move.
- `MintRetryStarted` carries a serde-defaulted `manual_retry_id` correlating operator retries with dispatch (replay-safe for events #305 already wrote); recovery tests assert their logs.
- Auth probe hardening: `PositiveExpirySeconds` newtype, overflow-checked expiry, `Clock` variant renamed `SystemTime`.
- SPEC.md documents the guard; trigger lifecycles covered by regression tests (admin-close release, competing mint AND burn intents, backfill conflict/duplicate/unknown-network aborts, failed/resumed retention).
- **Restores `deploy-prod.yaml` to main's normal gated workflow**, removing the temporary break-glass variant #305 used for the mid-outage deploys.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added operator-authorized manual mint retries with unique tracking and clearer outcomes.
  * Added safeguards to coordinate wallet signing across minting and redemptions, preventing conflicting transactions.
* **Bug Fixes**
  * Improved recovery handling for stalled or ambiguous mint and burn operations.
  * Added wallet nonce checks before receipt transfers and custody migrations.
  * Improved legacy receipt sweep validation and handling of already-drained balances.
  * Strengthened authentication expiry validation, including invalid and overflowed expiry values.
* **Deployment**
  * Production deployments now validate tags against the main branch and run all production profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->