### PR TITLE
feat: audited CLI to burn excess shares from a duplicate mint

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -806,6 +806,9 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
 - `issuer freeze <UNDERLYING>` — dispatch the `Freeze` command.
 - `issuer unfreeze <UNDERLYING>` — dispatch the `Unfreeze` command.
 - `issuer status <UNDERLYING>` — print the underlying's current freeze status.
+- `issuer burn-excess internal|external …` — administrative supply correction
+  that burns excess shares from a proven duplicate deposit (see **Burn excess
+  shares** below). Never calls Alpaca; never opens a `Redemption` aggregate.
 - `issuer migrate-receipts <UNDERLYING>` — move a vault's ERC-1155 deposit
   receipts between the Fireblocks and Turnkey wallets. Temporary, for the
   Turnkey signing-backend cutover; removed once every vault has migrated.
@@ -825,7 +828,174 @@ The custody subcommands are listing-scoped and therefore take `--network`, plus
 against the chain that endpoint reports). `migrate-receipts` and
 `verify-custodians` require both custodians' configurations — the `TURNKEY_*`
 group and the `FIREBLOCKS_*` group the retired integration used — all from the
-service's own environment.
+service's own environment. `burn-excess` is listing/network-scoped and takes
+`--network` / `--chain-id` (cross-checked against the RPC-reported chain); its
+RPC endpoint is **not** a CLI flag — it uses the service environment for that
+network (`CHAIN_<NETWORK>_RPC_URL`, with legacy `RPC_URL` as Base fallback), the
+same secrets the long-running bot loads.
+
+### Burn excess shares
+
+There is no supported recovery path for an excess successful mint other than
+this CLI. A duplicate deposit often mints shares to a mint recipient while the
+matching receipt stays in the issuer wallet. Burning that excess via ordinary
+redemption would call Alpaca and release backing — wrong for
+undercollateralisation — and a raw Transfer of shares **into** the issuer wallet
+looks like a real redemption to the transfer poller.
+
+`issuer burn-excess` is an audited administrative supply correction:
+
+1. Prove the **duplicate deposit** (issuer request, deposit tx, receipt id,
+   exact shares, strict `receiptInformation` → issuer request, original share
+   recipient from the deposit path).
+2. Ensure the **issuer wallet** holds exactly the excess shares and enough
+   matching receipt (either already true, or after a proven funding Transfer).
+3. If (and only if) a funding Transfer into the issuer is part of recovery:
+   prove it, persist a durable exclusion so the redemption poller skips **only
+   that log**, then burn.
+4. Burn via vault `redeem` with persist-before-broadcast. **Never** Alpaca;
+   **never** a `Redemption` aggregate for this path.
+
+#### Path selection: required mode keyword
+
+The operator must pick the path with a required mode keyword immediately after
+`burn-excess`. The CLI never infers path from balances or from whether a funding
+hash happens to be present.
+
+```text
+issuer burn-excess <internal|external> [shared args…] [mode-specific…]
+```
+
+| Mode keyword | Path               | Meaning                                                                                                                        |
+| ------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| `internal`   | A — issuer-held    | Excess shares already sit in the issuer wallet (deposit original recipient must be the issuer); no funding Transfer to exclude |
+| `external`   | B — fund-then-burn | Shares were moved into the issuer by a Transfer that would look like a redemption; prove + exclude that log, then burn         |
+
+Shared args (both modes): `--issuer-request-id`, `--deposit-tx-hash`,
+`--receipt-id`, `--shares`, `--reason`, `--incident-id`, `--network`,
+`--chain-id`, `--execute`, `--close`, plus SignerEnv / DB. RPC comes from the
+service environment for `--network` (not passed on the command line).
+
+Mode-specific:
+
+| Mode       | Required                                   | Forbidden                                     |
+| ---------- | ------------------------------------------ | --------------------------------------------- |
+| `internal` | (none beyond shared)                       | `--funding-tx-hash` is not on this subcommand |
+| `external` | `--funding-tx-hash <0x…>` required by clap | —                                             |
+
+**Fresh run:** path is chosen **only** from the mode keyword. Issuer share
+balance, original recipient == issuer, freeze status, and funding-hash presence
+do **not** select path.
+
+**Resume:** aggregate id is the **deposit tx hash**. When a `BurnExcess` stream
+already exists, **stored path wins**. Re-invoke must use the same mode keyword;
+switching modes is `PathConflict`. External resumes also require the same
+funding tx hash as recorded.
+
+| Aggregate state                 | Locked path  | Required mode            | Funding hash                |
+| ------------------------------- | ------------ | ------------------------ | --------------------------- |
+| `NotStarted`                    | from keyword | `internal` or `external` | required only if `external` |
+| `FundingExcluded`               | External     | `external` only          | must match recorded         |
+| `Intended`/`Submitted` External | External     | `external` only          | must match recorded         |
+| `Intended`/`Submitted` Internal | Internal     | `internal` only          | N/A                         |
+| `Completed` / `Closed`          | locked       | report-only              | no re-path                  |
+
+#### Path behaviour
+
+|                                        | `internal` (Path A)               | `external` (Path B)                                   |
+| -------------------------------------- | --------------------------------- | ----------------------------------------------------- |
+| Funding                                | N/A                               | Required `--funding-tx-hash`                          |
+| Poller exclusion                       | **None**                          | **Yes** — only that verified funding log identity     |
+| First irreversible step on `--execute` | Sign + persist `IntendExcessBurn` | Persist `FundingExclusionRecorded`, then later intend |
+| Burn                                   | Same `VaultService` redeem        | Same                                                  |
+
+**Freeze is not a gate.** Freeze status may be printed as advisory; a frozen
+underlying neither blocks nor unlocks burn-excess. Ops still stop issuance /
+pause conflicting producers as needed.
+
+**Exact issuer share balance.** After path-specific funding (Path B) or
+immediately (Path A), issuer ERC-20 share balance must **exactly** equal the
+excess amount. Any extra shares at the issuer refuse
+(`IssuerShareBalanceNotExact`).
+
+**Path A recipient gate.** `internal` refuses when the deposit's original share
+recipient is not the issuer wallet (`InternalRequiresIssuerAsRecipient`); ops
+must fund shares back and use `external --funding-tx-hash …`.
+
+**Funding exclusion (Path B only).** The proof binds
+`(network, vault, tx_hash, log_index, from, to, amount)`; `from`, `to`, and
+`amount` are persisted for audit. The durable skip key is
+`(network, vault, tx_hash, log_index)`, and the poller skips only logs present
+under that key (`SkippedAdminRecovery`). Neighbours in the same tx/block remain
+eligible. No block-range skip; no checkpoint jump; no “skip all from address X”.
+Exclusion once recorded is permanent for that log (including after burn
+complete/close). Engine dual-writes the SQL index after `RecordFundingExclusion`
+and refuses prepare if the row is missing (resume re-writes the row from the
+recorded event before the presence check). Startup and CLI store open rebuild
+the index from every `FundingExclusionRecorded` event so a restored or truncated
+index table cannot leave the poller free to open a `Redemption` for an excluded
+funding Transfer. If a `Redemption` already exists for that funding tx → refuse
+(`FundingAlreadyRedeemed`), re-checked immediately before exclusion record.
+Transfer logs without `log_index` fail closed (`MissingLogIndex`) so Detect
+cannot open a redemption for an unidentifiable excluded funding log.
+
+**Dead intent / Closed.** `--close` clears the wallet nonce gate only. `Closed`
+is report-only terminal for that deposit stream (no re-intend on the same
+`deposit_tx_hash`). Reverted/ProvablyDead on resume surfaces `DeadBurnIntent`
+with that guidance.
+
+**Post-burn inventory.** After on-chain verify the stream completes, then
+inventory is reconciled. Reconcile failure fails the CLI (non-zero) even though
+the burn already landed — ops re-run report-only + manual inventory.
+
+**Dry-run (default)** proves and prints the plan (including `mode=` / `path=`
+and, for Path B, the funding log id) without events, signing, or exclusion.
+Wallet intent gates still run on dry-run (an unresolved mint/burn signer-intent
+reservation on the deposit's network, or any unresolved excess intent, refuses
+prove) so operators see the same blockers they would hit on `--execute`.
+`--execute` requires confirmation before the first irreversible step (Path A:
+intend; Path B: exclusion record) and before resume broadcast/confirm of a
+persisted `sendable_tx.hash`.
+
+**Wallet intent gates.** An unresolved excess-burn recovery refuses competing
+mint prepare and redemption burn prepare/replace paths (same family as mint/burn
+intent gates). `BurnExcess` holds no `active_signer_intents` reservation, so it
+is checked separately from the network-keyed signer-intent guard rather than
+through it. `Intended` / `Submitted` count because they hold a signed nonce.
+`FundingExcluded` counts too: it holds no signed transaction yet, but its
+exclusion write is already permanent and the stream will sign against the same
+issuer wallet, so a Path B recovery abandoned before intend must be resumed or
+`--close`d rather than raced. Gates are re-read at the irreversible sign
+boundary, together with the issuer receipt and exact share balances — the
+operator confirm prompt blocks for an unbounded time, so balances proven at plan
+time are re-read immediately before `prepare_burn_tx` signs. Deposit and funding
+proofs are mined history and are not re-read.
+
+**The issuer service must be stopped for Path B.** `FundingAlreadyRedeemed` is
+re-checked immediately before the exclusion write, but that is a check, not a
+cross-process lock: a running transfer poller can open a `Redemption` for the
+funding Transfer first and steer incident remediation onto the ordinary Alpaca
+path. Poller quiescence is therefore an operator precondition, in the same
+family as the `migrate-receipts` sequence, and the Path B plan output states it
+before the confirmation prompt.
+
+**Non-goals:** Alpaca journal / release of backing; moving the receipt to a
+liquidity wallet; block-range skip or manual checkpoint mutation; general
+redemption bypass (exclusion is one verified funding log only); auto dead-tx
+replacement; admin HTTP; multi-receipt burns; hard-coded production hashes as
+the sole path.
+
+**Production incident bind (Path B shape; values are proven inputs, never typed
+addresses as free-form operator targets):**
+
+| Input                   | Value                                                                |
+| ----------------------- | -------------------------------------------------------------------- |
+| Issuer request          | `d3042b2f-4845-4acd-9a67-92d743e4e58c`                               |
+| Duplicate deposit       | `0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd` |
+| Issuer wallet           | `0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE`                         |
+| Original mint recipient | `0xA9C16673F65AE808688cB18952AFE3d9658C808f`                         |
+| Receipt ID              | `7`                                                                  |
+| Shares                  | `0.750` (`750000000000000000` raw)                                   |
 
 **No wallet address is ever an argument.** An ERC-1155 transfer to a wrong
 address is final — no counterparty, no recovery, and the receipts back tokens

--- a/migrations/20260804214608_create_burn_excess_funding_exclusions.sql
+++ b/migrations/20260804214608_create_burn_excess_funding_exclusions.sql
@@ -1,0 +1,15 @@
+-- Path B burn-excess: exact funding Transfer log identities the redemption
+-- poller must skip. Bound to one verified (network, vault, tx_hash, log_index);
+-- never a general bypass.
+CREATE TABLE IF NOT EXISTS burn_excess_funding_exclusions (
+    network TEXT NOT NULL,
+    vault TEXT NOT NULL,
+    tx_hash TEXT NOT NULL,
+    log_index INTEGER NOT NULL,
+    from_address TEXT NOT NULL,
+    to_address TEXT NOT NULL,
+    amount TEXT NOT NULL,
+    deposit_tx_hash TEXT NOT NULL,
+    excluded_at TEXT NOT NULL,
+    PRIMARY KEY (network, vault, tx_hash, log_index)
+);

--- a/src/burn_excess/cli.rs
+++ b/src/burn_excess/cli.rs
@@ -1,0 +1,298 @@
+//! Clap surface for `issuer burn-excess internal|external`.
+
+use alloy::primitives::{B256, U256};
+use alloy::providers::fillers::BlobGasFiller;
+use alloy::providers::{Provider, ProviderBuilder};
+use clap::{Args, Subcommand};
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
+use sqlx::{Pool, Sqlite};
+use std::io;
+use std::str::FromStr;
+use std::sync::Arc;
+use url::Url;
+
+use super::engine::{BurnExcessRequest, run_burn_excess};
+use super::proof::BurnExcessMode;
+use crate::Quantity;
+use crate::config::{
+    DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, configured_rpc_url,
+    wss_to_http,
+};
+use crate::mint::IssuerMintRequestId;
+use crate::tokenized_asset::Network;
+use crate::vault::rain_meta::{OA_SCHEMA_HASH, OaSchemaCache};
+use crate::vault::service::RealBlockchainService;
+use crate::wallet::local::resolve_local_signer;
+use crate::wallet::turnkey::resolve_turnkey_signer;
+use crate::wallet::{SignerConfig, SignerEnv};
+
+/// Parent command: path is a required mode subcommand (`internal` | `external`).
+#[derive(Debug, Subcommand)]
+pub(crate) enum BurnExcessCommand {
+    /// Path A — excess shares already sit in the issuer wallet; no funding
+    /// Transfer to exclude from the redemption poller.
+    Internal(BurnExcessSharedArgs),
+    /// Path B — prove a funding Transfer into the issuer, persist a poller
+    /// exclusion for that log only, then burn.
+    External(BurnExcessExternalArgs),
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BurnExcessSharedArgs {
+    /// Issuer mint request id bound by the deposit receiptInformation.
+    #[arg(long)]
+    issuer_request_id: IssuerMintRequestId,
+
+    /// Deposit transaction that created the excess receipt/shares.
+    #[arg(long)]
+    deposit_tx_hash: B256,
+
+    /// Excess receipt id from the deposit.
+    #[arg(long)]
+    receipt_id: U256,
+
+    /// Excess share amount as a decimal (18-decimal fixed point on chain),
+    /// e.g. `0.750`.
+    #[arg(long, value_parser = parse_shares)]
+    shares: U256,
+
+    /// Why this recovery is being run; recorded on events.
+    #[arg(long)]
+    reason: String,
+
+    /// Optional incident / ticket id for the audit trail.
+    #[arg(long)]
+    incident_id: Option<String>,
+
+    /// Network of the vault listing (cross-checked with mint + chain-id).
+    /// RPC is taken from the service environment for this network
+    /// (`CHAIN_<NETWORK>_RPC_URL`, or legacy `RPC_URL` for Base) — same
+    /// secrets as the long-running bot; not a CLI flag.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// Chain id; must match `--network` and the configured RPC-reported chain.
+    #[arg(long)]
+    chain_id: u64,
+
+    /// Perform mutations (exclusion / sign / broadcast). Default is dry-run.
+    #[arg(long)]
+    execute: bool,
+
+    /// Close a dead Intended/Submitted/FundingExcluded stream instead of
+    /// burning.
+    #[arg(long)]
+    close: bool,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL
+    )]
+    database_url: String,
+
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Debug, Args)]
+pub(crate) struct BurnExcessExternalArgs {
+    #[clap(flatten)]
+    shared: BurnExcessSharedArgs,
+
+    /// Funding Transfer that moved excess shares into the issuer wallet.
+    /// Required on `external`; not present on `internal`.
+    #[arg(long)]
+    funding_tx_hash: B256,
+}
+
+fn parse_shares(value: &str) -> Result<U256, String> {
+    let decimal = rust_decimal::Decimal::from_str(value)
+        .map_err(|error| format!("invalid shares decimal: {error}"))?;
+    Quantity::new(decimal)
+        .to_u256_with_18_decimals()
+        .map_err(|error| error.to_string())
+}
+
+/// Dispatches `issuer burn-excess …` after clap has selected the mode keyword.
+pub(crate) async fn run_burn_excess_cli(
+    command: BurnExcessCommand,
+    confirm: impl Fn(&str) -> io::Result<bool> + Send + Sync,
+) -> anyhow::Result<()> {
+    let (mode, shared, funding_tx_hash) = match command {
+        BurnExcessCommand::Internal(shared) => {
+            (BurnExcessMode::Internal, shared, None)
+        }
+        BurnExcessCommand::External(external) => (
+            BurnExcessMode::External,
+            external.shared,
+            Some(external.funding_tx_hash),
+        ),
+    };
+
+    if shared.chain_id != shared.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            shared.network,
+            shared.network.chain_id(),
+            shared.chain_id
+        );
+    }
+
+    // Same process environment the service loads (issuer bin calls dotenv).
+    // Grouped CHAIN_* wins for Base when both forms are present.
+    let rpc_url = configured_rpc_url(shared.network)?;
+
+    println!("Using database: {}", shared.database_url);
+    println!(
+        "Using configured RPC for network {} (host {})",
+        shared.network,
+        rpc_url.host_str().unwrap_or("(none)")
+    );
+    let pool =
+        connect_pool(&shared.database_url, shared.database_max_connections)
+            .await?;
+
+    let chain_id = verified_chain_id(&rpc_url, shared.chain_id).await?;
+    let signer_config = shared.signer.into_config()?;
+    let issuer_wallet = signer_config.address()?;
+
+    let resolved = match &signer_config {
+        SignerConfig::Local(key) => resolve_local_signer(key, chain_id)?,
+        SignerConfig::Turnkey(config) => {
+            resolve_turnkey_signer(config, chain_id)?
+        }
+    };
+
+    let http_url = wss_to_http(&rpc_url)?;
+    let signing_provider = ProviderBuilder::new()
+        .disable_recommended_fillers()
+        .with_gas_estimation()
+        .filler(BlobGasFiller)
+        .with_simple_nonce_management()
+        .with_chain_id(chain_id)
+        .wallet(resolved.wallet)
+        .connect_http(http_url.clone());
+
+    // receipt_info_bytes always present from deposit; fixed cache avoids
+    // subgraph dependency for burn-excess admin recovery.
+    let vault_service = RealBlockchainService::new(
+        signing_provider,
+        Arc::new(OaSchemaCache::fixed(OA_SCHEMA_HASH)),
+    );
+
+    let read_provider = ProviderBuilder::new().connect_http(http_url);
+
+    let request = BurnExcessRequest {
+        mode,
+        issuer_request_id: shared.issuer_request_id,
+        deposit_tx_hash: shared.deposit_tx_hash,
+        funding_tx_hash,
+        receipt_id: shared.receipt_id,
+        shares: shared.shares,
+        reason: shared.reason,
+        incident_id: shared.incident_id,
+        network: shared.network,
+        chain_id,
+        execute: shared.execute,
+        close: shared.close,
+    };
+
+    run_burn_excess(
+        &pool,
+        &vault_service,
+        &read_provider,
+        issuer_wallet,
+        request,
+        confirm,
+    )
+    .await
+    .map_err(Into::into)
+}
+
+async fn connect_pool(
+    database_url: &str,
+    max_connections: u32,
+) -> anyhow::Result<Pool<Sqlite>> {
+    if !database_url.starts_with("sqlite:") {
+        anyhow::bail!(
+            "database URL must use the sqlite: scheme, got: {database_url}"
+        );
+    }
+    // `create_if_missing(false)` cannot guard an in-memory URL: sqlx sets
+    // `in_memory` for `:memory:` and `mode=memory` and always passes
+    // SQLITE_OPEN_MEMORY, so the open succeeds against a fresh empty database
+    // with no event history — exactly the state the guard below exists to
+    // prevent.
+    if database_url.contains(":memory:") || database_url.contains("mode=memory")
+    {
+        anyhow::bail!(
+            "burn-excess requires an existing on-disk issuance database, got \
+             in-memory URL: {database_url}"
+        );
+    }
+    // burn-excess is operational against an existing issuance DB — never create
+    // an empty file that would look like a successful open with no history.
+    let options =
+        SqliteConnectOptions::from_str(database_url)?.create_if_missing(false);
+    SqlitePoolOptions::new()
+        .max_connections(max_connections)
+        .connect_with(options)
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "failed to open database at {database_url} (file must already \
+                 exist for burn-excess): {error}"
+            )
+        })
+}
+
+async fn verified_chain_id(
+    rpc_url: &Url,
+    expected_chain_id: u64,
+) -> anyhow::Result<u64> {
+    let chain_id = ProviderBuilder::new()
+        .connect(rpc_url.as_str())
+        .await?
+        .get_chain_id()
+        .await?;
+
+    if chain_id != expected_chain_id {
+        anyhow::bail!(
+            "--chain-id is {expected_chain_id} but configured RPC reports \
+             chain {chain_id}"
+        );
+    }
+
+    Ok(chain_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::connect_pool;
+
+    #[tokio::test]
+    async fn connect_pool_rejects_in_memory_urls() {
+        for url in [
+            "sqlite::memory:",
+            "sqlite:file::memory:",
+            "sqlite:file:shared?mode=memory&cache=shared",
+        ] {
+            let error = connect_pool(url, 1).await.unwrap_err();
+            assert!(
+                error
+                    .to_string()
+                    .contains("existing on-disk issuance database"),
+                "in-memory URL {url} must be refused, got: {error}"
+            );
+        }
+    }
+}

--- a/src/burn_excess/cmd.rs
+++ b/src/burn_excess/cmd.rs
@@ -1,0 +1,42 @@
+use alloy::primitives::B256;
+use serde::{Deserialize, Serialize};
+
+use super::{BurnExcessPath, ExcessBurnBind, FundingTransferId};
+use crate::vault::{SendableTxWithHash, TxId};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) enum BurnExcessCommand {
+    /// Path B only: record a verified funding Transfer so the poller skips it.
+    RecordFundingExclusion {
+        bind: ExcessBurnBind,
+        funding_log_id: FundingTransferId,
+        reason: String,
+        incident_id: Option<String>,
+    },
+    /// Persist the exact signed burn before broadcast.
+    ///
+    /// Path A may originate the stream; Path B requires
+    /// [`Self::RecordFundingExclusion`] first.
+    ///
+    /// `receipt_id`, `shares`, and issuer wallet (owner) come from `bind` —
+    /// do not duplicate them here.
+    IntendExcessBurn {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        reason: String,
+        incident_id: Option<String>,
+        sendable_tx: SendableTxWithHash,
+    },
+    RecordExcessBurnSubmitted {
+        tx_id: TxId,
+        burn_tx_hash: B256,
+    },
+    CompleteExcessBurn {
+        burn_tx_hash: B256,
+        block_number: u64,
+    },
+    CloseExcessBurn {
+        reason: String,
+    },
+}

--- a/src/burn_excess/engine.rs
+++ b/src/burn_excess/engine.rs
@@ -1,0 +1,2832 @@
+//! Orchestrates dual-path burn-excess recovery (D0.5).
+//!
+//! Dry-run proves and prints; `--execute` persists exclusion (Path B), then
+//! signs/intends/submits/confirms the vault redeem and updates inventory.
+
+use alloy::primitives::{Address, B256, Bytes, U256};
+use alloy::providers::Provider;
+use alloy::rpc::types::TransactionReceipt;
+use chrono::{DateTime, Utc};
+use event_sorcery::{Store, StoreBuilder};
+use sqlx::{Pool, Sqlite};
+use std::io;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+use super::exclusion::{
+    FundingExclusionReactor, is_excluded_funding_log,
+    rebuild_funding_exclusion_index, record_funding_exclusion,
+};
+use super::proof::{
+    BurnExcessMode, BurnExcessProofError, DepositProof,
+    FundingTransferCandidate, FundingTransferExpectation, PathResolution,
+    bind_deposit_proof, decode_receipt_information_strict,
+    require_exact_issuer_share_balance, require_funding_hash_match,
+    require_issuer_receipt_balance, resolve_path, select_funding_transfer,
+};
+use super::{
+    BurnExcess, BurnExcessCommand, BurnExcessId, BurnExcessPath,
+    ExcessBurnBind, FundingTransferId, has_unresolved_excess_burn_intent,
+};
+use crate::bindings::{OffchainAssetReceiptVault, Receipt};
+use crate::mint::{IssuerMintRequestId, Mint, has_unresolved_signer_intent};
+use crate::receipt_inventory::{
+    ReceiptId, ReceiptInventory, ReceiptInventoryCommand, Shares,
+    load_inventory, send_receipt_inventory_command,
+};
+use crate::redemption::IssuerRedemptionRequestId;
+use crate::tokenized_asset::view::find_vault;
+use crate::tokenized_asset::{Network, UnderlyingSymbol};
+use crate::vault::{
+    BurnRequestOrigin, BurnTxStatus, MultiBurnEntry, MultiBurnParams,
+    VaultService,
+};
+
+/// Operator inputs after clap parse (mode keyword already selected).
+#[derive(Debug, Clone)]
+pub(crate) struct BurnExcessRequest {
+    pub(crate) mode: BurnExcessMode,
+    pub(crate) issuer_request_id: IssuerMintRequestId,
+    pub(crate) deposit_tx_hash: B256,
+    /// Required on `external`; must be `None` on `internal`.
+    pub(crate) funding_tx_hash: Option<B256>,
+    pub(crate) receipt_id: U256,
+    pub(crate) shares: U256,
+    pub(crate) reason: String,
+    pub(crate) incident_id: Option<String>,
+    pub(crate) network: Network,
+    pub(crate) chain_id: u64,
+    pub(crate) execute: bool,
+    pub(crate) close: bool,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum BurnExcessEngineError {
+    #[error(transparent)]
+    Proof(#[from] BurnExcessProofError),
+
+    #[error(transparent)]
+    Aggregate(Box<super::BurnExcessError>),
+
+    #[error(transparent)]
+    Store(Box<event_sorcery::SendError<BurnExcess>>),
+
+    #[error(transparent)]
+    MintStore(Box<event_sorcery::SendError<Mint>>),
+
+    #[error(transparent)]
+    Inventory(Box<event_sorcery::SendError<ReceiptInventory>>),
+
+    #[error(transparent)]
+    Vault(#[from] crate::vault::VaultError),
+
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error("failed to reconcile event schema: {0}")]
+    Reconcile(#[from] event_sorcery::ReconcileError),
+
+    #[error("failed to build the {aggregate} store: {message}")]
+    StoreBuild { aggregate: &'static str, message: String },
+
+    #[error(transparent)]
+    TokenizedAsset(
+        #[from] crate::tokenized_asset::view::TokenizedAssetViewError,
+    ),
+
+    #[error(transparent)]
+    Provider(
+        Box<alloy::transports::RpcError<alloy::transports::TransportErrorKind>>,
+    ),
+
+    #[error(transparent)]
+    Contract(Box<alloy::contract::Error>),
+
+    #[error("mint {issuer_request_id} has no event history in this database")]
+    MintNotFound { issuer_request_id: IssuerMintRequestId },
+
+    #[error(
+        "mint {issuer_request_id} does not carry underlying/network \
+         (state={state}); burn-excess needs a mint that still has asset fields"
+    )]
+    MintMissingAsset { issuer_request_id: IssuerMintRequestId, state: String },
+
+    #[error(
+        "mint {issuer_request_id} is on network {mint_network}, not \
+         --network {requested}"
+    )]
+    MintNetworkMismatch {
+        issuer_request_id: IssuerMintRequestId,
+        mint_network: Network,
+        requested: Network,
+    },
+
+    #[error(
+        "no vault listing for underlying {underlying} on network {network}"
+    )]
+    VaultNotListed { underlying: UnderlyingSymbol, network: Network },
+
+    #[error(
+        "deposit transaction {tx_hash} is missing, reverted, or not a vault \
+         Deposit on the listed vault"
+    )]
+    DepositTxInvalid { tx_hash: B256 },
+
+    #[error(
+        "deposit transaction {tx_hash} has multiple Deposit logs on the listed \
+         vault; refuse ambiguous receipt selection"
+    )]
+    AmbiguousDepositTx { tx_hash: B256 },
+
+    #[error(
+        "deposit transaction {tx_hash} has multiple outbound share Transfers \
+         matching the deposit; refuse ambiguous original recipient"
+    )]
+    AmbiguousShareTransferOut { tx_hash: B256 },
+
+    #[error(
+        "funding transaction {tx_hash} is missing or reverted on this chain"
+    )]
+    FundingTxInvalid { tx_hash: B256 },
+
+    #[error(
+        "an unresolved mint or redemption burn intent holds a signed wallet \
+         nonce on {network}; clear it before burn-excess"
+    )]
+    UnresolvedSignerIntent { network: Network },
+
+    #[error(
+        "another excess-burn recovery is unresolved (funding excluded, \
+         intended, or submitted); resume or --close it first"
+    )]
+    UnresolvedExcessBurnIntent,
+
+    #[error("operator aborted")]
+    Aborted,
+
+    #[error("I/O error during operator confirmation: {0}")]
+    Io(#[from] io::Error),
+
+    #[error(
+        "persisted burn intent is {status:?}; use `burn-excess … --close \
+         --execute` to clear the wallet nonce gate for this deposit. Closed is \
+         report-only terminal for this stream — it does not unlock a \
+         replacement intend on the same deposit_tx_hash; follow the ops \
+         runbook if a new signed burn is required"
+    )]
+    DeadBurnIntent { status: BurnTxStatus },
+
+    #[error(
+        "burn result did not match planned withdrawal: expected receipt \
+         {expected_receipt} shares {expected_shares}, on-chain {onchain:?}"
+    )]
+    BurnDeltaMismatch {
+        expected_receipt: U256,
+        expected_shares: U256,
+        onchain: Vec<(U256, U256)>,
+    },
+
+    #[error(
+        "funding exclusion index missing after RecordFundingExclusion for \
+         tx {tx_hash:?} log_index={log_index}; refusing to prepare burn"
+    )]
+    FundingExclusionIndexMissing { tx_hash: B256, log_index: u64 },
+
+    #[error(
+        "post-burn inventory reconcile failed for receipt {receipt_id} \
+         (on-chain burn already completed): {source}"
+    )]
+    InventoryReconcileFailed {
+        receipt_id: U256,
+        #[source]
+        source: Box<event_sorcery::SendError<ReceiptInventory>>,
+    },
+
+    #[error(transparent)]
+    RebuildFundingExclusion(
+        #[from] super::exclusion::RebuildFundingExclusionError,
+    ),
+}
+
+impl From<event_sorcery::SendError<BurnExcess>> for BurnExcessEngineError {
+    fn from(error: event_sorcery::SendError<BurnExcess>) -> Self {
+        Self::Store(Box::new(error))
+    }
+}
+
+impl From<event_sorcery::SendError<Mint>> for BurnExcessEngineError {
+    fn from(error: event_sorcery::SendError<Mint>) -> Self {
+        Self::MintStore(Box::new(error))
+    }
+}
+
+impl From<event_sorcery::SendError<ReceiptInventory>>
+    for BurnExcessEngineError
+{
+    fn from(error: event_sorcery::SendError<ReceiptInventory>) -> Self {
+        Self::Inventory(Box::new(error))
+    }
+}
+
+impl From<super::BurnExcessError> for BurnExcessEngineError {
+    fn from(error: super::BurnExcessError) -> Self {
+        Self::Aggregate(Box::new(error))
+    }
+}
+
+impl From<alloy::transports::RpcError<alloy::transports::TransportErrorKind>>
+    for BurnExcessEngineError
+{
+    fn from(
+        error: alloy::transports::RpcError<
+            alloy::transports::TransportErrorKind,
+        >,
+    ) -> Self {
+        Self::Provider(Box::new(error))
+    }
+}
+
+impl From<alloy::contract::Error> for BurnExcessEngineError {
+    fn from(error: alloy::contract::Error) -> Self {
+        Self::Contract(Box::new(error))
+    }
+}
+
+/// Builds the `BurnExcess` store with the funding-exclusion reactor attached.
+///
+/// Rebuilds the funding-exclusion SQL index from events first: custom reactors
+/// on `Nil`-materialized aggregates are not catch_up'd by `StoreBuilder`.
+pub(crate) async fn burn_excess_store(
+    pool: Pool<Sqlite>,
+) -> Result<Arc<Store<BurnExcess>>, BurnExcessEngineError> {
+    crate::prepare_event_sourced_startup::<BurnExcess>(&pool).await?;
+    rebuild_funding_exclusion_index(&pool).await?;
+    Ok(StoreBuilder::<BurnExcess>::new(pool.clone())
+        .with(Arc::new(FundingExclusionReactor::new(pool)))
+        .build(())
+        .await?)
+}
+
+/// Full dry-run / execute orchestration for one deposit stream.
+pub(crate) async fn run_burn_excess<P: Provider>(
+    pool: &Pool<Sqlite>,
+    vault_service: &dyn VaultService,
+    provider: &P,
+    issuer_wallet: Address,
+    request: BurnExcessRequest,
+    confirm: impl Fn(&str) -> io::Result<bool> + Send + Sync,
+) -> Result<(), BurnExcessEngineError> {
+    let aggregate_id = BurnExcessId::new(request.deposit_tx_hash);
+    let store = burn_excess_store(pool.clone()).await?;
+
+    let state = store.load(&aggregate_id).await?;
+    let path_resolution = resolve_path(request.mode, state.as_ref())?;
+
+    match path_resolution {
+        PathResolution::ReportOnly(path) => {
+            print_terminal_report(path, state.as_ref());
+            Ok(())
+        }
+        PathResolution::Start(path) | PathResolution::Resume(path) => {
+            if request.close {
+                return close_stream(
+                    &store,
+                    &aggregate_id,
+                    state.as_ref(),
+                    path,
+                    &request.reason,
+                    request.execute,
+                    &confirm,
+                )
+                .await;
+            }
+
+            let plan = prove_plan(
+                pool,
+                vault_service,
+                provider,
+                issuer_wallet,
+                &request,
+                state.as_ref(),
+                path,
+            )
+            .await?;
+
+            print_plan(&plan, request.execute);
+
+            if !request.execute {
+                return Ok(());
+            }
+
+            execute_plan(
+                MutationCtx {
+                    pool,
+                    vault_service,
+                    provider,
+                    store: &store,
+                    aggregate_id: &aggregate_id,
+                    plan: &plan,
+                    request: &request,
+                },
+                state.as_ref(),
+                &confirm,
+            )
+            .await
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ProvenPlan {
+    path: BurnExcessPath,
+    bind: ExcessBurnBind,
+    deposit_proof: DepositProof,
+    funding_log_id: Option<FundingTransferId>,
+    /// From `FundingExclusionRecorded.excluded_at` when resuming Path B, so
+    /// index repair re-inserts the event timestamp rather than `Utc::now()`.
+    exclusion_excluded_at: Option<DateTime<Utc>>,
+    underlying: UnderlyingSymbol,
+    freeze_advisory: Option<&'static str>,
+    resume_note: Option<&'static str>,
+}
+
+async fn prove_plan<P: Provider>(
+    pool: &Pool<Sqlite>,
+    vault_service: &dyn VaultService,
+    provider: &P,
+    issuer_wallet: Address,
+    request: &BurnExcessRequest,
+    state: Option<&BurnExcess>,
+    path: BurnExcessPath,
+) -> Result<ProvenPlan, BurnExcessEngineError> {
+    require_wallet_intent_gates(pool, request.network, request.deposit_tx_hash)
+        .await?;
+
+    let (underlying, mint_network) =
+        load_mint_asset(pool, &request.issuer_request_id).await?;
+    if mint_network != request.network {
+        return Err(BurnExcessEngineError::MintNetworkMismatch {
+            issuer_request_id: request.issuer_request_id.clone(),
+            mint_network,
+            requested: request.network,
+        });
+    }
+
+    let listed_vault =
+        find_vault(pool, &underlying, &request.network).await?.ok_or_else(
+            || BurnExcessEngineError::VaultNotListed {
+                underlying: underlying.clone(),
+                network: request.network,
+            },
+        )?;
+
+    let deposit_proof =
+        fetch_deposit_proof(provider, request.deposit_tx_hash, listed_vault)
+            .await?;
+    bind_deposit_proof(
+        &request.issuer_request_id,
+        request.receipt_id,
+        request.shares,
+        &deposit_proof,
+    )?;
+
+    // Path A safety: internal only when the deposit left shares with the issuer.
+    // A non-issuer original recipient means shares need a funding Transfer first.
+    if path == BurnExcessPath::Internal
+        && deposit_proof.original_recipient != issuer_wallet
+    {
+        return Err(BurnExcessProofError::InternalRequiresIssuerAsRecipient {
+            original_recipient: deposit_proof.original_recipient,
+            issuer_wallet,
+        }
+        .into());
+    }
+
+    let receipt_contract =
+        receipt_contract_address(provider, listed_vault).await?;
+    let receipt_balance = receipt_balance_of(
+        provider,
+        receipt_contract,
+        issuer_wallet,
+        request.receipt_id,
+    )
+    .await?;
+    require_issuer_receipt_balance(
+        request.receipt_id,
+        receipt_balance,
+        request.shares,
+    )?;
+
+    let bind = ExcessBurnBind {
+        issuer_request_id: request.issuer_request_id.clone(),
+        deposit_tx_hash: request.deposit_tx_hash,
+        receipt_id: request.receipt_id,
+        shares: request.shares,
+        original_recipient: deposit_proof.original_recipient,
+        vault: listed_vault,
+        network: request.network,
+        issuer_wallet,
+    };
+
+    let (funding_log_id, exclusion_excluded_at, resume_note) =
+        match (path, state) {
+            (BurnExcessPath::Internal, _) => {
+                let balance = vault_service
+                    .get_share_balance(listed_vault, issuer_wallet)
+                    .await?;
+                require_exact_issuer_share_balance(balance, request.shares)?;
+                let note = match state {
+                    Some(
+                        BurnExcess::Intended { .. }
+                        | BurnExcess::Submitted { .. },
+                    ) => Some("resume; burn already intended/submitted"),
+                    _ => None,
+                };
+                (None, None, note)
+            }
+            (
+                BurnExcessPath::External,
+                Some(BurnExcess::FundingExcluded {
+                    funding_log_id,
+                    excluded_at,
+                    ..
+                }),
+            ) => {
+                let funding_hash_arg = request
+                    .funding_tx_hash
+                    .ok_or(BurnExcessProofError::FundingTxHashRequired)?;
+                require_funding_hash_match(funding_hash_arg, funding_log_id)?;
+                let balance = vault_service
+                    .get_share_balance(listed_vault, issuer_wallet)
+                    .await?;
+                require_exact_issuer_share_balance(balance, request.shares)?;
+                (
+                    Some(funding_log_id.clone()),
+                    Some(*excluded_at),
+                    Some("resume; exclusion already recorded"),
+                )
+            }
+            (
+                BurnExcessPath::External,
+                Some(
+                    BurnExcess::Intended {
+                        funding_log_id: Some(funding_log_id),
+                        ..
+                    }
+                    | BurnExcess::Submitted {
+                        funding_log_id: Some(funding_log_id),
+                        ..
+                    },
+                ),
+            ) => {
+                let funding_hash_arg = request
+                    .funding_tx_hash
+                    .ok_or(BurnExcessProofError::FundingTxHashRequired)?;
+                require_funding_hash_match(funding_hash_arg, funding_log_id)?;
+                let balance = vault_service
+                    .get_share_balance(listed_vault, issuer_wallet)
+                    .await?;
+                require_exact_issuer_share_balance(balance, request.shares)?;
+                (
+                    Some(funding_log_id.clone()),
+                    None,
+                    Some("resume; burn already intended/submitted"),
+                )
+            }
+            (BurnExcessPath::External, _) => {
+                let funding_tx_hash = request
+                    .funding_tx_hash
+                    .ok_or(BurnExcessProofError::FundingTxHashRequired)?;
+                let funding_log_id = prove_funding_transfer(
+                    pool,
+                    provider,
+                    FundingTransferExpectation {
+                        network: request.network,
+                        vault: listed_vault,
+                        tx_hash: funding_tx_hash,
+                        from: deposit_proof.original_recipient,
+                        to: issuer_wallet,
+                        amount: request.shares,
+                    },
+                )
+                .await?;
+                let balance = vault_service
+                    .get_share_balance(listed_vault, issuer_wallet)
+                    .await?;
+                require_exact_issuer_share_balance(balance, request.shares)?;
+                (Some(funding_log_id), None, None)
+            }
+        };
+
+    let freeze_advisory = match crate::underlying::load_freeze_status(
+        pool,
+        &underlying,
+    )
+    .await
+    {
+        Ok(crate::underlying::AssetStatus::Frozen) => Some(
+            "advisory: underlying is frozen (freeze is not a burn-excess gate)",
+        ),
+        Ok(crate::underlying::AssetStatus::Enabled) => None,
+        Err(error) => {
+            warn!(
+                target: "burn_excess",
+                error = %error,
+                %underlying,
+                "Failed to load freeze status; continuing without advisory"
+            );
+            None
+        }
+    };
+
+    Ok(ProvenPlan {
+        path,
+        bind,
+        deposit_proof,
+        funding_log_id,
+        exclusion_excluded_at,
+        underlying,
+        freeze_advisory,
+        resume_note,
+    })
+}
+
+fn print_plan(plan: &ProvenPlan, execute: bool) {
+    let mode = match plan.path {
+        BurnExcessPath::Internal => "internal",
+        BurnExcessPath::External => "external",
+    };
+    let path_letter = match plan.path {
+        BurnExcessPath::Internal => "A",
+        BurnExcessPath::External => "B",
+    };
+
+    match plan.path {
+        BurnExcessPath::Internal => {
+            if let Some(note) = plan.resume_note {
+                println!(
+                    "mode={mode} path={path_letter} ({note}; issuer holds exact \
+                     shares; no funding exclusion)"
+                );
+            } else {
+                println!(
+                    "mode={mode} path={path_letter} (issuer must hold exact shares; \
+                     no funding exclusion)"
+                );
+            }
+        }
+        BurnExcessPath::External => {
+            let funding = plan.funding_log_id.as_ref().map_or_else(
+                || "unknown".into(),
+                |log| format!("{:#x}", log.tx_hash),
+            );
+            if let Some(note) = plan.resume_note {
+                let log_index = plan.funding_log_id.as_ref().map_or_else(
+                    || "?".into(),
+                    |log| log.log_index.to_string(),
+                );
+                println!(
+                    "mode={mode} path={path_letter} ({note}; funding_tx_hash={funding}; \
+                     log_index={log_index})"
+                );
+            } else {
+                println!(
+                    "mode={mode} path={path_letter} (funding_tx_hash={funding}; will \
+                     exclude that Transfer log then burn)"
+                );
+            }
+        }
+    }
+
+    println!(
+        "bind: underlying={} network={} vault={:#x} issuer_request={} \
+         deposit={:#x} receipt_id={} shares={} original_recipient={:#x} \
+         issuer_wallet={:#x}",
+        plan.underlying,
+        plan.bind.network,
+        plan.bind.vault,
+        plan.bind.issuer_request_id,
+        plan.bind.deposit_tx_hash,
+        plan.bind.receipt_id,
+        plan.bind.shares,
+        plan.bind.original_recipient,
+        plan.bind.issuer_wallet,
+    );
+    if let Some(funding) = &plan.funding_log_id {
+        println!(
+            "funding_log: tx={:#x} log_index={} from={:#x} to={:#x} amount={}",
+            funding.tx_hash,
+            funding.log_index,
+            funding.from,
+            funding.to,
+            funding.amount,
+        );
+    }
+    if let Some(advisory) = plan.freeze_advisory {
+        println!("{advisory}");
+    }
+    // The exclusion write only beats the transfer poller to the funding log if
+    // the poller is not running. `redemption_exists_for_tx` re-checks right
+    // before the write, but it is a check, not a lock across processes.
+    if plan.path == BurnExcessPath::External {
+        println!(
+            "precondition: the issuer service must be STOPPED; a running \
+             transfer poller can open a Redemption for the funding Transfer \
+             first and steer this recovery onto the Alpaca path"
+        );
+    }
+    if execute {
+        println!("mode=execute (mutations will run after confirmation)");
+    } else {
+        println!("mode=dry-run (no events, no sign, no exclusion write)");
+    }
+}
+
+fn print_terminal_report(path: BurnExcessPath, state: Option<&BurnExcess>) {
+    match state {
+        Some(
+            state @ BurnExcess::Completed {
+                burn_tx_hash,
+                block_number,
+                completed_at,
+                ..
+            },
+        ) => {
+            println!(
+                "stream completed path={} burn_tx={burn_tx_hash:#x} \
+                 block={block_number} at={completed_at}",
+                state.path()
+            );
+            if let Some(funding) = state.funding_log_id() {
+                println!(
+                    "funding exclusion remains permanent: tx={:#x} log_index={}",
+                    funding.tx_hash, funding.log_index
+                );
+            }
+        }
+        Some(state @ BurnExcess::Closed { reason, closed_at, .. }) => {
+            println!(
+                "stream closed path={} reason={reason} at={closed_at}",
+                state.path()
+            );
+            if let Some(funding) = state.funding_log_id() {
+                println!(
+                    "funding exclusion remains permanent: tx={:#x} log_index={}",
+                    funding.tx_hash, funding.log_index
+                );
+            }
+        }
+        other => {
+            println!("stream terminal path={path} state={other:?}");
+        }
+    }
+}
+
+async fn close_stream(
+    store: &Store<BurnExcess>,
+    aggregate_id: &BurnExcessId,
+    state: Option<&BurnExcess>,
+    path: BurnExcessPath,
+    reason: &str,
+    execute: bool,
+    confirm: &(impl Fn(&str) -> io::Result<bool> + Send + Sync),
+) -> Result<(), BurnExcessEngineError> {
+    let state = state.ok_or_else(|| super::BurnExcessError::InvalidState {
+        expected: "FundingExcluded, Intended, or Submitted".to_string(),
+        found: "Uninitialized".to_string(),
+    })?;
+
+    match state {
+        BurnExcess::FundingExcluded { .. }
+        | BurnExcess::Intended { .. }
+        | BurnExcess::Submitted { .. } => {}
+        other => {
+            return Err(super::BurnExcessError::InvalidState {
+                expected: "FundingExcluded, Intended, or Submitted".to_string(),
+                found: other.state_name().to_string(),
+            }
+            .into());
+        }
+    }
+
+    println!(
+        "close plan: path={path} state={} reason={reason} \
+         (clears wallet nonce gate only; Closed is report-only for this deposit)",
+        state.state_name()
+    );
+    if !execute {
+        println!("mode=dry-run (no close event)");
+        return Ok(());
+    }
+
+    if !confirm(&format!(
+        "Close dead excess-burn stream {aggregate_id} (path={path}; clears \
+         wallet gates only)?"
+    ))? {
+        return Err(BurnExcessEngineError::Aborted);
+    }
+
+    store
+        .send(
+            aggregate_id,
+            BurnExcessCommand::CloseExcessBurn { reason: reason.to_string() },
+        )
+        .await?;
+    println!(
+        "Closed excess-burn stream {aggregate_id} (wallet gate cleared; stream \
+         is report-only terminal)"
+    );
+    Ok(())
+}
+
+/// Shared handles for burn-excess mutation steps (avoids long arg lists).
+struct MutationCtx<'a, P> {
+    pool: &'a Pool<Sqlite>,
+    vault_service: &'a dyn VaultService,
+    provider: &'a P,
+    store: &'a Store<BurnExcess>,
+    aggregate_id: &'a BurnExcessId,
+    plan: &'a ProvenPlan,
+    request: &'a BurnExcessRequest,
+}
+
+struct ConfirmCtx<'a, P> {
+    pool: &'a Pool<Sqlite>,
+    vault_service: &'a dyn VaultService,
+    provider: &'a P,
+    store: &'a Store<BurnExcess>,
+    aggregate_id: &'a BurnExcessId,
+    tx_id: crate::vault::TxId,
+    dust_shares: U256,
+    receipt_id: U256,
+    shares: U256,
+    bind: &'a ExcessBurnBind,
+    owner: Address,
+    chain_id: u64,
+}
+
+async fn execute_plan<P: Provider>(
+    mutation: MutationCtx<'_, P>,
+    state: Option<&BurnExcess>,
+    confirm: &(impl Fn(&str) -> io::Result<bool> + Send + Sync),
+) -> Result<(), BurnExcessEngineError> {
+    match state {
+        None => {
+            let prompt = match mutation.plan.path {
+                BurnExcessPath::Internal => format!(
+                    "Sign and persist excess burn for deposit {:#x} (path A \
+                     internal), then broadcast?",
+                    mutation.request.deposit_tx_hash
+                ),
+                BurnExcessPath::External => format!(
+                    "Record funding exclusion for deposit {:#x} (path B \
+                     external), then sign/broadcast the excess burn?",
+                    mutation.request.deposit_tx_hash
+                ),
+            };
+            if !confirm(&prompt)? {
+                return Err(BurnExcessEngineError::Aborted);
+            }
+
+            if mutation.plan.path == BurnExcessPath::External {
+                let funding = mutation
+                    .plan
+                    .funding_log_id
+                    .clone()
+                    .ok_or(BurnExcessProofError::FundingTxHashRequired)?;
+                // Irreversible boundary: re-check race vs redemption poller.
+                if redemption_exists_for_tx(mutation.pool, funding.tx_hash)
+                    .await?
+                {
+                    return Err(BurnExcessProofError::FundingAlreadyRedeemed {
+                        tx_hash: funding.tx_hash,
+                        log_index: funding.log_index,
+                    }
+                    .into());
+                }
+                record_exclusion(
+                    mutation.pool,
+                    mutation.store,
+                    mutation.aggregate_id,
+                    mutation.plan.bind.clone(),
+                    funding,
+                    &mutation.request.reason,
+                    mutation.request.incident_id.clone(),
+                )
+                .await?;
+            }
+
+            intend_submit_confirm(&mutation).await
+        }
+        Some(BurnExcess::FundingExcluded { funding_log_id, .. }) => {
+            if !confirm(&format!(
+                "Sign and persist excess burn for deposit {:#x} (exclusion \
+                 already recorded log_index={})?",
+                mutation.request.deposit_tx_hash, funding_log_id.log_index
+            ))? {
+                return Err(BurnExcessEngineError::Aborted);
+            }
+            intend_submit_confirm(&mutation).await
+        }
+        Some(BurnExcess::Intended { sendable_tx, bind, .. }) => {
+            if !confirm(&format!(
+                "Resume broadcast of persisted excess burn \
+                 sendable_tx.hash={:#x} for deposit {:#x}?",
+                sendable_tx.hash, mutation.request.deposit_tx_hash
+            ))? {
+                return Err(BurnExcessEngineError::Aborted);
+            }
+            resume_from_intended(
+                &mutation,
+                bind.issuer_wallet,
+                sendable_tx.clone(),
+                bind.receipt_id,
+                bind.shares,
+                bind,
+            )
+            .await
+        }
+        Some(BurnExcess::Submitted { sendable_tx, tx_id, bind, .. }) => {
+            if !confirm(&format!(
+                "Resume confirmation of submitted excess burn \
+                 sendable_tx.hash={:#x} for deposit {:#x}?",
+                sendable_tx.hash, mutation.request.deposit_tx_hash
+            ))? {
+                return Err(BurnExcessEngineError::Aborted);
+            }
+            resume_from_submitted(
+                &mutation,
+                bind.issuer_wallet,
+                sendable_tx.clone(),
+                tx_id.clone(),
+                bind.receipt_id,
+                bind.shares,
+                bind,
+            )
+            .await
+        }
+        Some(BurnExcess::Completed { .. } | BurnExcess::Closed { .. }) => {
+            Ok(())
+        }
+    }
+}
+
+async fn record_exclusion(
+    pool: &Pool<Sqlite>,
+    store: &Store<BurnExcess>,
+    aggregate_id: &BurnExcessId,
+    bind: ExcessBurnBind,
+    funding_log_id: FundingTransferId,
+    reason: &str,
+    incident_id: Option<String>,
+) -> Result<(), BurnExcessEngineError> {
+    let excluded_at = Utc::now();
+    store
+        .send(
+            aggregate_id,
+            BurnExcessCommand::RecordFundingExclusion {
+                bind,
+                funding_log_id: funding_log_id.clone(),
+                reason: reason.to_string(),
+                incident_id,
+            },
+        )
+        .await?;
+
+    // Dual-write: reactor is best-effort (Never cannot fail the command). The
+    // engine must own durability before any prepare/sign/broadcast.
+    record_funding_exclusion(
+        pool,
+        &funding_log_id,
+        aggregate_id.deposit_tx_hash(),
+        excluded_at,
+    )
+    .await?;
+
+    if !is_excluded_funding_log(
+        pool,
+        funding_log_id.network,
+        funding_log_id.vault,
+        funding_log_id.tx_hash,
+        funding_log_id.log_index,
+    )
+    .await?
+    {
+        return Err(BurnExcessEngineError::FundingExclusionIndexMissing {
+            tx_hash: funding_log_id.tx_hash,
+            log_index: funding_log_id.log_index,
+        });
+    }
+
+    info!(
+        target: "burn_excess",
+        deposit = %aggregate_id,
+        funding_tx = %format!("{:#x}", funding_log_id.tx_hash),
+        log_index = funding_log_id.log_index,
+        "Recorded funding exclusion"
+    );
+    println!(
+        "Recorded funding exclusion tx={:#x} log_index={}",
+        funding_log_id.tx_hash, funding_log_id.log_index
+    );
+    Ok(())
+}
+
+async fn require_wallet_intent_gates(
+    pool: &Pool<Sqlite>,
+    network: Network,
+    deposit_tx_hash: B256,
+) -> Result<(), BurnExcessEngineError> {
+    // The reservation is keyed by network alone, so this single check covers
+    // both an unresolved mint and an unresolved redemption burn holding a
+    // signed nonce on the signer this excess burn would use. BurnExcess is not
+    // tracked in that table, so its own intents need the separate check below.
+    if has_unresolved_signer_intent(pool, network, None).await? {
+        return Err(BurnExcessEngineError::UnresolvedSignerIntent { network });
+    }
+    let excluding = Some(&BurnExcessId::new(deposit_tx_hash));
+    if has_unresolved_excess_burn_intent(pool, excluding).await? {
+        return Err(BurnExcessEngineError::UnresolvedExcessBurnIntent);
+    }
+    Ok(())
+}
+
+async fn ensure_path_b_exclusion_indexed(
+    pool: &Pool<Sqlite>,
+    plan: &ProvenPlan,
+) -> Result<(), BurnExcessEngineError> {
+    let Some(funding) = plan.funding_log_id.as_ref() else {
+        return Ok(());
+    };
+    // Idempotent repair: the event is the source of truth, the SQL index is a
+    // derived read model. Re-write it before refusing so a dual-write failure
+    // after RecordFundingExclusion cannot permanently brick the stream.
+    // Prefer the event's excluded_at so the index timestamp matches history.
+    let excluded_at = plan.exclusion_excluded_at.unwrap_or_else(Utc::now);
+    record_funding_exclusion(
+        pool,
+        funding,
+        plan.bind.deposit_tx_hash,
+        excluded_at,
+    )
+    .await?;
+    if is_excluded_funding_log(
+        pool,
+        funding.network,
+        funding.vault,
+        funding.tx_hash,
+        funding.log_index,
+    )
+    .await?
+    {
+        return Ok(());
+    }
+    Err(BurnExcessEngineError::FundingExclusionIndexMissing {
+        tx_hash: funding.tx_hash,
+        log_index: funding.log_index,
+    })
+}
+
+/// Live-state gates re-read at the irreversible sign boundary.
+///
+/// `prove_plan` reads these before `print_plan` and the operator confirm
+/// prompt, which blocks on stdin for an unbounded time. Balances can move in
+/// that window, so a plan proven minutes ago must not be the last word before
+/// `prepare_burn_tx` signs and fixes a nonce. The deposit proof and the funding
+/// Transfer are mined history and cannot change, so only balances are re-read.
+async fn require_issuer_balances<P: Provider>(
+    provider: &P,
+    vault_service: &dyn VaultService,
+    bind: &ExcessBurnBind,
+) -> Result<(), BurnExcessEngineError> {
+    let receipt_contract =
+        receipt_contract_address(provider, bind.vault).await?;
+    let receipt_balance = receipt_balance_of(
+        provider,
+        receipt_contract,
+        bind.issuer_wallet,
+        bind.receipt_id,
+    )
+    .await?;
+    require_issuer_receipt_balance(
+        bind.receipt_id,
+        receipt_balance,
+        bind.shares,
+    )?;
+
+    let share_balance =
+        vault_service.get_share_balance(bind.vault, bind.issuer_wallet).await?;
+    require_exact_issuer_share_balance(share_balance, bind.shares)?;
+
+    Ok(())
+}
+
+async fn intend_submit_confirm<P: Provider>(
+    ctx: &MutationCtx<'_, P>,
+) -> Result<(), BurnExcessEngineError> {
+    // Irreversible sign boundary: re-check gates, balances, and Path B
+    // exclusion index.
+    require_wallet_intent_gates(
+        ctx.pool,
+        ctx.request.network,
+        ctx.request.deposit_tx_hash,
+    )
+    .await?;
+    require_issuer_balances(ctx.provider, ctx.vault_service, &ctx.plan.bind)
+        .await?;
+    if ctx.plan.path == BurnExcessPath::External {
+        ensure_path_b_exclusion_indexed(ctx.pool, ctx.plan).await?;
+    }
+
+    let params = multi_burn_params(ctx.plan);
+    let sendable_tx = ctx.vault_service.prepare_burn_tx(&params).await?;
+
+    ctx.store
+        .send(
+            ctx.aggregate_id,
+            BurnExcessCommand::IntendExcessBurn {
+                bind: ctx.plan.bind.clone(),
+                path: ctx.plan.path,
+                funding_log_id: ctx.plan.funding_log_id.clone(),
+                reason: ctx.request.reason.clone(),
+                incident_id: ctx.request.incident_id.clone(),
+                sendable_tx: sendable_tx.clone(),
+            },
+        )
+        .await?;
+    println!(
+        "Persisted IntendExcessBurn hash={:#x} nonce={}",
+        sendable_tx.hash, sendable_tx.nonce
+    );
+
+    let submitted =
+        ctx.vault_service.submit_burn(params, sendable_tx.clone()).await?;
+    ctx.store
+        .send(
+            ctx.aggregate_id,
+            BurnExcessCommand::RecordExcessBurnSubmitted {
+                tx_id: submitted.tx_id.clone(),
+                burn_tx_hash: sendable_tx.hash,
+            },
+        )
+        .await?;
+    println!("Submitted excess burn tx={:#x}", sendable_tx.hash);
+
+    confirm_and_complete(&ConfirmCtx {
+        pool: ctx.pool,
+        vault_service: ctx.vault_service,
+        provider: ctx.provider,
+        store: ctx.store,
+        aggregate_id: ctx.aggregate_id,
+        tx_id: submitted.tx_id,
+        dust_shares: sendable_tx.dust_shares,
+        receipt_id: ctx.plan.bind.receipt_id,
+        shares: ctx.plan.bind.shares,
+        bind: &ctx.plan.bind,
+        owner: ctx.plan.bind.issuer_wallet,
+        chain_id: ctx.request.chain_id,
+    })
+    .await
+}
+
+async fn resume_from_intended<P: Provider>(
+    ctx: &MutationCtx<'_, P>,
+    owner: Address,
+    sendable_tx: crate::vault::SendableTxWithHash,
+    receipt_id: U256,
+    shares: U256,
+    bind: &ExcessBurnBind,
+) -> Result<(), BurnExcessEngineError> {
+    let status =
+        ctx.vault_service.classify_burn_tx(owner, &sendable_tx).await?;
+    match status {
+        BurnTxStatus::Mined => {
+            confirm_and_complete(&ConfirmCtx {
+                pool: ctx.pool,
+                vault_service: ctx.vault_service,
+                provider: ctx.provider,
+                store: ctx.store,
+                aggregate_id: ctx.aggregate_id,
+                tx_id: sendable_tx.hash.into(),
+                dust_shares: sendable_tx.dust_shares,
+                receipt_id,
+                shares,
+                bind,
+                owner,
+                chain_id: ctx.request.chain_id,
+            })
+            .await
+        }
+        BurnTxStatus::StillMineable => {
+            // Rebroadcast persisted bytes; MultiBurnParams only supplies
+            // external_tx_id metadata (deposit-scoped placeholders).
+            let submitted = ctx
+                .vault_service
+                .submit_burn(
+                    multi_burn_params_from_bind(bind, &Bytes::new(), None),
+                    sendable_tx.clone(),
+                )
+                .await?;
+            ctx.store
+                .send(
+                    ctx.aggregate_id,
+                    BurnExcessCommand::RecordExcessBurnSubmitted {
+                        tx_id: submitted.tx_id.clone(),
+                        burn_tx_hash: sendable_tx.hash,
+                    },
+                )
+                .await?;
+            confirm_and_complete(&ConfirmCtx {
+                pool: ctx.pool,
+                vault_service: ctx.vault_service,
+                provider: ctx.provider,
+                store: ctx.store,
+                aggregate_id: ctx.aggregate_id,
+                tx_id: submitted.tx_id,
+                dust_shares: sendable_tx.dust_shares,
+                receipt_id,
+                shares,
+                bind,
+                owner,
+                chain_id: ctx.request.chain_id,
+            })
+            .await
+        }
+        BurnTxStatus::Reverted | BurnTxStatus::ProvablyDead => {
+            Err(BurnExcessEngineError::DeadBurnIntent { status })
+        }
+    }
+}
+
+async fn resume_from_submitted<P: Provider>(
+    ctx: &MutationCtx<'_, P>,
+    owner: Address,
+    sendable_tx: crate::vault::SendableTxWithHash,
+    tx_id: crate::vault::TxId,
+    receipt_id: U256,
+    shares: U256,
+    bind: &ExcessBurnBind,
+) -> Result<(), BurnExcessEngineError> {
+    let status =
+        ctx.vault_service.classify_burn_tx(owner, &sendable_tx).await?;
+    match status {
+        BurnTxStatus::Mined | BurnTxStatus::StillMineable => {
+            confirm_and_complete(&ConfirmCtx {
+                pool: ctx.pool,
+                vault_service: ctx.vault_service,
+                provider: ctx.provider,
+                store: ctx.store,
+                aggregate_id: ctx.aggregate_id,
+                tx_id,
+                dust_shares: sendable_tx.dust_shares,
+                receipt_id,
+                shares,
+                bind,
+                owner,
+                chain_id: ctx.request.chain_id,
+            })
+            .await
+        }
+        BurnTxStatus::Reverted | BurnTxStatus::ProvablyDead => {
+            Err(BurnExcessEngineError::DeadBurnIntent { status })
+        }
+    }
+}
+
+async fn confirm_and_complete<P: Provider>(
+    ctx: &ConfirmCtx<'_, P>,
+) -> Result<(), BurnExcessEngineError> {
+    let result =
+        ctx.vault_service.confirm_burn(&ctx.tx_id, ctx.dust_shares).await?;
+
+    let onchain: Vec<(U256, U256)> = result
+        .burns
+        .iter()
+        .map(|burn| (burn.receipt_id, burn.shares_burned))
+        .collect();
+    if onchain.as_slice() != [(ctx.receipt_id, ctx.shares)] {
+        return Err(BurnExcessEngineError::BurnDeltaMismatch {
+            expected_receipt: ctx.receipt_id,
+            expected_shares: ctx.shares,
+            onchain,
+        });
+    }
+
+    // Complete after on-chain verify so the stream is not stuck Intended if
+    // inventory reconcile fails. Reconcile failures still fail the CLI so ops
+    // re-run report-only + manual inventory.
+    ctx.store
+        .send(
+            ctx.aggregate_id,
+            BurnExcessCommand::CompleteExcessBurn {
+                burn_tx_hash: result.tx_hash,
+                block_number: result.block_number,
+            },
+        )
+        .await?;
+
+    println!(
+        "Completed excess burn tx={:#x} block={} receipt_id={} shares={}",
+        result.tx_hash, result.block_number, ctx.receipt_id, ctx.shares
+    );
+
+    // Before reconcile, which fails the CLI on error: the operator most needs
+    // the final balance in exactly that case — burn landed, Complete
+    // persisted, inventory read model now stale.
+    let share_balance =
+        ctx.vault_service.get_share_balance(ctx.bind.vault, ctx.owner).await?;
+    println!(
+        "post-burn: issuer_share_balance={share_balance} (delta expected -{})",
+        ctx.shares
+    );
+
+    reconcile_inventory_after_burn(
+        ctx.pool,
+        ctx.provider,
+        ctx.chain_id,
+        ctx.bind.vault,
+        ctx.owner,
+        ctx.receipt_id,
+    )
+    .await?;
+
+    Ok(())
+}
+
+async fn reconcile_inventory_after_burn<P: Provider>(
+    pool: &Pool<Sqlite>,
+    provider: &P,
+    chain_id: u64,
+    vault: Address,
+    owner: Address,
+    receipt_id: U256,
+) -> Result<(), BurnExcessEngineError> {
+    // The CLI is its own process and never runs the service startup that
+    // reconciles this aggregate, so do it here. Reaching `build()` on a stale
+    // schema fails the reconcile after `CompleteExcessBurn` is already
+    // persisted — the one window where the burn is done and the read model is
+    // not.
+    crate::prepare_event_sourced_startup::<ReceiptInventory>(pool).await?;
+    let inventory_store = StoreBuilder::<ReceiptInventory>::new(pool.clone())
+        .build(())
+        .await
+        .map_err(|error| BurnExcessEngineError::StoreBuild {
+            aggregate: "ReceiptInventory",
+            message: error.to_string(),
+        })?;
+
+    let inventory = load_inventory(&inventory_store, chain_id, &vault).await?;
+    let tracked = inventory
+        .receipts_with_balance()
+        .into_iter()
+        .any(|row| row.receipt_id.inner() == receipt_id);
+
+    if !tracked {
+        println!(
+            "inventory: receipt {receipt_id} not tracked; skipping reconcile \
+             (no Discover / no ReserveBurn)"
+        );
+        return Ok(());
+    }
+
+    let receipt_contract = receipt_contract_address(provider, vault).await?;
+    let on_chain =
+        receipt_balance_of(provider, receipt_contract, owner, receipt_id)
+            .await?;
+
+    if let Err(error) = send_receipt_inventory_command(
+        &inventory_store,
+        chain_id,
+        &vault,
+        ReceiptInventoryCommand::ReconcileBalance {
+            receipt_id: ReceiptId::from(receipt_id),
+            on_chain_balance: Shares::from(on_chain),
+            observed_wallet: owner,
+        },
+    )
+    .await
+    {
+        error!(
+            target: "burn_excess",
+            %receipt_id,
+            error = %error,
+            "Inventory reconcile after excess burn failed; on-chain burn \
+             completed — re-run inventory reconcile / report-only"
+        );
+        return Err(BurnExcessEngineError::InventoryReconcileFailed {
+            receipt_id,
+            source: Box::new(error),
+        });
+    }
+
+    println!(
+        "inventory: reconciled receipt {receipt_id} to on-chain balance \
+         {on_chain}"
+    );
+    Ok(())
+}
+
+/// MultiBurnParams placeholders: reuse vault redeem path. `detected_tx_hash`
+/// is deposit-scoped (not a Redemption aggregate).
+fn multi_burn_params(plan: &ProvenPlan) -> MultiBurnParams {
+    multi_burn_params_from_bind(
+        &plan.bind,
+        &plan.deposit_proof.receipt_info_bytes,
+        Some(plan.deposit_proof.receipt_info.clone()),
+    )
+}
+
+fn multi_burn_params_from_bind(
+    bind: &ExcessBurnBind,
+    receipt_info_bytes: &Bytes,
+    receipt_info: Option<crate::vault::ReceiptInformation>,
+) -> MultiBurnParams {
+    MultiBurnParams {
+        vault: bind.vault,
+        burns: vec![MultiBurnEntry {
+            receipt_id: bind.receipt_id,
+            burn_shares: bind.shares,
+            receipt_info,
+            receipt_info_bytes: Some(receipt_info_bytes.clone()),
+        }],
+        dust_shares: U256::ZERO,
+        owner: bind.issuer_wallet,
+        user: bind.issuer_wallet,
+        origin: BurnRequestOrigin::ExcessRecovery(BurnExcessId::new(
+            bind.deposit_tx_hash,
+        )),
+        detected_tx_hash: bind.deposit_tx_hash,
+        external_tx_id: None,
+    }
+}
+
+async fn load_mint_asset(
+    pool: &Pool<Sqlite>,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<(UnderlyingSymbol, Network), BurnExcessEngineError> {
+    crate::prepare_event_sourced_startup::<Mint>(pool).await?;
+    let (store, _projection) = StoreBuilder::<Mint>::new(pool.clone())
+        .build(())
+        .await
+        .map_err(|error| BurnExcessEngineError::StoreBuild {
+            aggregate: "Mint",
+            message: error.to_string(),
+        })?;
+    let mint = store.load(issuer_request_id).await?.ok_or_else(|| {
+        BurnExcessEngineError::MintNotFound {
+            issuer_request_id: issuer_request_id.clone(),
+        }
+    })?;
+
+    match mint {
+        Mint::Initiated { underlying, network, .. }
+        | Mint::JournalConfirmed { underlying, network, .. }
+        | Mint::JournalRejected { underlying, network, .. }
+        | Mint::Minting { underlying, network, .. }
+        | Mint::TxIntended { underlying, network, .. }
+        | Mint::TxSubmitted { underlying, network, .. }
+        | Mint::MintingFailed { underlying, network, .. }
+        | Mint::CallbackPending { underlying, network, .. }
+        | Mint::Completed { underlying, network, .. } => {
+            Ok((underlying, network))
+        }
+        closed @ Mint::Closed { .. } => {
+            Err(BurnExcessEngineError::MintMissingAsset {
+                issuer_request_id: issuer_request_id.clone(),
+                state: closed.state_name().to_string(),
+            })
+        }
+    }
+}
+
+async fn fetch_deposit_proof<P: Provider>(
+    provider: &P,
+    deposit_tx_hash: B256,
+    expected_vault: Address,
+) -> Result<DepositProof, BurnExcessEngineError> {
+    let receipt = provider
+        .get_transaction_receipt(deposit_tx_hash)
+        .await?
+        .ok_or(BurnExcessEngineError::DepositTxInvalid {
+            tx_hash: deposit_tx_hash,
+        })?;
+    if !receipt.status() {
+        return Err(BurnExcessEngineError::DepositTxInvalid {
+            tx_hash: deposit_tx_hash,
+        });
+    }
+
+    parse_deposit_proof(&receipt, expected_vault, deposit_tx_hash)
+}
+
+fn parse_deposit_proof(
+    receipt: &TransactionReceipt,
+    expected_vault: Address,
+    deposit_tx_hash: B256,
+) -> Result<DepositProof, BurnExcessEngineError> {
+    let mut deposit: Option<(U256, U256, Bytes, Address)> = None;
+    let mut share_transfer_out: Option<Address> = None;
+
+    for log in receipt.inner.logs() {
+        if log.address() != expected_vault {
+            continue;
+        }
+
+        if let Ok(decoded) =
+            log.log_decode::<OffchainAssetReceiptVault::Deposit>()
+        {
+            if deposit.is_some() {
+                return Err(BurnExcessEngineError::AmbiguousDepositTx {
+                    tx_hash: deposit_tx_hash,
+                });
+            }
+            let data = decoded.data();
+            deposit = Some((
+                data.id,
+                data.shares,
+                data.receiptInformation.clone(),
+                data.owner,
+            ));
+            continue;
+        }
+
+        if let Ok(decoded) =
+            log.log_decode::<OffchainAssetReceiptVault::Transfer>()
+        {
+            let transfer = decoded.data();
+            // Production mint multicall: deposit(to=issuer) then
+            // transfer(user, shares). The outbound Transfer after mint is the
+            // original share recipient for Path B funding proofs.
+            if let Some((_, shares, _, owner)) = deposit.as_ref()
+                && transfer.from == *owner
+                && transfer.to != Address::ZERO
+                && transfer.value == *shares
+            {
+                if share_transfer_out.is_some() {
+                    return Err(
+                        BurnExcessEngineError::AmbiguousShareTransferOut {
+                            tx_hash: deposit_tx_hash,
+                        },
+                    );
+                }
+                share_transfer_out = Some(transfer.to);
+            }
+        }
+    }
+
+    let Some((receipt_id, shares, receipt_info_bytes, deposit_owner)) = deposit
+    else {
+        return Err(BurnExcessEngineError::DepositTxInvalid {
+            tx_hash: deposit_tx_hash,
+        });
+    };
+
+    let receipt_info = decode_receipt_information_strict(&receipt_info_bytes)?;
+    let original_recipient = share_transfer_out.unwrap_or(deposit_owner);
+
+    Ok(DepositProof {
+        receipt_id,
+        shares,
+        receipt_info,
+        receipt_info_bytes,
+        original_recipient,
+        vault: expected_vault,
+    })
+}
+
+async fn prove_funding_transfer<P: Provider>(
+    pool: &Pool<Sqlite>,
+    provider: &P,
+    expectation: FundingTransferExpectation,
+) -> Result<FundingTransferId, BurnExcessEngineError> {
+    let receipt = provider
+        .get_transaction_receipt(expectation.tx_hash)
+        .await?
+        .ok_or(BurnExcessEngineError::FundingTxInvalid {
+            tx_hash: expectation.tx_hash,
+        })?;
+    if !receipt.status() {
+        return Err(BurnExcessEngineError::FundingTxInvalid {
+            tx_hash: expectation.tx_hash,
+        });
+    }
+
+    // Tx-scoped race check before log candidates exist — no log_index yet.
+    if redemption_exists_for_tx(pool, expectation.tx_hash).await? {
+        return Err(BurnExcessProofError::FundingAlreadyRedeemedTx {
+            tx_hash: expectation.tx_hash,
+        }
+        .into());
+    }
+
+    let mut candidates = Vec::new();
+    for log in receipt.inner.logs() {
+        let Ok(decoded) =
+            log.log_decode::<OffchainAssetReceiptVault::Transfer>()
+        else {
+            continue;
+        };
+        let Some(log_index) = log.log_index else {
+            return Err(BurnExcessProofError::FundingLogIndexMissing {
+                tx_hash: expectation.tx_hash,
+            }
+            .into());
+        };
+        let data = decoded.data();
+        candidates.push(FundingTransferCandidate {
+            log_index,
+            vault: log.address(),
+            from: data.from,
+            to: data.to,
+            amount: data.value,
+        });
+    }
+
+    Ok(select_funding_transfer(&expectation, &candidates)?)
+}
+
+async fn redemption_exists_for_tx(
+    pool: &Pool<Sqlite>,
+    tx_hash: B256,
+) -> Result<bool, sqlx::Error> {
+    let aggregate_id = IssuerRedemptionRequestId::new(tx_hash).to_string();
+    let exists = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+              AND aggregate_id = ?
+        )
+        ",
+    )
+    .bind(aggregate_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
+}
+
+async fn receipt_contract_address<P: Provider>(
+    provider: &P,
+    vault: Address,
+) -> Result<Address, BurnExcessEngineError> {
+    let vault_contract = OffchainAssetReceiptVault::new(vault, provider);
+    Ok(Address::from(vault_contract.receipt().call().await?.0))
+}
+
+async fn receipt_balance_of<P: Provider>(
+    provider: &P,
+    receipt_contract: Address,
+    owner: Address,
+    receipt_id: U256,
+) -> Result<U256, BurnExcessEngineError> {
+    let contract = Receipt::new(receipt_contract, provider);
+    Ok(contract.balanceOf(owner, receipt_id).call().await?)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::network::EthereumWallet;
+    use alloy::primitives::{Bytes, U256, address, b256};
+    use alloy::providers::fillers::{BlobGasFiller, ChainIdFiller};
+    use alloy::providers::{Provider, ProviderBuilder};
+    use alloy::signers::local::PrivateKeySigner;
+    use chrono::Utc;
+    use cqrs_es::DomainEvent;
+    use event_sorcery::StoreBuilder;
+    use rust_decimal::Decimal;
+    use sqlx::sqlite::SqlitePoolOptions;
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::Quantity;
+    use crate::account::ClientId;
+    use crate::bindings::OffchainAssetReceiptVault;
+    use crate::burn_excess::exclusion::is_excluded_funding_log;
+    use crate::burn_excess::proof::BurnExcessMode;
+    use crate::mint::{MintEvent, TokenizationRequestId};
+    use crate::receipt_inventory::{
+        ReceiptSource, ReceiptVaultKey, send_receipt_inventory_command,
+    };
+    use crate::test_utils::{ANVIL_CHAIN_ID, LocalEvm};
+    use crate::tokenized_asset::{
+        AssetKey, TokenSymbol, TokenizedAsset, TokenizedAssetCommand,
+        UnderlyingSymbol,
+    };
+    use crate::vault::ReceiptInformation;
+    use crate::vault::mock::MockVaultService;
+    use crate::vault::rain_meta::OaSchemaCache;
+    use crate::vault::service::RealBlockchainService;
+    use crate::vault::{
+        BurnTxStatus, MultiBurnResult, MultiBurnResultEntry, SendableTxWithHash,
+    };
+
+    const TEST_OA_SCHEMA: &str =
+        "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
+    const SHARES_RAW: u64 = 750_000_000_000_000_000;
+
+    async fn pool() -> Pool<Sqlite> {
+        let pool = SqlitePoolOptions::new()
+            .max_connections(5)
+            .connect(":memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn excess_shares() -> U256 {
+        U256::from(SHARES_RAW)
+    }
+
+    fn sample_receipt_info(
+        issuer_request_id: IssuerMintRequestId,
+    ) -> ReceiptInformation {
+        ReceiptInformation::new(
+            TokenizationRequestId::new("tok-excess"),
+            issuer_request_id,
+            UnderlyingSymbol::new("PTY").unwrap(),
+            Quantity::new(Decimal::new(750, 3)),
+            Utc::now(),
+            None,
+        )
+    }
+
+    async fn seed_listing(
+        pool: &Pool<Sqlite>,
+        vault: Address,
+    ) -> UnderlyingSymbol {
+        let underlying = UnderlyingSymbol::new("PTY").unwrap();
+        let (store, _projection) =
+            StoreBuilder::<TokenizedAsset>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        let key = AssetKey::new(underlying.clone(), Network::Base);
+        store
+            .send(
+                &key,
+                TokenizedAssetCommand::Add {
+                    underlying: underlying.clone(),
+                    token: TokenSymbol::new("tPTY"),
+                    network: Network::Base,
+                    vault,
+                },
+            )
+            .await
+            .unwrap();
+        underlying
+    }
+
+    async fn seed_mint_initiated(
+        pool: &Pool<Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        underlying: &UnderlyingSymbol,
+    ) {
+        let initiated = MintEvent::Initiated {
+            issuer_request_id: issuer_request_id.clone(),
+            tokenization_request_id: TokenizationRequestId::new("tok-excess"),
+            quantity: Quantity::new(Decimal::new(750, 3)),
+            underlying: underlying.clone(),
+            token: TokenSymbol::new("tPTY"),
+            network: Network::Base,
+            client_id: ClientId::new(),
+            wallet: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            initiated_at: Utc::now(),
+        };
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES ('Mint', ?, 1, ?, '1.0', ?, '{}')
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .bind(initiated.event_type())
+        .bind(serde_json::to_string(&initiated).unwrap())
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn prepared_evm() -> (
+        LocalEvm,
+        RealBlockchainService,
+        impl Provider + Clone,
+        PrivateKeySigner,
+    ) {
+        let evm = LocalEvm::new().await.unwrap();
+        evm.grant_deposit_role(evm.wallet_address).await.unwrap();
+        evm.grant_withdraw_role(evm.wallet_address).await.unwrap();
+        evm.grant_certify_role(evm.wallet_address).await.unwrap();
+        evm.certify_vault(U256::MAX).await.unwrap();
+
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .disable_recommended_fillers()
+            .with_gas_estimation()
+            .filler(BlobGasFiller)
+            .with_simple_nonce_management()
+            .filler(ChainIdFiller::default())
+            .wallet(EthereumWallet::from(signer.clone()))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        let service = RealBlockchainService::new(
+            provider.clone(),
+            Arc::new(OaSchemaCache::fixed(TEST_OA_SCHEMA)),
+        );
+        (evm, service, provider, signer)
+    }
+
+    async fn mint_with_info(
+        evm: &LocalEvm,
+        to: Address,
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> (U256, U256, Bytes, B256) {
+        let info = sample_receipt_info(issuer_request_id.clone());
+        let encoded = info.encode(Some(TEST_OA_SCHEMA)).unwrap();
+        let (receipt_id, shares, bytes) = evm
+            .mint_directly_with_info(excess_shares(), to, encoded)
+            .await
+            .unwrap();
+        // LocalEvm doesn't return tx hash; fetch latest from chain via
+        // balance-bearing deposit by scanning is hard — re-deposit path uses
+        // mint_directly_with_info which returns shares. Read the last
+        // transaction from the block.
+        let signer = PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        let block = provider
+            .get_block_by_number(alloy::eips::BlockNumberOrTag::Latest)
+            .await
+            .unwrap()
+            .unwrap();
+        let tx_hash = *block
+            .transactions
+            .as_hashes()
+            .and_then(|hashes| hashes.last())
+            .expect("deposit tx hash");
+        assert_eq!(shares, excess_shares());
+        (receipt_id, shares, bytes, tx_hash)
+    }
+
+    fn request(
+        mode: BurnExcessMode,
+        issuer_request_id: IssuerMintRequestId,
+        deposit_tx_hash: B256,
+        receipt_id: U256,
+        funding_tx_hash: Option<B256>,
+        execute: bool,
+    ) -> BurnExcessRequest {
+        BurnExcessRequest {
+            mode,
+            issuer_request_id,
+            deposit_tx_hash,
+            funding_tx_hash,
+            receipt_id,
+            shares: excess_shares(),
+            reason: "duplicate mint recovery".into(),
+            incident_id: Some("rai-1632-test".into()),
+            network: Network::Base,
+            chain_id: ANVIL_CHAIN_ID,
+            execute,
+            close: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn internal_dry_run_does_not_mutate() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let underlying = seed_listing(&pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(&pool, &issuer_request_id, &underlying).await;
+
+        let (receipt_id, _, _, deposit_tx) =
+            mint_with_info(&evm, evm.wallet_address, &issuer_request_id).await;
+
+        let before_share = service
+            .get_share_balance(evm.vault_address, evm.wallet_address)
+            .await
+            .unwrap();
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        let after_share = service
+            .get_share_balance(evm.vault_address, evm.wallet_address)
+            .await
+            .unwrap();
+        assert_eq!(before_share, after_share);
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        assert!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().is_none()
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_execute_burns_exact_shares_and_receipt() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let underlying = seed_listing(&pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(&pool, &issuer_request_id, &underlying).await;
+
+        let (receipt_id, shares, _, deposit_tx) =
+            mint_with_info(&evm, evm.wallet_address, &issuer_request_id).await;
+
+        // Numeric shape: receipt id is sequential; assert shares match 0.750e18.
+        assert_eq!(shares, excess_shares());
+
+        let receipt_contract =
+            receipt_contract_address(&provider, evm.vault_address)
+                .await
+                .unwrap();
+        let receipt_before = receipt_balance_of(
+            &provider,
+            receipt_contract,
+            evm.wallet_address,
+            receipt_id,
+        )
+        .await
+        .unwrap();
+        assert!(receipt_before >= shares);
+
+        // Track inventory + custody so post-burn reconcile can drop the row.
+        let inventory_store =
+            StoreBuilder::<ReceiptInventory>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+        send_receipt_inventory_command(
+            &inventory_store,
+            ANVIL_CHAIN_ID,
+            &evm.vault_address,
+            ReceiptInventoryCommand::DiscoverReceipt {
+                receipt_id: receipt_id.into(),
+                balance: Shares::from(shares),
+                block_number: 1,
+                tx_hash: deposit_tx,
+                source: ReceiptSource::External,
+                receipt_info: None,
+                receipt_info_bytes: None,
+            },
+        )
+        .await
+        .unwrap();
+        send_receipt_inventory_command(
+            &inventory_store,
+            ANVIL_CHAIN_ID,
+            &evm.vault_address,
+            ReceiptInventoryCommand::ConfirmCustody {
+                holder: evm.wallet_address,
+            },
+        )
+        .await
+        .unwrap();
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        let share_after = service
+            .get_share_balance(evm.vault_address, evm.wallet_address)
+            .await
+            .unwrap();
+        assert_eq!(share_after, U256::ZERO);
+
+        let receipt_after = receipt_balance_of(
+            &provider,
+            receipt_contract,
+            evm.wallet_address,
+            receipt_id,
+        )
+        .await
+        .unwrap();
+        assert_eq!(receipt_after, receipt_before - shares);
+
+        let inventory = inventory_store
+            .load(&ReceiptVaultKey::new(ANVIL_CHAIN_ID, evm.vault_address))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            inventory.receipts_with_balance().iter().all(|row| row
+                .receipt_id
+                .inner()
+                != receipt_id
+                || row.available_balance.is_zero()),
+            "burned receipt must not remain available: {:?}",
+            inventory.receipts_with_balance()
+        );
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        let state =
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().unwrap();
+        assert!(matches!(
+            state,
+            BurnExcess::Completed { path: BurnExcessPath::Internal, .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn external_fund_exclude_burn_and_poller_skips_only_that_log() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            funding_log_index,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id.clone(),
+                deposit_tx,
+                receipt_id,
+                Some(funding_tx),
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            service
+                .get_share_balance(evm.vault_address, evm.wallet_address)
+                .await
+                .unwrap(),
+            U256::ZERO
+        );
+
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap(),
+            "the proven funding log must be excluded"
+        );
+
+        // "Only that log": a neighbour in the same transaction stays eligible,
+        // so the exclusion is a single log identity and not a tx-wide skip.
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index.saturating_add(1),
+            )
+            .await
+            .unwrap(),
+            "a neighbouring log in the same tx must remain eligible"
+        );
+
+        // Terminal stream is report-only (no PathConflict); exclusion stays.
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap(),
+            "funding exclusion remains permanent after complete"
+        );
+    }
+
+    #[tokio::test]
+    async fn path_conflict_when_switching_mode_mid_stream() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let underlying = seed_listing(&pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(&pool, &issuer_request_id, &underlying).await;
+        let (receipt_id, _, _, deposit_tx) =
+            mint_with_info(&evm, evm.wallet_address, &issuer_request_id).await;
+
+        // Start internal by intending only: execute full burn then we can't
+        // switch — use FundingExcluded seed for external lock instead.
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        let bind = ExcessBurnBind {
+            issuer_request_id: issuer_request_id.clone(),
+            deposit_tx_hash: deposit_tx,
+            receipt_id,
+            shares: excess_shares(),
+            original_recipient: evm.wallet_address,
+            vault: evm.vault_address,
+            network: Network::Base,
+            issuer_wallet: evm.wallet_address,
+        };
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::IntendExcessBurn {
+                    bind,
+                    path: BurnExcessPath::Internal,
+                    funding_log_id: None,
+                    reason: "mid".into(),
+                    incident_id: None,
+                    sendable_tx: crate::vault::SendableTxWithHash::default(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                Some(B256::ZERO),
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BurnExcessEngineError::Proof(BurnExcessProofError::PathConflict {
+                locked: BurnExcessPath::Internal,
+                requested: BurnExcessMode::External,
+            })
+        ));
+    }
+
+    /// Shared Path B setup: deposit multicall (issuer deposit + transfer to
+    /// recipient) and funding transfer back to issuer.
+    /// Named rather than a tuple: callers pick out two or three fields each,
+    /// and a positional mix-up here previously produced a wrong
+    /// `funding_log_index`.
+    struct ExternalPathFixture {
+        issuer_request_id: IssuerMintRequestId,
+        receipt_id: U256,
+        deposit_tx: B256,
+        funding_tx: B256,
+        recipient: Address,
+        funding_log_index: u64,
+    }
+
+    async fn setup_external_path(
+        pool: &Pool<Sqlite>,
+        evm: &LocalEvm,
+    ) -> ExternalPathFixture {
+        let underlying = seed_listing(pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(pool, &issuer_request_id, &underlying).await;
+
+        let recipient = PrivateKeySigner::random();
+        let recipient_address = recipient.address();
+
+        let issuer_signer =
+            PrivateKeySigner::from_bytes(&evm.private_key).unwrap();
+        let issuer_provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(issuer_signer))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        let _ = issuer_provider
+            .send_transaction(
+                alloy::rpc::types::TransactionRequest::default()
+                    .to(recipient_address)
+                    .value(U256::from(10u64).pow(U256::from(18u64))),
+            )
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+
+        let info = sample_receipt_info(issuer_request_id.clone());
+        let encoded = info.encode(Some(TEST_OA_SCHEMA)).unwrap();
+        let vault_issuer =
+            OffchainAssetReceiptVault::new(evm.vault_address, &issuer_provider);
+        let ratio = U256::from(10).pow(U256::from(18));
+        let shares = excess_shares();
+        let deposit_call = vault_issuer
+            .deposit(shares, evm.wallet_address, ratio, encoded)
+            .calldata()
+            .clone();
+        let transfer_call =
+            vault_issuer.transfer(recipient_address, shares).calldata().clone();
+        let multicall_receipt = vault_issuer
+            .multicall(vec![deposit_call, transfer_call])
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+        let deposit_tx = multicall_receipt.transaction_hash;
+        let receipt_id = multicall_receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                log.log_decode::<OffchainAssetReceiptVault::Deposit>()
+                    .ok()
+                    .map(|decoded| decoded.data().id)
+            })
+            .unwrap();
+
+        let recipient_provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(recipient))
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        let vault_recipient = OffchainAssetReceiptVault::new(
+            evm.vault_address,
+            recipient_provider,
+        );
+        let funding_receipt = vault_recipient
+            .transfer(evm.wallet_address, shares)
+            .send()
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+        let funding_tx = funding_receipt.transaction_hash;
+        let funding_log_index = funding_receipt
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                let decoded = log
+                    .log_decode::<OffchainAssetReceiptVault::Transfer>()
+                    .ok()?;
+                let data = decoded.data();
+                if data.from == recipient_address
+                    && data.to == evm.wallet_address
+                    && data.value == shares
+                {
+                    log.log_index
+                } else {
+                    None
+                }
+            })
+            .expect("funding transfer log index");
+
+        ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            recipient: recipient_address,
+            funding_log_index,
+        }
+    }
+
+    #[tokio::test]
+    async fn external_dry_run_does_not_mutate() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            funding_log_index,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+
+        let before_share = service
+            .get_share_balance(evm.vault_address, evm.wallet_address)
+            .await
+            .unwrap();
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                Some(funding_tx),
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        let after_share = service
+            .get_share_balance(evm.vault_address, evm.wallet_address)
+            .await
+            .unwrap();
+        assert_eq!(before_share, after_share);
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        assert!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().is_none(),
+            "dry-run must not open a BurnExcess stream"
+        );
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap(),
+            "dry-run must not write an exclusion row"
+        );
+    }
+
+    #[tokio::test]
+    async fn external_execute_has_burn_excess_not_redemption() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            funding_log_index,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                Some(funding_tx),
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        let redemption_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Redemption'
+            ",
+        )
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            redemption_count, 0,
+            "Path B must never open a Redemption for funding/deposit txs"
+        );
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        let state =
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().unwrap();
+        assert!(matches!(
+            state,
+            BurnExcess::Completed { path: BurnExcessPath::External, .. }
+        ));
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn funding_already_redeemed_refuses_external() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+
+        // Seed a Redemption aggregate for the funding tx (poller race).
+        let redemption_id =
+            IssuerRedemptionRequestId::new(funding_tx).to_string();
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                1,
+                'RedemptionEvent::Detected',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .bind(&redemption_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let err = run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                Some(funding_tx),
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                BurnExcessEngineError::Proof(
+                    BurnExcessProofError::FundingAlreadyRedeemedTx { .. }
+                )
+            ),
+            "expected FundingAlreadyRedeemedTx, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn internal_refuses_when_original_recipient_is_not_issuer() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            recipient,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+        assert_ne!(recipient, evm.wallet_address);
+
+        // Shares sit at issuer after funding, but original recipient is not
+        // issuer — Path A must refuse and direct ops to external.
+        let err = run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                err,
+                BurnExcessEngineError::Proof(
+                    BurnExcessProofError::InternalRequiresIssuerAsRecipient { .. }
+                )
+            ),
+            "expected InternalRequiresIssuerAsRecipient, got {err:?}"
+        );
+        assert!(
+            err.to_string().contains("burn-excess external"),
+            "error should direct ops to external mode: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn path_conflict_funding_excluded_then_internal() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            ..
+        } = setup_external_path(&pool, &evm).await;
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        let funding = FundingTransferId {
+            network: Network::Base,
+            vault: evm.vault_address,
+            tx_hash: funding_tx,
+            log_index: 0,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: evm.wallet_address,
+            amount: excess_shares(),
+        };
+        let bind = ExcessBurnBind {
+            issuer_request_id: issuer_request_id.clone(),
+            deposit_tx_hash: deposit_tx,
+            receipt_id,
+            shares: excess_shares(),
+            original_recipient: funding.from,
+            vault: evm.vault_address,
+            network: Network::Base,
+            issuer_wallet: evm.wallet_address,
+        };
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::RecordFundingExclusion {
+                    bind,
+                    funding_log_id: funding,
+                    reason: "seed".into(),
+                    incident_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let err = run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            err,
+            BurnExcessEngineError::Proof(BurnExcessProofError::PathConflict {
+                locked: BurnExcessPath::External,
+                requested: BurnExcessMode::Internal,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn path_b_resume_repairs_missing_exclusion_index_row() {
+        let pool = pool().await;
+        let (evm, service, provider, _) = prepared_evm().await;
+        let ExternalPathFixture {
+            issuer_request_id,
+            receipt_id,
+            deposit_tx,
+            funding_tx,
+            recipient,
+            funding_log_index,
+        } = setup_external_path(&pool, &evm).await;
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        let funding = FundingTransferId {
+            network: Network::Base,
+            vault: evm.vault_address,
+            tx_hash: funding_tx,
+            log_index: funding_log_index,
+            from: recipient,
+            to: evm.wallet_address,
+            amount: excess_shares(),
+        };
+        let bind = ExcessBurnBind {
+            issuer_request_id: issuer_request_id.clone(),
+            deposit_tx_hash: deposit_tx,
+            receipt_id,
+            shares: excess_shares(),
+            original_recipient: recipient,
+            vault: evm.vault_address,
+            network: Network::Base,
+            issuer_wallet: evm.wallet_address,
+        };
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::RecordFundingExclusion {
+                    bind,
+                    funding_log_id: funding.clone(),
+                    reason: "seed".into(),
+                    incident_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Simulate dual-write gap / truncated index: event exists, row gone.
+        sqlx::query("DELETE FROM burn_excess_funding_exclusions")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap()
+        );
+
+        run_burn_excess(
+            &pool,
+            &service,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                Some(funding_tx),
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                Network::Base,
+                evm.vault_address,
+                funding_tx,
+                funding_log_index,
+            )
+            .await
+            .unwrap(),
+            "resume must re-insert the exclusion index from the event"
+        );
+        let state =
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().unwrap();
+        assert!(matches!(
+            state,
+            BurnExcess::Completed { path: BurnExcessPath::External, .. }
+        ));
+    }
+
+    /// The confirm prompt blocks on stdin for an unbounded time, so balances
+    /// proven before it can move before the burn is signed. The re-check at the
+    /// sign boundary must catch that and refuse, leaving nothing intended.
+    #[tokio::test]
+    async fn balance_moving_at_the_confirm_prompt_refuses_before_signing() {
+        let pool = pool().await;
+        let (evm, _real_service, provider, _) = prepared_evm().await;
+        let underlying = seed_listing(&pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(&pool, &issuer_request_id, &underlying).await;
+
+        let (receipt_id, shares, _, deposit_tx) =
+            mint_with_info(&evm, evm.wallet_address, &issuer_request_id).await;
+
+        // Proven balance is exact, so `prove_plan` and the prompt both pass.
+        let mock = MockVaultService::new_success().with_share_balance(shares);
+
+        let error = run_burn_excess(
+            &pool,
+            &mock,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                true,
+            ),
+            |_| {
+                // The operator's balance moves while the prompt is open.
+                mock.set_share_balance(shares + U256::from(1u64));
+                Ok(true)
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                error,
+                BurnExcessEngineError::Proof(
+                    BurnExcessProofError::IssuerShareBalanceNotExact { .. }
+                )
+            ),
+            "a balance that moved at the prompt must fail the re-check, got: \
+             {error:?}"
+        );
+        assert_eq!(
+            mock.burn_preparation_call_count(),
+            0,
+            "the re-check must refuse before anything is signed"
+        );
+
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        assert!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().is_none(),
+            "a refused re-check must leave no BurnExcess stream behind"
+        );
+    }
+
+    #[tokio::test]
+    async fn resume_intended_mined_completes_without_second_prepare() {
+        let pool = pool().await;
+        let (evm, _real_service, provider, _) = prepared_evm().await;
+        let underlying = seed_listing(&pool, evm.vault_address).await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_initiated(&pool, &issuer_request_id, &underlying).await;
+
+        let (receipt_id, shares, _, deposit_tx) =
+            mint_with_info(&evm, evm.wallet_address, &issuer_request_id).await;
+
+        let sendable = SendableTxWithHash {
+            tx: vec![0xde, 0xad],
+            hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            nonce: 7,
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        };
+        let bind = ExcessBurnBind {
+            issuer_request_id: issuer_request_id.clone(),
+            deposit_tx_hash: deposit_tx,
+            receipt_id,
+            shares,
+            original_recipient: evm.wallet_address,
+            vault: evm.vault_address,
+            network: Network::Base,
+            issuer_wallet: evm.wallet_address,
+        };
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::IntendExcessBurn {
+                    bind: bind.clone(),
+                    path: BurnExcessPath::Internal,
+                    funding_log_id: None,
+                    reason: "resume".into(),
+                    incident_id: None,
+                    sendable_tx: sendable.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let mock = MockVaultService::new_success()
+            .with_share_balance(shares)
+            .with_burn_tx_status(BurnTxStatus::Mined)
+            .with_pending_burn_result(MultiBurnResult {
+                tx_hash: sendable.hash,
+                burns: vec![MultiBurnResultEntry {
+                    receipt_id,
+                    shares_burned: shares,
+                }],
+                dust_returned: U256::ZERO,
+                gas_used: 50_000,
+                block_number: 99,
+            });
+
+        run_burn_excess(
+            &pool,
+            &mock,
+            &provider,
+            evm.wallet_address,
+            request(
+                BurnExcessMode::Internal,
+                issuer_request_id,
+                deposit_tx,
+                receipt_id,
+                None,
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            mock.burn_preparation_call_count(),
+            0,
+            "Intended+Mined resume must not re-prepare"
+        );
+        assert_eq!(mock.burn_classification_call_count(), 1);
+
+        let state =
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().unwrap();
+        assert!(matches!(state, BurnExcess::Completed { .. }));
+    }
+}

--- a/src/burn_excess/event.rs
+++ b/src/burn_excess/event.rs
@@ -1,0 +1,86 @@
+use alloy::primitives::B256;
+use chrono::{DateTime, Utc};
+use cqrs_es::DomainEvent;
+use serde::{Deserialize, Serialize};
+
+use super::{BurnExcessPath, ExcessBurnBind, FundingTransferId};
+use crate::vault::{SendableTxWithHash, TxId};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) enum BurnExcessEvent {
+    FundingExclusionRecorded {
+        bind: ExcessBurnBind,
+        funding_log_id: FundingTransferId,
+        reason: String,
+        incident_id: Option<String>,
+        excluded_at: DateTime<Utc>,
+    },
+    ExcessBurnIntended {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        reason: String,
+        incident_id: Option<String>,
+        sendable_tx: SendableTxWithHash,
+        intended_at: DateTime<Utc>,
+    },
+    ExcessBurnSubmitted {
+        tx_id: TxId,
+        burn_tx_hash: B256,
+        submitted_at: DateTime<Utc>,
+    },
+    ExcessBurnCompleted {
+        burn_tx_hash: B256,
+        block_number: u64,
+        completed_at: DateTime<Utc>,
+    },
+    ExcessBurnClosed {
+        reason: String,
+        closed_at: DateTime<Utc>,
+    },
+}
+
+impl BurnExcessEvent {
+    /// Stored `event_type` values, shared with the raw SQL that filters on
+    /// them: the wallet intent gate (`has_unresolved_excess_burn_intent`) and
+    /// the exclusion index rebuild (`rebuild_funding_exclusion_index`). Bound
+    /// here so a renamed variant is a compile error rather than a query that
+    /// silently matches nothing — a gate that returns zero rows is a gate that
+    /// is off.
+    pub(crate) const FUNDING_EXCLUSION_RECORDED: &'static str =
+        "BurnExcessEvent::FundingExclusionRecorded";
+    pub(crate) const EXCESS_BURN_INTENDED: &'static str =
+        "BurnExcessEvent::ExcessBurnIntended";
+    pub(crate) const EXCESS_BURN_SUBMITTED: &'static str =
+        "BurnExcessEvent::ExcessBurnSubmitted";
+    pub(crate) const EXCESS_BURN_COMPLETED: &'static str =
+        "BurnExcessEvent::ExcessBurnCompleted";
+    pub(crate) const EXCESS_BURN_CLOSED: &'static str =
+        "BurnExcessEvent::ExcessBurnClosed";
+}
+
+impl DomainEvent for BurnExcessEvent {
+    fn event_type(&self) -> String {
+        match self {
+            Self::FundingExclusionRecorded { .. } => {
+                Self::FUNDING_EXCLUSION_RECORDED.to_string()
+            }
+            Self::ExcessBurnIntended { .. } => {
+                Self::EXCESS_BURN_INTENDED.to_string()
+            }
+            Self::ExcessBurnSubmitted { .. } => {
+                Self::EXCESS_BURN_SUBMITTED.to_string()
+            }
+            Self::ExcessBurnCompleted { .. } => {
+                Self::EXCESS_BURN_COMPLETED.to_string()
+            }
+            Self::ExcessBurnClosed { .. } => {
+                Self::EXCESS_BURN_CLOSED.to_string()
+            }
+        }
+    }
+
+    fn event_version(&self) -> String {
+        "1.0".to_string()
+    }
+}

--- a/src/burn_excess/exclusion.rs
+++ b/src/burn_excess/exclusion.rs
@@ -1,0 +1,469 @@
+//! Durable SQL index of Path B funding Transfer identities the poller must skip.
+//!
+//! The index is a derived read model of `FundingExclusionRecorded` events. Live
+//! dispatch is best-effort (reactor `Error = Never`); durability for the CLI run
+//! is the engine dual-write. Custom reactors on `Materialized = Nil` aggregates
+//! are **not** catch_up'd by `StoreBuilder` — only live commits call
+//! [`Reactor::react`]. Startup and CLI store open must call
+//! [`rebuild_funding_exclusion_index`] so a restored DB (or a dual-write gap)
+//! cannot leave the poller free to open a `Redemption` for an excluded funding
+//! Transfer.
+
+use alloy::primitives::{Address, B256};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use event_sorcery::{EntityList, Never, Reactor, deps};
+use sqlx::{Pool, Sqlite, SqlitePool};
+use tracing::{debug, info};
+
+use super::{BurnExcess, BurnExcessEvent, FundingTransferId};
+use crate::tokenized_asset::Network;
+
+fn address_key(address: Address) -> String {
+    address.to_string().to_ascii_lowercase()
+}
+
+fn hash_key(hash: B256) -> String {
+    format!("{hash:#x}")
+}
+
+fn log_index_key(log_index: u64) -> Result<i64, sqlx::Error> {
+    // Encode, not Decode: this converts a value on its way into a bind
+    // parameter, so a "decode" error would point an operator at the read path.
+    i64::try_from(log_index).map_err(|error| {
+        sqlx::Error::Encode(Box::new(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            error.to_string(),
+        )))
+    })
+}
+
+/// Persist a verified funding log identity so the redemption poller skips it.
+///
+/// Idempotent on the primary key `(network, vault, tx_hash, log_index)`.
+pub(crate) async fn record_funding_exclusion(
+    pool: &Pool<Sqlite>,
+    funding: &FundingTransferId,
+    deposit_tx_hash: B256,
+    excluded_at: DateTime<Utc>,
+) -> Result<(), sqlx::Error> {
+    let network = funding.network.as_str();
+    let vault = address_key(funding.vault);
+    let tx_hash = hash_key(funding.tx_hash);
+    let from_address = address_key(funding.from);
+    let to_address = address_key(funding.to);
+    let amount = funding.amount.to_string();
+    let deposit = hash_key(deposit_tx_hash);
+    let excluded_at = excluded_at.to_rfc3339();
+    let log_index = log_index_key(funding.log_index)?;
+
+    sqlx::query(
+        "
+        INSERT INTO burn_excess_funding_exclusions (
+            network,
+            vault,
+            tx_hash,
+            log_index,
+            from_address,
+            to_address,
+            amount,
+            deposit_tx_hash,
+            excluded_at
+        )
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(network, vault, tx_hash, log_index) DO NOTHING
+        ",
+    )
+    .bind(network)
+    .bind(vault)
+    .bind(tx_hash)
+    .bind(log_index)
+    .bind(from_address)
+    .bind(to_address)
+    .bind(amount)
+    .bind(deposit)
+    .bind(excluded_at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Whether this exact Transfer log was recorded as an admin recovery funding move.
+pub(crate) async fn is_excluded_funding_log(
+    pool: &Pool<Sqlite>,
+    network: Network,
+    vault: Address,
+    tx_hash: B256,
+    log_index: u64,
+) -> Result<bool, sqlx::Error> {
+    let network = network.as_str();
+    let vault = address_key(vault);
+    let tx_hash = hash_key(tx_hash);
+    let log_index = log_index_key(log_index)?;
+
+    let exists = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM burn_excess_funding_exclusions
+            WHERE network = ?
+              AND vault = ?
+              AND tx_hash = ?
+              AND log_index = ?
+        )
+        ",
+    )
+    .bind(network)
+    .bind(vault)
+    .bind(tx_hash)
+    .bind(log_index)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists)
+}
+
+/// Re-insert every `FundingExclusionRecorded` row from the event store.
+///
+/// Idempotent (`ON CONFLICT DO NOTHING`). Call on main-service startup and
+/// before the burn-excess CLI opens its store. This is the recovery path when
+/// the SQL index was lost (backup restore, table recreate) while events remain.
+pub(crate) async fn rebuild_funding_exclusion_index(
+    pool: &Pool<Sqlite>,
+) -> Result<usize, RebuildFundingExclusionError> {
+    let rows = sqlx::query_as::<_, (String, String)>(
+        "
+        SELECT
+            aggregate_id,
+            payload
+        FROM events
+        WHERE aggregate_type = 'BurnExcess'
+          AND event_type = ?
+        ORDER BY sequence
+        ",
+    )
+    .bind(BurnExcessEvent::FUNDING_EXCLUSION_RECORDED)
+    .fetch_all(pool)
+    .await?;
+
+    let mut recorded = 0usize;
+    for (aggregate_id, payload) in rows {
+        let deposit_tx_hash =
+            aggregate_id.parse::<B256>().map_err(|error| {
+                RebuildFundingExclusionError::AggregateId {
+                    aggregate_id: aggregate_id.clone(),
+                    message: error.to_string(),
+                }
+            })?;
+        let event: BurnExcessEvent = serde_json::from_str(&payload)?;
+        let BurnExcessEvent::FundingExclusionRecorded {
+            funding_log_id,
+            excluded_at,
+            ..
+        } = event
+        else {
+            // Per-row, so DEBUG; the summary after the loop is the INFO. Only
+            // reachable when the `event_type` column disagrees with the stored
+            // payload, since any other payload shape fails deserialization
+            // above.
+            debug!(
+                target: "burn_excess",
+                %aggregate_id,
+                "Skipping non-exclusion payload under FundingExclusionRecorded \
+                 event_type"
+            );
+            continue;
+        };
+        record_funding_exclusion(
+            pool,
+            &funding_log_id,
+            deposit_tx_hash,
+            excluded_at,
+        )
+        .await?;
+        recorded = recorded.saturating_add(1);
+    }
+
+    if recorded > 0 {
+        info!(
+            target: "burn_excess",
+            recorded,
+            "Rebuilt funding exclusion index from FundingExclusionRecorded events"
+        );
+    }
+
+    Ok(recorded)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum RebuildFundingExclusionError {
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+
+    #[error(
+        "invalid BurnExcess aggregate_id {aggregate_id} while rebuilding \
+         funding exclusion index: {message}"
+    )]
+    AggregateId { aggregate_id: String, message: String },
+}
+
+deps!(FundingExclusionReactor, [BurnExcess]);
+
+/// Writes Path B funding identities into the SQL exclusion index when the
+/// aggregate records them, so the transfer poller can skip without scanning
+/// the event store.
+///
+/// Live-only: `StoreBuilder` does not catch_up custom reactors for
+/// `Materialized = Nil` entities. Use [`rebuild_funding_exclusion_index`] on
+/// startup for durability across process restarts and DB restores.
+pub(crate) struct FundingExclusionReactor {
+    pool: SqlitePool,
+}
+
+impl FundingExclusionReactor {
+    pub(crate) const fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+
+    async fn on_event(
+        &self,
+        deposit_tx_hash: B256,
+        event: &BurnExcessEvent,
+    ) -> Result<(), sqlx::Error> {
+        if let BurnExcessEvent::FundingExclusionRecorded {
+            funding_log_id,
+            excluded_at,
+            ..
+        } = event
+        {
+            record_funding_exclusion(
+                &self.pool,
+                funding_log_id,
+                deposit_tx_hash,
+                *excluded_at,
+            )
+            .await?;
+            info!(
+                target: "burn_excess",
+                %deposit_tx_hash,
+                funding_tx = %format!("{:#x}", funding_log_id.tx_hash),
+                log_index = funding_log_id.log_index,
+                "Recorded funding exclusion for admin recovery"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Reactor for FundingExclusionReactor {
+    type Error = Never;
+
+    async fn react(
+        &self,
+        event: <Self::Dependencies as EntityList>::Event,
+    ) -> Result<(), Self::Error> {
+        let (aggregate_id, domain_event) = event.into_inner();
+        // Reactor Error = Never cannot surface DB failures to the command path.
+        // Engine dual-write owns durability for the active CLI run; resume
+        // re-writes the row (ensure_path_b_exclusion_indexed). Live dispatch
+        // failures and lost index tables are healed by
+        // rebuild_funding_exclusion_index on next startup / CLI open.
+        if let Err(error) =
+            self.on_event(aggregate_id.deposit_tx_hash(), &domain_event).await
+        {
+            tracing::error!(
+                target: "burn_excess",
+                deposit_tx_hash = %aggregate_id,
+                error = %error,
+                "Failed to persist funding exclusion index row"
+            );
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{B256, U256, address, b256};
+    use chrono::Utc;
+
+    use super::*;
+    use crate::tokenized_asset::Network;
+
+    async fn pool() -> Pool<Sqlite> {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    fn sample_funding() -> FundingTransferId {
+        FundingTransferId {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            log_index: 3,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(750_000_000_000_000_000u64),
+        }
+    }
+
+    fn sample_deposit() -> B256 {
+        b256!(
+            "0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd"
+        )
+    }
+
+    #[tokio::test]
+    async fn record_and_lookup_exclusion_is_exact() {
+        let pool = pool().await;
+        let funding = sample_funding();
+        let deposit = sample_deposit();
+
+        record_funding_exclusion(&pool, &funding, deposit, Utc::now())
+            .await
+            .unwrap();
+
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                funding.tx_hash,
+                funding.log_index,
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                funding.tx_hash,
+                funding.log_index + 1,
+            )
+            .await
+            .unwrap()
+        );
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                B256::ZERO,
+                funding.log_index,
+            )
+            .await
+            .unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn rebuild_restores_index_from_events_after_row_loss() {
+        let pool = pool().await;
+        let funding = sample_funding();
+        let deposit = sample_deposit();
+        let excluded_at = Utc::now();
+
+        let event = BurnExcessEvent::FundingExclusionRecorded {
+            bind: super::super::ExcessBurnBind {
+                issuer_request_id: crate::mint::IssuerMintRequestId::new(
+                    uuid::Uuid::parse_str(
+                        "d3042b2f-4845-4acd-9a67-92d743e4e58c",
+                    )
+                    .unwrap(),
+                ),
+                deposit_tx_hash: deposit,
+                receipt_id: U256::from(7u64),
+                shares: funding.amount,
+                original_recipient: funding.from,
+                vault: funding.vault,
+                network: funding.network,
+                issuer_wallet: funding.to,
+            },
+            funding_log_id: funding.clone(),
+            reason: "duplicate mint".into(),
+            incident_id: None,
+            excluded_at,
+        };
+        let payload = serde_json::to_string(&event).unwrap();
+        let aggregate_id = format!("{deposit:#x}");
+
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'BurnExcess',
+                ?,
+                1,
+                'BurnExcessEvent::FundingExclusionRecorded',
+                '1.0',
+                ?,
+                '{}'
+            )
+            ",
+        )
+        .bind(&aggregate_id)
+        .bind(&payload)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            !is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                funding.tx_hash,
+                funding.log_index,
+            )
+            .await
+            .unwrap(),
+            "index empty before rebuild"
+        );
+
+        let recorded = rebuild_funding_exclusion_index(&pool).await.unwrap();
+        assert_eq!(recorded, 1);
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                funding.tx_hash,
+                funding.log_index,
+            )
+            .await
+            .unwrap()
+        );
+
+        // Idempotent.
+        assert_eq!(rebuild_funding_exclusion_index(&pool).await.unwrap(), 1);
+        assert!(
+            is_excluded_funding_log(
+                &pool,
+                funding.network,
+                funding.vault,
+                funding.tx_hash,
+                funding.log_index,
+            )
+            .await
+            .unwrap()
+        );
+    }
+}

--- a/src/burn_excess/mod.rs
+++ b/src/burn_excess/mod.rs
@@ -1,0 +1,1185 @@
+//! Administrative burn of excess shares from a proven duplicate mint.
+//!
+//! See SPEC.md "Burn excess shares". Path A (`internal`) burns when the issuer
+//! already holds the excess; Path B (`external`) records a funding-transfer
+//! exclusion then burns. Never Alpaca; never a `Redemption` aggregate.
+
+pub(crate) mod cli;
+mod cmd;
+pub(crate) mod engine;
+mod event;
+pub(crate) mod exclusion;
+pub(crate) mod proof;
+
+use alloy::primitives::{Address, B256, U256};
+use async_trait::async_trait;
+use chrono::{DateTime, Utc};
+use event_sorcery::{EventSourced, Nil};
+use serde::{Deserialize, Serialize};
+use sqlx::{Pool, Sqlite};
+
+use crate::mint::IssuerMintRequestId;
+use crate::tokenized_asset::Network;
+use crate::vault::{SendableTxWithHash, TxId};
+
+pub(crate) use cmd::BurnExcessCommand;
+pub(crate) use event::BurnExcessEvent;
+
+/// Operator / aggregate path after selection (persisted on first progress).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum BurnExcessPath {
+    Internal,
+    External,
+}
+
+impl std::fmt::Display for BurnExcessPath {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Internal => formatter.write_str("internal"),
+            Self::External => formatter.write_str("external"),
+        }
+    }
+}
+
+/// Verified identity of a Path B funding Transfer log.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct FundingTransferId {
+    pub(crate) network: Network,
+    pub(crate) vault: Address,
+    pub(crate) tx_hash: B256,
+    pub(crate) log_index: u64,
+    pub(crate) from: Address,
+    pub(crate) to: Address,
+    pub(crate) amount: U256,
+}
+
+/// Proven deposit bind shared across the burn-excess stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct ExcessBurnBind {
+    pub(crate) issuer_request_id: IssuerMintRequestId,
+    pub(crate) deposit_tx_hash: B256,
+    pub(crate) receipt_id: U256,
+    pub(crate) shares: U256,
+    pub(crate) original_recipient: Address,
+    pub(crate) vault: Address,
+    pub(crate) network: Network,
+    pub(crate) issuer_wallet: Address,
+}
+
+/// Aggregate id is the deposit transaction hash that created the excess.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub(crate) struct BurnExcessId(B256);
+
+impl BurnExcessId {
+    #[must_use]
+    pub(crate) const fn new(deposit_tx_hash: B256) -> Self {
+        Self(deposit_tx_hash)
+    }
+
+    #[must_use]
+    pub(crate) const fn deposit_tx_hash(self) -> B256 {
+        self.0
+    }
+}
+
+impl std::fmt::Display for BurnExcessId {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{:#x}", self.0)
+    }
+}
+
+impl std::str::FromStr for BurnExcessId {
+    type Err = alloy::hex::FromHexError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        value.parse::<B256>().map(Self)
+    }
+}
+
+/// Lifecycle of one excess-burn recovery stream.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub(crate) enum BurnExcess {
+    FundingExcluded {
+        bind: ExcessBurnBind,
+        funding_log_id: FundingTransferId,
+        reason: String,
+        incident_id: Option<String>,
+        excluded_at: DateTime<Utc>,
+    },
+    Intended {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        reason: String,
+        incident_id: Option<String>,
+        sendable_tx: SendableTxWithHash,
+        intended_at: DateTime<Utc>,
+    },
+    Submitted {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        reason: String,
+        incident_id: Option<String>,
+        sendable_tx: SendableTxWithHash,
+        tx_id: TxId,
+        burn_tx_hash: B256,
+        intended_at: DateTime<Utc>,
+        submitted_at: DateTime<Utc>,
+    },
+    Completed {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        burn_tx_hash: B256,
+        block_number: u64,
+        completed_at: DateTime<Utc>,
+    },
+    Closed {
+        bind: ExcessBurnBind,
+        path: BurnExcessPath,
+        funding_log_id: Option<FundingTransferId>,
+        reason: String,
+        closed_at: DateTime<Utc>,
+    },
+}
+
+#[derive(
+    Debug, Clone, PartialEq, Eq, Serialize, Deserialize, thiserror::Error,
+)]
+pub(crate) enum BurnExcessError {
+    #[error("invalid state: expected {expected}, found {found}")]
+    InvalidState { expected: String, found: String },
+
+    #[error(
+        "external path requires FundingExcluded before IntendExcessBurn; \
+         got {found}"
+    )]
+    ExternalRequiresExclusion { found: String },
+
+    #[error("internal path must not record a funding exclusion")]
+    InternalMustNotExclude,
+
+    #[error(
+        "IntendExcessBurn path {command_path} conflicts with stream path \
+         {stream_path}"
+    )]
+    PathConflict { stream_path: BurnExcessPath, command_path: BurnExcessPath },
+
+    #[error(
+        "funding log on intend does not match recorded exclusion: \
+         command={command:?}, recorded={recorded:?}"
+    )]
+    FundingMismatch {
+        command: Option<Box<FundingTransferId>>,
+        recorded: Box<FundingTransferId>,
+    },
+
+    #[error("deposit bind does not match the stream bind")]
+    BindMismatch,
+}
+
+impl BurnExcess {
+    pub(crate) const fn path(&self) -> BurnExcessPath {
+        match self {
+            Self::FundingExcluded { .. } => BurnExcessPath::External,
+            Self::Intended { path, .. }
+            | Self::Submitted { path, .. }
+            | Self::Completed { path, .. }
+            | Self::Closed { path, .. } => *path,
+        }
+    }
+
+    pub(crate) const fn state_name(&self) -> &'static str {
+        match self {
+            Self::FundingExcluded { .. } => "FundingExcluded",
+            Self::Intended { .. } => "Intended",
+            Self::Submitted { .. } => "Submitted",
+            Self::Completed { .. } => "Completed",
+            Self::Closed { .. } => "Closed",
+        }
+    }
+
+    pub(crate) const fn funding_log_id(&self) -> Option<&FundingTransferId> {
+        match self {
+            Self::FundingExcluded { funding_log_id, .. } => {
+                Some(funding_log_id)
+            }
+            Self::Intended { funding_log_id, .. }
+            | Self::Submitted { funding_log_id, .. }
+            | Self::Completed { funding_log_id, .. }
+            | Self::Closed { funding_log_id, .. } => funding_log_id.as_ref(),
+        }
+    }
+
+    fn apply_event(&mut self, event: BurnExcessEvent) {
+        match event {
+            BurnExcessEvent::FundingExclusionRecorded {
+                bind,
+                funding_log_id,
+                reason,
+                incident_id,
+                excluded_at,
+            } => {
+                *self = Self::FundingExcluded {
+                    bind,
+                    funding_log_id,
+                    reason,
+                    incident_id,
+                    excluded_at,
+                };
+            }
+            BurnExcessEvent::ExcessBurnIntended {
+                bind,
+                path,
+                funding_log_id,
+                reason,
+                incident_id,
+                sendable_tx,
+                intended_at,
+            } => {
+                *self = Self::Intended {
+                    bind,
+                    path,
+                    funding_log_id,
+                    reason,
+                    incident_id,
+                    sendable_tx,
+                    intended_at,
+                };
+            }
+            BurnExcessEvent::ExcessBurnSubmitted {
+                tx_id,
+                burn_tx_hash,
+                submitted_at,
+            } => {
+                let Self::Intended {
+                    bind,
+                    path,
+                    funding_log_id,
+                    reason,
+                    incident_id,
+                    sendable_tx,
+                    intended_at,
+                } = self.clone()
+                else {
+                    return;
+                };
+                *self = Self::Submitted {
+                    bind,
+                    path,
+                    funding_log_id,
+                    reason,
+                    incident_id,
+                    sendable_tx,
+                    tx_id,
+                    burn_tx_hash,
+                    intended_at,
+                    submitted_at,
+                };
+            }
+            BurnExcessEvent::ExcessBurnCompleted {
+                burn_tx_hash,
+                block_number,
+                completed_at,
+            } => {
+                let (bind, path, funding_log_id) = match self {
+                    Self::Intended { bind, path, funding_log_id, .. }
+                    | Self::Submitted { bind, path, funding_log_id, .. } => {
+                        (bind.clone(), *path, funding_log_id.clone())
+                    }
+                    Self::FundingExcluded { bind, funding_log_id, .. } => (
+                        bind.clone(),
+                        BurnExcessPath::External,
+                        Some(funding_log_id.clone()),
+                    ),
+                    Self::Completed { .. } | Self::Closed { .. } => return,
+                };
+                *self = Self::Completed {
+                    bind,
+                    path,
+                    funding_log_id,
+                    burn_tx_hash,
+                    block_number,
+                    completed_at,
+                };
+            }
+            BurnExcessEvent::ExcessBurnClosed { reason, closed_at } => {
+                let (bind, path, funding_log_id) = match self {
+                    Self::FundingExcluded { bind, funding_log_id, .. } => (
+                        bind.clone(),
+                        BurnExcessPath::External,
+                        Some(funding_log_id.clone()),
+                    ),
+                    Self::Intended { bind, path, funding_log_id, .. }
+                    | Self::Submitted { bind, path, funding_log_id, .. } => {
+                        (bind.clone(), *path, funding_log_id.clone())
+                    }
+                    Self::Completed { .. } | Self::Closed { .. } => return,
+                };
+                *self = Self::Closed {
+                    bind,
+                    path,
+                    funding_log_id,
+                    reason,
+                    closed_at,
+                };
+            }
+        }
+    }
+
+    fn handle_record_funding_exclusion(
+        bind: ExcessBurnBind,
+        funding_log_id: FundingTransferId,
+        reason: String,
+        incident_id: Option<String>,
+    ) -> Vec<BurnExcessEvent> {
+        vec![BurnExcessEvent::FundingExclusionRecorded {
+            bind,
+            funding_log_id,
+            reason,
+            incident_id,
+            excluded_at: Utc::now(),
+        }]
+    }
+
+    fn handle_intend(
+        &self,
+        command: BurnExcessCommand,
+    ) -> Result<Vec<BurnExcessEvent>, BurnExcessError> {
+        let BurnExcessCommand::IntendExcessBurn {
+            bind: command_bind,
+            path,
+            funding_log_id,
+            reason,
+            incident_id,
+            sendable_tx,
+        } = command
+        else {
+            return Err(BurnExcessError::InvalidState {
+                expected: "IntendExcessBurn".to_string(),
+                found: self.state_name().to_string(),
+            });
+        };
+
+        match self {
+            Self::FundingExcluded {
+                bind, funding_log_id: recorded, ..
+            } => {
+                if path != BurnExcessPath::External {
+                    return Err(BurnExcessError::PathConflict {
+                        stream_path: BurnExcessPath::External,
+                        command_path: path,
+                    });
+                }
+                if command_bind != *bind {
+                    return Err(BurnExcessError::BindMismatch);
+                }
+                match &funding_log_id {
+                    Some(command_funding) if command_funding == recorded => {}
+                    other => {
+                        return Err(BurnExcessError::FundingMismatch {
+                            command: other.clone().map(Box::new),
+                            recorded: Box::new(recorded.clone()),
+                        });
+                    }
+                }
+                Ok(vec![BurnExcessEvent::ExcessBurnIntended {
+                    bind: command_bind,
+                    path,
+                    funding_log_id,
+                    reason,
+                    incident_id,
+                    sendable_tx,
+                    intended_at: Utc::now(),
+                }])
+            }
+            other => Err(BurnExcessError::InvalidState {
+                expected:
+                    "FundingExcluded (external) or uninitialized (internal)"
+                        .to_string(),
+                found: other.state_name().to_string(),
+            }),
+        }
+    }
+}
+
+/// Returns whether any excess-burn stream is an unresolved recovery in
+/// progress, without a terminal complete/close.
+///
+/// `Intended` / `Submitted` hold a signed nonce. `FundingExcluded` holds no
+/// signed transaction yet, but its exclusion write is already permanent and the
+/// stream will sign against the same issuer wallet, so it counts too: a Path B
+/// recovery abandoned before intend must be resumed or `--close`d, never raced
+/// by a second recovery or by mint/redemption burn prepare.
+pub(crate) async fn has_unresolved_excess_burn_intent(
+    pool: &Pool<Sqlite>,
+    excluding: Option<&BurnExcessId>,
+) -> Result<bool, sqlx::Error> {
+    let excluding = excluding.map(ToString::to_string).unwrap_or_default();
+    let exists = sqlx::query_scalar::<_, bool>(
+        "
+        SELECT EXISTS (
+            SELECT 1
+            FROM events AS intent
+            WHERE intent.aggregate_type = 'BurnExcess'
+              AND intent.event_type IN (?, ?, ?)
+              AND intent.aggregate_id != ?
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM events AS terminal
+                  WHERE terminal.aggregate_type = intent.aggregate_type
+                    AND terminal.aggregate_id = intent.aggregate_id
+                    AND terminal.event_type IN (?, ?)
+              )
+        )
+        ",
+    )
+    .bind(BurnExcessEvent::FUNDING_EXCLUSION_RECORDED)
+    .bind(BurnExcessEvent::EXCESS_BURN_INTENDED)
+    .bind(BurnExcessEvent::EXCESS_BURN_SUBMITTED)
+    .bind(excluding)
+    .bind(BurnExcessEvent::EXCESS_BURN_COMPLETED)
+    .bind(BurnExcessEvent::EXCESS_BURN_CLOSED)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists)
+}
+
+#[async_trait]
+impl EventSourced for BurnExcess {
+    type Id = BurnExcessId;
+    type Event = BurnExcessEvent;
+    type Command = BurnExcessCommand;
+    type Error = BurnExcessError;
+    type Services = ();
+    type Materialized = Nil;
+
+    const AGGREGATE_TYPE: &'static str = "BurnExcess";
+    const PROJECTION: Nil = Nil;
+    const SCHEMA_VERSION: u64 = 1;
+    const SNAPSHOT_SIZE: usize = usize::MAX;
+
+    fn originate(event: &Self::Event) -> Option<Self> {
+        match event {
+            BurnExcessEvent::FundingExclusionRecorded {
+                bind,
+                funding_log_id,
+                reason,
+                incident_id,
+                excluded_at,
+            } => Some(Self::FundingExcluded {
+                bind: bind.clone(),
+                funding_log_id: funding_log_id.clone(),
+                reason: reason.clone(),
+                incident_id: incident_id.clone(),
+                excluded_at: *excluded_at,
+            }),
+            BurnExcessEvent::ExcessBurnIntended {
+                bind,
+                path,
+                funding_log_id,
+                reason,
+                incident_id,
+                sendable_tx,
+                intended_at,
+            } => Some(Self::Intended {
+                bind: bind.clone(),
+                path: *path,
+                funding_log_id: funding_log_id.clone(),
+                reason: reason.clone(),
+                incident_id: incident_id.clone(),
+                sendable_tx: sendable_tx.clone(),
+                intended_at: *intended_at,
+            }),
+            _ => None,
+        }
+    }
+
+    fn evolve(
+        entity: &Self,
+        event: &Self::Event,
+    ) -> Result<Option<Self>, Self::Error> {
+        let mut next = entity.clone();
+        next.apply_event(event.clone());
+        Ok(Some(next))
+    }
+
+    async fn initialize(
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            BurnExcessCommand::RecordFundingExclusion {
+                bind,
+                funding_log_id,
+                reason,
+                incident_id,
+            } => Ok(Self::handle_record_funding_exclusion(
+                bind,
+                funding_log_id,
+                reason,
+                incident_id,
+            )),
+            BurnExcessCommand::IntendExcessBurn {
+                bind,
+                path,
+                funding_log_id,
+                reason,
+                incident_id,
+                sendable_tx,
+            } => {
+                if path != BurnExcessPath::Internal {
+                    return Err(BurnExcessError::ExternalRequiresExclusion {
+                        found: "Uninitialized".to_string(),
+                    });
+                }
+                if funding_log_id.is_some() {
+                    return Err(BurnExcessError::InternalMustNotExclude);
+                }
+                Ok(vec![BurnExcessEvent::ExcessBurnIntended {
+                    bind,
+                    path,
+                    funding_log_id: None,
+                    reason,
+                    incident_id,
+                    sendable_tx,
+                    intended_at: Utc::now(),
+                }])
+            }
+            BurnExcessCommand::RecordExcessBurnSubmitted { .. }
+            | BurnExcessCommand::CompleteExcessBurn { .. }
+            | BurnExcessCommand::CloseExcessBurn { .. } => {
+                Err(BurnExcessError::InvalidState {
+                    expected: "Intended or later".to_string(),
+                    found: "Uninitialized".to_string(),
+                })
+            }
+        }
+    }
+
+    async fn transition(
+        &self,
+        command: Self::Command,
+        _services: &Self::Services,
+    ) -> Result<Vec<Self::Event>, Self::Error> {
+        match command {
+            BurnExcessCommand::RecordFundingExclusion { .. } => {
+                Err(BurnExcessError::InvalidState {
+                    expected: "Uninitialized".to_string(),
+                    found: self.state_name().to_string(),
+                })
+            }
+            command @ BurnExcessCommand::IntendExcessBurn { .. } => {
+                self.handle_intend(command)
+            }
+            BurnExcessCommand::RecordExcessBurnSubmitted {
+                tx_id,
+                burn_tx_hash,
+            } => match self {
+                Self::Intended { .. } => {
+                    Ok(vec![BurnExcessEvent::ExcessBurnSubmitted {
+                        tx_id,
+                        burn_tx_hash,
+                        submitted_at: Utc::now(),
+                    }])
+                }
+                other => Err(BurnExcessError::InvalidState {
+                    expected: "Intended".to_string(),
+                    found: other.state_name().to_string(),
+                }),
+            },
+            BurnExcessCommand::CompleteExcessBurn {
+                burn_tx_hash,
+                block_number,
+            } => match self {
+                Self::Submitted { .. } | Self::Intended { .. } => {
+                    Ok(vec![BurnExcessEvent::ExcessBurnCompleted {
+                        burn_tx_hash,
+                        block_number,
+                        completed_at: Utc::now(),
+                    }])
+                }
+                other => Err(BurnExcessError::InvalidState {
+                    expected: "Intended or Submitted".to_string(),
+                    found: other.state_name().to_string(),
+                }),
+            },
+            BurnExcessCommand::CloseExcessBurn { reason } => match self {
+                Self::FundingExcluded { .. }
+                | Self::Intended { .. }
+                | Self::Submitted { .. } => {
+                    Ok(vec![BurnExcessEvent::ExcessBurnClosed {
+                        reason,
+                        closed_at: Utc::now(),
+                    }])
+                }
+                other => Err(BurnExcessError::InvalidState {
+                    expected: "FundingExcluded, Intended, or Submitted"
+                        .to_string(),
+                    found: other.state_name().to_string(),
+                }),
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{U256, address, b256};
+    use event_sorcery::{LifecycleError, TestHarness};
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::mint::IssuerMintRequestId;
+
+    fn issuer_request() -> IssuerMintRequestId {
+        IssuerMintRequestId::new(
+            Uuid::parse_str("d3042b2f-4845-4acd-9a67-92d743e4e58c").unwrap(),
+        )
+    }
+
+    fn sample_bind() -> ExcessBurnBind {
+        ExcessBurnBind {
+            issuer_request_id: issuer_request(),
+            deposit_tx_hash: b256!(
+                "0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd"
+            ),
+            receipt_id: U256::from(7u64),
+            shares: U256::from(750_000_000_000_000_000u64),
+            original_recipient: address!(
+                "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
+            ),
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            network: Network::Base,
+            issuer_wallet: address!(
+                "0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"
+            ),
+        }
+    }
+
+    fn funding_id() -> FundingTransferId {
+        FundingTransferId {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            log_index: 3,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(750_000_000_000_000_000u64),
+        }
+    }
+
+    fn sample_sendable() -> SendableTxWithHash {
+        SendableTxWithHash {
+            tx: vec![0xde, 0xad],
+            hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            nonce: 7,
+            signed_at: Utc::now(),
+            dust_shares: U256::ZERO,
+        }
+    }
+
+    #[tokio::test]
+    async fn internal_intend_without_exclusion() {
+        let bind = sample_bind();
+        let sendable = sample_sendable();
+
+        let events = TestHarness::<BurnExcess>::with(())
+            .given_no_previous_events()
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind: bind.clone(),
+                path: BurnExcessPath::Internal,
+                funding_log_id: None,
+                reason: "duplicate mint".into(),
+                incident_id: Some("inc-1".into()),
+                sendable_tx: sendable.clone(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let BurnExcessEvent::ExcessBurnIntended {
+            path,
+            funding_log_id,
+            bind: event_bind,
+            sendable_tx,
+            ..
+        } = &events[0]
+        else {
+            panic!("expected ExcessBurnIntended, got {:?}", events[0]);
+        };
+        assert_eq!(*path, BurnExcessPath::Internal);
+        assert!(funding_log_id.is_none());
+        assert_eq!(event_bind, &bind);
+        assert_eq!(sendable_tx, &sendable);
+    }
+
+    #[tokio::test]
+    async fn external_requires_exclusion_before_intend() {
+        let bind = sample_bind();
+        let err = TestHarness::<BurnExcess>::with(())
+            .given_no_previous_events()
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind: bind.clone(),
+                path: BurnExcessPath::External,
+                funding_log_id: Some(funding_id()),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(
+                BurnExcessError::ExternalRequiresExclusion { .. }
+            )
+        ));
+    }
+
+    #[tokio::test]
+    async fn external_exclusion_then_intend() {
+        let bind = sample_bind();
+        let funding = funding_id();
+        let excluded_at = Utc::now();
+
+        let events = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::FundingExclusionRecorded {
+                bind: bind.clone(),
+                funding_log_id: funding.clone(),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                excluded_at,
+            }])
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind: bind.clone(),
+                path: BurnExcessPath::External,
+                funding_log_id: Some(funding.clone()),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        let BurnExcessEvent::ExcessBurnIntended {
+            path, funding_log_id, ..
+        } = &events[0]
+        else {
+            panic!("expected ExcessBurnIntended");
+        };
+        assert_eq!(*path, BurnExcessPath::External);
+        assert_eq!(funding_log_id.as_ref(), Some(&funding));
+    }
+
+    #[tokio::test]
+    async fn path_conflict_on_intend_with_wrong_path() {
+        let bind = sample_bind();
+        let funding = funding_id();
+        let err = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::FundingExclusionRecorded {
+                bind: bind.clone(),
+                funding_log_id: funding,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                excluded_at: Utc::now(),
+            }])
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind,
+                path: BurnExcessPath::Internal,
+                funding_log_id: None,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(BurnExcessError::PathConflict {
+                stream_path: BurnExcessPath::External,
+                command_path: BurnExcessPath::Internal,
+            })
+        ));
+    }
+
+    #[tokio::test]
+    async fn bind_mismatch_on_intend_with_wrong_bind() {
+        let bind = sample_bind();
+        let mut wrong_bind = bind.clone();
+        wrong_bind.receipt_id = U256::from(999u64);
+        let funding = funding_id();
+        let err = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::FundingExclusionRecorded {
+                bind: bind.clone(),
+                funding_log_id: funding.clone(),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                excluded_at: Utc::now(),
+            }])
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind: wrong_bind,
+                path: BurnExcessPath::External,
+                funding_log_id: Some(funding),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(BurnExcessError::BindMismatch)
+        ));
+    }
+
+    #[tokio::test]
+    async fn funding_mismatch_on_intend_with_wrong_funding() {
+        let bind = sample_bind();
+        let funding = funding_id();
+        let mut wrong_funding = funding.clone();
+        wrong_funding.log_index = 99;
+        let err = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::FundingExclusionRecorded {
+                bind: bind.clone(),
+                funding_log_id: funding,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                excluded_at: Utc::now(),
+            }])
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind,
+                path: BurnExcessPath::External,
+                funding_log_id: Some(wrong_funding),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(matches!(
+            err,
+            LifecycleError::Apply(BurnExcessError::FundingMismatch { .. })
+        ));
+    }
+
+    /// `handle_intend` accepts only `FundingExcluded`. On an already-`Intended`
+    /// stream the fall-through arm is what stops a second signed transaction
+    /// against the same issuer wallet nonce, so an identical retry of the
+    /// command must be refused rather than re-signed.
+    #[tokio::test]
+    async fn intend_refuses_a_second_intent_on_an_intended_stream() {
+        let bind = sample_bind();
+        let funding = funding_id();
+        let err = TestHarness::<BurnExcess>::with(())
+            .given(vec![
+                BurnExcessEvent::FundingExclusionRecorded {
+                    bind: bind.clone(),
+                    funding_log_id: funding.clone(),
+                    reason: "duplicate mint".into(),
+                    incident_id: None,
+                    excluded_at: Utc::now(),
+                },
+                BurnExcessEvent::ExcessBurnIntended {
+                    bind: bind.clone(),
+                    path: BurnExcessPath::External,
+                    funding_log_id: Some(funding.clone()),
+                    reason: "duplicate mint".into(),
+                    incident_id: None,
+                    sendable_tx: sample_sendable(),
+                    intended_at: Utc::now(),
+                },
+            ])
+            .when(BurnExcessCommand::IntendExcessBurn {
+                bind,
+                path: BurnExcessPath::External,
+                funding_log_id: Some(funding),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                err,
+                LifecycleError::Apply(BurnExcessError::InvalidState { .. })
+            ),
+            "a second IntendExcessBurn must not re-sign against a live intent"
+        );
+    }
+
+    /// The recorded exclusion is what the poller skips on, so a live stream
+    /// must not be able to swap in a second, different funding log.
+    #[tokio::test]
+    async fn record_funding_exclusion_refuses_a_second_funding_log() {
+        let bind = sample_bind();
+        let other_funding = FundingTransferId {
+            log_index: funding_id().log_index + 1,
+            ..funding_id()
+        };
+
+        let err = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::FundingExclusionRecorded {
+                bind: bind.clone(),
+                funding_log_id: funding_id(),
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                excluded_at: Utc::now(),
+            }])
+            .when(BurnExcessCommand::RecordFundingExclusion {
+                bind,
+                funding_log_id: other_funding,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+            })
+            .await
+            .then_expect_error();
+
+        assert!(
+            matches!(
+                err,
+                LifecycleError::Apply(BurnExcessError::InvalidState { .. })
+            ),
+            "a second funding log on a live stream must be refused, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_from_intended() {
+        let bind = sample_bind();
+        let intended_at = Utc::now();
+        let events = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::ExcessBurnIntended {
+                bind: bind.clone(),
+                path: BurnExcessPath::Internal,
+                funding_log_id: None,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sample_sendable(),
+                intended_at,
+            }])
+            .when(BurnExcessCommand::CloseExcessBurn {
+                reason: "abandoned".into(),
+            })
+            .await
+            .events();
+
+        assert_eq!(events.len(), 1);
+        assert!(matches!(
+            &events[0],
+            BurnExcessEvent::ExcessBurnClosed { reason, .. }
+                if reason == "abandoned"
+        ));
+    }
+
+    #[tokio::test]
+    async fn submit_and_complete_lifecycle() {
+        let bind = sample_bind();
+        let intended_at = Utc::now();
+        let sendable = sample_sendable();
+
+        let submitted = TestHarness::<BurnExcess>::with(())
+            .given(vec![BurnExcessEvent::ExcessBurnIntended {
+                bind: bind.clone(),
+                path: BurnExcessPath::Internal,
+                funding_log_id: None,
+                reason: "duplicate mint".into(),
+                incident_id: None,
+                sendable_tx: sendable.clone(),
+                intended_at,
+            }])
+            .when(BurnExcessCommand::RecordExcessBurnSubmitted {
+                tx_id: TxId::from(sendable.hash),
+                burn_tx_hash: sendable.hash,
+            })
+            .await
+            .events();
+        assert!(matches!(
+            &submitted[0],
+            BurnExcessEvent::ExcessBurnSubmitted { burn_tx_hash, .. }
+                if *burn_tx_hash == sendable.hash
+        ));
+
+        let completed = TestHarness::<BurnExcess>::with(())
+            .given(vec![
+                BurnExcessEvent::ExcessBurnIntended {
+                    bind: bind.clone(),
+                    path: BurnExcessPath::Internal,
+                    funding_log_id: None,
+                    reason: "duplicate mint".into(),
+                    incident_id: None,
+                    sendable_tx: sendable.clone(),
+                    intended_at,
+                },
+                BurnExcessEvent::ExcessBurnSubmitted {
+                    tx_id: TxId::from(sendable.hash),
+                    burn_tx_hash: sendable.hash,
+                    submitted_at: Utc::now(),
+                },
+            ])
+            .when(BurnExcessCommand::CompleteExcessBurn {
+                burn_tx_hash: sendable.hash,
+                block_number: 99,
+            })
+            .await
+            .events();
+        assert!(matches!(
+            &completed[0],
+            BurnExcessEvent::ExcessBurnCompleted {
+                burn_tx_hash,
+                block_number: 99,
+                ..
+            } if *burn_tx_hash == sendable.hash
+        ));
+    }
+
+    #[test]
+    fn serde_round_trip_path_and_events() {
+        let intended = BurnExcessEvent::ExcessBurnIntended {
+            bind: sample_bind(),
+            path: BurnExcessPath::External,
+            funding_log_id: Some(funding_id()),
+            reason: "r".into(),
+            incident_id: Some("i".into()),
+            sendable_tx: sample_sendable(),
+            intended_at: Utc::now(),
+        };
+        let json = serde_json::to_string(&intended).unwrap();
+        let back: BurnExcessEvent = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, intended);
+
+        let path_json =
+            serde_json::to_string(&BurnExcessPath::Internal).unwrap();
+        assert_eq!(path_json, "\"internal\"");
+    }
+
+    #[test]
+    fn burn_excess_id_display_parse() {
+        let hash = b256!(
+            "0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd"
+        );
+        let id = BurnExcessId::new(hash);
+        let parsed: BurnExcessId = id.to_string().parse().unwrap();
+        assert_eq!(parsed.deposit_tx_hash(), hash);
+    }
+
+    #[tokio::test]
+    async fn unresolved_excess_burn_intent_tracks_intended_and_submitted() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        assert!(!has_unresolved_excess_burn_intent(&pool, None).await.unwrap());
+
+        let store = event_sorcery::test_store::<BurnExcess>(pool.clone(), ());
+        let bind = sample_bind();
+        let id = BurnExcessId::new(bind.deposit_tx_hash);
+        store
+            .send(
+                &id,
+                BurnExcessCommand::IntendExcessBurn {
+                    bind: bind.clone(),
+                    path: BurnExcessPath::Internal,
+                    funding_log_id: None,
+                    reason: "dup".into(),
+                    incident_id: None,
+                    sendable_tx: sample_sendable(),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(has_unresolved_excess_burn_intent(&pool, None).await.unwrap());
+        assert!(
+            !has_unresolved_excess_burn_intent(&pool, Some(&id)).await.unwrap()
+        );
+
+        store
+            .send(
+                &id,
+                BurnExcessCommand::CloseExcessBurn { reason: "done".into() },
+            )
+            .await
+            .unwrap();
+        assert!(!has_unresolved_excess_burn_intent(&pool, None).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn unresolved_excess_burn_intent_tracks_funding_excluded() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+
+        let store = event_sorcery::test_store::<BurnExcess>(pool.clone(), ());
+        let bind = sample_bind();
+        let id = BurnExcessId::new(bind.deposit_tx_hash);
+        store
+            .send(
+                &id,
+                BurnExcessCommand::RecordFundingExclusion {
+                    bind: bind.clone(),
+                    funding_log_id: funding_id(),
+                    reason: "dup".into(),
+                    incident_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Path B before intend holds no signed nonce, but the exclusion write
+        // is permanent and the stream still owns the issuer wallet.
+        assert!(has_unresolved_excess_burn_intent(&pool, None).await.unwrap());
+        assert!(
+            !has_unresolved_excess_burn_intent(&pool, Some(&id)).await.unwrap()
+        );
+
+        store
+            .send(
+                &id,
+                BurnExcessCommand::CloseExcessBurn {
+                    reason: "abandoned".into(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(!has_unresolved_excess_burn_intent(&pool, None).await.unwrap());
+    }
+
+    #[test]
+    fn path_and_funding_accessors() {
+        let excluded = BurnExcess::FundingExcluded {
+            bind: sample_bind(),
+            funding_log_id: funding_id(),
+            reason: "r".into(),
+            incident_id: None,
+            excluded_at: Utc::now(),
+        };
+        assert_eq!(excluded.path(), BurnExcessPath::External);
+        assert_eq!(excluded.funding_log_id(), Some(&funding_id()));
+        assert_eq!(excluded.state_name(), "FundingExcluded");
+
+        let intended = BurnExcess::Intended {
+            bind: sample_bind(),
+            path: BurnExcessPath::Internal,
+            funding_log_id: None,
+            reason: "r".into(),
+            incident_id: None,
+            sendable_tx: sample_sendable(),
+            intended_at: Utc::now(),
+        };
+        assert_eq!(intended.path(), BurnExcessPath::Internal);
+        assert!(intended.funding_log_id().is_none());
+    }
+}

--- a/src/burn_excess/proof.rs
+++ b/src/burn_excess/proof.rs
@@ -1,0 +1,894 @@
+//! Pure proof helpers for burn-excess path selection and bind validation.
+//!
+//! Chain I/O lives in the engine (later tasks). These functions take already
+//! fetched facts and refuse invalid binds without side effects.
+
+use alloy::primitives::{Address, B256, Bytes, U256};
+
+use super::{BurnExcess, BurnExcessPath, FundingTransferId};
+use crate::mint::IssuerMintRequestId;
+use crate::tokenized_asset::Network;
+use crate::vault::ReceiptInformation;
+use crate::vault::rain_meta;
+
+/// Operator-selected CLI mode keyword (`internal` | `external`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BurnExcessMode {
+    Internal,
+    External,
+}
+
+impl BurnExcessMode {
+    pub(crate) const fn as_path(self) -> BurnExcessPath {
+        match self {
+            Self::Internal => BurnExcessPath::Internal,
+            Self::External => BurnExcessPath::External,
+        }
+    }
+
+    pub(crate) const fn as_str(self) -> &'static str {
+        match self {
+            Self::Internal => "internal",
+            Self::External => "external",
+        }
+    }
+}
+
+impl std::fmt::Display for BurnExcessMode {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// How a CLI invocation should treat path after loading the aggregate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PathResolution {
+    /// Fresh stream: path comes solely from the mode keyword.
+    Start(BurnExcessPath),
+    /// Resume an in-progress stream; path locked from history.
+    Resume(BurnExcessPath),
+    /// Terminal stream: report only; mode mismatch is not PathConflict.
+    ReportOnly(BurnExcessPath),
+}
+
+/// Proven deposit bind facts (engine-fetched; pure-checked here).
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct DepositProof {
+    pub(crate) receipt_id: U256,
+    pub(crate) shares: U256,
+    pub(crate) receipt_info: ReceiptInformation,
+    pub(crate) receipt_info_bytes: Bytes,
+    pub(crate) original_recipient: Address,
+    pub(crate) vault: Address,
+}
+
+/// Expected funding Transfer shape for Path B.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FundingTransferExpectation {
+    pub(crate) network: Network,
+    pub(crate) vault: Address,
+    pub(crate) tx_hash: B256,
+    pub(crate) from: Address,
+    pub(crate) to: Address,
+    pub(crate) amount: U256,
+}
+
+/// One Transfer log candidate from a funding transaction receipt.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct FundingTransferCandidate {
+    pub(crate) log_index: u64,
+    pub(crate) vault: Address,
+    pub(crate) from: Address,
+    pub(crate) to: Address,
+    pub(crate) amount: U256,
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub(crate) enum BurnExcessProofError {
+    #[error(
+        "path conflict: stream is locked to {locked} but mode keyword is \
+         {requested}; re-run with `burn-excess {locked}`"
+    )]
+    PathConflict { locked: BurnExcessPath, requested: BurnExcessMode },
+
+    #[error(
+        "funding tx hash {provided:?} does not match recorded funding \
+         {recorded:?}"
+    )]
+    FundingMismatch { provided: B256, recorded: B256 },
+
+    #[error(
+        "issuer share balance {balance} is not exactly the excess amount \
+         {amount}; move exact excess to the issuer, or use \
+         `burn-excess external --funding-tx-hash …` after funding"
+    )]
+    IssuerShareBalanceNotExact { balance: U256, amount: U256 },
+
+    #[error(
+        "issuer receipt balance {balance} for receipt {receipt_id} is below \
+         the excess amount {amount}"
+    )]
+    IssuerReceiptBalanceInsufficient {
+        receipt_id: U256,
+        balance: U256,
+        amount: U256,
+    },
+
+    #[error("deposit receipt id {found} does not match expected {expected}")]
+    DepositReceiptIdMismatch { expected: U256, found: U256 },
+
+    #[error("deposit shares {found} do not match expected {expected}")]
+    DepositSharesMismatch { expected: U256, found: U256 },
+
+    #[error(
+        "deposit receiptInformation issuer request {found} does not match \
+         expected {expected}"
+    )]
+    DepositIssuerRequestMismatch {
+        expected: IssuerMintRequestId,
+        found: IssuerMintRequestId,
+    },
+
+    #[error("deposit receiptInformation is empty")]
+    EmptyReceiptInformation,
+
+    #[error("deposit receiptInformation is not Rain metadata v1")]
+    ReceiptInformationNotRainMeta,
+
+    #[error("failed to decode Rain receipt metadata: {message}")]
+    ReceiptInformationDecode { message: String },
+
+    #[error(
+        "receiptInformation JSON is not valid ReceiptInformation: {message}"
+    )]
+    ReceiptInformationParse { message: String },
+
+    #[error("no matching funding Transfer log in transaction {tx_hash:?}")]
+    FundingTransferNotFound { tx_hash: B256 },
+
+    #[error(
+        "ambiguous funding Transfer: {count} logs match vault/from/to/amount \
+         in transaction {tx_hash:?}"
+    )]
+    FundingTransferAmbiguous { tx_hash: B256, count: usize },
+
+    #[error(
+        "funding Transfer from {found:?} does not match original mint \
+         recipient {expected:?}"
+    )]
+    FundingFromMismatch { expected: Address, found: Address },
+
+    #[error(
+        "funding Transfer to {found:?} does not match issuer wallet \
+         {expected:?}"
+    )]
+    FundingToMismatch { expected: Address, found: Address },
+
+    #[error(
+        "funding Transfer amount {found} does not match excess amount \
+         {expected}"
+    )]
+    FundingAmountMismatch { expected: U256, found: U256 },
+
+    #[error(
+        "funding Transfer vault {found:?} does not match expected vault \
+         {expected:?}"
+    )]
+    FundingVaultMismatch { expected: Address, found: Address },
+
+    #[error(
+        "funding log already bound to a Redemption aggregate \
+         (tx={tx_hash:#x} log_index={log_index}); refuse exclusion"
+    )]
+    FundingAlreadyRedeemed { tx_hash: B256, log_index: u64 },
+
+    #[error(
+        "funding transaction {tx_hash:#x} is already bound to a Redemption \
+         aggregate; refuse exclusion"
+    )]
+    FundingAlreadyRedeemedTx { tx_hash: B256 },
+
+    #[error(
+        "funding transaction {tx_hash:#x} has a Transfer log without \
+         log_index; refuse funding selection"
+    )]
+    FundingLogIndexMissing { tx_hash: B256 },
+
+    #[error(
+        "external mode requires --funding-tx-hash (missing on prove or execute)"
+    )]
+    FundingTxHashRequired,
+
+    #[error(
+        "internal mode requires deposit original recipient to be the issuer \
+         wallet ({issuer_wallet:?}); found {original_recipient:?}. Shares were \
+         minted to a non-issuer recipient — fund them back then use \
+         `burn-excess external --funding-tx-hash …`"
+    )]
+    InternalRequiresIssuerAsRecipient {
+        original_recipient: Address,
+        issuer_wallet: Address,
+    },
+}
+
+/// D0.3–D0.4: resolve path from mode keyword and optional loaded aggregate.
+pub(crate) fn resolve_path(
+    mode: BurnExcessMode,
+    state: Option<&BurnExcess>,
+) -> Result<PathResolution, BurnExcessProofError> {
+    let requested = mode.as_path();
+
+    match state {
+        None => Ok(PathResolution::Start(requested)),
+        Some(BurnExcess::FundingExcluded { .. }) => {
+            require_path(mode, BurnExcessPath::External)?;
+            Ok(PathResolution::Resume(BurnExcessPath::External))
+        }
+        Some(
+            BurnExcess::Intended { path, .. }
+            | BurnExcess::Submitted { path, .. },
+        ) => {
+            require_path(mode, *path)?;
+            Ok(PathResolution::Resume(*path))
+        }
+        Some(
+            BurnExcess::Completed { path, .. }
+            | BurnExcess::Closed { path, .. },
+        ) => Ok(PathResolution::ReportOnly(*path)),
+    }
+}
+
+fn require_path(
+    mode: BurnExcessMode,
+    locked: BurnExcessPath,
+) -> Result<(), BurnExcessProofError> {
+    if mode.as_path() == locked {
+        Ok(())
+    } else {
+        Err(BurnExcessProofError::PathConflict { locked, requested: mode })
+    }
+}
+
+/// When resuming Path B, the CLI funding hash must match the recorded log.
+pub(crate) fn require_funding_hash_match(
+    provided: B256,
+    recorded: &FundingTransferId,
+) -> Result<(), BurnExcessProofError> {
+    if provided == recorded.tx_hash {
+        Ok(())
+    } else {
+        Err(BurnExcessProofError::FundingMismatch {
+            provided,
+            recorded: recorded.tx_hash,
+        })
+    }
+}
+
+/// Path A / Path B share balance gate: issuer must hold exactly `amount`.
+pub(crate) fn require_exact_issuer_share_balance(
+    balance: U256,
+    amount: U256,
+) -> Result<(), BurnExcessProofError> {
+    if balance == amount {
+        Ok(())
+    } else {
+        Err(BurnExcessProofError::IssuerShareBalanceNotExact {
+            balance,
+            amount,
+        })
+    }
+}
+
+/// Issuer receipt balance for the excess receipt must cover the burn.
+pub(crate) fn require_issuer_receipt_balance(
+    receipt_id: U256,
+    balance: U256,
+    amount: U256,
+) -> Result<(), BurnExcessProofError> {
+    if balance >= amount {
+        Ok(())
+    } else {
+        Err(BurnExcessProofError::IssuerReceiptBalanceInsufficient {
+            receipt_id,
+            balance,
+            amount,
+        })
+    }
+}
+
+/// Strict deposit `receiptInformation` decoder.
+///
+/// Unlike inventory `determine_source`, this refuses empty, non-Rain-meta, and
+/// unparseable payloads — burn-excess must bind the excess to a known issuer
+/// request, not forgive and classify as External.
+pub(crate) fn decode_receipt_information_strict(
+    receipt_information: &Bytes,
+) -> Result<ReceiptInformation, BurnExcessProofError> {
+    if receipt_information.is_empty() {
+        return Err(BurnExcessProofError::EmptyReceiptInformation);
+    }
+
+    if !rain_meta::is_rain_meta(receipt_information) {
+        return Err(BurnExcessProofError::ReceiptInformationNotRainMeta);
+    }
+
+    let json_bytes = rain_meta::decode_receipt_meta(receipt_information)
+        .map_err(|error| BurnExcessProofError::ReceiptInformationDecode {
+            message: error.to_string(),
+        })?;
+
+    serde_json::from_slice(&json_bytes).map_err(|error| {
+        BurnExcessProofError::ReceiptInformationParse {
+            message: error.to_string(),
+        }
+    })
+}
+
+/// Bind a fetched deposit proof to operator-supplied excess args.
+pub(crate) fn bind_deposit_proof(
+    expected_issuer_request_id: &IssuerMintRequestId,
+    expected_receipt_id: U256,
+    expected_shares: U256,
+    proof: &DepositProof,
+) -> Result<(), BurnExcessProofError> {
+    if proof.receipt_id != expected_receipt_id {
+        return Err(BurnExcessProofError::DepositReceiptIdMismatch {
+            expected: expected_receipt_id,
+            found: proof.receipt_id,
+        });
+    }
+
+    if proof.shares != expected_shares {
+        return Err(BurnExcessProofError::DepositSharesMismatch {
+            expected: expected_shares,
+            found: proof.shares,
+        });
+    }
+
+    if &proof.receipt_info.issuer_request_id != expected_issuer_request_id {
+        return Err(BurnExcessProofError::DepositIssuerRequestMismatch {
+            expected: expected_issuer_request_id.clone(),
+            found: proof.receipt_info.issuer_request_id.clone(),
+        });
+    }
+
+    Ok(())
+}
+
+/// Select the unique funding Transfer log matching Path B expectations.
+pub(crate) fn select_funding_transfer(
+    expectation: &FundingTransferExpectation,
+    candidates: &[FundingTransferCandidate],
+) -> Result<FundingTransferId, BurnExcessProofError> {
+    let matches: Vec<&FundingTransferCandidate> = candidates
+        .iter()
+        .filter(|candidate| {
+            candidate.vault == expectation.vault
+                && candidate.from == expectation.from
+                && candidate.to == expectation.to
+                && candidate.amount == expectation.amount
+        })
+        .collect();
+
+    match matches.as_slice() {
+        [] => {
+            if let Some(mismatch) =
+                first_shape_mismatch(expectation, candidates)
+            {
+                return Err(mismatch);
+            }
+
+            Err(BurnExcessProofError::FundingTransferNotFound {
+                tx_hash: expectation.tx_hash,
+            })
+        }
+        [only] => Ok(FundingTransferId {
+            network: expectation.network,
+            vault: only.vault,
+            tx_hash: expectation.tx_hash,
+            log_index: only.log_index,
+            from: only.from,
+            to: only.to,
+            amount: only.amount,
+        }),
+        many => Err(BurnExcessProofError::FundingTransferAmbiguous {
+            tx_hash: expectation.tx_hash,
+            count: many.len(),
+        }),
+    }
+}
+
+fn first_shape_mismatch(
+    expectation: &FundingTransferExpectation,
+    candidates: &[FundingTransferCandidate],
+) -> Option<BurnExcessProofError> {
+    // Prefer a same-vault candidate so the first mismatch is useful; fall back
+    // to the first log when none share the expected vault.
+    let candidate = candidates
+        .iter()
+        .find(|candidate| candidate.vault == expectation.vault)
+        .or_else(|| candidates.first())?;
+
+    if candidate.vault != expectation.vault {
+        return Some(BurnExcessProofError::FundingVaultMismatch {
+            expected: expectation.vault,
+            found: candidate.vault,
+        });
+    }
+
+    if candidate.from != expectation.from {
+        return Some(BurnExcessProofError::FundingFromMismatch {
+            expected: expectation.from,
+            found: candidate.from,
+        });
+    }
+
+    if candidate.to != expectation.to {
+        return Some(BurnExcessProofError::FundingToMismatch {
+            expected: expectation.to,
+            found: candidate.to,
+        });
+    }
+
+    if candidate.amount != expectation.amount {
+        return Some(BurnExcessProofError::FundingAmountMismatch {
+            expected: expectation.amount,
+            found: candidate.amount,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::primitives::{Address, B256, Bytes, U256, address, b256};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::Quantity;
+    use crate::mint::{IssuerMintRequestId, TokenizationRequestId};
+    use crate::tokenized_asset::{Network, UnderlyingSymbol};
+    use crate::vault::ReceiptInformation;
+
+    fn issuer_request() -> IssuerMintRequestId {
+        IssuerMintRequestId::new(
+            Uuid::parse_str("d3042b2f-4845-4acd-9a67-92d743e4e58c").unwrap(),
+        )
+    }
+
+    fn other_issuer_request() -> IssuerMintRequestId {
+        IssuerMintRequestId::new(Uuid::new_v4())
+    }
+
+    fn sample_receipt_info(
+        issuer_request_id: IssuerMintRequestId,
+    ) -> ReceiptInformation {
+        ReceiptInformation::new(
+            TokenizationRequestId::new("tok-1"),
+            issuer_request_id,
+            UnderlyingSymbol::new("PTY").unwrap(),
+            Quantity::new(rust_decimal::Decimal::new(750, 3)),
+            Utc::now(),
+            None,
+        )
+    }
+
+    fn sample_bind() -> super::super::ExcessBurnBind {
+        super::super::ExcessBurnBind {
+            issuer_request_id: issuer_request(),
+            deposit_tx_hash: b256!(
+                "0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd"
+            ),
+            receipt_id: U256::from(7u64),
+            shares: U256::from(750_000_000_000_000_000u64),
+            original_recipient: address!(
+                "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
+            ),
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            network: Network::Base,
+            issuer_wallet: address!(
+                "0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"
+            ),
+        }
+    }
+
+    fn funding_id() -> FundingTransferId {
+        FundingTransferId {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: b256!(
+                "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            ),
+            log_index: 3,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(750_000_000_000_000_000u64),
+        }
+    }
+
+    #[test]
+    fn resolve_path_not_started_uses_mode_keyword_only() {
+        assert_eq!(
+            resolve_path(BurnExcessMode::Internal, None).unwrap(),
+            PathResolution::Start(BurnExcessPath::Internal)
+        );
+        assert_eq!(
+            resolve_path(BurnExcessMode::External, None).unwrap(),
+            PathResolution::Start(BurnExcessPath::External)
+        );
+    }
+
+    #[test]
+    fn resolve_path_funding_excluded_locks_external() {
+        let state = BurnExcess::FundingExcluded {
+            bind: sample_bind(),
+            funding_log_id: funding_id(),
+            reason: "dup".into(),
+            incident_id: None,
+            excluded_at: Utc::now(),
+        };
+
+        assert_eq!(
+            resolve_path(BurnExcessMode::External, Some(&state)).unwrap(),
+            PathResolution::Resume(BurnExcessPath::External)
+        );
+
+        let conflict =
+            resolve_path(BurnExcessMode::Internal, Some(&state)).unwrap_err();
+        assert!(matches!(
+            conflict,
+            BurnExcessProofError::PathConflict {
+                locked: BurnExcessPath::External,
+                requested: BurnExcessMode::Internal,
+            }
+        ));
+    }
+
+    #[test]
+    fn resolve_path_intended_internal_rejects_external_mode() {
+        let state = BurnExcess::Intended {
+            bind: sample_bind(),
+            path: BurnExcessPath::Internal,
+            funding_log_id: None,
+            reason: "dup".into(),
+            incident_id: None,
+            sendable_tx: crate::vault::SendableTxWithHash::default(),
+            intended_at: Utc::now(),
+        };
+
+        let conflict =
+            resolve_path(BurnExcessMode::External, Some(&state)).unwrap_err();
+        assert!(matches!(
+            conflict,
+            BurnExcessProofError::PathConflict {
+                locked: BurnExcessPath::Internal,
+                requested: BurnExcessMode::External,
+            }
+        ));
+    }
+
+    #[test]
+    fn resolve_path_completed_is_report_only_any_mode() {
+        let state = BurnExcess::Completed {
+            bind: sample_bind(),
+            path: BurnExcessPath::External,
+            funding_log_id: Some(funding_id()),
+            burn_tx_hash: B256::ZERO,
+            block_number: 1,
+            completed_at: Utc::now(),
+        };
+
+        assert_eq!(
+            resolve_path(BurnExcessMode::Internal, Some(&state)).unwrap(),
+            PathResolution::ReportOnly(BurnExcessPath::External)
+        );
+        assert_eq!(
+            resolve_path(BurnExcessMode::External, Some(&state)).unwrap(),
+            PathResolution::ReportOnly(BurnExcessPath::External)
+        );
+    }
+
+    #[test]
+    fn funding_hash_match_and_mismatch() {
+        let recorded = funding_id();
+        require_funding_hash_match(recorded.tx_hash, &recorded).unwrap();
+        let err =
+            require_funding_hash_match(B256::ZERO, &recorded).unwrap_err();
+        assert!(matches!(err, BurnExcessProofError::FundingMismatch { .. }));
+    }
+
+    #[test]
+    fn exact_share_balance_gate() {
+        let amount = U256::from(750_000_000_000_000_000u64);
+        require_exact_issuer_share_balance(amount, amount).unwrap();
+        let err = require_exact_issuer_share_balance(U256::from(1u64), amount)
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BurnExcessProofError::IssuerShareBalanceNotExact { .. }
+        ));
+    }
+
+    #[test]
+    fn receipt_balance_gate() {
+        let receipt_id = U256::from(7u64);
+        let amount = U256::from(10u64);
+        require_issuer_receipt_balance(receipt_id, U256::from(10u64), amount)
+            .unwrap();
+        require_issuer_receipt_balance(receipt_id, U256::from(11u64), amount)
+            .unwrap();
+        let err = require_issuer_receipt_balance(
+            receipt_id,
+            U256::from(9u64),
+            amount,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            BurnExcessProofError::IssuerReceiptBalanceInsufficient { .. }
+        ));
+    }
+
+    #[test]
+    fn strict_receipt_information_decoder_round_trip() {
+        let info = sample_receipt_info(issuer_request());
+        let encoded = info.encode(None).unwrap();
+        let decoded = decode_receipt_information_strict(&encoded).unwrap();
+        assert_eq!(decoded.issuer_request_id, info.issuer_request_id);
+    }
+
+    #[test]
+    fn strict_receipt_information_refuses_empty_and_plain_json() {
+        assert!(matches!(
+            decode_receipt_information_strict(&Bytes::new()).unwrap_err(),
+            BurnExcessProofError::EmptyReceiptInformation
+        ));
+
+        let plain = Bytes::from(
+            serde_json::to_vec(&sample_receipt_info(issuer_request())).unwrap(),
+        );
+        assert!(matches!(
+            decode_receipt_information_strict(&plain).unwrap_err(),
+            BurnExcessProofError::ReceiptInformationNotRainMeta
+        ));
+    }
+
+    #[test]
+    fn bind_deposit_proof_refusal_matrix() {
+        let issuer = issuer_request();
+        let receipt_id = U256::from(7u64);
+        let shares = U256::from(750_000_000_000_000_000u64);
+        let info = sample_receipt_info(issuer.clone());
+        let encoded = info.encode(None).unwrap();
+
+        let ok = DepositProof {
+            receipt_id,
+            shares,
+            receipt_info: info,
+            receipt_info_bytes: encoded,
+            original_recipient: Address::ZERO,
+            vault: Address::ZERO,
+        };
+        bind_deposit_proof(&issuer, receipt_id, shares, &ok).unwrap();
+
+        let wrong_receipt =
+            DepositProof { receipt_id: U256::from(8u64), ..ok.clone() };
+        assert!(matches!(
+            bind_deposit_proof(&issuer, receipt_id, shares, &wrong_receipt)
+                .unwrap_err(),
+            BurnExcessProofError::DepositReceiptIdMismatch { .. }
+        ));
+
+        let wrong_shares =
+            DepositProof { shares: U256::from(1u64), ..ok.clone() };
+        assert!(matches!(
+            bind_deposit_proof(&issuer, receipt_id, shares, &wrong_shares)
+                .unwrap_err(),
+            BurnExcessProofError::DepositSharesMismatch { .. }
+        ));
+
+        let wrong_issuer_info = sample_receipt_info(other_issuer_request());
+        let wrong_issuer =
+            DepositProof { receipt_info: wrong_issuer_info, ..ok };
+        assert!(matches!(
+            bind_deposit_proof(&issuer, receipt_id, shares, &wrong_issuer)
+                .unwrap_err(),
+            BurnExcessProofError::DepositIssuerRequestMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn select_funding_transfer_unique_match() {
+        let expectation = FundingTransferExpectation {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: b256!(
+                "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+            ),
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(750_000_000_000_000_000u64),
+        };
+
+        let candidates = vec![
+            FundingTransferCandidate {
+                log_index: 1,
+                vault: expectation.vault,
+                from: address!("0x2222222222222222222222222222222222222222"),
+                to: expectation.to,
+                amount: expectation.amount,
+            },
+            FundingTransferCandidate {
+                log_index: 2,
+                vault: expectation.vault,
+                from: expectation.from,
+                to: expectation.to,
+                amount: expectation.amount,
+            },
+        ];
+
+        let selected =
+            select_funding_transfer(&expectation, &candidates).unwrap();
+        assert_eq!(selected.log_index, 2);
+        assert_eq!(selected.tx_hash, expectation.tx_hash);
+    }
+
+    #[test]
+    fn select_funding_transfer_not_found_and_ambiguous() {
+        let expectation = FundingTransferExpectation {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: B256::ZERO,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(1u64),
+        };
+
+        let none = select_funding_transfer(&expectation, &[]).unwrap_err();
+        assert!(matches!(
+            none,
+            BurnExcessProofError::FundingTransferNotFound { .. }
+        ));
+
+        let match_shape = FundingTransferCandidate {
+            log_index: 0,
+            vault: expectation.vault,
+            from: expectation.from,
+            to: expectation.to,
+            amount: expectation.amount,
+        };
+        let ambiguous = select_funding_transfer(
+            &expectation,
+            &[
+                match_shape.clone(),
+                FundingTransferCandidate { log_index: 1, ..match_shape },
+            ],
+        )
+        .unwrap_err();
+        assert!(matches!(
+            ambiguous,
+            BurnExcessProofError::FundingTransferAmbiguous { count: 2, .. }
+        ));
+    }
+
+    #[test]
+    fn select_funding_reports_shape_mismatch_when_only_wrong_from() {
+        let expectation = FundingTransferExpectation {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: B256::ZERO,
+            from: address!("0xA9C16673F65AE808688cB18952AFE3d9658C808f"),
+            to: address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            amount: U256::from(1u64),
+        };
+        let candidates = [FundingTransferCandidate {
+            log_index: 0,
+            vault: expectation.vault,
+            from: address!("0x2222222222222222222222222222222222222222"),
+            to: expectation.to,
+            amount: expectation.amount,
+        }];
+        let err =
+            select_funding_transfer(&expectation, &candidates).unwrap_err();
+        assert!(matches!(
+            err,
+            BurnExcessProofError::FundingFromMismatch { .. }
+        ));
+    }
+
+    #[test]
+    fn funding_already_redeemed_error_is_constructible() {
+        let err = BurnExcessProofError::FundingAlreadyRedeemed {
+            tx_hash: B256::ZERO,
+            log_index: 2,
+        };
+        let message = err.to_string();
+        assert!(message.contains("Redemption"));
+        assert!(message.contains("log_index=2"));
+        assert!(message.contains("0x"));
+    }
+
+    #[test]
+    fn funding_already_redeemed_tx_error_is_constructible() {
+        let err = BurnExcessProofError::FundingAlreadyRedeemedTx {
+            tx_hash: B256::ZERO,
+        };
+        let message = err.to_string();
+        assert!(message.contains("Redemption"));
+        assert!(message.contains("0x"));
+    }
+
+    #[test]
+    fn first_shape_mismatch_prefers_same_vault_candidate() {
+        let expectation = FundingTransferExpectation {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: B256::ZERO,
+            from: address!("0x2222222222222222222222222222222222222222"),
+            to: address!("0x3333333333333333333333333333333333333333"),
+            amount: U256::from(1u64),
+        };
+        let other_vault =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let candidates = vec![
+            FundingTransferCandidate {
+                log_index: 0,
+                vault: other_vault,
+                from: expectation.from,
+                to: expectation.to,
+                amount: expectation.amount,
+            },
+            FundingTransferCandidate {
+                log_index: 1,
+                vault: expectation.vault,
+                from: address!("0x4444444444444444444444444444444444444444"),
+                to: expectation.to,
+                amount: expectation.amount,
+            },
+        ];
+        let err =
+            select_funding_transfer(&expectation, &candidates).unwrap_err();
+        assert!(
+            matches!(err, BurnExcessProofError::FundingFromMismatch { .. }),
+            "same-vault candidate should drive the mismatch report, got {err:?}"
+        );
+    }
+
+    /// The fallback the preference test cannot reach: with nothing on the
+    /// expected vault, the operator has to be told the funding transaction
+    /// touched the wrong vault rather than which field differed on it.
+    #[test]
+    fn first_shape_mismatch_reports_vault_when_no_candidate_matches_it() {
+        let expectation = FundingTransferExpectation {
+            network: Network::Base,
+            vault: address!("0x1111111111111111111111111111111111111111"),
+            tx_hash: B256::ZERO,
+            from: address!("0x2222222222222222222222222222222222222222"),
+            to: address!("0x3333333333333333333333333333333333333333"),
+            amount: U256::from(1u64),
+        };
+        let other_vault =
+            address!("0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+        let candidates = vec![FundingTransferCandidate {
+            log_index: 0,
+            vault: other_vault,
+            // Every other field matches, so only the vault check can fire.
+            from: expectation.from,
+            to: expectation.to,
+            amount: expectation.amount,
+        }];
+
+        let err =
+            select_funding_transfer(&expectation, &candidates).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                BurnExcessProofError::FundingVaultMismatch { expected, found }
+                    if expected == expectation.vault && found == other_vault
+            ),
+            "no same-vault candidate must report the vault, got {err:?}"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -563,6 +563,17 @@ pub enum ConfigError {
         network.as_str().to_uppercase()
     )]
     ChainIdNotForNetwork { network: Network, configured: u64, expected: u64 },
+    #[error(
+        "no RPC URL configured for {network}; set {hint} in the service \
+         environment (deployment secrets / .env)"
+    )]
+    NetworkRpcNotConfigured { network: Network, hint: &'static str },
+    #[error("configured RPC URL for {network} is not a valid URL: {source}")]
+    InvalidConfiguredRpcUrl {
+        network: Network,
+        #[source]
+        source: url::ParseError,
+    },
     #[error("chain registry initialization failed: {0}")]
     ChainRegistry(#[source] Box<ChainRegistryError>),
 }
@@ -587,6 +598,46 @@ pub(crate) fn wss_to_http(url: &Url) -> Result<Url, InvalidRpcScheme> {
         .map_err(|()| InvalidRpcScheme(url.scheme().to_string()))?;
 
     Ok(http_url)
+}
+
+/// Resolves the service RPC URL for `network` from process environment
+/// (deployment secrets / `.env` — the same variables the long-running bot
+/// loads). Operator CLIs call this instead of taking `--rpc-url`.
+///
+/// Precedence matches service config: for Base, `CHAIN_BASE_RPC_URL` wins over
+/// legacy `RPC_URL`; other networks use only their `CHAIN_<NETWORK>_RPC_URL`.
+pub(crate) fn configured_rpc_url(network: Network) -> Result<Url, ConfigError> {
+    resolve_configured_rpc_url(network, |name| {
+        std::env::var(name).ok().filter(|value| !value.is_empty())
+    })
+}
+
+fn resolve_configured_rpc_url(
+    network: Network,
+    env_get: impl Fn(&str) -> Option<String>,
+) -> Result<Url, ConfigError> {
+    let (primary, fallback, hint) = match network {
+        Network::Base => (
+            "CHAIN_BASE_RPC_URL",
+            Some("RPC_URL"),
+            "CHAIN_BASE_RPC_URL or RPC_URL",
+        ),
+        Network::Ethereum => {
+            ("CHAIN_ETHEREUM_RPC_URL", None, "CHAIN_ETHEREUM_RPC_URL")
+        }
+        Network::HyperEvm => {
+            ("CHAIN_HYPEREVM_RPC_URL", None, "CHAIN_HYPEREVM_RPC_URL")
+        }
+    };
+
+    let raw = env_get(primary)
+        .or_else(|| fallback.and_then(&env_get))
+        .ok_or(ConfigError::NetworkRpcNotConfigured { network, hint })?;
+
+    Url::parse(&raw).map_err(|source| ConfigError::InvalidConfiguredRpcUrl {
+        network,
+        source,
+    })
 }
 
 /// Domain target categories used in `target:` on all tracing macros.
@@ -1051,6 +1102,62 @@ mod tests {
             result,
             Err(ConfigError::InvalidSubgraphScheme { variable, .. })
                 if variable == "SUBGRAPH_URL"
+        ));
+    }
+
+    #[test]
+    fn configured_rpc_url_base_prefers_grouped_over_legacy() {
+        let lookup = |name: &str| match name {
+            "CHAIN_BASE_RPC_URL" => Some("wss://base-grouped.example".into()),
+            "RPC_URL" => Some("wss://legacy.example".into()),
+            _ => None,
+        };
+
+        let url = resolve_configured_rpc_url(Network::Base, lookup).unwrap();
+        assert_eq!(url, Url::parse("wss://base-grouped.example").unwrap());
+    }
+
+    #[test]
+    fn configured_rpc_url_base_falls_back_to_legacy() {
+        let lookup = |name: &str| match name {
+            "RPC_URL" => Some("wss://legacy.example".into()),
+            _ => None,
+        };
+
+        let url = resolve_configured_rpc_url(Network::Base, lookup).unwrap();
+        assert_eq!(url, Url::parse("wss://legacy.example").unwrap());
+    }
+
+    #[test]
+    fn configured_rpc_url_ethereum_requires_grouped_var() {
+        let lookup = |name: &str| match name {
+            "RPC_URL" => Some("wss://legacy.example".into()),
+            _ => None,
+        };
+
+        let err =
+            resolve_configured_rpc_url(Network::Ethereum, lookup).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::NetworkRpcNotConfigured {
+                network: Network::Ethereum,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn configured_rpc_url_rejects_invalid_url() {
+        let lookup = |name: &str| match name {
+            "RPC_URL" => Some("not a url".into()),
+            _ => None,
+        };
+
+        let err =
+            resolve_configured_rpc_url(Network::Base, lookup).unwrap_err();
+        assert!(matches!(
+            err,
+            ConfigError::InvalidConfiguredRpcUrl { network: Network::Base, .. }
         ));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ use uuid::Uuid;
 use crate::account::Account;
 use crate::alpaca::AlpacaService;
 use crate::auth::FailedAuthRateLimiter;
+use crate::burn_excess::{
+    BurnExcess, exclusion::rebuild_funding_exclusion_index,
+};
 use crate::chain::{
     ChainRegistry, ConfiguredNetworks, validate_configured_asset_networks,
 };
@@ -76,6 +79,7 @@ pub mod underlying;
 pub(crate) mod admin;
 pub(crate) mod alpaca;
 pub(crate) mod auth;
+pub(crate) mod burn_excess;
 pub(crate) mod catchers;
 pub(crate) mod chain;
 pub(crate) mod config;
@@ -645,6 +649,17 @@ async fn setup_aggregate_cqrs(
         .with(Arc::new(ReceiptBurnsViewReactor::new(pool.clone())))
         .build(redemption_services)
         .await?;
+
+    // BurnExcess has no Table projection; the funding-exclusion SQL index is a
+    // derived read model, and this rebuild is what the server needs: it
+    // repopulates the index before the transfer pollers spawn, so a restored
+    // DB cannot leave the poller free to open a Redemption for an excluded
+    // funding Transfer. No reactor is wired here — the server dispatches no
+    // `BurnExcess` command, and the CLI builds its own store in
+    // `burn_excess_store`, so a reactor on a server-side store would never
+    // fire.
+    prepare_event_sourced_startup::<BurnExcess>(pool).await?;
+    rebuild_funding_exclusion_index(pool).await?;
 
     Ok(AggregateCqrsSetup { mint_store, redemption_store })
 }

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -30,6 +30,7 @@ use super::{
     IssuerMintRequestId, Mint, MintCommand, has_unresolved_signer_intent,
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
+use crate::burn_excess::has_unresolved_excess_burn_intent;
 use crate::jobs::{Job, JobQueue, QueuePushError};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
@@ -185,6 +186,8 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     Some(&self.issuer_request_id),
                 )
                 .await?
+                    || has_unresolved_excess_burn_intent(&ctx.pool, None)
+                        .await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),
@@ -277,6 +280,8 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                     Some(&self.issuer_request_id),
                 )
                 .await?
+                    || has_unresolved_excess_burn_intent(&ctx.pool, None)
+                        .await?
                 {
                     return Err(MintJobError::UnresolvedWalletIntent {
                         issuer_request_id: self.issuer_request_id.clone(),

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -15,6 +15,7 @@ use super::{
     Redemption, RedemptionCommand, RedemptionError, RedemptionEvent,
     next_burn_retry_external_tx_id_from_history,
 };
+use crate::burn_excess::has_unresolved_excess_burn_intent;
 use crate::mint::QuantityConversionError;
 use crate::receipt_inventory::{
     BurnPlan, BurnTrackingError, ReceiptRegistrationError, ReceiptService,
@@ -954,18 +955,24 @@ impl BurnManager {
         if status == BurnTxStatus::ProvablyDead {
             // Network-keyed reservation: one check covers competing burn AND
             // mint intents on this signer's nonce domain, excluding only this
-            // redemption's own reservation.
+            // redemption's own reservation. BurnExcess is not tracked in
+            // `active_signer_intents`, so its intents need their own check.
             let unresolved_intent = has_unresolved_signer_intent(
                 &self.view_pool,
                 metadata.network,
                 Some(issuer_request_id),
             )
             .await?;
-            if unresolved_intent {
+            let unresolved_excess =
+                has_unresolved_excess_burn_intent(&self.view_pool, None)
+                    .await?;
+            if unresolved_intent || unresolved_excess {
                 drop(wallet_guard);
                 debug!(target: "redemption",
                     issuer_request_id = %issuer_request_id,
                     tx_hash = %sendable_tx.hash,
+                    unresolved_intent,
+                    unresolved_excess,
                     "Deferring dead burn replacement behind another persisted wallet intent"
                 );
                 return Ok(RecoveryOutcome::SkippedManualIntervention);
@@ -1637,7 +1644,10 @@ impl BurnManager {
                 Some(issuer_request_id),
             )
             .await?;
-            if !unresolved_intent {
+            let unresolved_excess =
+                has_unresolved_excess_burn_intent(&self.view_pool, None)
+                    .await?;
+            if !unresolved_intent && !unresolved_excess {
                 break wallet_guard;
             }
 
@@ -1656,6 +1666,8 @@ impl BurnManager {
             }
             debug!(target: "redemption",
                 issuer_request_id = %issuer_request_id,
+                unresolved_intent,
+                unresolved_excess,
                 "Waiting for an earlier wallet intent before preparing burn"
             );
             tokio::time::sleep(Duration::from_secs(1)).await;

--- a/src/redemption/mod.rs
+++ b/src/redemption/mod.rs
@@ -191,9 +191,9 @@ impl std::fmt::Display for BurnExternalTxId {
 }
 use crate::tokenized_asset::{Network, TokenSymbol, UnderlyingSymbol};
 use crate::vault::{
-    BurnTxStatus, MultiBurnEntry, MultiBurnParams, NetworkVaultServices,
-    SendableTxWithHash, TxId, UnconfiguredNetworkError, VaultError,
-    VaultService,
+    BurnRequestOrigin, BurnTxStatus, MultiBurnEntry, MultiBurnParams,
+    NetworkVaultServices, SendableTxWithHash, TxId, UnconfiguredNetworkError,
+    VaultError, VaultService,
 };
 
 pub(super) const fn default_redemption_network() -> Network {
@@ -541,7 +541,7 @@ impl Redemption {
             dust_shares: input.dust_shares,
             owner: input.owner,
             user: user_wallet,
-            issuer_request_id: issuer_request_id.clone(),
+            origin: BurnRequestOrigin::Redemption(issuer_request_id.clone()),
             detected_tx_hash: metadata.detected_tx_hash,
             external_tx_id: input.external_tx_id,
         };
@@ -1046,7 +1046,7 @@ impl Redemption {
             dust_shares: input.dust_shares,
             owner: input.owner,
             user: user_wallet,
-            issuer_request_id: issuer_request_id.clone(),
+            origin: BurnRequestOrigin::Redemption(issuer_request_id.clone()),
             detected_tx_hash: metadata.detected_tx_hash,
             external_tx_id: input.external_tx_id,
         };

--- a/src/redemption/poller.rs
+++ b/src/redemption/poller.rs
@@ -498,7 +498,8 @@ where
             }
             TransferOutcome::AlreadyDetected
             | TransferOutcome::SkippedMint
-            | TransferOutcome::SkippedNoAccount => {}
+            | TransferOutcome::SkippedNoAccount
+            | TransferOutcome::SkippedAdminRecovery => {}
         }
 
         Ok(ProcessedLog::Handled)

--- a/src/redemption/test_utils.rs
+++ b/src/redemption/test_utils.rs
@@ -93,6 +93,26 @@ pub(crate) fn create_transfer_log(
     tx_hash: B256,
     block_number: u64,
 ) -> Log {
+    create_transfer_log_with_index(
+        vault_address,
+        from,
+        to,
+        value,
+        tx_hash,
+        block_number,
+        0,
+    )
+}
+
+pub(crate) fn create_transfer_log_with_index(
+    vault_address: Address,
+    from: Address,
+    to: Address,
+    value: U256,
+    tx_hash: B256,
+    block_number: u64,
+    log_index: u64,
+) -> Log {
     let topics = vec![
         OffchainAssetReceiptVault::Transfer::SIGNATURE_HASH,
         B256::left_padding_from(&from[..]),
@@ -113,7 +133,7 @@ pub(crate) fn create_transfer_log(
         block_timestamp: None,
         transaction_hash: Some(tx_hash),
         transaction_index: Some(0),
-        log_index: Some(0),
+        log_index: Some(log_index),
         removed: false,
     }
 }

--- a/src/redemption/transfer.rs
+++ b/src/redemption/transfer.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::account::view::{AccountViewError, find_by_wallet};
 use crate::account::{AccountView, AlpacaAccountNumber, ClientId};
 use crate::bindings;
+use crate::burn_excess::exclusion::is_excluded_funding_log;
 use crate::tokenized_asset::{
     Network, TokenSymbol, TokenizedAssetView, UnderlyingSymbol,
 };
@@ -29,6 +30,8 @@ pub(crate) enum TransferOutcome {
     AlreadyDetected,
     SkippedMint,
     SkippedNoAccount,
+    /// Path B burn-excess funding Transfer — not a real AP redemption.
+    SkippedAdminRecovery,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -39,6 +42,10 @@ pub(crate) enum TransferProcessingError {
     MissingTxHash,
     #[error("Missing block number in log")]
     MissingBlockNumber,
+    #[error(
+        "Missing log index in log (required for funding-exclusion identity)"
+    )]
+    MissingLogIndex,
     #[error("Quantity conversion error: {0}")]
     QuantityConversion(#[from] QuantityConversionError),
     #[error("CQRS error: {0}")]
@@ -52,6 +59,8 @@ pub(crate) enum TransferProcessingError {
          attribute its redemptions to an arbitrary underlying"
     )]
     AmbiguousVault { vault: Address },
+    #[error(transparent)]
+    Sqlx(#[from] sqlx::Error),
 }
 
 // `AggregateError<LifecycleError<Redemption>>` is large (it can carry a full
@@ -74,6 +83,7 @@ impl TransferProcessingError {
             Self::SolTypes(_)
                 | Self::MissingTxHash
                 | Self::MissingBlockNumber
+                | Self::MissingLogIndex
                 | Self::QuantityConversion(_)
                 | Self::NoMatchingAsset { .. }
         )
@@ -108,6 +118,24 @@ pub(crate) async fn detect_transfer(
 
     let block_number =
         log.block_number.ok_or(TransferProcessingError::MissingBlockNumber)?;
+
+    // Fail closed: exclusion identity is (network, vault, tx_hash, log_index).
+    // Without log_index we cannot prove the transfer is not an excluded Path B
+    // funding log, so refuse Detect rather than open a Redemption by accident.
+    let log_index =
+        log.log_index.ok_or(TransferProcessingError::MissingLogIndex)?;
+
+    if is_excluded_funding_log(pool, network, vault, tx_hash, log_index).await?
+    {
+        debug!(
+            target: "redemption",
+            %tx_hash,
+            log_index,
+            %vault,
+            "Skipping admin recovery funding transfer"
+        );
+        return Ok(TransferOutcome::SkippedAdminRecovery);
+    }
 
     let account_view = find_by_wallet(pool, &transfer_event.from).await?;
 
@@ -342,10 +370,12 @@ mod tests {
     use tracing_test::traced_test;
 
     use super::{TransferOutcome, TransferProcessingError, detect_transfer};
+    use crate::redemption::IssuerRedemptionRequestId;
     use crate::redemption::Redemption;
     use crate::redemption::RedemptionServices;
     use crate::redemption::test_utils::{
-        create_transfer_log, setup_test_db_with_asset,
+        create_transfer_log, create_transfer_log_with_index,
+        setup_test_db_with_asset,
     };
     use crate::test_utils::logs_contain_at;
     use crate::tokenized_asset::view::list_enabled_assets;
@@ -475,6 +505,197 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    async fn detect_transfer_skips_excluded_funding_log_only() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+        let ap_wallet = address!("0x9999999999999999999999999999999999999999");
+        let other_wallet =
+            address!("0x8888888888888888888888888888888888888888");
+
+        let pool = setup_test_db_with_asset(vault, Some(ap_wallet)).await;
+        // Adjacent same-wallet transfer still redeems: also whitelist other.
+        {
+            use crate::account::{
+                Account, AccountCommand, AlpacaAccountNumber, ClientId, Email,
+            };
+            use event_sorcery::StoreBuilder;
+
+            let (account_store, _) = StoreBuilder::<Account>::new(pool.clone())
+                .build(())
+                .await
+                .unwrap();
+            let client_id = ClientId::new();
+            account_store
+                .send(
+                    &client_id,
+                    AccountCommand::Register {
+                        client_id,
+                        email: Email::new("other@example.com").unwrap(),
+                    },
+                )
+                .await
+                .unwrap();
+            account_store
+                .send(
+                    &client_id,
+                    AccountCommand::LinkToAlpaca {
+                        alpaca_account: AlpacaAccountNumber(
+                            "ALPACA999".to_string(),
+                        ),
+                    },
+                )
+                .await
+                .unwrap();
+            account_store
+                .send(
+                    &client_id,
+                    AccountCommand::WhitelistWallet { wallet: other_wallet },
+                )
+                .await
+                .unwrap();
+        }
+
+        let store = setup_test_store(&pool);
+        let value = U256::from_str_radix("750000000000000000", 10).unwrap();
+        let funding_tx = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let neighbor_tx = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+        let unrecorded_tx = b256!(
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+
+        let funding = crate::burn_excess::FundingTransferId {
+            network: Network::Base,
+            vault,
+            tx_hash: funding_tx,
+            log_index: 2,
+            from: ap_wallet,
+            to: bot_wallet,
+            amount: value,
+        };
+        crate::burn_excess::exclusion::record_funding_exclusion(
+            &pool,
+            &funding,
+            b256!(
+                "0x1bb6afc590e58095099373a8fea2242017b31acc7940bcd0d6b68820ebeb8ebd"
+            ),
+            chrono::Utc::now(),
+        )
+        .await
+        .unwrap();
+
+        let assets = list_enabled_assets(&pool).await.unwrap();
+
+        let excluded = create_transfer_log_with_index(
+            vault, ap_wallet, bot_wallet, value, funding_tx, 100, 2,
+        );
+        let excluded_outcome = detect_transfer(
+            &excluded,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(excluded_outcome, TransferOutcome::SkippedAdminRecovery),
+            "excluded funding log must not open a redemption: {excluded_outcome:?}"
+        );
+        assert!(
+            store
+                .load(&IssuerRedemptionRequestId::new(funding_tx))
+                .await
+                .unwrap()
+                .is_none(),
+            "no Redemption aggregate for excluded funding log"
+        );
+
+        // Sibling log in the *same* transaction as the excluded one. The skip
+        // key is (network, vault, tx_hash, log_index), so only log_index 2 is
+        // excluded; log 3 must still redeem. This is what pins the exclusion to
+        // one log rather than to the whole transaction.
+        let sibling = create_transfer_log_with_index(
+            vault, ap_wallet, bot_wallet, value, funding_tx, 100, 3,
+        );
+        let sibling_outcome = detect_transfer(
+            &sibling,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(sibling_outcome, TransferOutcome::Detected { .. }),
+            "a sibling log in the excluded transaction must still redeem: \
+             {sibling_outcome:?}"
+        );
+
+        // Neighbor transfer (different tx / log) still redeems; exclusion is
+        // exact-identity only, not "skip all from this wallet".
+        let neighbor = create_transfer_log_with_index(
+            vault,
+            other_wallet,
+            bot_wallet,
+            value,
+            neighbor_tx,
+            100,
+            0,
+        );
+        let neighbor_outcome = detect_transfer(
+            &neighbor,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(neighbor_outcome, TransferOutcome::Detected { .. }),
+            "neighbor transfer must still redeem: {neighbor_outcome:?}"
+        );
+
+        let unrecorded = create_transfer_log_with_index(
+            vault,
+            ap_wallet,
+            bot_wallet,
+            value,
+            unrecorded_tx,
+            101,
+            0,
+        );
+        let unrecorded_outcome = detect_transfer(
+            &unrecorded,
+            vault,
+            Network::Base,
+            &assets,
+            &store,
+            &pool,
+        )
+        .await
+        .unwrap();
+        assert!(
+            matches!(unrecorded_outcome, TransferOutcome::Detected { .. }),
+            "unrecorded same-wallet transfer must still redeem: {unrecorded_outcome:?}"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Skipping admin recovery funding transfer"]
+        ));
+    }
+
+    #[traced_test]
+    #[tokio::test]
     async fn detect_transfer_skips_mint_events() {
         let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
         let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
@@ -573,6 +794,42 @@ mod tests {
         assert!(
             matches!(result, Err(TransferProcessingError::MissingBlockNumber)),
             "Expected MissingBlockNumber, got {result:?}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn detect_transfer_missing_log_index_fails_closed() {
+        let vault = address!("0x1234567890abcdef1234567890abcdef12345678");
+        let bot_wallet = address!("0xabcdefabcdefabcdefabcdefabcdefabcdefabcd");
+
+        let pool = setup_test_db_with_asset(vault, None).await;
+        let store = setup_test_store(&pool);
+
+        let mut log = create_transfer_log(
+            vault,
+            address!("0x9999999999999999999999999999999999999999"),
+            bot_wallet,
+            U256::from(100),
+            b256!(
+                "0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcd"
+            ),
+            12345,
+        );
+        log.log_index = None;
+
+        let assets = list_enabled_assets(&pool).await.unwrap();
+        let result =
+            detect_transfer(&log, vault, Network::Base, &assets, &store, &pool)
+                .await;
+
+        assert!(
+            matches!(result, Err(TransferProcessingError::MissingLogIndex)),
+            "Expected MissingLogIndex, got {result:?}"
+        );
+        assert!(
+            result.as_ref().unwrap_err().is_non_transient(),
+            "missing log_index must not retry/freeze checkpoint indefinitely"
         );
     }
 

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -18,6 +18,9 @@ use super::view::{
 use super::{TokenizedAsset, UnderlyingSymbol};
 use crate::Network;
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
+use crate::burn_excess::cli::{
+    BurnExcessCommand as BurnExcessCliCommand, run_burn_excess_cli,
+};
 use crate::config::{
     DEFAULT_DATABASE_MAX_CONNECTIONS, DEFAULT_DATABASE_URL, LogLevel,
     setup_tracing,
@@ -154,6 +157,12 @@ enum IssuerCommand {
     /// documented bound; identical rejections carry the server's own error
     /// code for diagnosis. Submits nothing and reads only the vault address.
     FireblocksAuthProbe(Box<FireblocksAuthProbeArgs>),
+    /// Administrative supply correction: burn excess shares from a proven
+    /// duplicate deposit. Path is a required mode keyword
+    /// (`internal` | `external`); never Alpaca, never a Redemption aggregate.
+    /// Default is dry-run inspection; pass `--execute` to mutate.
+    #[command(subcommand)]
+    BurnExcess(Box<BurnExcessCliCommand>),
 }
 
 #[derive(Args)]
@@ -862,6 +871,9 @@ impl IssuerCli {
             }
             IssuerCommand::SweepLegacyReceipts(args) => {
                 run_sweep_legacy_receipts(*args, prompt_confirm).await
+            }
+            IssuerCommand::BurnExcess(command) => {
+                run_burn_excess_cli(*command, prompt_confirm).await
             }
         }
     }

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -516,8 +516,15 @@ impl MockVaultService {
 
     #[cfg(test)]
     pub(crate) fn with_share_balance(self, balance: U256) -> Self {
-        *self.share_balance.lock().unwrap() = balance;
+        self.set_share_balance(balance);
         self
+    }
+
+    /// Moves the balance on an already-shared mock, so a test can model the
+    /// issuer's balance changing part-way through a run.
+    #[cfg(test)]
+    pub(crate) fn set_share_balance(&self, balance: U256) {
+        *self.share_balance.lock().unwrap() = balance;
     }
 
     /// Configures `verify_burn_tx` to report the operator-supplied tx as a
@@ -658,6 +665,17 @@ impl MockVaultService {
     #[cfg(test)]
     pub(crate) fn set_prepared_tx(&self, sendable_tx: SendableTxWithHash) {
         *self.prepared_tx.lock().unwrap() = Some(sendable_tx);
+    }
+
+    /// Seeds the result returned by the next `confirm_burn` (resume paths that
+    /// skip `submit_burn` otherwise fall back to default mock burn deltas).
+    #[cfg(test)]
+    pub(crate) fn with_pending_burn_result(
+        self,
+        result: MultiBurnResult,
+    ) -> Self {
+        *self.pending_burn_result.lock().unwrap() = Some(result);
+        self
     }
 }
 
@@ -1132,7 +1150,7 @@ mod tests {
     };
     use crate::redemption::IssuerRedemptionRequestId;
     use crate::vault::{
-        MultiBurnEntry, MultiBurnParams, ReceiptInformation,
+        BurnRequestOrigin, MultiBurnEntry, MultiBurnParams, ReceiptInformation,
         SendableTxWithHash, VaultError, VaultService,
     };
 
@@ -1353,7 +1371,9 @@ mod tests {
             dust_shares: U256::from(10),
             owner: test_receiver(),
             user: address!("0x2222222222222222222222222222222222222222"),
-            issuer_request_id: IssuerRedemptionRequestId::new(detected_tx_hash),
+            origin: BurnRequestOrigin::Redemption(
+                IssuerRedemptionRequestId::new(detected_tx_hash),
+            ),
             detected_tx_hash,
             external_tx_id: None,
         }

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -20,6 +20,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::bindings::OffchainAssetReceiptVault;
+use crate::burn_excess::BurnExcessId;
 use crate::mint::{
     IssuerMintRequestId, Quantity, TokenizationRequestId, UnderlyingSymbol,
 };
@@ -518,6 +519,18 @@ pub(crate) struct MultiBurnEntry {
     pub(crate) receipt_info_bytes: Option<Bytes>,
 }
 
+/// Which domain flow asked for a burn.
+///
+/// The vault burn path serves both the redemption pipeline and the operator
+/// excess-recovery CLI. Each owns its own aggregate keyspace, so the
+/// correlation id must carry that keyspace with it: an excess recovery must
+/// not be able to name a slot in the `Redemption` keyspace, even by accident.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) enum BurnRequestOrigin {
+    Redemption(IssuerRedemptionRequestId),
+    ExcessRecovery(BurnExcessId),
+}
+
 /// Parameters for a multi-receipt burn operation.
 ///
 /// Atomically burns shares from multiple receipts in a single transaction.
@@ -533,8 +546,8 @@ pub(crate) struct MultiBurnParams {
     pub(crate) owner: Address,
     /// User's address that will receive the dust
     pub(crate) user: Address,
-    /// Redemption's issuer request ID
-    pub(crate) issuer_request_id: IssuerRedemptionRequestId,
+    /// Domain flow this burn belongs to, and its correlation ID
+    pub(crate) origin: BurnRequestOrigin,
     /// Full transaction hash that triggered this redemption, used for
     /// constructing a collision-resistant `externalTxId`.
     pub(crate) detected_tx_hash: B256,

--- a/src/vault/rain_meta.rs
+++ b/src/vault/rain_meta.rs
@@ -277,11 +277,18 @@ enum OaSchemaCacheMode {
     /// Fetches schema hashes from the Goldsky subgraph on cache miss.
     Live { client: reqwest::Client, subgraph_url: Url },
 
-    /// Returns a fixed schema hash for any vault. Used in tests to exercise
-    /// the full CBOR encoding path without requiring a live subgraph.
-    #[cfg(test)]
+    /// Returns a fixed schema hash for any vault. Used when the subgraph is
+    /// unavailable (admin burn-excess recovery) and in tests to exercise the
+    /// full CBOR encoding path without a live subgraph.
     Fixed(String),
 }
+
+/// OA schema hash the Rain vaults are deployed against.
+///
+/// Admin paths that always carry the original deposit `receipt_info_bytes` pass
+/// this to [`OaSchemaCache::fixed`] so they need no subgraph.
+pub(crate) const OA_SCHEMA_HASH: &str =
+    "bafkreiahuttak2jvjzsd4r62xhf2fwvy7hbpbfdetxrieqxf4ivyxgpdm";
 
 /// Connect timeout for subgraph HTTP requests.
 const SUBGRAPH_CONNECT_TIMEOUT: std::time::Duration =
@@ -305,7 +312,9 @@ impl OaSchemaCache {
     }
 
     /// Creates a cache that returns a fixed schema hash for any vault address.
-    #[cfg(test)]
+    ///
+    /// Prefer this for admin paths that always pass original deposit
+    /// `receipt_info_bytes` (no re-encoding) so the subgraph is not required.
     pub(crate) fn fixed(schema_hash: &str) -> Self {
         Self {
             mode: OaSchemaCacheMode::Fixed(schema_hash.to_string()),
@@ -323,7 +332,6 @@ impl OaSchemaCache {
     /// timeouts) are NOT cached so subsequent calls will retry.
     pub(crate) async fn get(&self, vault: Address) -> Option<String> {
         match &self.mode {
-            #[cfg(test)]
             OaSchemaCacheMode::Fixed(schema) => return Some(schema.clone()),
             OaSchemaCacheMode::Live { .. } => {}
         }
@@ -399,7 +407,6 @@ impl OaSchemaCache {
                 (client, subgraph_url)
             }
 
-            #[cfg(test)]
             OaSchemaCacheMode::Fixed(_) => {
                 // Fixed mode is handled in get() before reaching here
                 return Ok(None);

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -639,8 +639,8 @@ mod tests {
     use crate::test_utils::{LocalEvm, logs_contain_at};
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
-        BurnTxStatus, MultiBurnEntry, MultiBurnParams, ReceiptInformation,
-        SendableTxWithHash, TxId, VaultError, VaultService,
+        BurnRequestOrigin, BurnTxStatus, MultiBurnEntry, MultiBurnParams,
+        ReceiptInformation, SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
     const TEST_OA_SCHEMA: &str =
@@ -683,7 +683,7 @@ mod tests {
             dust_shares: U256::ZERO,
             owner,
             user: address!("0x3333333333333333333333333333333333333333"),
-            issuer_request_id: test_issuer_redemption_id(),
+            origin: BurnRequestOrigin::Redemption(test_issuer_redemption_id()),
             detected_tx_hash: b256!(
                 "0xabababababababababababababababababababababababababababababababab"
             ),
@@ -1741,7 +1741,9 @@ mod tests {
                     dust_shares: U256::ZERO,
                     owner,
                     user,
-                    issuer_request_id: test_issuer_redemption_id(),
+                    origin: BurnRequestOrigin::Redemption(
+                        test_issuer_redemption_id(),
+                    ),
                     detected_tx_hash,
                     external_tx_id: None,
                 },
@@ -1814,7 +1816,9 @@ mod tests {
                     dust_shares: U256::ZERO,
                     owner,
                     user,
-                    issuer_request_id: test_issuer_redemption_id(),
+                    origin: BurnRequestOrigin::Redemption(
+                        test_issuer_redemption_id(),
+                    ),
                     detected_tx_hash,
                     external_tx_id: Some(BurnExternalTxId::from_string(
                         override_id.clone(),
@@ -1888,7 +1892,7 @@ mod tests {
                 dust_shares: U256::ZERO,
                 owner,
                 user,
-                issuer_request_id: test_issuer_redemption_id(),
+                origin: BurnRequestOrigin::Redemption(test_issuer_redemption_id()),
                 detected_tx_hash: b256!(
                     "0xabababababababababababababababababababababababababababababababab"
                 ),
@@ -1933,7 +1937,7 @@ mod tests {
             dust_shares,
             owner,
             user,
-            issuer_request_id: test_issuer_redemption_id(),
+            origin: BurnRequestOrigin::Redemption(test_issuer_redemption_id()),
             detected_tx_hash,
             external_tx_id: None,
         };
@@ -1978,7 +1982,7 @@ mod tests {
             dust_shares: U256::ZERO,
             owner,
             user,
-            issuer_request_id: test_issuer_redemption_id(),
+            origin: BurnRequestOrigin::Redemption(test_issuer_redemption_id()),
             detected_tx_hash,
             external_tx_id: None,
         };


### PR DESCRIPTION
## What

- Adds `issuer burn-excess internal|external` for administrative supply correction after a duplicate mint.
- `internal`: burn when excess shares already sit at the issuer wallet (no funding Transfer to hide).
- `external`: prove a funding Transfer into the issuer, exclude only that log from the redemption poller, then burn.
- New `BurnExcess` ES aggregate (deposit tx hash id) for persist-before-broadcast burn, funding exclusion audit, and restart recovery.
- SQL exclusion index `(network, vault, tx_hash, log_index)` so the poller skips only the verified funding log.
- Wires unresolved excess-burn intents into mint prepare and redemption burn prepare gates.

## Why

- There is no supported way to reconcile an excess successful mint.
- Normal redemption calls Alpaca and releases backing, so it does not fix undercollateralisation.
- A raw Transfer into the issuer looks like a real redemption and is backfilled after restart.
- Tracked in [RAI-1632](https://linear.app/makeitrain/issue/RAI-1632/add-an-audited-cli-to-burn-excess-shares-from-a-duplicate-mint) (parent [RAI-1631](https://linear.app/makeitrain/issue/RAI-1631)).

## How

- Mode keyword after `burn-excess` selects the path (`internal` vs `external`). Not inferred from balances or from whether a funding hash is present.
- `--funding-tx-hash` is required only on `external` (clap).
- Proves deposit bind (issuer request, receipt id, exact shares, strict `receiptInformation`) from the event store and chain. Never accepts typed vault/wallet addresses.
- Freeze is not a precondition. In-flight mint/burn/excess intents refuse execute.
- Path A (`internal`) refuses if the original mint recipient is not the issuer (forces `external` when a funding Transfer is in play).
- Path B records funding exclusion before any sign; engine dual-writes the SQL index and verifies it before prepare. Re-checks no Redemption and re-checks wallet intents at the irreversible boundary.
- Reuses `VaultService` exact `redeem` (persist intend → submit → confirm Withdraw → inventory reconcile). No Alpaca. No `Redemption` aggregate for the burn.
- Default is inspection only. `--execute` requires operator confirm before the first irreversible step.

## Testing

- Aggregate GWT, proof/path selection unit tests, exclusion exact-identity tests.
- Poller: skip excluded log only; neighbor and unrecorded same-wallet transfers still detect as redemptions; missing `log_index` fails closed.
- Engine/Anvil: internal dry-run and execute; external dry-run (no exclusion write); external fund→exclude→burn; PathConflict on mode switch; FundingAlreadyRedeemed; resume Intended+Mined without second prepare; zero Redemption events on burn path.
- `cargo test -p st0x-issuance --lib -- burn_excess` and transfer skip/missing-field tests: 41 related tests passed locally.

## Anything else

- Ops for Path B: stop the issuance service (or at least the transfer poller) before the funding Transfer, then run the CLI. Live poller race is still possible if you fund while the service is up.
- `--close` only clears wallet intent gates for a dead burn intent. The stream stays report-only after close (no auto replace-dead-burn).
- Production bind for the incident still proven at runtime (issuer request, deposit tx, funding tx, receipt 7, 0.750e18). Not hard-coded as the only path.
- The exclusion index is rebuilt from `FundingExclusionRecorded` history in `setup_aggregate_cqrs` (`src/lib.rs:662`), which runs before the receipt backfills and transfer pollers spawn, so a restored or truncated index table cannot leave the poller free to open a `Redemption` for an excluded funding log. The CLI rebuilds it on store open too. Engine dual-write plus verify-before-prepare remains the hard guarantee for new recoveries.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `issuer burn-excess internal|external` administrative workflow.
  * Added dry-run previews, confirmation controls, resumable execution, reconciliation, and safe closure handling.
  * Added durable tracking for excluded funding transfers and network-specific RPC configuration.
  * Added strict validation for deposits, balances, funding transfers, and transaction metadata.

* **Bug Fixes**
  * Prevented conflicting mint and burn operations while excess-burn actions remain unresolved.
  * Redemption processing now skips verified recovery funding transfers and fails closed when transfer identity is incomplete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
