### PR TITLE
fix: prevent vault-direct double-mint after uncertain confirmation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ rsa = "0.9.10"
 rust_decimal_macros = "1.40.0"
 st0x-issuance-client = { path = "crates/client" }
 tempfile = "3.23.0"
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [workspace]

--- a/SPEC.md
+++ b/SPEC.md
@@ -178,6 +178,13 @@ initial request through journal confirmation to on-chain minting and callback.
 - `tx_hash`, `receipt_id`, `shares_minted`: On-chain transaction details
 - Timestamps for each lifecycle stage
 
+**Durable jobs vs pure commands:** On-chain I/O and Alpaca callbacks are
+performed by durable jobs (`SubmitMintJob`, `ConfirmMintJob`, `SendCallbackJob`,
+`MintRecoveryJob`). Aggregate commands are pure `Record*` / transition commands:
+they validate state and emit events from job-supplied payloads (no network I/O
+in the handler). Recovery advances a mint via `drive_one_step` (pure transitions
+plus enqueue of the next job), not a wallet-locked aggregate command.
+
 **Commands:**
 
 - `Initiate { tokenization_request_id, quantity, underlying, token, network, client_id, wallet }` -
@@ -191,35 +198,26 @@ initial request through journal confirmation to on-chain minting and callback.
   `MintingStarted`. Intent is persisted before the network call so that a crash
   during submission leaves the aggregate in a recoverable `Minting` state rather
   than `JournalConfirmed` (which would lose track of the submission)
-- `PrepareMint { issuer_request_id }` - Build and sign the exact on-chain
-  deposit transaction. Requires `Minting` state. Produces `MintTxIntended`,
-  which persists the raw transaction, hash, nonce, signing time, and stable
-  external transaction ID before any broadcast
-- `SubmitMint { issuer_request_id }` - Broadcast the exact transaction stored by
-  `MintTxIntended`. Requires `MintIntended` state. Produces `MintTxSubmitted` on
-  success. An uncertain broadcast failure leaves the aggregate in
-  `MintIntended`, so recovery rebroadcasts the same bytes
-- `ConfirmMint { issuer_request_id, tx_id }` - Confirm a previously submitted
-  mint transaction. Re-fetches the on-chain receipt for the stored `tx_id` and
-  produces `TokensMinted` or `MintingFailed`
-- `SendCallback { issuer_request_id }` - Send the callback to Alpaca confirming
-  mint completion
-- `Recover { issuer_request_id, mode }` - Recover a mint stuck in an incomplete
-  state. Startup recovery drives any mint in `JournalConfirmed`, `Minting`,
-  `MintIntended`, `TxSubmitted`, `MintingFailed`, or `CallbackPending` state; at
-  runtime, live retry scheduling is triggered specifically when a mint lands in
-  `MintingFailed` during the journal-confirmation flow. Both paths hand a mint
-  that is waiting on a retry window to a background scheduled-recovery task, so
-  retries fire on schedule without waiting for a restart. Queries the receipt
-  inventory for a receipt matching the `issuer_request_id`. If a matching
-  receipt is found, the mint already succeeded on-chain, so recovery records the
-  existing mint (`ExistingMintRecovered`) and proceeds to callback. If no
-  receipt is found and the previous transaction is terminally failed, automatic
-  recovery submits up to four retry transactions after 1m, 10m, 30m, and 1h
-  delays. Manual admin reprocess uses the same recovery path but bypasses the
-  automatic retry cap so an operator can retry after fixing the underlying
-  cause. This prevents double-minting after crashes while ensuring terminal
-  failures can be retried with new `externalTxId`s
+- `RecordTxIntended { issuer_request_id, prepared_tx }` - Pure: persists the
+  exact signed deposit (`MintTxIntended`) before broadcast. Requires `Minting`.
+  Built and signed by `SubmitMintJob` (or recovery enqueue of that job), not by
+  a network-calling aggregate command
+- `RecordTxSubmitted { issuer_request_id, external_tx_id, tx_id }` - Pure:
+  records a successful broadcast (`MintTxSubmitted`). Accepts `Minting` and
+  legacy `MintIntended`. Uncertain broadcast with a live prepared identity
+  leaves `MintIntended` (no event) so the same bytes are rebroadcast
+- `RecordTokensMinted { issuer_request_id, tx_id, ... }` - Pure: records
+  on-chain success (`TokensMinted`) from `ConfirmMintJob`. Requires
+  `TxSubmitted` and a matching stored `tx_id` (stale confirm jobs are rejected)
+- `RecordMintFailed { issuer_request_id, error }` - Pure: records
+  `MintingFailed` from a durable job. Observation rules (job-side) allow this
+  only for definitive failure (mined revert / provably dead after classify, or
+  pre-intent prepare rejection) — never for uncertain receipt/RPC observation
+  while a prepared identity is still live
+- `RecordCallbackSent { issuer_request_id }` - Pure: records `MintCompleted`
+  after `SendCallbackJob` delivers the Alpaca callback
+- `RetryMint { issuer_request_id }` - Pure: `MintingFailed` → `Minting`
+  (`MintRetryStarted`) before recovery re-enqueues `SubmitMintJob`
 - `ManualRetryMint { issuer_request_id, manual_retry_id }` - Operator-authorized
   retry of a `MintingFailed` mint past the exhausted automatic budget, gated on
   the aggregate's own failure provenance (not a snapshot that may be stale by
@@ -230,20 +228,45 @@ initial request through journal confirmation to on-chain minting and callback.
   before the job-based submit flow are refused outright — their provenance
   cannot be proven from event history. Produces the same `MintRetryStarted`
   event as automatic retry
-- `RecoverWalletStep { issuer_request_id, mode }` - Internal recovery variant
-  used only while the wallet lock is held. It performs the same recoverable
-  on-chain steps as `Recover`, but becomes a no-op if a concurrent transition
-  already reached `CallbackPending`; the next recovery iteration then sends the
-  callback without the wallet lock
-- `RecoverFromReceipt { issuer_request_id, tx_hash }` - Recover a mint that
-  failed during the minting step, or whose broadcast outcome was not persisted,
-  when an ITN receipt is discovered on-chain. Triggered by the receipt monitor
-  when it finds a Deposit event with a matching `issuer_request_id`. Accepts
-  `MintIntended`, because the persisted transaction may have been mined before
-  submission recording, and `MintingFailed` when the non-failed predecessor was
-  `Minting`. Rejects `JournalConfirmed` and `Minting` because neither state
-  proves a transaction was signed or submitted. Emits `ExistingMintRecovered`
-  and proceeds to callback
+- `RecordExistingMint { issuer_request_id, tx_hash, receipt_id, shares_minted, block_number }` -
+  Pure: records an already-mined on-chain deposit (`ExistingMintRecovered`) and
+  advances to `CallbackPending` without rebroadcasting. Accepts `Minting`,
+  `MintIntended`, `TxSubmitted`, and `MintingFailed` (inventory or confirm
+  success under any of those states). Idempotent once already minted /
+  callback-pending / completed
+- `CloseMint { issuer_request_id, reason, acknowledged_unresolved_mint_tx_hash }` -
+  Admin-closes a non-terminal mint. When the mint still holds an unresolved
+  deposit identity, `acknowledged_unresolved_mint_tx_hash` must equal that exact
+  hash (422 on miss/mismatch). That identity is the prepared hash
+  (`MintTxIntended` / `TxSubmitted` with prepared bytes, including via
+  `MintingFailed`), and for a legacy `TxSubmitted` carrying no prepared bytes it
+  falls back to the stored `tx_id` when that id is a transaction hash — the
+  submission is already on the wire and recovery still confirm-polls it, so
+  closing it must not be cheaper than closing an intended mint. Omit only when
+  there is no such identity (no prepared bytes and no hash `tx_id`); providing a
+  hash when none exists is also 422.
+
+**Recovery orchestration (not aggregate commands):** Startup and the scheduled
+`MintRecoveryJob` drive any mint in `JournalConfirmed`, `Minting`,
+`MintIntended`, `TxSubmitted`, `MintingFailed`, or `CallbackPending` via
+`drive_one_step` + enqueue of the matching durable job. Inventory hits use
+`RecordExistingMint`; otherwise recovery re-classifies any persisted signed mint
+intent under the wallet lock (burn-parity observation below) and only allows a
+**new** signed deposit after `MinedReverted` or `ProvablyDead` with a recheck.
+Automatic recovery submits up to four replacement transactions after 1m, 10m,
+30m, and 1h delays once the prior identity is terminal. Manual admin reprocess
+uses the **same** recovery path and **does not** bypass the automatic retry cap:
+when automatic retries are `Exhausted`, admin reprocess is `Unrecoverable`
+(operator must fix the underlying cause and/or use an explicit close/remediation
+path — not another free deposit). Correctness depends on exact-hash rebroadcast
+and classification — **not** on `external_tx_id` (the signer does not dedup on
+it).
+
+`ConfirmMintJob` observes a submitted `tx_id` by bounded
+`eth_getTransactionReceipt(H)` polling as `Option`, not
+`PendingTransactionBuilder::get_receipt` as the terminal classifier. The
+vault-direct mint recovery model under **Command -> Event Mappings** is the
+authoritative statement of what each observation records.
 
 **Events:**
 
@@ -283,41 +306,41 @@ dual-format reader or restore the pre-cutover backup.
 
 **Command -> Event Mappings:**
 
-| Command              | Events                  | Notes                                          |
-| -------------------- | ----------------------- | ---------------------------------------------- |
-| `Initiate`           | `Initiated`             | Mint request created                           |
-| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                              |
-| `RejectJournal`      | `JournalRejected`       | Terminal failure                               |
-| `Deposit`            | `MintingStarted`        | Records intent (no network call)               |
-| `PrepareMint`        | `MintTxIntended`        | Persists exact signed tx before broadcast      |
-| `SubmitMint`         | `MintTxSubmitted`       | Broadcasts the persisted transaction           |
-| `ConfirmMint`        | See below               | Confirms submitted tx                          |
-| `SendCallback`       | `MintCompleted`         | Calls Alpaca callback                          |
-| `Recover`            | See below               | Checks receipt inventory                       |
-| `RecoverWalletStep`  | See below               | Never sends callbacks while wallet-locked      |
-| `RecoverFromReceipt` | `ExistingMintRecovered` | Receipt recovery from intended or failed state |
+| Command              | Events                  | Notes                                                     |
+| -------------------- | ----------------------- | --------------------------------------------------------- |
+| `Initiate`           | `Initiated`             | Mint request created                                      |
+| `ConfirmJournal`     | `JournalConfirmed`      | Journal confirmed                                         |
+| `RejectJournal`      | `JournalRejected`       | Terminal failure                                          |
+| `Deposit`            | `MintingStarted`        | Records intent (no network call)                          |
+| `RecordTxIntended`   | `MintTxIntended`        | Pure; `SubmitMintJob` signed first                        |
+| `RecordTxSubmitted`  | `MintTxSubmitted`       | Pure; job already broadcast                               |
+| `RecordTokensMinted` | `TokensMinted`          | Pure; requires matching `tx_id`                           |
+| `RecordMintFailed`   | `MintingFailed`         | Pure; job-side observation gates                          |
+| `RecordCallbackSent` | `MintCompleted`         | Pure; `SendCallbackJob` already called Alpaca             |
+| `RetryMint`          | `MintRetryStarted`      | Pure; recovery before re-enqueue submit                   |
+| `RecordExistingMint` | `ExistingMintRecovered` | Pure; `Minting` / `MintIntended` / `TxSubmitted` / failed |
+| `CloseMint`          | (closed)                | Admin terminal                                            |
 
-`Deposit` emits only `MintingStarted` (business intent). `PrepareMint` builds
-and signs the transaction, then persists the exact bytes and hash in
-`MintTxIntended`. Only `SubmitMint` may broadcast those persisted bytes. A crash
-before `MintTxIntended` cannot have broadcast anything; a crash after it causes
-recovery to rebroadcast or poll that same transaction, never prepare a second
-one. A crash after broadcast but before `MintTxSubmitted` therefore remains safe
-because rebroadcasting identical signed bytes is idempotent. Preparing,
-persisting, and initially broadcasting a mint transaction share one wallet
-critical section. Startup mint recovery processes its persisted intents in nonce
-order before mint states that may prepare a new transaction. Mint and redemption
-recovery run concurrently so persisted transactions from either domain can fill
-lower nonce gaps while higher transactions await confirmation. Live mint and
-burn preparation consult the trigger-maintained signer-intent reservation and
-are blocked while any other wallet intent remains unresolved; this safety check
-does not depend on a fallible read-model projection. Together these rules
-prevent two aggregate commands from signing the same wallet nonce without
-relying on in-memory nonce state that would be lost on restart. Each live burn
-attempt waits at most 30 seconds behind an earlier unresolved wallet intent. On
-timeout it prepares and broadcasts nothing, leaves the redemption recoverable,
-and defers the burn to recovery rather than occupying the live flow
-indefinitely.
+`Deposit` emits only `MintingStarted` (business intent). `SubmitMintJob` builds
+and signs the transaction, persists exact bytes via `RecordTxIntended`, then
+broadcasts. A crash before `MintTxIntended` cannot have broadcast anything; a
+crash after it causes recovery to rebroadcast or poll that same transaction,
+never prepare a second one. A crash after broadcast but before `MintTxSubmitted`
+therefore remains safe because rebroadcasting identical signed bytes is
+idempotent. Preparing, persisting, and initially broadcasting a mint transaction
+share one wallet critical section. Startup mint recovery processes its persisted
+intents in nonce order before mint states that may prepare a new transaction.
+Mint and redemption recovery run concurrently so persisted transactions from
+either domain can fill lower nonce gaps while higher transactions await
+confirmation. Live mint and burn preparation consult the trigger-maintained
+signer-intent reservation and are blocked while any other wallet intent remains
+unresolved; this safety check does not depend on a fallible read-model
+projection. Together these rules prevent two jobs from signing the same wallet
+nonce without relying on in-memory nonce state that would be lost on restart.
+Each live burn attempt waits at most 30 seconds behind an earlier unresolved
+wallet intent. On timeout it prepares and broadcasts nothing, leaves the
+redemption recoverable, and defers the burn to recovery rather than occupying
+the live flow indefinitely.
 
 **Cross-instance signer-intent guard.** The pre-check above is an
 application-level read; it cannot by itself stop two separate processes from
@@ -347,36 +370,133 @@ wallet are unsupported because the wallet critical section is process-local.
 Deployments must terminate the old process before the replacement begins serving
 or recovering work.
 
-`ConfirmMint` re-fetches the on-chain receipt for the submitted `tx_id` and
-emits either `TokensMinted` (success) or `MintingFailed` (failure).
+`ConfirmMintJob` observes the submitted `tx_id` via bounded
+`get_transaction_receipt` polling and records `TokensMinted` only on a mined
+success with a valid `Deposit`. It may record `MintingFailed` only for a mined
+revert (`status=0`) when the job's `tx_id` matches the mint's current
+submission. Uncertain observations (no receipt within the poll budget,
+RPC/transport errors, invalid receipt shape, or a mined success body missing
+`Deposit` logs) leave the aggregate in `TxSubmitted` — or `MintIntended` if it
+was never submitted — with **no** event, never auto-replace. A missing `Deposit`
+on a successful receipt is anomalous and requires operator intervention, not a
+second deposit.
 
-`Recover` checks the receipt inventory for a receipt matching the
-`issuer_request_id`. If found, emits `ExistingMintRecovered`. If not found and
-in `Minting` state, prepares and persists `MintTxIntended`. If in
-`MintIntended`, rebroadcasts the persisted raw transaction. If in `TxSubmitted`
-(or `MintingFailed` with a known prior transaction), calls `ConfirmMint` with
-the stored `tx_id` to re-fetch the on-chain receipt. `TxSubmitted` means the
-persisted transaction was broadcast; it does not mean the transaction succeeded
-on-chain. `ConfirmMint` waits for the receipt and emits `TokensMinted` for a
-successful transaction or `MintingFailed` for a reverted or otherwise failed
-transaction. Retry transactions use `mint-{issuer_request_id}-retry-{n}` where
-automatic retries use n = 1..4 and the delay schedule is 1m, 10m, 30m, then 1h.
+Vault-direct mint recovery uses the same observation predicate as burn recovery
+for a persisted signed identity `(H, N)` of wallet `W` (the signing bot):
+
+```
+observe(H, N, W):
+  receipt(H) with block + status=1 + Deposit → MinedSuccess
+  receipt(H) with block + status=0           → MinedReverted
+  receipt None + finalized_nonce(W) ≤ N      → StillMineable
+  receipt None + finalized_nonce(W) > N
+    then recheck receipt(H):
+      Some(...) → reclassify
+      None      → then corroborate with transaction(H):
+                    None    → ProvablyDead
+                    Some(_) → Uncertain (contradictory death signals)
+  anything else                             → Uncertain (fail closed; Err)
+```
+
+`ProvablyDead` unlocks `RecordMintFailed` and a replacement prepare, so it is
+never read out of a single absent receipt: a lagging or load-balanced RPC node
+can answer `None` for a receipt that exists. A finalized nonce past `N` says the
+nonce is spent; the node having also forgotten the transaction is what says it
+was not spent by this one. A node that reports the nonce finalized while still
+holding the unmined transaction is contradicting itself, and a death proof
+cannot be read out of an inconsistent node — that is `Uncertain`, which
+preserves the identity instead of authorizing a second deposit.
+
+`Uncertain` is a fail-closed error classification, not a durable aggregate
+state. Every arm that preserves an identity instead of advancing it — uncertain
+classify, a recheck that is no longer terminal, an unrecoverable signer, and the
+prepare-path equivalents — re-drives recovery before returning, so
+re-observation is never left to the periodic reconciler alone. The enqueue
+dedups on the mint's idempotency key, so arms that already re-drove cost
+nothing. After the first `MintTxIntended`, the persisted signed bytes/hash/nonce
+are authoritative for the whole recovery lifetime of that attempt. Fresh signed
+mint is allowed only when the exact hash is `MinedReverted` or `ProvablyDead`,
+and only after a wallet-guard recheck of hash/nonce/inventory immediately before
+`prepare_mint_tx`. `external_tx_id` is **not** vault-direct double-mint
+protection.
+
+| State + observation                                                   | Action                                                                                                                                                                                                                                                                                                                                           |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Inventory hit for `issuer_request_id`                                 | `ExistingMintRecovered` (unchanged)                                                                                                                                                                                                                                                                                                              |
+| `MintIntended` + StillMineable / Uncertain                            | Rebroadcast same bytes or wait; no new sign                                                                                                                                                                                                                                                                                                      |
+| `MintIntended` + MinedSuccess                                         | Rebroadcast the same bytes, as for StillMineable; the confirm path records the mint. Never a new sign                                                                                                                                                                                                                                            |
+| `TxSubmitted` + MinedSuccess                                          | `TokensMinted`                                                                                                                                                                                                                                                                                                                                   |
+| `TxSubmitted` + StillMineable                                         | Rebroadcast same bytes and/or re-enqueue confirm; stay `TxSubmitted`                                                                                                                                                                                                                                                                             |
+| `TxSubmitted` + Uncertain                                             | No event; retry observe later (scheduled recovery re-polls ~60s)                                                                                                                                                                                                                                                                                 |
+| `TxSubmitted` / failed-from-submitted + MinedReverted or ProvablyDead | `MintingFailed` (if not already), then budgeted retry may prepare **new** `MintTxIntended` **only after wallet-guard recheck**. Only the job whose `tx_id` is the mint's current submission may record it — a stale confirm job for a superseded submission re-drives recovery instead, the same identity gate the reverted-confirm path applies |
+| `MintingFailed` + MinedSuccess                                        | `ConfirmMintJob` for the prepared hash, **not** `RetryMint`, so `RecordExistingMint` can run. A mined deposit under a failed aggregate resolves forward and does not consume a retry                                                                                                                                                             |
+| Pre-intent prep failure (`Minting` never intended)                    | Existing `MintingFailed` + retry schedule (unchanged; no on-chain identity)                                                                                                                                                                                                                                                                      |
+
+Recovery (`drive_one_step` + durable jobs) checks the receipt inventory for a
+receipt matching the `issuer_request_id`. If found, records
+`ExistingMintRecovered`. If not found and in `Minting` state, `SubmitMintJob`
+prepares and persists `MintTxIntended` only when no live prepared identity
+remains. If in `MintIntended`, classifies then rebroadcasts the persisted raw
+transaction only when StillMineable/MinedSuccess; terminal dead/revert records
+`MintingFailed` so a budgeted retry may replace. If in `TxSubmitted` (or
+`MintingFailed` with a known prior transaction), re-observes the stored identity
+as above rather than treating every confirmation error as terminal failure.
+`TxSubmitted` means the persisted transaction was broadcast; it does not mean
+the transaction succeeded on-chain. Retry transactions use
+`mint-{issuer_request_id}-retry-{n}` where automatic retries use n = 1..4 and
+the delay schedule is 1m, 10m, 30m, then 1h — only after the prior identity is
+`MinedReverted` or `ProvablyDead`.
 
 The retry-delay/exhaustion schedule is driven by a `MintingFailed` attempt
-counter. A transaction-preparation failure records `MintingFailed`; an uncertain
-broadcast failure instead preserves `MintIntended` and recovery rebroadcasts the
-exact same signed bytes without advancing the attempt. A running service keeps
-driving deferred retries via a background scheduled-recovery task (also spawned
-at startup and after a manual reprocess), rather than waiting for the next
-restart.
+counter. A free-prepare (no live prepared identity) RPC/rejection records
+`MintingFailed`; an uncertain broadcast or prepare-replacement failure while a
+prior prepared identity remains live instead preserves that identity (no
+`MintingFailed` for uncertain broadcast) so recovery rebroadcasts the exact same
+signed bytes without advancing the attempt. A running service keeps driving
+deferred retries via `MintRecoveryJob` (also spawned at startup and after a
+manual reprocess of an eligible mint), rather than waiting for the next restart.
 
-`RecoverFromReceipt` is triggered when the receipt monitor discovers an on-chain
-receipt for a mint in `MintIntended`, or in `MintingFailed` where the
-predecessor was `Minting`. It emits `ExistingMintRecovered`, transitions to
-`CallbackPending`, then continues through the existing `SendCallback` ->
-`MintCompleted` flow without rebroadcasting. Automated recovery persists the
-`CallbackPending` boundary before delivering the callback, so receipt polling
-and Alpaca requests do not hold the wallet transaction lock.
+Uncertain `TxSubmitted` re-polls on the scheduled recovery cadence (~60s). The
+no-progress budget (~6h / 360 polls) still applies: prolonged RPC uncertainty
+can abandon automatic recovery until process restart. Exhausted automatic
+retries remain `Unrecoverable` for admin reprocess as well — that is intentional
+correctness: neither automatic nor manual reprocess may authorize unlimited
+replacement deposits.
+
+**Duplicate deposit observability:** receipt inventory is 1:1 on
+`issuer_request_id`. When backfill or the live monitor discovers a second
+Deposit (different `receipt_id` or `tx_hash`) for an already-tracked ITN mint
+id, the bot logs an **ERROR** with both identities **and** records
+`RecordConflictingItnDeposit` → `ConflictingItnDepositObserved` on that vault's
+inventory stream. The event is required because backfill advances its checkpoint
+past the block once the pass completes and never re-scans that range: without it
+the duplicate would survive only as one log line. `DiscoverReceipt` is still
+refused, so the duplicate is recorded as evidence and never becomes tracked,
+spendable, or burnable balance. Recording is idempotent on the duplicate's own
+`(receipt_id, tx_hash)`, so a re-scanned range cannot grow the log a pass at a
+time. The 1:1 index outliving its metadata row counts as a conflict, not as
+"nothing tracked" — that is the one shape in which this gate could fail open.
+There is no admin health endpoint listing historical duplicates yet — operators
+read the event (or the ERROR log) plus on-chain Deposit history, then remediate
+excess supply with `issuer burn-excess` (never by forcing another mint). Do not
+manually force a second deposit when confirm is uncertain; leave `TxSubmitted`
+and wait for re-observe or restart.
+
+**Vault-direct vs orchestrator:** vault-direct mints confirm via vault `Deposit`
+logs and receipt inventory. Orchestrator mints (when enabled) use the
+orchestrator `Minted` log and authorization nonce recovery surface. The
+observation model in this section is **vault-direct only**; orchestrator failure
+classification is a separate coordination surface and must not treat RPC
+uncertainty as an auto-retryable mint failure.
+
+When the receipt monitor discovers an on-chain receipt for a mint, it enqueues
+`MintRecoveryJob` (or the submit path loads inventory). `RecordExistingMint`
+accepts `Minting`, `MintIntended`, `TxSubmitted`, and `MintingFailed`, emits
+`ExistingMintRecovered`, transitions to `CallbackPending`, then continues
+through `SendCallbackJob` → `RecordCallbackSent` / `MintCompleted` without
+rebroadcasting. Automated recovery persists the `CallbackPending` boundary
+before delivering the callback, so receipt polling and Alpaca requests do not
+hold the wallet transaction lock.
 
 ### Redemption Aggregate
 
@@ -1927,20 +2047,36 @@ stateDiagram-v2
     PendingJournal --> JournalConfirmed: ConfirmJournal
     PendingJournal --> JournalRejected: RejectJournal
     JournalConfirmed --> Minting: Deposit (MintingStarted)
-    Minting --> MintIntended: PrepareMint (MintTxIntended)
-    Minting --> MintingFailed: PrepareMint (MintingFailed)
-    MintIntended --> TxSubmitted: SubmitMint (MintTxSubmitted)
-    MintIntended --> MintIntended: SubmitMint uncertain failure (no event)
-    MintIntended --> CallbackPending: Recover or RecoverFromReceipt (ExistingMintRecovered)
-    TxSubmitted --> CallbackPending: ConfirmMint (TokensMinted)
-    TxSubmitted --> MintingFailed: ConfirmMint (MintingFailed)
-    MintingFailed --> MintIntended: Recover after automatic retry delay, or manual reprocess (MintRetryStarted + MintTxIntended)
-    MintingFailed --> CallbackPending: Recover (ExistingMintRecovered)
-    MintingFailed --> CallbackPending: RecoverFromReceipt (ExistingMintRecovered)
-    CallbackPending --> Completed: SendCallback
+    Minting --> MintIntended: SubmitMintJob / RecordTxIntended
+    Minting --> MintingFailed: free-prepare rejection (RecordMintFailed)
+    Minting --> CallbackPending: RecordExistingMint
+    MintIntended --> TxSubmitted: SubmitMintJob / RecordTxSubmitted
+    MintIntended --> MintIntended: uncertain classify or uncertain broadcast (no event)
+    MintIntended --> MintingFailed: terminal dead/revert before rebroadcast
+    MintIntended --> CallbackPending: RecordExistingMint
+    TxSubmitted --> CallbackPending: ConfirmMintJob / RecordTokensMinted
+    TxSubmitted --> CallbackPending: RecordExistingMint
+    TxSubmitted --> TxSubmitted: uncertain / still mineable (no event)
+    TxSubmitted --> MintingFailed: matching tx_id reverted or provably dead only
+    MintingFailed --> Minting: RetryMint after terminal dead/revert + wallet-guard recheck
+    MintingFailed --> CallbackPending: RecordExistingMint
+    CallbackPending --> Completed: SendCallbackJob / RecordCallbackSent
+    PendingJournal --> Closed: CloseMint
+    JournalConfirmed --> Closed: CloseMint
+    Minting --> Closed: CloseMint
+    MintIntended --> Closed: CloseMint
+    TxSubmitted --> Closed: CloseMint
+    MintingFailed --> Closed: CloseMint
+    CallbackPending --> Closed: CloseMint
     JournalRejected --> [*]
     Completed --> [*]
+    Closed --> [*]
 ```
+
+Automatic retry after `MintingFailed` re-classifies the predecessor's persisted
+intent under the wallet lock before any new prepare. Still-mineable or uncertain
+observations rebroadcast or wait; they never authorize a different signed
+deposit.
 
 **Data Structures:**
 
@@ -1962,11 +2098,15 @@ struct StoredMintRequest {
 
 enum MintStatus {
     PendingJournal,
-    JournalCompleted,
+    JournalConfirmed,
+    JournalRejected,
     Minting,
+    MintIntended,
+    TxSubmitted,
+    MintingFailed,
     CallbackPending,
     Completed,
-    Failed(String),
+    Closed,
 }
 ```
 
@@ -2765,10 +2905,11 @@ Auto-detects the right recovery path from the event history:
 
 **Mint:** `POST /admin/reprocess/mint/<aggregate_id>`
 
-Dispatches the manual `Recover` command which handles `JournalConfirmed`,
-`Minting`, `MintIntended`, `TxSubmitted`, `MintingFailed`, and `CallbackPending`
-states. Manual reprocess can submit the next deterministic retry even after
-automatic retries have exhausted.
+Enqueues the same `MintRecoveryJob` / `drive_one_step` path used by automatic
+recovery for `JournalConfirmed`, `Minting`, `MintIntended`, `TxSubmitted`,
+`MintingFailed`, and `CallbackPending`. Manual reprocess does **not** bypass the
+automatic retry cap: when retries are `Exhausted`, the endpoint returns
+unrecoverable rather than authorizing unlimited replacement deposits.
 
 **Post-Alpaca with existing on-chain burn:** If a `BurningFailed` event carries
 a tx ID, the endpoint scans on-chain for the transaction. If the tx completed
@@ -2856,7 +2997,10 @@ Lists all non-completed aggregates that may need manual intervention.
 
 Returns all redemptions in `Failed` or `BurnFailed` state (excluding `Closed`),
 and all mints in recoverable states (`JournalConfirmed`, `Minting`,
-`MintingFailed`, `CallbackPending`).
+`MintIntended`, `TxSubmitted` / view `MintTxSubmitted`, `MintingFailed`,
+`CallbackPending`). `MintIntended` and `TxSubmitted` surface unresolved
+persisted signed transactions so operators can discover wallet-nonce holders via
+the stuck list.
 
 ## Configuration
 

--- a/docs/ops-recovery-guide.md
+++ b/docs/ops-recovery-guide.md
@@ -72,6 +72,62 @@ request ID, transaction hash, nonce, and required operator action.
   persisted signed transaction. Reconcile legacy or unverifiable burns off-chain
   before closing.
 
+### Uncertain mint confirmation (do not force a second deposit)
+
+Vault-direct mint confirm polls `eth_getTransactionReceipt` as `Option`. A null
+receipt, timeout, transport error, or other uncertain observation **does not**
+record `MintingFailed` and **must not** be "fixed" by submitting another
+deposit. The aggregate stays in `TxSubmitted`; scheduled recovery re-polls
+(~60s). After ~6h with no progress, automatic recovery abandons until process
+restart or admin reprocess — restart is safe because the prepared hash is
+rebroadcast / re-confirmed, not replaced.
+
+**Reprocess / recover only rebroadcasts or reconfirms the exact signed hash**
+already on the aggregate. A new deposit (replacement prepare) is authorized only
+after the prior identity is terminal (`MinedReverted` or `ProvablyDead`), with a
+wallet-guard TOCTOU recheck immediately before signing, and only when inventory
+has **no** receipt for that `issuer_request_id`. Do not hand-craft a second
+deposit while identity is still mineable, uncertain, or inventory already shows
+a mint receipt.
+
+If logs show `Duplicate Deposit/receipt for already-tracked issuer_request_id`,
+a second on-chain deposit already landed for that mint. Do **not** mint again —
+the excess shares must be burned, and `issuer burn-excess` is the only supported
+way to do it.
+
+The observation is also recorded durably as a
+`ReceiptInventoryEvent::ConflictingItnDepositObserved` event on the vault's
+receipt-inventory stream, so the evidence survives the backfill checkpoint
+advancing past that block. There is no admin health list of duplicates yet; read
+the event (or the ERROR log fields) for both identities.
+
+Collect these before running anything:
+
+| Input              | Where it comes from                                                 |
+| ------------------ | ------------------------------------------------------------------- |
+| Issuer request id  | `issuer_request_id` on the event / log line                         |
+| Tracked deposit    | `tracked` — the receipt and tx the mint is already accounted for    |
+| Duplicate deposit  | `discovered_receipt_id` + `discovered_tx_hash` — the excess to burn |
+| Excess shares      | The duplicate `Deposit` log's share amount, read from the explorer  |
+| Network / chain id | The vault's listing (`--network`, cross-checked `--chain-id`)       |
+| Vault              | The vault the duplicate deposit hit                                 |
+
+Then pick the mode by where the excess shares sit **now** — the CLI never infers
+it:
+
+- Shares still in the issuer wallet (the deposit's original recipient is the
+  issuer):
+  `issuer burn-excess internal --issuer-request-id <id> --deposit-tx-hash
+  <discovered_tx_hash> --receipt-id <discovered_receipt_id> --shares <raw>
+  --network <net> --chain-id <id> --reason "<why>" --incident-id <id> --execute`
+- Shares were minted to someone else and must be moved back first: transfer them
+  to the issuer wallet, then run the same command as `external` with
+  `--funding-tx-hash <that transfer's tx>` added. Stop the issuer service first
+  — a running transfer poller can open a `Redemption` for that funding transfer.
+
+Run it without `--execute` first: the dry run proves the deposit and prints the
+plan without signing or writing an exclusion.
+
 ## Step 2: Diagnose the failure
 
 ### Common failure patterns
@@ -111,14 +167,17 @@ curl -s -X POST -H "X-API-KEY: $ISSUER_API_KEY" \
   http://localhost:8000/admin/reprocess/mint/<aggregate_id> | python3 -m json.tool
 ```
 
-This retries recovery inline (no restart needed). If the previous on-chain mint
-transaction failed, manual reprocess submits the next deterministic retry
-transaction even after automatic retries are exhausted, and hands the mint to a
-background task that drives that submitted transaction through confirmation. A
-single reprocess is usually enough. The exception is a retry submitted past the
-automatic cap (e.g. `retry-5`): if that transaction also fails, the background
-task is exhausted and gives up, so you must reprocess again. A 409 Conflict
-response means it already completed — no action needed.
+This retries recovery inline (no restart needed). Reprocess re-drives the
+**persisted** mint identity only: it rebroadcasts or reconfirms the exact signed
+hash already on the aggregate. It does **not** create a second deposit for an
+unresolved intent. A replacement prepare is signed only after classification
+proves the prior hash is terminal (`MinedReverted` or `ProvablyDead`), with a
+wallet-guard recheck and only when inventory has no receipt for that
+`issuer_request_id` (same rules as Step 1 above). After a successful rebroadcast
+or reconfirm path, a background task drives confirmation. A single reprocess is
+usually enough; if recovery abandons again (e.g. still pending after the
+budget), reprocess once more. A 409 Conflict response means it already completed
+— no action needed.
 
 ### Recovering redemptions
 
@@ -171,11 +230,15 @@ curl -s -X POST -H "X-API-KEY: $ISSUER_API_KEY" -H "Content-Type: application/js
 ```
 
 Closing just marks the transaction as done in our system. **It does not perform
-or prove any on-chain action.** If the redemption has a persisted signed burn,
-the JSON body must also include
-`"acknowledged_unresolved_burn_tx_hash": "0x..."` with that exact hash. The
-reservation remains held because the acknowledged transaction may still land.
-The reason and acknowledgement are recorded in the event store for audit.
+or prove any on-chain action.** If the mint still holds a prepared deposit
+identity (`MintTxIntended` / prepared bytes on `TxSubmitted`, including via
+`MintingFailed`), the JSON body must also include
+`"acknowledged_unresolved_mint_tx_hash": "0x..."` with that exact hash (422 on
+miss/mismatch). If the redemption has a persisted signed burn, the JSON body
+must also include `"acknowledged_unresolved_burn_tx_hash": "0x..."` with that
+exact hash. The reservation remains held because the acknowledged transaction
+may still land. The reason and acknowledgement are recorded in the event store
+for audit.
 
 ### Force-completing a verified burn
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1234,6 +1234,11 @@ pub(crate) async fn reprocess_mint(
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub(crate) struct CloseMintRequest {
     reason: String,
+    /// Required when the mint still holds a prepared deposit identity: must
+    /// equal the exact `MintTxIntended` / prepared hash. Omit only when the
+    /// mint has no prepared identity.
+    #[schema(value_type = Option<String>)]
+    acknowledged_unresolved_mint_tx_hash: Option<B256>,
 }
 
 /// Admin endpoint to close a mint that cannot be automatically recovered.
@@ -1269,17 +1274,22 @@ pub(crate) async fn close_mint(
         .map(IssuerMintRequestId::new)
         .map_err(|_| Status::BadRequest)?;
 
+    let CloseMintRequest { reason, acknowledged_unresolved_mint_tx_hash } =
+        body.into_inner();
+
     store
         .send(
             &issuer_request_id,
             MintCommand::CloseMint {
                 issuer_request_id: issuer_request_id.clone(),
-                reason: body.into_inner().reason,
+                reason,
+                acknowledged_unresolved_mint_tx_hash,
             },
         )
         .await
         .map_err(|err| {
             error!(target: "admin", aggregate_id = %aggregate_id,
+                acknowledged_unresolved_mint_tx_hash = ?acknowledged_unresolved_mint_tx_hash,
                 error = %err,
                 "Failed to close mint"
             );
@@ -1289,13 +1299,25 @@ pub(crate) async fn close_mint(
             }
         })?;
 
-    info!(target: "admin", aggregate_id = %aggregate_id, "Mint closed");
+    info!(target: "admin", aggregate_id = %aggregate_id,
+        acknowledged_unresolved_mint_tx_hash = ?acknowledged_unresolved_mint_tx_hash,
+        "Mint closed"
+    );
+
+    let message = acknowledged_unresolved_mint_tx_hash.map_or_else(
+        || "Mint closed by admin".to_string(),
+        |acknowledged_hash| {
+            format!(
+                "Mint closed by admin after acknowledging unresolved mint {acknowledged_hash:#x}"
+            )
+        },
+    );
 
     Ok(Json(ReprocessResponse {
         aggregate_type: AggregateKind::Mint,
         aggregate_id: aggregate_id.to_string(),
         previous_state: "Unknown".to_string(),
-        message: "Mint closed by admin".to_string(),
+        message,
     }))
 }
 
@@ -5002,6 +5024,7 @@ mod tests {
             super::mint_view_summary(&MintView::Closed {
                 issuer_request_id,
                 reason: "closed by admin".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
                 closed_at: failed_at,
             })
             .is_none()

--- a/src/mint/cmd.rs
+++ b/src/mint/cmd.rs
@@ -130,9 +130,19 @@ pub(crate) enum MintCommand {
     /// Admin-closes a mint that cannot be automatically recovered.
     ///
     /// Valid from any non-terminal state. Closed mints are excluded from
-    /// recovery and stuck queries.
+    /// recovery and stuck queries. When the mint still holds a prepared
+    /// deposit identity (`MintTxIntended` / `TxSubmitted` with prepared
+    /// bytes, including via `MintingFailed`), the operator must supply
+    /// `acknowledged_unresolved_mint_tx_hash` equal to that exact hash.
+    ///
+    /// A legacy `TxSubmitted` carrying no prepared bytes falls back to its
+    /// stored `tx_id` when that id is a transaction hash, and requires the
+    /// same acknowledgement — the submission is on the wire and recovery still
+    /// confirm-polls it. Supplying an acknowledgement when no such identity
+    /// exists is rejected.
     CloseMint {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
     },
 }

--- a/src/mint/event.rs
+++ b/src/mint/event.rs
@@ -75,6 +75,11 @@ pub(crate) enum MintEvent {
     MintClosed {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
+        /// Exact prepared deposit hash the operator acknowledged when closing
+        /// over an unresolved intent. `None` when the mint had no prepared
+        /// identity. Older events omit this field.
+        #[serde(default)]
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
         closed_at: DateTime<Utc>,
     },
 

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -17,28 +17,30 @@
 //! submission resolves, while every outcome command is a no-op once its event
 //! is recorded.
 
-use alloy::primitives::Address;
+use alloy::primitives::{Address, U256};
 use apalis_sqlite::SqlitePool;
+use chrono::{DateTime, Utc};
 use event_sorcery::{SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
-use super::recovery::enqueue_scheduled_mint_recovery;
+use super::recovery::{enqueue_scheduled_mint_recovery, release_terminal_job};
 use super::{
-    IssuerMintRequestId, Mint, MintCommand, has_unresolved_signer_intent,
+    IssuerMintRequestId, Mint, MintCommand, Quantity, TokenizationRequestId,
+    UnderlyingSymbol, has_unresolved_signer_intent,
 };
 use crate::alpaca::{AlpacaError, AlpacaService, MintCallbackRequest};
 use crate::burn_excess::has_unresolved_excess_burn_intent;
-use crate::jobs::{Job, JobQueue, QueuePushError};
+use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{
     MintedReceiptParams, ReceiptId, ReceiptLookupError, ReceiptService, Shares,
 };
 use crate::tokenized_asset::Network;
 use crate::vault::{
-    NetworkVaultServices, ReceiptInformation, TxId, UnconfiguredNetworkError,
-    VaultError, VaultService,
+    MintTxStatus, NetworkVaultServices, PreparedMintTx, ReceiptInformation,
+    TxId, UnconfiguredNetworkError, VaultError, VaultService,
 };
 
 /// Failure of a mint side-effect job. A domain rejection is recorded as a
@@ -121,199 +123,29 @@ impl Job<SubmitMintContext> for SubmitMintJob {
                 journal_confirmed_at,
                 ..
             } => {
-                if self.record_existing_receipt(ctx).await? {
-                    return Ok(());
-                }
-
-                let Some(vault) =
-                    self.resolve_vault_service(ctx, *network).await?
-                else {
-                    return Ok(());
-                };
-
-                // A quantity that cannot be converted is deterministic for
-                // the persisted mint: record a domain failure instead of
-                // returning a job error apalis would re-drive forever.
-                let assets = match quantity.to_u256_with_18_decimals() {
-                    Ok(assets) => assets,
-                    Err(error) => {
-                        warn!(
-                            target: "mint",
-                            issuer_request_id = %self.issuer_request_id,
-                            error = %error,
-                            "Mint quantity cannot be converted to on-chain \
-                             units"
-                        );
-
-                        ctx.mint_store
-                            .send(
-                                &self.issuer_request_id,
-                                MintCommand::RecordMintFailed {
-                                    issuer_request_id: self
-                                        .issuer_request_id
-                                        .clone(),
-                                    error: error.to_string(),
-                                },
-                            )
-                            .await?;
-
-                        return Ok(());
-                    }
-                };
-                let receipt_info = ReceiptInformation::new(
-                    tokenization_request_id.clone(),
-                    self.issuer_request_id.clone(),
-                    underlying.clone(),
-                    quantity.clone(),
-                    *journal_confirmed_at,
-                    None,
-                );
-
-                let external_tx_id = mint
-                    .retry_submission_external_tx_id()
-                    .map(super::MintExternalTxId::into_string);
-
-                let wallet_guard = vault.lock_wallet().await;
-                // The reservation is keyed by network alone, so this single
-                // check also blocks behind an unresolved burn on the same
-                // signer: a persisted-but-unbroadcast burn transaction may
-                // still land, and signing a mint over it risks a nonce
-                // conflict. Intents on other networks use independent nonce
-                // domains and must not block this one.
-                if has_unresolved_signer_intent(
-                    &ctx.pool,
-                    *network,
-                    Some(&self.issuer_request_id),
+                self.submit_from_minting(
+                    ctx,
+                    &mint,
+                    SubmitFromMintingParams {
+                        tokenization_request_id,
+                        quantity,
+                        underlying,
+                        network: *network,
+                        wallet: *wallet,
+                        journal_confirmed_at: *journal_confirmed_at,
+                    },
                 )
-                .await?
-                    || has_unresolved_excess_burn_intent(&ctx.pool, None)
-                        .await?
-                {
-                    return Err(MintJobError::UnresolvedWalletIntent {
-                        issuer_request_id: self.issuer_request_id.clone(),
-                    });
-                }
-                let prepared = if let Some(prepared) =
-                    mint.pending_prepared_tx()
-                {
-                    prepared
-                } else {
-                    let prepared = match vault
-                        .prepare_mint_tx(
-                            self.vault,
-                            assets,
-                            ctx.bot,
-                            *wallet,
-                            receipt_info,
-                            external_tx_id,
-                        )
-                        .await
-                    {
-                        Ok(prepared) => prepared,
-                        Err(error) => {
-                            drop(wallet_guard);
-                            self.record_submission_failure(ctx, error).await?;
-                            return Ok(());
-                        }
-                    };
-
-                    ctx.mint_store
-                        .send(
-                            &self.issuer_request_id,
-                            MintCommand::RecordTxIntended {
-                                issuer_request_id: self
-                                    .issuer_request_id
-                                    .clone(),
-                                prepared_tx: prepared.clone(),
-                            },
-                        )
-                        .await?;
-                    prepared
-                };
-
-                let submitted = vault.submit_mint(&prepared).await;
-
-                match submitted {
-                    Ok(submitted) => {
-                        let tx_id = submitted.tx_id;
-                        ctx.mint_store
-                            .send(
-                                &self.issuer_request_id,
-                                MintCommand::RecordTxSubmitted {
-                                    issuer_request_id: self
-                                        .issuer_request_id
-                                        .clone(),
-                                    external_tx_id:
-                                        super::MintExternalTxId::from_string(
-                                            submitted.external_tx_id,
-                                        ),
-                                    tx_id: tx_id.clone(),
-                                },
-                            )
-                            .await?;
-
-                        self.enqueue_confirm(ctx, tx_id).await?;
-                    }
-                    Err(error) => {
-                        self.record_submission_failure(ctx, error).await?;
-                    }
-                }
-                drop(wallet_guard);
+                .await?;
             }
             // Crash recovery for a prepare-then-submit job that persisted
             // intent via the inline PrepareMint path before the job rewrite.
+            // Classify first (same predicate as `resolve_prepared_for_submit`):
+            // rebroadcast only when StillMineable/MinedSuccess; terminal
+            // dead/revert records MintingFailed so recovery may replace;
+            // uncertain observation preserves MintIntended (no MintingFailed).
             Mint::TxIntended { prepared_tx, network, .. } => {
-                if self.record_existing_receipt(ctx).await? {
-                    return Ok(());
-                }
-                let Some(vault) =
-                    self.resolve_vault_service(ctx, *network).await?
-                else {
-                    return Ok(());
-                };
-                let wallet_guard = vault.lock_wallet().await;
-                // Network-keyed reservation: one check covers competing mint
-                // AND burn intents on this signer's nonce domain.
-                if has_unresolved_signer_intent(
-                    &ctx.pool,
-                    *network,
-                    Some(&self.issuer_request_id),
-                )
-                .await?
-                    || has_unresolved_excess_burn_intent(&ctx.pool, None)
-                        .await?
-                {
-                    return Err(MintJobError::UnresolvedWalletIntent {
-                        issuer_request_id: self.issuer_request_id.clone(),
-                    });
-                }
-
-                match vault.submit_mint(prepared_tx).await {
-                    Ok(submitted) => {
-                        let tx_id = submitted.tx_id;
-                        ctx.mint_store
-                            .send(
-                                &self.issuer_request_id,
-                                MintCommand::RecordTxSubmitted {
-                                    issuer_request_id: self
-                                        .issuer_request_id
-                                        .clone(),
-                                    external_tx_id:
-                                        super::MintExternalTxId::from_string(
-                                            submitted.external_tx_id,
-                                        ),
-                                    tx_id: tx_id.clone(),
-                                },
-                            )
-                            .await?;
-
-                        self.enqueue_confirm(ctx, tx_id).await?;
-                    }
-                    Err(error) => {
-                        self.record_submission_failure(ctx, error).await?;
-                    }
-                }
-                drop(wallet_guard);
+                self.submit_from_tx_intended(ctx, prepared_tx, *network)
+                    .await?;
             }
             // A re-run after the submission was already recorded: the
             // confirm job may not have been enqueued before a crash, so
@@ -336,44 +168,562 @@ impl Job<SubmitMintContext> for SubmitMintJob {
     }
 }
 
+struct SubmitFromMintingParams<'a> {
+    tokenization_request_id: &'a TokenizationRequestId,
+    quantity: &'a Quantity,
+    underlying: &'a UnderlyingSymbol,
+    network: Network,
+    wallet: Address,
+    journal_confirmed_at: DateTime<Utc>,
+}
+
+struct ResolvePreparedParams {
+    assets: U256,
+    wallet: Address,
+    receipt_info: ReceiptInformation,
+    external_tx_id: Option<String>,
+}
+
 impl SubmitMintJob {
+    /// Rebroadcast a legacy `TxIntended` prepared identity under the wallet
+    /// lock, after burn-parity classification (aligned with
+    /// [`Self::resolve_prepared_for_submit`]).
+    async fn submit_from_tx_intended(
+        &self,
+        ctx: &SubmitMintContext,
+        prepared_tx: &PreparedMintTx,
+        network: Network,
+    ) -> Result<(), MintJobError> {
+        if self.record_existing_receipt(ctx).await? {
+            return Ok(());
+        }
+
+        let Some(vault) = self.resolve_vault_service(ctx, network).await?
+        else {
+            return Ok(());
+        };
+
+        let wallet_guard = vault.lock_wallet().await;
+        // Network-keyed reservation: one check covers competing mint AND burn
+        // intents on this signer's nonce domain. BurnExcess holds no
+        // reservation row there, so it needs its own check.
+        if has_unresolved_signer_intent(
+            &ctx.pool,
+            network,
+            Some(&self.issuer_request_id),
+        )
+        .await?
+            || has_unresolved_excess_burn_intent(&ctx.pool, None).await?
+        {
+            return Err(MintJobError::UnresolvedWalletIntent {
+                issuer_request_id: self.issuer_request_id.clone(),
+            });
+        }
+
+        let owner = match prepared_tx.recover_signer() {
+            Ok(owner) => owner,
+            Err(error) => {
+                // Corrupt envelope: cannot classify death/liveness; preserve
+                // MintIntended for operator/restart (fail closed).
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared_tx.hash,
+                    error = %error,
+                    "Failed to recover signer from prepared mint; \
+                     preserving MintIntended"
+                );
+                drop(wallet_guard);
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+                return Ok(());
+            }
+        };
+        let classification = vault.classify_mint_tx(owner, prepared_tx).await;
+
+        match classification {
+            Ok(MintTxStatus::StillMineable | MintTxStatus::MinedSuccess) => {
+                match vault.submit_mint(prepared_tx).await {
+                    Ok(submitted) => {
+                        let tx_id = submitted.tx_id;
+                        ctx.mint_store
+                            .send(
+                                &self.issuer_request_id,
+                                MintCommand::RecordTxSubmitted {
+                                    issuer_request_id: self
+                                        .issuer_request_id
+                                        .clone(),
+                                    external_tx_id:
+                                        super::MintExternalTxId::from_string(
+                                            submitted.external_tx_id,
+                                        ),
+                                    tx_id: tx_id.clone(),
+                                },
+                            )
+                            .await?;
+
+                        self.enqueue_confirm(ctx, tx_id).await?;
+                    }
+                    Err(error) => {
+                        // TxIntended always has live prepared bytes at submit.
+                        self.record_submission_failure(
+                            ctx,
+                            error,
+                            PreparedLiveness::Live,
+                        )
+                        .await?;
+                    }
+                }
+            }
+            Ok(MintTxStatus::MinedReverted | MintTxStatus::ProvablyDead) => {
+                // Prefer inventory before terminal MintingFailed: a receipt
+                // means the deposit already succeeded.
+                if !self.record_existing_receipt(ctx).await? {
+                    // TOCTOU: re-classify under the same wallet guard before
+                    // recording failure that authorizes replacement prepare.
+                    let recheck = match vault
+                        .classify_mint_tx(owner, prepared_tx)
+                        .await
+                    {
+                        Ok(status) => status,
+                        Err(error) => {
+                            warn!(
+                                target: "mint",
+                                issuer_request_id = %self.issuer_request_id,
+                                tx_hash = %prepared_tx.hash,
+                                nonce = prepared_tx.nonce,
+                                error = %error,
+                                "TxIntended recheck uncertain; preserving MintIntended"
+                            );
+                            drop(wallet_guard);
+                            kick_mint_recovery(
+                                &ctx.pool,
+                                &ctx.apalis_pool,
+                                &self.issuer_request_id,
+                            )
+                            .await;
+                            return Ok(());
+                        }
+                    };
+                    if matches!(
+                        recheck,
+                        MintTxStatus::MinedReverted
+                            | MintTxStatus::ProvablyDead
+                    ) {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %self.issuer_request_id,
+                            tx_hash = %prepared_tx.hash,
+                            nonce = prepared_tx.nonce,
+                            recheck = ?recheck,
+                            "TxIntended prepared identity terminal; recording MintingFailed"
+                        );
+                        ctx.mint_store
+                            .send(
+                                &self.issuer_request_id,
+                                MintCommand::RecordMintFailed {
+                                    issuer_request_id: self
+                                        .issuer_request_id
+                                        .clone(),
+                                    error: format!(
+                                        "Prepared mint terminal before \
+                                         rebroadcast: {recheck:?}"
+                                    ),
+                                },
+                            )
+                            .await?;
+                        kick_mint_recovery(
+                            &ctx.pool,
+                            &ctx.apalis_pool,
+                            &self.issuer_request_id,
+                        )
+                        .await;
+                    } else {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %self.issuer_request_id,
+                            tx_hash = %prepared_tx.hash,
+                            nonce = prepared_tx.nonce,
+                            recheck = ?recheck,
+                            "TxIntended recheck no longer terminal; preserving MintIntended"
+                        );
+                        drop(wallet_guard);
+                        kick_mint_recovery(
+                            &ctx.pool,
+                            &ctx.apalis_pool,
+                            &self.issuer_request_id,
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                }
+            }
+            Err(error) => {
+                // Uncertain classification: keep MintIntended live; never
+                // MintingFailed (would authorize a second deposit).
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared_tx.hash,
+                    nonce = prepared_tx.nonce,
+                    error = %error,
+                    "TxIntended classification uncertain; preserving MintIntended"
+                );
+                drop(wallet_guard);
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+                return Ok(());
+            }
+        }
+
+        drop(wallet_guard);
+        Ok(())
+    }
+
+    /// Prepare (or rebroadcast) and submit while the aggregate is `Minting`.
+    /// Classification of any live prepared identity gates replacement under
+    /// the wallet guard so uncertain observation never signs a second deposit.
+    async fn submit_from_minting(
+        &self,
+        ctx: &SubmitMintContext,
+        mint: &Mint,
+        params: SubmitFromMintingParams<'_>,
+    ) -> Result<(), MintJobError> {
+        if self.record_existing_receipt(ctx).await? {
+            return Ok(());
+        }
+
+        let Some(vault) =
+            self.resolve_vault_service(ctx, params.network).await?
+        else {
+            return Ok(());
+        };
+
+        // A quantity that cannot be converted is deterministic for the
+        // persisted mint: record a domain failure instead of returning a job
+        // error apalis would re-drive forever.
+        let assets = match params.quantity.to_u256_with_18_decimals() {
+            Ok(assets) => assets,
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "Mint quantity cannot be converted to on-chain units"
+                );
+
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordMintFailed {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            error: error.to_string(),
+                        },
+                    )
+                    .await?;
+
+                return Ok(());
+            }
+        };
+        let receipt_info = ReceiptInformation::new(
+            params.tokenization_request_id.clone(),
+            self.issuer_request_id.clone(),
+            params.underlying.clone(),
+            params.quantity.clone(),
+            params.journal_confirmed_at,
+            None,
+        );
+
+        let external_tx_id = mint
+            .retry_submission_external_tx_id()
+            .map(super::MintExternalTxId::into_string);
+
+        let wallet_guard = vault.lock_wallet().await;
+        // Network-keyed reservation: one check covers competing mint AND burn
+        // intents on this signer's nonce domain. BurnExcess holds no
+        // reservation row there, so it needs its own check.
+        if has_unresolved_signer_intent(
+            &ctx.pool,
+            params.network,
+            Some(&self.issuer_request_id),
+        )
+        .await?
+            || has_unresolved_excess_burn_intent(&ctx.pool, None).await?
+        {
+            return Err(MintJobError::UnresolvedWalletIntent {
+                issuer_request_id: self.issuer_request_id.clone(),
+            });
+        }
+
+        let Some(prepared) = self
+            .resolve_prepared_for_submit(
+                ctx,
+                vault.as_ref(),
+                mint,
+                ResolvePreparedParams {
+                    assets,
+                    wallet: params.wallet,
+                    receipt_info,
+                    external_tx_id,
+                },
+            )
+            .await?
+        else {
+            // Every `None` arm preserved the existing identity instead of
+            // submitting. Re-drive recovery so re-observation is not left to
+            // the periodic reconciler; the enqueue dedups on the mint's
+            // idempotency key, so arms that already kicked cost nothing.
+            drop(wallet_guard);
+            kick_mint_recovery(
+                &ctx.pool,
+                &ctx.apalis_pool,
+                &self.issuer_request_id,
+            )
+            .await;
+            return Ok(());
+        };
+
+        match vault.submit_mint(&prepared).await {
+            Ok(submitted) => {
+                let tx_id = submitted.tx_id;
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordTxSubmitted {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            external_tx_id:
+                                super::MintExternalTxId::from_string(
+                                    submitted.external_tx_id,
+                                ),
+                            tx_id: tx_id.clone(),
+                        },
+                    )
+                    .await?;
+
+                self.enqueue_confirm(ctx, tx_id).await?;
+            }
+            Err(error) => {
+                // Submit always has live prepared bytes (existing or just signed).
+                self.record_submission_failure(
+                    ctx,
+                    error,
+                    PreparedLiveness::Live,
+                )
+                .await?;
+            }
+        }
+        drop(wallet_guard);
+        Ok(())
+    }
+
+    /// Resolve prepared bytes: rebroadcast same hash when still mineable /
+    /// mined success; prepare replacement only after terminal dead/revert with
+    /// a wallet-guard TOCTOU recheck; `None` means fail closed (caller leaves
+    /// state unchanged).
+    async fn resolve_prepared_for_submit(
+        &self,
+        ctx: &SubmitMintContext,
+        vault: &dyn VaultService,
+        mint: &Mint,
+        params: ResolvePreparedParams,
+    ) -> Result<Option<PreparedMintTx>, MintJobError> {
+        if let Some(existing) = mint.pending_prepared_tx() {
+            let owner = match existing.recover_signer() {
+                Ok(owner) => owner,
+                Err(error) => {
+                    // Corrupt envelope: cannot prove death; fail closed.
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        tx_hash = %existing.hash,
+                        nonce = existing.nonce,
+                        error = %error,
+                        "Failed to recover signer from prepared mint; not replacing"
+                    );
+                    return Ok(None);
+                }
+            };
+            return match vault.classify_mint_tx(owner, &existing).await {
+                Ok(
+                    MintTxStatus::StillMineable | MintTxStatus::MinedSuccess,
+                ) => Ok(Some(existing)),
+                Ok(
+                    MintTxStatus::MinedReverted | MintTxStatus::ProvablyDead,
+                ) => {
+                    // TOCTOU: re-classify immediately under the same wallet
+                    // guard before signing a replacement. A concurrent mine
+                    // between the first classify and prepare must abort.
+                    let recheck = match vault
+                        .classify_mint_tx(owner, &existing)
+                        .await
+                    {
+                        Ok(status) => status,
+                        Err(error) => {
+                            warn!(
+                                target: "mint",
+                                issuer_request_id = %self.issuer_request_id,
+                                tx_hash = %existing.hash,
+                                nonce = existing.nonce,
+                                error = %error,
+                                "Mint prepare-path recheck uncertain; not replacing"
+                            );
+                            return Ok(None);
+                        }
+                    };
+                    if !matches!(
+                        recheck,
+                        MintTxStatus::MinedReverted
+                            | MintTxStatus::ProvablyDead
+                    ) {
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %self.issuer_request_id,
+                            tx_hash = %existing.hash,
+                            nonce = existing.nonce,
+                            recheck = ?recheck,
+                            "Mint prepare-path recheck no longer terminal; not replacing"
+                        );
+                        return Ok(None);
+                    }
+
+                    // Inventory may have discovered a successful deposit for
+                    // this issuer_request_id while we classified death of the
+                    // prior identity — never prepare if a receipt already exists.
+                    // Re-check under the wallet lock immediately before signing.
+                    if self.record_existing_receipt(ctx).await? {
+                        return Ok(None);
+                    }
+
+                    let prepared = match vault
+                        .prepare_mint_tx(
+                            self.vault,
+                            params.assets,
+                            ctx.bot,
+                            params.wallet,
+                            params.receipt_info,
+                            params.external_tx_id,
+                        )
+                        .await
+                    {
+                        Ok(prepared) => prepared,
+                        Err(error) => {
+                            // Prior prepared identity is still live on the mint.
+                            self.record_submission_failure(
+                                ctx,
+                                error,
+                                PreparedLiveness::Live,
+                            )
+                            .await?;
+                            return Ok(None);
+                        }
+                    };
+                    ctx.mint_store
+                        .send(
+                            &self.issuer_request_id,
+                            MintCommand::RecordTxIntended {
+                                issuer_request_id: self
+                                    .issuer_request_id
+                                    .clone(),
+                                prepared_tx: prepared.clone(),
+                            },
+                        )
+                        .await?;
+                    Ok(Some(prepared))
+                }
+                Err(error) => {
+                    // Uncertain classification: keep the old intent live;
+                    // never prepare a second deposit.
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        tx_hash = %existing.hash,
+                        nonce = existing.nonce,
+                        error = %error,
+                        "Mint prepared-intent classification uncertain; \
+                         preserving existing identity"
+                    );
+                    Ok(None)
+                }
+            };
+        }
+
+        // Defense in depth: post-submit identity without prepared bytes must
+        // never free-prepare (recovery also fail-closes this path).
+        if mint.has_unclassifiable_post_intent_identity() {
+            error!(
+                target: "mint",
+                issuer_request_id = %self.issuer_request_id,
+                tx_id = ?mint.latest_known_tx_id(),
+                "Submit path refused free-prepare for post-submit identity \
+                 without prepared_tx"
+            );
+            return Ok(None);
+        }
+
+        // Under wallet lock (caller holds it): re-check inventory immediately
+        // before free-prepare so a concurrent discovery cannot race a second
+        // deposit signature.
+        if self.record_existing_receipt(ctx).await? {
+            return Ok(None);
+        }
+
+        let prepared = match vault
+            .prepare_mint_tx(
+                self.vault,
+                params.assets,
+                ctx.bot,
+                params.wallet,
+                params.receipt_info,
+                params.external_tx_id,
+            )
+            .await
+        {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                // Free-prepare: no live prepared identity yet.
+                self.record_submission_failure(
+                    ctx,
+                    error,
+                    PreparedLiveness::None,
+                )
+                .await?;
+                return Ok(None);
+            }
+        };
+
+        ctx.mint_store
+            .send(
+                &self.issuer_request_id,
+                MintCommand::RecordTxIntended {
+                    issuer_request_id: self.issuer_request_id.clone(),
+                    prepared_tx: prepared.clone(),
+                },
+            )
+            .await?;
+        Ok(Some(prepared))
+    }
+
     async fn record_existing_receipt(
         &self,
         ctx: &SubmitMintContext,
     ) -> Result<bool, MintJobError> {
-        let Some(receipt) = ctx
-            .receipts
-            .find_by_issuer_request_id(
-                self.chain_id,
-                &self.vault,
-                &self.issuer_request_id,
-            )
-            .await?
-        else {
-            return Ok(false);
-        };
-
-        info!(
-            target: "mint",
-            issuer_request_id = %self.issuer_request_id,
-            tx_hash = %receipt.tx_hash,
-            block_number = receipt.block_number,
-            "Found existing receipt, recording recovery"
-        );
-        ctx.mint_store
-            .send(
-                &self.issuer_request_id,
-                MintCommand::RecordExistingMint {
-                    issuer_request_id: self.issuer_request_id.clone(),
-                    tx_hash: receipt.tx_hash,
-                    receipt_id: receipt.receipt_id,
-                    shares_minted: receipt.shares,
-                    block_number: receipt.block_number,
-                },
-            )
-            .await?;
-        self.enqueue_callback(ctx).await?;
-        Ok(true)
+        record_existing_receipt_from_inventory(
+            ctx.receipts.as_ref(),
+            ctx.mint_store.as_ref(),
+            &ctx.callback_queue,
+            self.chain_id,
+            self.vault,
+            &self.issuer_request_id,
+        )
+        .await
     }
 
     /// Resolves the signing backend for `network`. An unconfigured network is
@@ -408,11 +758,45 @@ impl SubmitMintJob {
         }
     }
 
+    /// Records a domain failure after a vault prepare/submit error.
+    ///
+    /// `prepared_liveness` is the caller's knowledge at the failure site — do
+    /// **not** re-load the mint to re-derive it. A load failure or race must not
+    /// turn an uncertain broadcast of known-live prepared bytes into
+    /// `MintingFailed` (that authorizes a replacement deposit).
     async fn record_submission_failure(
         &self,
         ctx: &SubmitMintContext,
         error: VaultError,
+        prepared_liveness: PreparedLiveness,
     ) -> Result<(), MintJobError> {
+        // Uncertain broadcast while a prepared identity is already live must
+        // preserve MintIntended / leave the hash mineable — never MintingFailed
+        // (SPEC: uncertain broadcast rebroadcasts the same bytes). Definitive
+        // submit rejections (e.g. mock InvalidReceipt) still record failure.
+        if prepared_liveness == PreparedLiveness::Live
+            && is_uncertain_broadcast_error(&error)
+        {
+            warn!(
+                target: "mint",
+                issuer_request_id = %self.issuer_request_id,
+                error = %error,
+                "Uncertain mint broadcast with live prepared identity; \
+                 preserving MintIntended"
+            );
+            // Preserving without re-driving would leave the mint in
+            // TxIntended with no confirm job and no recovery job, waiting on
+            // the periodic reconciler — the same reason every other preserve
+            // arm here kicks.
+            kick_mint_recovery(
+                &ctx.pool,
+                &ctx.apalis_pool,
+                &self.issuer_request_id,
+            )
+            .await;
+            return Ok(());
+        }
+
         warn!(
             target: "mint",
             issuer_request_id = %self.issuer_request_id,
@@ -440,11 +824,22 @@ impl SubmitMintJob {
         Ok(())
     }
 
+    /// Enqueues [`ConfirmMintJob`], first freeing any TERMINAL prior confirm
+    /// row for this mint (same pattern as recovery `enqueue_confirm`). Without
+    /// the release, a prior `Done` confirm holds the idempotency key and apalis
+    /// silently drops the re-enqueue — stranding a mint still in `TxSubmitted`.
     async fn enqueue_confirm(
         &self,
         ctx: &SubmitMintContext,
         tx_id: TxId,
     ) -> Result<(), MintJobError> {
+        release_terminal_job(
+            &ctx.pool,
+            job_type::<ConfirmMintJob>(),
+            &self.issuer_request_id.to_string(),
+        )
+        .await?;
+
         ctx.confirm_queue
             .clone()
             .push_with_idempotency_key(
@@ -453,25 +848,6 @@ impl SubmitMintJob {
                     vault: self.vault,
                     chain_id: self.chain_id,
                     tx_id,
-                },
-                self.issuer_request_id.to_string(),
-            )
-            .await?;
-
-        Ok(())
-    }
-
-    /// Enqueued after recording an already-succeeded mint
-    /// (`RecordExistingMint` advances it straight to `CallbackPending`).
-    async fn enqueue_callback(
-        &self,
-        ctx: &SubmitMintContext,
-    ) -> Result<(), MintJobError> {
-        ctx.callback_queue
-            .clone()
-            .push_with_idempotency_key(
-                SendCallbackJob {
-                    issuer_request_id: self.issuer_request_id.clone(),
                 },
                 self.issuer_request_id.to_string(),
             )
@@ -527,30 +903,213 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
             return Ok(());
         };
 
-        let Mint::TxSubmitted {
-            tokenization_request_id,
-            quantity,
-            underlying,
-            network,
-            journal_confirmed_at,
-            ..
-        } = &mint
-        else {
+        match &mint {
+            Mint::TxSubmitted {
+                tokenization_request_id,
+                quantity,
+                underlying,
+                network,
+                journal_confirmed_at,
+                prepared_tx,
+                tx_id: stored_tx_id,
+                ..
+            } => {
+                self.confirm_while_tx_submitted(
+                    ctx,
+                    ConfirmWhileTxSubmitted {
+                        tokenization_request_id: tokenization_request_id
+                            .clone(),
+                        quantity: quantity.clone(),
+                        underlying: underlying.clone(),
+                        network: *network,
+                        journal_confirmed_at: *journal_confirmed_at,
+                        prepared_tx: prepared_tx.clone(),
+                        stored_tx_id: stored_tx_id.clone(),
+                    },
+                )
+                .await?;
+            }
+            // Recovery enqueues confirm for a failed mint whose predecessor
+            // still has a known tx_id (legacy post-submit without prepared
+            // bytes, or re-observe after an earlier fail-closed path). Must
+            // actually poll — never free-prepare from this job.
+            Mint::MintingFailed {
+                tokenization_request_id,
+                quantity,
+                underlying,
+                network,
+                journal_confirmed_at,
+                ..
+            } => {
+                if self.matches_failed_identity(&mint) {
+                    self.confirm_while_minting_failed(
+                        ctx,
+                        ConfirmWhileMintingFailed {
+                            tokenization_request_id: tokenization_request_id
+                                .clone(),
+                            quantity: quantity.clone(),
+                            underlying: underlying.clone(),
+                            network: *network,
+                            journal_confirmed_at: *journal_confirmed_at,
+                            prepared_tx: mint.pending_prepared_tx(),
+                        },
+                    )
+                    .await?;
+                }
+            }
             // A re-run after the mint was already confirmed: keep the chain
             // moving if it is awaiting its callback.
-            if matches!(&mint, Mint::CallbackPending { .. }) {
+            Mint::CallbackPending { .. } => {
                 self.enqueue_callback(ctx).await?;
             }
-            return Ok(());
-        };
+            Mint::Initiated { .. }
+            | Mint::JournalConfirmed { .. }
+            | Mint::JournalRejected { .. }
+            | Mint::Minting { .. }
+            | Mint::TxIntended { .. }
+            | Mint::Completed { .. }
+            | Mint::Closed { .. } => {}
+        }
 
-        let vault = match ctx.vault_for(*network) {
+        Ok(())
+    }
+}
+
+struct ConfirmWhileTxSubmitted {
+    tokenization_request_id: TokenizationRequestId,
+    quantity: Quantity,
+    underlying: UnderlyingSymbol,
+    network: Network,
+    journal_confirmed_at: DateTime<Utc>,
+    prepared_tx: Option<PreparedMintTx>,
+    /// Aggregate's current submission identity; stale confirm jobs (older
+    /// `tx_id` after a replacement) must not record `MintingFailed` for the
+    /// successor attempt.
+    stored_tx_id: TxId,
+}
+
+/// Owned fields from `Mint::MintingFailed` needed for re-observe + receipt
+/// registration. Passing them explicitly avoids re-destructuring `mint` and
+/// silently skipping registration if the match fails.
+struct ConfirmWhileMintingFailed {
+    tokenization_request_id: TokenizationRequestId,
+    quantity: Quantity,
+    underlying: UnderlyingSymbol,
+    network: Network,
+    journal_confirmed_at: DateTime<Utc>,
+    prepared_tx: Option<PreparedMintTx>,
+}
+
+/// Whether a prepared mint identity was already live when a prepare/submit
+/// error occurred. Call-site knowledge only — never re-load the mint to
+/// re-derive this (a load race must not turn uncertain broadcast into
+/// `MintingFailed`).
+///
+/// - [`Self::Live`]: replace-prepare after terminal prior identity, or
+///   broadcast of bytes already on the mint / just recorded → preserve
+///   `MintIntended` on uncertain broadcast.
+/// - [`Self::None`]: free-prepare with no prepared identity yet → domain
+///   `MintingFailed` is allowed so the retry schedule advances.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PreparedLiveness {
+    Live,
+    None,
+}
+
+/// Broadcast-path uncertainty: node may already hold the signed tx. Never
+/// `MintingFailed` while a prepared identity is live. Includes hash mismatch
+/// after broadcast — the node may still mine the submitted envelope.
+///
+/// Exhaustive over [`VaultError`]: any new variant must be classified
+/// deliberately (fail closed for unknown definitive-ness).
+const fn is_uncertain_broadcast_error(error: &VaultError) -> bool {
+    match error {
+        VaultError::ConfirmationPending { .. }
+        | VaultError::PendingTransaction(_)
+        | VaultError::Rpc(_)
+        | VaultError::ContradictoryDeathSignals { .. }
+        | VaultError::BroadcastHashMismatch { .. } => true,
+        VaultError::InvalidReceipt
+        | VaultError::MissingBlockNumber { .. }
+        | VaultError::EventNotFound { .. }
+        | VaultError::Reverted { .. }
+        | VaultError::NotABurn { .. }
+        | VaultError::PreparedMintHashMismatch { .. }
+        | VaultError::PreparedMintNonceMismatch { .. }
+        | VaultError::PreparedMintSignerMismatch { .. }
+        | VaultError::PreparedBurnHashMismatch { .. }
+        | VaultError::PreparedBurnNonceMismatch { .. }
+        | VaultError::PreparedBurnSignerMismatch { .. }
+        | VaultError::BurnReplacementDestinationMismatch { .. }
+        | VaultError::BurnReplacementValueMismatch { .. }
+        | VaultError::BurnReplacementInputMismatch { .. }
+        | VaultError::SignerRecovery(_)
+        | VaultError::Eip2718(_)
+        | VaultError::Contract(_)
+        | VaultError::ReceiptEncode(_)
+        | VaultError::SendableTxErr(_) => false,
+    }
+}
+
+/// Confirm-path uncertainty / invalid observation shapes. Fail closed — stay
+/// `TxSubmitted`, never auto-replace. Includes receipt-shape errors that are
+/// not mined-revert proofs.
+///
+/// Exhaustive over [`VaultError`]: new variants must choose uncertain vs
+/// definitive deliberately.
+const fn is_uncertain_confirm_observation(error: &VaultError) -> bool {
+    match error {
+        VaultError::ConfirmationPending { .. }
+        | VaultError::PendingTransaction(_)
+        | VaultError::Rpc(_)
+        | VaultError::ContradictoryDeathSignals { .. }
+        | VaultError::InvalidReceipt
+        | VaultError::MissingBlockNumber { .. } => true,
+        VaultError::EventNotFound { .. }
+        | VaultError::Reverted { .. }
+        | VaultError::NotABurn { .. }
+        | VaultError::BroadcastHashMismatch { .. }
+        | VaultError::PreparedMintHashMismatch { .. }
+        | VaultError::PreparedMintNonceMismatch { .. }
+        | VaultError::PreparedMintSignerMismatch { .. }
+        | VaultError::PreparedBurnHashMismatch { .. }
+        | VaultError::PreparedBurnNonceMismatch { .. }
+        | VaultError::PreparedBurnSignerMismatch { .. }
+        | VaultError::BurnReplacementDestinationMismatch { .. }
+        | VaultError::BurnReplacementValueMismatch { .. }
+        | VaultError::BurnReplacementInputMismatch { .. }
+        | VaultError::SignerRecovery(_)
+        | VaultError::Eip2718(_)
+        | VaultError::Contract(_)
+        | VaultError::ReceiptEncode(_)
+        | VaultError::SendableTxErr(_) => false,
+    }
+}
+
+impl ConfirmMintJob {
+    /// Whether this job's `tx_id` is the mint's latest known submission (or
+    /// the prepared envelope hash when that is the only failed identity).
+    fn matches_failed_identity(&self, mint: &Mint) -> bool {
+        if mint.latest_known_tx_id().as_ref() == Some(&self.tx_id) {
+            return true;
+        }
+
+        mint.pending_prepared_tx()
+            .is_some_and(|prepared| TxId::from(prepared.hash) == self.tx_id)
+    }
+
+    async fn confirm_while_tx_submitted(
+        &self,
+        ctx: &ConfirmMintContext,
+        params: ConfirmWhileTxSubmitted,
+    ) -> Result<(), MintJobError> {
+        let vault = match ctx.vault_for(params.network) {
             Ok(vault) => vault,
             Err(error) => {
                 warn!(
                     target: "mint",
                     issuer_request_id = %self.issuer_request_id,
-                    network = %network,
+                    network = %params.network,
                     error = %error,
                     "No vault service configured for mint network"
                 );
@@ -576,11 +1135,11 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
         match vault.confirm_mint(&self.tx_id).await {
             Ok(result) => {
                 let receipt_info = ReceiptInformation::new(
-                    tokenization_request_id.clone(),
+                    params.tokenization_request_id,
                     self.issuer_request_id.clone(),
-                    underlying.clone(),
-                    quantity.clone(),
-                    *journal_confirmed_at,
+                    params.underlying,
+                    params.quantity,
+                    params.journal_confirmed_at,
                     None,
                 );
 
@@ -626,12 +1185,28 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
 
                 self.enqueue_callback(ctx).await?;
             }
-            Err(error) => {
+            Err(VaultError::Reverted { tx_hash }) => {
+                // Same identity gate as success (`RecordTokensMinted` rejects
+                // mismatched `tx_id`): a stale confirm job for a superseded
+                // submission must not fail the current attempt.
+                if params.stored_tx_id != self.tx_id {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        job_tx_id = %self.tx_id,
+                        stored_tx_id = %params.stored_tx_id,
+                        tx_hash = %tx_hash,
+                        "Ignoring reverted confirm for stale tx_id; \
+                         does not match mint's current submission"
+                    );
+                    return Ok(());
+                }
+
                 warn!(
                     target: "mint",
                     issuer_request_id = %self.issuer_request_id,
-                    error = %error,
-                    "On-chain deposit confirmation failed"
+                    tx_hash = %tx_hash,
+                    "On-chain deposit reverted (status=0); recording MintingFailed"
                 );
 
                 ctx.mint_store
@@ -639,7 +1214,9 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
                         &self.issuer_request_id,
                         MintCommand::RecordMintFailed {
                             issuer_request_id: self.issuer_request_id.clone(),
-                            error: error.to_string(),
+                            error: format!(
+                                "Transaction reverted on-chain: {tx_hash:?}"
+                            ),
                         },
                     )
                     .await?;
@@ -651,13 +1228,553 @@ impl Job<ConfirmMintContext> for ConfirmMintJob {
                 )
                 .await;
             }
+            Err(VaultError::EventNotFound { tx_hash }) => {
+                // Mined success body without Deposit is anomalous — never
+                // authorize a second deposit. Leave TxSubmitted for ops, but
+                // kick recovery so re-observe is not only the 300s orphan path.
+                error!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %tx_hash,
+                    "Mint mined without Deposit log; fail closed without \
+                     MintingFailed (operator intervention required)"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Err(error) if is_uncertain_confirm_observation(&error) => {
+                self.handle_uncertain_confirm(
+                    ctx,
+                    vault.as_ref(),
+                    params.prepared_tx.as_ref(),
+                    &params.stored_tx_id,
+                    &error,
+                )
+                .await?;
+            }
+            Err(error) => {
+                // Any other vault error is fail-closed: stay TxSubmitted and
+                // re-drive recovery so re-observe continues.
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "On-chain deposit confirmation failed closed; staying TxSubmitted"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
         }
 
         Ok(())
     }
-}
 
-impl ConfirmMintJob {
+    /// Re-observe a known submission while the aggregate is already
+    /// `MintingFailed`. Success records `ExistingMint` (TokensMinted only
+    /// applies from `TxSubmitted`); revert stays failed without free-prepare;
+    /// EventNotFound / uncertain fail closed and kick recovery.
+    async fn confirm_while_minting_failed(
+        &self,
+        ctx: &ConfirmMintContext,
+        params: ConfirmWhileMintingFailed,
+    ) -> Result<(), MintJobError> {
+        let vault = match ctx.vault_for(params.network) {
+            Ok(vault) => vault,
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    network = %params.network,
+                    error = %error,
+                    "No vault service configured for mint network during \
+                     MintingFailed re-observe"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+                return Ok(());
+            }
+        };
+
+        info!(
+            target: "mint",
+            issuer_request_id = %self.issuer_request_id,
+            tx_id = %self.tx_id,
+            "Re-observing mint while MintingFailed"
+        );
+
+        match vault.confirm_mint(&self.tx_id).await {
+            Ok(result) => {
+                let receipt_info = ReceiptInformation::new(
+                    params.tokenization_request_id,
+                    self.issuer_request_id.clone(),
+                    params.underlying,
+                    params.quantity,
+                    params.journal_confirmed_at,
+                    None,
+                );
+
+                if let Err(error) = ctx
+                    .receipts
+                    .register_minted_receipt(MintedReceiptParams {
+                        chain_id: self.chain_id,
+                        vault: self.vault,
+                        receipt_id: ReceiptId::from(result.receipt_id),
+                        shares: Shares::from(result.shares_minted),
+                        block_number: result.block_number,
+                        tx_hash: result.tx_hash,
+                        receipt_info,
+                        receipt_info_bytes: result.receipt_info_bytes.clone(),
+                    })
+                    .await
+                {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        error = %error,
+                        "Failed to register minted receipt during \
+                         MintingFailed re-observe \
+                         (monitor/backfill will discover it)"
+                    );
+                }
+
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordExistingMint {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            tx_hash: result.tx_hash,
+                            receipt_id: result.receipt_id,
+                            shares_minted: result.shares_minted,
+                            block_number: result.block_number,
+                        },
+                    )
+                    .await?;
+
+                self.enqueue_callback(ctx).await?;
+            }
+            Err(VaultError::Reverted { tx_hash }) => {
+                // Already MintingFailed: leave state unchanged and never
+                // free-prepare a replacement from the confirm job.
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %tx_hash,
+                    "On-chain deposit still reverted while MintingFailed; \
+                     staying failed without free-prepare"
+                );
+            }
+            Err(VaultError::EventNotFound { tx_hash }) => {
+                error!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %tx_hash,
+                    "Mint mined without Deposit log while MintingFailed; \
+                     fail closed without free-prepare"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Err(error) if is_uncertain_confirm_observation(&error) => {
+                // Prefer inventory before failing closed: a receipt means the
+                // deposit already succeeded despite the uncertain confirm.
+                if self.record_existing_receipt_if_present(ctx).await? {
+                    return Ok(());
+                }
+
+                // When prepared bytes exist, classify so StillMineable can
+                // rebroadcast without leaving MintingFailed forever; terminal
+                // death stays failed (no free-prepare from this job).
+                if let Some(prepared) = params.prepared_tx.as_ref() {
+                    self.handle_uncertain_confirm_while_failed(
+                        ctx,
+                        vault.as_ref(),
+                        prepared,
+                        &error,
+                    )
+                    .await?;
+                } else {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        tx_id = %self.tx_id,
+                        error = %error,
+                        "MintingFailed re-observe uncertain without prepared \
+                         identity; fail closed and kick recovery"
+                    );
+                    kick_mint_recovery(
+                        &ctx.pool,
+                        &ctx.apalis_pool,
+                        &self.issuer_request_id,
+                    )
+                    .await;
+                }
+            }
+            Err(error) => {
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %error,
+                    "MintingFailed re-observe failed closed; staying failed"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Uncertain confirm while already `MintingFailed`: rebroadcast
+    /// StillMineable under the wallet lock; never free-prepare. Terminal
+    /// classify leaves MintingFailed for recovery's RetryMint path.
+    async fn handle_uncertain_confirm_while_failed(
+        &self,
+        ctx: &ConfirmMintContext,
+        vault: &dyn VaultService,
+        prepared: &PreparedMintTx,
+        error: &VaultError,
+    ) -> Result<(), MintJobError> {
+        warn!(
+            target: "mint",
+            issuer_request_id = %self.issuer_request_id,
+            tx_id = %self.tx_id,
+            error = %error,
+            "MintingFailed re-observe uncertain; classifying prepared identity"
+        );
+
+        let owner = match prepared.recover_signer() {
+            Ok(owner) => owner,
+            Err(error) => {
+                // Corrupt envelope: leave MintingFailed for recovery/ops.
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    error = %error,
+                    "Failed to recover signer from prepared mint; \
+                     staying MintingFailed without rebroadcast"
+                );
+                return Ok(());
+            }
+        };
+        let wallet_guard = vault.lock_wallet().await;
+        let classification = vault.classify_mint_tx(owner, prepared).await;
+
+        match classification {
+            Ok(MintTxStatus::StillMineable) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    nonce = prepared.nonce,
+                    "Rebroadcasting still-mineable mint while MintingFailed"
+                );
+                if let Err(rebroadcast_error) =
+                    vault.submit_mint(prepared).await
+                {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        tx_hash = %prepared.hash,
+                        error = %rebroadcast_error,
+                        "Mint rebroadcast while MintingFailed failed; \
+                         will retry observe later"
+                    );
+                }
+                drop(wallet_guard);
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Ok(MintTxStatus::MinedReverted | MintTxStatus::ProvablyDead) => {
+                if self.record_existing_receipt_if_present(ctx).await? {
+                    drop(wallet_guard);
+                    return Ok(());
+                }
+
+                drop(wallet_guard);
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    "Prepared mint terminal while MintingFailed; staying failed \
+                     without free-prepare"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Ok(MintTxStatus::MinedSuccess) => {
+                drop(wallet_guard);
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    "Mint appears mined while MintingFailed; re-driving recovery"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Err(classify_error) => {
+                drop(wallet_guard);
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %classify_error,
+                    "Mint classify uncertain while MintingFailed; fail closed"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Uncertain confirm observation: leave `TxSubmitted`, optionally
+    /// rebroadcast StillMineable bytes, or record failure only when classify
+    /// proves terminal dead/revert. Always re-drives recovery (except when
+    /// already kicking after MintingFailed) so re-observe is not limited to
+    /// the periodic reconciler / 300s orphan path.
+    ///
+    /// Classify + rebroadcast and terminal dead/revert → `RecordMintFailed`
+    /// run under `vault.lock_wallet()` so a concurrent free-prepare cannot
+    /// race a still-live or just-failed identity.
+    async fn handle_uncertain_confirm(
+        &self,
+        ctx: &ConfirmMintContext,
+        vault: &dyn VaultService,
+        prepared_tx: Option<&PreparedMintTx>,
+        stored_tx_id: &TxId,
+        error: &VaultError,
+    ) -> Result<(), MintJobError> {
+        warn!(
+            target: "mint",
+            issuer_request_id = %self.issuer_request_id,
+            tx_id = %self.tx_id,
+            error = %error,
+            "Mint confirmation uncertain/pending; classifying prepared identity"
+        );
+
+        let Some(prepared) = prepared_tx else {
+            // No prepared bytes to classify/rebroadcast: stay TxSubmitted and
+            // re-enqueue recovery so confirm is retried.
+            kick_mint_recovery(
+                &ctx.pool,
+                &ctx.apalis_pool,
+                &self.issuer_request_id,
+            )
+            .await;
+            return Ok(());
+        };
+
+        let owner = match prepared.recover_signer() {
+            Ok(owner) => owner,
+            Err(error) => {
+                // Corrupt envelope: stay TxSubmitted and re-drive recovery.
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    error = %error,
+                    "Failed to recover signer from prepared mint; \
+                     staying TxSubmitted without rebroadcast"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+                return Ok(());
+            }
+        };
+        let wallet_guard = vault.lock_wallet().await;
+        let classification = vault.classify_mint_tx(owner, prepared).await;
+
+        match classification {
+            Ok(MintTxStatus::StillMineable) => {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    nonce = prepared.nonce,
+                    "Rebroadcasting still-mineable mint transaction"
+                );
+                if let Err(rebroadcast_error) =
+                    vault.submit_mint(prepared).await
+                {
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        tx_hash = %prepared.hash,
+                        error = %rebroadcast_error,
+                        "Mint rebroadcast failed; will retry observe later"
+                    );
+                }
+                drop(wallet_guard);
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Ok(
+                terminal @ (MintTxStatus::MinedReverted
+                | MintTxStatus::ProvablyDead),
+            ) => {
+                // Prefer inventory before terminal MintingFailed: a receipt
+                // means the deposit already succeeded and must not authorize
+                // a replacement prepare via recovery.
+                if self.record_existing_receipt_if_present(ctx).await? {
+                    drop(wallet_guard);
+                    return Ok(());
+                }
+
+                // Same identity gate as the reverted-confirm arm: a stale job
+                // for a superseded submission must not record the failure that
+                // authorizes a replacement prepare. Recovery re-observes under
+                // the current tx_id.
+                if stored_tx_id != &self.tx_id {
+                    drop(wallet_guard);
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %self.issuer_request_id,
+                        job_tx_id = %self.tx_id,
+                        stored_tx_id = %stored_tx_id,
+                        tx_hash = %prepared.hash,
+                        classification = ?terminal,
+                        "Ignoring terminal classification for stale tx_id; \
+                         does not match mint's current submission"
+                    );
+                    kick_mint_recovery(
+                        &ctx.pool,
+                        &ctx.apalis_pool,
+                        &self.issuer_request_id,
+                    )
+                    .await;
+                    return Ok(());
+                }
+
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    classification = ?terminal,
+                    "Prepared mint is terminal after pending confirm; \
+                     recording MintingFailed"
+                );
+                ctx.mint_store
+                    .send(
+                        &self.issuer_request_id,
+                        MintCommand::RecordMintFailed {
+                            issuer_request_id: self.issuer_request_id.clone(),
+                            error: format!(
+                                "Prepared mint terminal after uncertain \
+                                 confirm ({terminal:?}): {error}"
+                            ),
+                        },
+                    )
+                    .await?;
+                drop(wallet_guard);
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Ok(MintTxStatus::MinedSuccess) => {
+                // Race: classify saw success after confirm pending. Re-drive
+                // confirm immediately so TokensMinted can complete without
+                // waiting for the next recovery poll.
+                drop(wallet_guard);
+                info!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    "Mint appears mined after uncertain confirm; re-driving confirm"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+            Err(classify_error) => {
+                drop(wallet_guard);
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %self.issuer_request_id,
+                    error = %classify_error,
+                    "Mint classify uncertain after pending confirm; fail closed"
+                );
+                kick_mint_recovery(
+                    &ctx.pool,
+                    &ctx.apalis_pool,
+                    &self.issuer_request_id,
+                )
+                .await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Records `ExistingMint` + callback when inventory already holds a receipt
+    /// for this mint. Used before terminal `MintingFailed` so a successful
+    /// deposit is never abandoned for replacement.
+    async fn record_existing_receipt_if_present(
+        &self,
+        ctx: &ConfirmMintContext,
+    ) -> Result<bool, MintJobError> {
+        record_existing_receipt_from_inventory(
+            ctx.receipts.as_ref(),
+            ctx.mint_store.as_ref(),
+            &ctx.callback_queue,
+            self.chain_id,
+            self.vault,
+            &self.issuer_request_id,
+        )
+        .await
+    }
+
     async fn enqueue_callback(
         &self,
         ctx: &ConfirmMintContext,
@@ -737,6 +1854,53 @@ impl Job<SendCallbackContext> for SendCallbackJob {
     }
 }
 
+/// Loads an inventory receipt for this mint and records `ExistingMint` +
+/// enqueues the callback. Shared by submit and confirm jobs so a successful
+/// deposit is never abandoned for replacement prepare.
+async fn record_existing_receipt_from_inventory(
+    receipts: &dyn ReceiptService,
+    mint_store: &Store<Mint>,
+    callback_queue: &JobQueue<SendCallbackJob>,
+    chain_id: u64,
+    vault: Address,
+    issuer_request_id: &IssuerMintRequestId,
+) -> Result<bool, MintJobError> {
+    let Some(receipt) = receipts
+        .find_by_issuer_request_id(chain_id, &vault, issuer_request_id)
+        .await?
+    else {
+        return Ok(false);
+    };
+
+    info!(
+        target: "mint",
+        issuer_request_id = %issuer_request_id,
+        tx_hash = %receipt.tx_hash,
+        block_number = receipt.block_number,
+        "Found existing receipt, recording recovery"
+    );
+    mint_store
+        .send(
+            issuer_request_id,
+            MintCommand::RecordExistingMint {
+                issuer_request_id: issuer_request_id.clone(),
+                tx_hash: receipt.tx_hash,
+                receipt_id: receipt.receipt_id,
+                shares_minted: receipt.shares,
+                block_number: receipt.block_number,
+            },
+        )
+        .await?;
+    callback_queue
+        .clone()
+        .push_with_idempotency_key(
+            SendCallbackJob { issuer_request_id: issuer_request_id.clone() },
+            issuer_request_id.to_string(),
+        )
+        .await?;
+    Ok(true)
+}
+
 /// Kicks the scheduled recovery loop immediately after a job recorded a
 /// `MintingFailed`, so the first automatic retry does not wait for the
 /// periodic reconciler. Enqueue failure is non-fatal: the reconciler
@@ -764,7 +1928,7 @@ async fn kick_mint_recovery(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::{B256, U256};
+    use alloy::primitives::{B256, Bytes, U256};
     use async_trait::async_trait;
     use cqrs_es::{AggregateError, DomainEvent};
     use event_sorcery::test_store;
@@ -789,6 +1953,8 @@ mod tests {
     use crate::test_utils::{
         ANVIL_CHAIN_ID, ETHEREUM_TEST_CHAIN_ID, logs_contain_at,
     };
+    use crate::vault::MintResult;
+    use crate::vault::MintTxStatus;
     use crate::vault::NetworkVault;
     use crate::vault::mock::MockVaultService;
 
@@ -896,6 +2062,36 @@ mod tests {
             intended_at: chrono::Utc::now(),
         });
         events
+    }
+
+    /// TxSubmitted after MintTxIntended so `prepared_tx` is retained on the
+    /// aggregate (needed for classify / rebroadcast on uncertain confirm).
+    fn events_through_tx_submitted_with_prepared(
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> (Vec<MintEvent>, crate::vault::PreparedMintTx) {
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            1,
+            format!("mint-{issuer_request_id}"),
+        );
+        let hash = prepared.hash;
+        // Built here rather than rewriting an index into
+        // `events_through_tx_intended`: a silent shape change there would stop
+        // the rewrite from landing, and the returned `prepared` would no longer
+        // be the envelope stored on the aggregate that classify/rebroadcast
+        // tests assert against.
+        let mut events = events_through_minting(issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared.clone(),
+            intended_at: chrono::Utc::now(),
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(hash),
+            submitted_at: chrono::Utc::now(),
+        });
+        (events, prepared)
     }
 
     fn cqrs_receipts(pool: &Pool<Sqlite>) -> Arc<dyn ReceiptService> {
@@ -1115,6 +2311,51 @@ mod tests {
         );
 
         let test = "submit_mint_job_on_vault_failure_records_mint_failed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Mint submission failed"]
+        ));
+    }
+
+    /// Free-prepare failure (`PreparedLiveness::None`): prepare_mint_tx rejects
+    /// before any live identity exists — domain `MintingFailed` is allowed so
+    /// the retry schedule advances.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_free_prepare_failure_records_mint_failed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_minting(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(MockVaultService::new_prepare_tx_failure());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "free-prepare failure must record MintingFailed (PreparedLiveness::None),              got: {mint:?}"
+        );
+        assert!(
+            mint.pending_prepared_tx().is_none(),
+            "failed free-prepare must not leave prepared bytes"
+        );
+
+        let test = "submit_mint_job_free_prepare_failure_records_mint_failed";
         assert!(logs_contain_at!(
             Level::WARN,
             &[test, "Mint submission failed"]
@@ -1361,11 +2602,11 @@ mod tests {
         );
     }
 
-    /// A failed on-chain confirmation must be recorded as a domain failure
-    /// (`MintingFailed`) so recovery owns the retry.
+    /// Uncertain confirmation (e.g. null receipt / InvalidReceipt) must leave
+    /// the mint in `TxSubmitted` — never `MintingFailed` (production double-mint).
     #[traced_test]
     #[tokio::test]
-    async fn confirm_mint_job_on_vault_failure_records_mint_failed() {
+    async fn confirm_mint_job_on_uncertain_confirmation_stays_tx_submitted() {
         let harness = TestHarness::new().await;
         let issuer_request_id = IssuerMintRequestId::random();
         seed_mint_events(
@@ -1394,15 +2635,311 @@ mod tests {
         let mint =
             harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
         assert!(
-            matches!(mint, Mint::MintingFailed { .. }),
-            "a failed confirmation must record MintingFailed, got: {mint:?}"
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "uncertain confirmation must stay TxSubmitted, got: {mint:?}"
         );
 
-        let test = "confirm_mint_job_on_vault_failure_records_mint_failed";
+        let test =
+            "confirm_mint_job_on_uncertain_confirmation_stays_tx_submitted";
         assert!(logs_contain_at!(
             Level::WARN,
-            &[test, "On-chain deposit confirmation failed"]
+            &[test, "Mint confirmation uncertain/pending", "classifying"]
         ));
+    }
+
+    /// Mined revert (status=0) is the only confirmation path that records
+    /// `MintingFailed` so recovery may prepare a replacement after classify.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_on_reverted_records_mint_failed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let ctx = confirm_ctx(
+            &harness,
+            Arc::new(MockVaultService::new_confirm_revert()),
+            cqrs_receipts(&harness.pool),
+        );
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "status=0 revert must record MintingFailed, got: {mint:?}"
+        );
+
+        let test = "confirm_mint_job_on_reverted_records_mint_failed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "On-chain deposit reverted"]
+        ));
+    }
+
+    /// ConfirmationPending must leave TxSubmitted and not kick MintingFailed.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_confirmation_pending_stays_tx_submitted() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let ctx = confirm_ctx(
+            &harness,
+            Arc::new(MockVaultService::new_confirm_pending()),
+            cqrs_receipts(&harness.pool),
+        );
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "ConfirmationPending must stay TxSubmitted, got: {mint:?}"
+        );
+
+        let test = "confirm_mint_job_confirmation_pending_stays_tx_submitted";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "uncertain/pending", "classifying prepared identity"]
+        ));
+    }
+
+    /// EventNotFound (mined without Deposit) fails closed — no MintingFailed.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_event_not_found_fails_closed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_confirm_mint_outcomes(vec![
+                Err(VaultError::EventNotFound {
+                    tx_hash: alloy::primitives::B256::ZERO,
+                }),
+            ]),
+        );
+        let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            tx_id: TxId::Legacy("fb-1".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "EventNotFound must not MintingFailed, got: {mint:?}"
+        );
+
+        let test = "confirm_mint_job_event_not_found_fails_closed";
+        assert!(logs_contain_at!(
+            Level::ERROR,
+            &[test, "without Deposit log", "fail closed"]
+        ));
+    }
+
+    /// Receipt at the retry boundary after RetryMint: SubmitMintJob must
+    /// record ExistingMint without preparing or broadcasting a second deposit.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_receipt_at_retry_boundary_records_existing() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            3,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let now = chrono::Utc::now();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared,
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: now,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "uncertain confirm misrecorded as failure".to_string(),
+            failed_at: now - chrono::Duration::minutes(2),
+        });
+        events.push(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            manual_retry_id: None,
+            started_at: now,
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let receipts = cqrs_receipts(&harness.pool);
+        let receipt_info = ReceiptInformation::new(
+            super::super::TokenizationRequestId::new("tok-123"),
+            issuer_request_id.clone(),
+            super::super::UnderlyingSymbol::new("AAPL").unwrap(),
+            crate::Quantity::new(rust_decimal::Decimal::from(100)),
+            now,
+            None,
+        );
+        receipts
+            .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
+                vault: VAULT,
+                receipt_id: ReceiptId::from(U256::from(7u64)),
+                shares: Shares::new(U256::from(100u64)),
+                block_number: 1_234,
+                tx_hash: expected_hash,
+                receipt_info_bytes: receipt_info.encode(None).unwrap(),
+                receipt_info,
+            })
+            .await
+            .unwrap();
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let mut ctx = submit_ctx(&harness, vault.clone());
+        ctx.receipts = receipts;
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "inventory hit at retry boundary must record ExistingMint, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "must not prepare a second deposit when inventory already has the receipt"
+        );
+
+        let test = "submit_mint_job_receipt_at_retry_boundary_records_existing";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Found existing receipt", "recording recovery"]
+        ));
+    }
+
+    /// StillMineable after RetryMint rebroadcasts the same prepared hash —
+    /// never `prepare_mint_tx` a replacement.
+    #[tokio::test]
+    async fn submit_mint_job_still_mineable_rebroadcasts_same_hash() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            4,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let now = chrono::Utc::now();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared.clone(),
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: now,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "still mineable after uncertain confirm".to_string(),
+            failed_at: now - chrono::Duration::minutes(2),
+        });
+        events.push(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            manual_retry_id: None,
+            started_at: now,
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_status(MintTxStatus::StillMineable),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "StillMineable rebroadcast must re-record TxSubmitted, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "StillMineable must rebroadcast existing prepared bytes, not prepare"
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash)
+        );
     }
 
     /// A re-run of the confirm job after the mint was already confirmed must
@@ -1489,6 +3026,977 @@ mod tests {
         assert!(logs_contain_at!(
             Level::WARN,
             &[test, "Failed to register minted receipt"]
+        ));
+    }
+
+    /// TOCTOU: first classify terminal, recheck no longer terminal → abort
+    /// without prepare_mint_tx.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_toctou_recheck_aborts_replacement() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            4,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let now = chrono::Utc::now();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared,
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: now,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "prior attempt dead".to_string(),
+            failed_at: now - chrono::Duration::minutes(2),
+        });
+        events.push(MintEvent::MintRetryStarted {
+            issuer_request_id: issuer_request_id.clone(),
+            tx_hash: None,
+            manual_retry_id: None,
+            started_at: now,
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_mint_tx_status_sequence(vec![
+                MintTxStatus::ProvablyDead,
+                MintTxStatus::StillMineable,
+            ]),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            2,
+            "must classify then recheck under the wallet guard"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "recheck no longer terminal must not prepare a replacement"
+        );
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "TOCTOU abort must leave Minting without new intent, got: {mint:?}"
+        );
+
+        let test = "submit_mint_job_toctou_recheck_aborts_replacement";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "recheck no longer terminal", "not replacing"]
+        ));
+    }
+
+    /// Uncertain broadcast after intent is persisted must preserve MintIntended
+    /// (never MintingFailed) so recovery rebroadcasts the same bytes.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_uncertain_broadcast_preserves_mint_intended() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault =
+            Arc::new(MockVaultService::new_success().with_submit_mint_error(
+                VaultError::ConfirmationPending {
+                    tx_id: TxId::Legacy("pending".to_string()),
+                    message: "broadcast uncertain".to_string(),
+                },
+            ));
+        let ctx = submit_ctx(&harness, vault);
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxIntended { .. }),
+            "uncertain broadcast must preserve MintIntended, got: {mint:?}"
+        );
+
+        let test =
+            "submit_mint_job_uncertain_broadcast_preserves_mint_intended";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Uncertain mint broadcast", "preserving MintIntended"]
+        ));
+    }
+
+    /// ConfirmationPending + StillMineable with prepared bytes: rebroadcast
+    /// the same hash under the wallet lock (never prepare a replacement).
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_pending_still_mineable_rebroadcasts_same_hash() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_confirm_pending()
+                .with_mint_tx_status(MintTxStatus::StillMineable),
+        );
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "StillMineable rebroadcast must stay TxSubmitted, got: {mint:?}"
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|tx| tx.hash),
+            Some(prepared.hash),
+            "rebroadcast must keep the same prepared hash"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "confirm rebroadcast must not prepare a new mint"
+        );
+        assert!(
+            vault.get_wallet_lock_call_count() >= 1,
+            "classify + rebroadcast must hold the wallet lock"
+        );
+
+        let test =
+            "confirm_mint_job_pending_still_mineable_rebroadcasts_same_hash";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Rebroadcasting still-mineable mint transaction"]
+        ));
+    }
+
+    /// The live race the Anvil e2e cannot reach: `confirm_mint` keeps
+    /// answering `ConfirmationPending` (what an `Ok(None)` receipt through the
+    /// whole poll budget produces — see `RealVaultService::confirm_mint`)
+    /// while the first deposit is still mining. Across every poll in that
+    /// window the mint must stay on one identity: same hash rebroadcast, never
+    /// a replacement prepare, until the deposit finally mines.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_never_replaces_across_a_pending_poll_window() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        const PENDING_POLLS: usize = 3;
+        let mut confirm_outcomes: Vec<Result<MintResult, VaultError>> = (0
+            ..PENDING_POLLS)
+            .map(|poll| {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: TxId::from(prepared.hash),
+                    message: format!("no receipt yet (poll {poll})"),
+                })
+            })
+            .collect();
+        confirm_outcomes.push(Ok(MintResult {
+            tx_hash: prepared.hash,
+            receipt_id: U256::from(7),
+            shares_minted: U256::from(100),
+            gas_used: 21000,
+            block_number: 1000,
+            receipt_info_bytes: Bytes::new(),
+        }));
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_confirm_mint_outcomes(confirm_outcomes)
+                // Still mineable for every pending poll: the deposit is in the
+                // mempool, not dead.
+                .with_mint_tx_status_sequence(vec![
+                    MintTxStatus::StillMineable;
+                    PENDING_POLLS
+                ]),
+        );
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        for poll in 0..PENDING_POLLS {
+            ConfirmMintJob {
+                issuer_request_id: issuer_request_id.clone(),
+                vault: VAULT,
+                chain_id: ANVIL_CHAIN_ID,
+                tx_id: TxId::from(prepared.hash),
+            }
+            .perform(&ctx)
+            .await
+            .unwrap();
+
+            let mint = harness
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(
+                matches!(mint, Mint::TxSubmitted { .. }),
+                "poll {poll} must stay TxSubmitted, got: {mint:?}"
+            );
+            assert_eq!(
+                mint.pending_prepared_tx().map(|tx| tx.hash),
+                Some(prepared.hash),
+                "poll {poll} must keep the original prepared hash"
+            );
+            assert_eq!(
+                vault.get_call_count(),
+                0,
+                "poll {poll} must not prepare a replacement mint"
+            );
+        }
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(
+                mint,
+                Mint::CallbackPending { .. } | Mint::Completed { .. }
+            ),
+            "the original identity must be the one that completes, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "no poll in the window may prepare a second deposit"
+        );
+
+        let test =
+            "confirm_mint_job_never_replaces_across_a_pending_poll_window";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Rebroadcasting still-mineable mint transaction"]
+        ));
+    }
+
+    /// ConfirmationPending + ProvablyDead with prepared bytes records
+    /// MintingFailed under the wallet-lock path (no free-prepare race).
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_pending_provably_dead_records_mint_failed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_confirm_pending()
+                .with_mint_tx_status(MintTxStatus::ProvablyDead),
+        );
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "ProvablyDead after pending confirm must record MintingFailed, got: {mint:?}"
+        );
+        assert!(
+            vault.get_wallet_lock_call_count() >= 1,
+            "terminal classify must hold the wallet lock before MintingFailed"
+        );
+
+        let test = "confirm_mint_job_pending_provably_dead_records_mint_failed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                test,
+                "terminal after pending confirm",
+                "recording MintingFailed"
+            ]
+        ));
+    }
+
+    /// BroadcastHashMismatch with live prepared bytes is uncertain — preserve
+    /// MintIntended without reloading the aggregate to re-derive preparedness.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_mint_job_broadcast_hash_mismatch_preserves_mint_intended() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let expected = alloy::primitives::B256::from([0x11; 32]);
+        let returned = alloy::primitives::B256::from([0x22; 32]);
+        let vault =
+            Arc::new(MockVaultService::new_success().with_submit_mint_error(
+                VaultError::BroadcastHashMismatch { expected, returned },
+            ));
+        let ctx = submit_ctx(&harness, vault);
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxIntended { .. }),
+            "BroadcastHashMismatch with live prepared must preserve MintIntended, \
+             got: {mint:?}"
+        );
+
+        let test =
+            "submit_mint_job_broadcast_hash_mismatch_preserves_mint_intended";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Uncertain mint broadcast", "preserving MintIntended"]
+        ));
+    }
+
+    /// SubmitMintJob wallet gate matches burn_manager: unresolved burn intent
+    /// blocks prepare/submit under the wallet lock.
+    #[tokio::test]
+    async fn submit_mint_job_waits_for_unresolved_burn_intent() {
+        let harness = TestHarness::new().await;
+        let redemption_id =
+            crate::redemption::IssuerRedemptionRequestId::random();
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'Redemption',
+                ?,
+                1,
+                'RedemptionEvent::BurnIntended',
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .bind(redemption_id.to_string())
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_minting(&issuer_request_id),
+        )
+        .await;
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id,
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .expect_err("unresolved burn intent must defer minting");
+
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "burn-intent gate must not prepare a mint"
+        );
+    }
+
+    /// Uncertain confirm with prepared identity + classify Err stays
+    /// TxSubmitted and never records MintingFailed.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_uncertain_classify_err_stays_tx_submitted() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_confirm_pending()
+                .with_mint_tx_classification_failure(),
+        );
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "uncertain confirm + classify Err must stay TxSubmitted, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            1,
+            "must classify prepared identity under the wallet lock"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "classify Err must not prepare a replacement"
+        );
+
+        let test = "confirm_mint_job_uncertain_classify_err_stays_tx_submitted";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "classify uncertain after pending confirm", "fail closed"]
+        ));
+    }
+
+    /// Terminal ProvablyDead after pending confirm must prefer inventory over
+    /// MintingFailed when a receipt already exists for the issuer request.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_provably_dead_with_inventory_records_existing() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let receipts = cqrs_receipts(&harness.pool);
+        let now = chrono::Utc::now();
+        let receipt_info = ReceiptInformation::new(
+            super::super::TokenizationRequestId::new("tok-123"),
+            issuer_request_id.clone(),
+            super::super::UnderlyingSymbol::new("AAPL").unwrap(),
+            crate::Quantity::new(rust_decimal::Decimal::from(100)),
+            now,
+            None,
+        );
+        receipts
+            .register_minted_receipt(MintedReceiptParams {
+                chain_id: ANVIL_CHAIN_ID,
+                vault: VAULT,
+                receipt_id: ReceiptId::from(U256::from(9u64)),
+                shares: Shares::new(U256::from(100u64)),
+                block_number: 2_222,
+                tx_hash: prepared.hash,
+                receipt_info_bytes: receipt_info.encode(None).unwrap(),
+                receipt_info,
+            })
+            .await
+            .unwrap();
+
+        let vault = Arc::new(
+            MockVaultService::new_confirm_pending()
+                .with_mint_tx_status(MintTxStatus::ProvablyDead),
+        );
+        let ctx = confirm_ctx(&harness, vault, receipts);
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "inventory hit before terminal MintingFailed must record ExistingMint, \
+             got: {mint:?}"
+        );
+
+        let test =
+            "confirm_mint_job_provably_dead_with_inventory_records_existing";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Found existing receipt", "recording recovery"]
+        ));
+    }
+
+    /// ConfirmMintJob must re-observe while already MintingFailed when the
+    /// job tx_id matches the failed identity — success records ExistingMint.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_runs_under_minting_failed_records_existing() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let tx_id = TxId::from(prepared.hash);
+        let now = chrono::Utc::now();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared,
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: tx_id.clone(),
+            submitted_at: now,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "earlier uncertain confirm misrecorded".to_string(),
+            failed_at: now - chrono::Duration::minutes(2),
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::CallbackPending { .. }),
+            "successful confirm under MintingFailed must record ExistingMint, \
+             got: {mint:?}"
+        );
+
+        let test =
+            "confirm_mint_job_runs_under_minting_failed_records_existing";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "Re-observing mint while MintingFailed"]
+        ));
+    }
+
+    /// ConfirmMintJob under MintingFailed + on-chain revert stays failed and
+    /// never free-prepares a replacement.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_minting_failed_reverted_stays_failed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared = crate::vault::PreparedMintTx::valid_for_test(
+            6,
+            format!("mint-{issuer_request_id}"),
+        );
+        let tx_id = TxId::from(prepared.hash);
+        let now = chrono::Utc::now();
+        let mut events = events_through_minting(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared,
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: tx_id.clone(),
+            submitted_at: now,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "prior attempt".to_string(),
+            failed_at: now - chrono::Duration::minutes(2),
+        });
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(MockVaultService::new_confirm_revert());
+        let ctx =
+            confirm_ctx(&harness, vault.clone(), cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "reverted re-observe under MintingFailed must stay failed, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "MintingFailed re-observe must never free-prepare"
+        );
+
+        let test = "confirm_mint_job_minting_failed_reverted_stays_failed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[
+                test,
+                "still reverted while MintingFailed",
+                "without free-prepare"
+            ]
+        ));
+    }
+
+    /// Confirm fixtures retain prepared_tx: MinedSuccess after uncertain
+    /// confirm kicks recovery so TokensMinted can complete.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_mined_success_after_uncertain_kicks_recovery() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let (events, prepared) =
+            events_through_tx_submitted_with_prepared(&issuer_request_id);
+        seed_mint_events(&harness.pool, &issuer_request_id, events).await;
+
+        let vault = Arc::new(
+            MockVaultService::new_confirm_pending()
+                .with_mint_tx_status(MintTxStatus::MinedSuccess),
+        );
+        let ctx = confirm_ctx(&harness, vault, cqrs_receipts(&harness.pool));
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+            tx_id: TxId::from(prepared.hash),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "MinedSuccess after uncertain must stay TxSubmitted for re-confirm, \
+             got: {mint:?}"
+        );
+
+        let recovery_jobs = count_jobs(
+            &harness.pool,
+            job_type::<crate::mint::recovery::MintRecoveryJob>(),
+            &issuer_request_id.to_string(),
+        )
+        .await;
+        assert!(
+            recovery_jobs >= 1,
+            "must kick mint recovery so re-confirm is not only every 300s"
+        );
+
+        let test =
+            "confirm_mint_job_mined_success_after_uncertain_kicks_recovery";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "mined after uncertain confirm", "re-driving confirm"]
+        ));
+    }
+
+    /// `SubmitMintJob::enqueue_confirm` must free a prior terminal ConfirmMintJob
+    /// so re-enqueue after Done is not silently dropped by apalis idempotency.
+    #[tokio::test]
+    async fn submit_mint_job_enqueue_confirm_releases_terminal_done() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        sqlx::query(
+            "
+            INSERT INTO Jobs (
+                job,
+                id,
+                job_type,
+                status,
+                attempts,
+                max_attempts,
+                idempotency_key
+            )
+            VALUES (X'00', ?, ?, 'Done', 0, 25, ?)
+            ",
+        )
+        .bind(format!("done-confirm-{issuer_request_id}"))
+        .bind(type_name::<ConfirmMintJob>())
+        .bind(issuer_request_id.to_string())
+        .execute(&harness.pool)
+        .await
+        .unwrap();
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault);
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let statuses: Vec<String> = sqlx::query_scalar(
+            "
+            SELECT status
+            FROM Jobs
+            WHERE
+                job_type = ?
+                AND idempotency_key = ?
+            ",
+        )
+        .bind(type_name::<ConfirmMintJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_all(&harness.pool)
+        .await
+        .unwrap();
+
+        assert_eq!(
+            statuses,
+            vec!["Pending".to_string()],
+            "terminal Done confirm must be released so re-enqueue is Pending, \
+             not silently dropped; got {statuses:?}"
+        );
+    }
+
+    /// Stale ConfirmMintJob (job.tx_id ≠ mint's current submission) must not
+    /// record MintingFailed when the old identity reverts.
+    #[traced_test]
+    #[tokio::test]
+    async fn confirm_mint_job_reverted_stale_tx_id_is_ignored() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_submitted(&issuer_request_id),
+        )
+        .await;
+
+        let ctx = confirm_ctx(
+            &harness,
+            Arc::new(MockVaultService::new_confirm_revert()),
+            cqrs_receipts(&harness.pool),
+        );
+
+        ConfirmMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: 1,
+            // Stored submission is Legacy("fb-1"); this is a superseded attempt.
+            tx_id: TxId::Legacy("stale-old-attempt".to_string()),
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "stale revert must not MintingFailed the current submission, got: \
+             {mint:?}"
+        );
+
+        let test = "confirm_mint_job_reverted_stale_tx_id_is_ignored";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "stale tx_id", "does not match mint's current submission"]
+        ));
+    }
+
+    /// TxIntended + terminal classify records MintingFailed (no blind rebroadcast
+    /// of a dead identity); recovery may then prepare a replacement.
+    #[traced_test]
+    #[tokio::test]
+    async fn tx_intended_terminal_classify_records_mint_failed() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_mint_tx_status_sequence(vec![
+                MintTxStatus::ProvablyDead,
+                MintTxStatus::ProvablyDead,
+            ]),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "terminal TxIntended must record MintingFailed, got: {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "terminal TxIntended must not prepare or rebroadcast"
+        );
+
+        let test = "tx_intended_terminal_classify_records_mint_failed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "TxIntended prepared identity terminal", "MintingFailed"]
+        ));
+    }
+
+    /// Uncertain classify on TxIntended preserves MintIntended (no MintingFailed).
+    #[traced_test]
+    #[tokio::test]
+    async fn tx_intended_uncertain_classify_preserves_mint_intended() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_classification_failure(),
+        );
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .unwrap();
+
+        let mint =
+            harness.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxIntended { .. }),
+            "uncertain TxIntended classify must preserve MintIntended, got: \
+             {mint:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "uncertain classify must not prepare or rebroadcast"
+        );
+
+        let test = "tx_intended_uncertain_classify_preserves_mint_intended";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "TxIntended classification uncertain", "preserving"]
         ));
     }
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -305,6 +305,8 @@ pub(crate) enum Mint {
     Closed {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
+        /// Exact prepared deposit hash acknowledged at close, when any.
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
         closed_at: DateTime<Utc>,
     },
 }
@@ -397,9 +399,42 @@ impl Mint {
         }
     }
 
+    /// Live prepared mint identity for rebroadcast / classification.
+    ///
+    /// Resolves through `MintingFailed` / `Minting { retry }` via
+    /// [`Self::non_failed_predecessor`], and returns prepared bytes from
+    /// `TxIntended` **or** `TxSubmitted` (when present). Without the
+    /// `TxSubmitted` arm, a post-submit failure always looked like "no
+    /// intent" and `SubmitMintJob` prepared a **new** hash — the double-mint
+    /// amplifier for uncertain confirmation recovery.
     pub(super) fn pending_prepared_tx(&self) -> Option<PreparedMintTx> {
         match self.non_failed_predecessor() {
             Self::TxIntended { prepared_tx, .. } => Some(prepared_tx.clone()),
+            Self::TxSubmitted { prepared_tx: Some(prepared_tx), .. } => {
+                Some(prepared_tx.clone())
+            }
+            _ => None,
+        }
+    }
+
+    /// Post-intent predecessor that cannot supply prepared bytes for
+    /// classification (legacy `TxSubmitted { prepared_tx: None }`).
+    ///
+    /// Free-preparing a replacement in this state risks double-minting: a
+    /// submission or intent already existed on-chain, but we cannot rebroadcast
+    /// or prove death without the signed envelope. Recovery must inventory /
+    /// confirm-poll only.
+    pub(super) fn has_unclassifiable_post_intent_identity(&self) -> bool {
+        matches!(
+            self.non_failed_predecessor(),
+            Self::TxSubmitted { prepared_tx: None, .. }
+        )
+    }
+
+    /// Backend `tx_id` of the latest `TxSubmitted` predecessor, if any.
+    pub(super) fn latest_known_tx_id(&self) -> Option<TxId> {
+        match self.non_failed_predecessor() {
+            Self::TxSubmitted { tx_id, .. } => Some(tx_id.clone()),
             _ => None,
         }
     }
@@ -1048,9 +1083,13 @@ impl Mint {
         tx_id: TxId,
         _submitted_at: DateTime<Utc>,
     ) {
+        // Rebroadcast after RetryMint submits from `Minting { retry }` without a
+        // new `MintTxIntended`. Preserve the live prepared identity from the
+        // predecessor chain so recovery can keep classifying/rebroadcasting the
+        // same hash (dropping it here re-opened the double-mint hole).
         let prepared_tx = match self {
             Self::TxIntended { prepared_tx, .. } => Some(prepared_tx.clone()),
-            Self::Minting { .. } => None,
+            Self::Minting { .. } => self.pending_prepared_tx(),
             _ => return,
         };
 
@@ -1517,19 +1556,70 @@ impl Mint {
         &self,
         issuer_request_id: IssuerMintRequestId,
         reason: String,
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
     ) -> Result<Vec<MintEvent>, MintError> {
-        match self {
-            Self::Completed { .. } | Self::Closed { .. } => {
-                Err(MintError::NotRecoverable {
-                    current_state: self.state_name().to_string(),
-                })
-            }
-            _ => Ok(vec![MintEvent::MintClosed {
-                issuer_request_id,
-                reason,
-                closed_at: Utc::now(),
-            }]),
+        if matches!(self, Self::Completed { .. } | Self::Closed { .. }) {
+            return Err(MintError::NotRecoverable {
+                current_state: self.state_name().to_string(),
+            });
         }
+
+        // A legacy `TxSubmitted { prepared_tx: None }` carries no prepared
+        // bytes, but its submission is already on the wire and recovery still
+        // enqueues confirm for the stored `tx_id`. Closing it terminal without
+        // an acknowledgement would mark a live deposit resolved, so fall back
+        // to the stored submission identity when there are no prepared bytes.
+        let unresolved_mint_tx_hash = self
+            .pending_prepared_tx()
+            .map(|prepared_tx| prepared_tx.hash)
+            .or_else(|| {
+                self.latest_known_tx_id().and_then(|tx_id| tx_id.to_hash())
+            });
+        let acknowledged_unresolved_mint_tx_hash = match (
+            unresolved_mint_tx_hash,
+            acknowledged_unresolved_mint_tx_hash,
+        ) {
+            (Some(mint_tx_hash), acknowledgement) => {
+                Some(Self::require_unresolved_mint_acknowledgement(
+                    mint_tx_hash,
+                    acknowledgement,
+                )?)
+            }
+            (None, Some(provided)) => {
+                return Err(
+                    MintError::UnexpectedUnresolvedMintAcknowledgement {
+                        provided,
+                    },
+                );
+            }
+            (None, None) => None,
+        };
+
+        Ok(vec![MintEvent::MintClosed {
+            issuer_request_id,
+            reason,
+            acknowledged_unresolved_mint_tx_hash,
+            closed_at: Utc::now(),
+        }])
+    }
+
+    fn require_unresolved_mint_acknowledgement(
+        persisted_mint_hash: B256,
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
+    ) -> Result<B256, MintError> {
+        let acknowledged_hash = acknowledged_unresolved_mint_tx_hash.ok_or(
+            MintError::UnresolvedMintRequiresAcknowledgement {
+                mint_tx_hash: persisted_mint_hash,
+            },
+        )?;
+        if acknowledged_hash != persisted_mint_hash {
+            return Err(MintError::UnresolvedMintAcknowledgementMismatch {
+                expected: persisted_mint_hash,
+                provided: acknowledged_hash,
+            });
+        }
+
+        Ok(acknowledged_hash)
     }
 }
 
@@ -1753,9 +1843,15 @@ impl EventSourced for Mint {
                 shares_minted,
                 block_number,
             ),
-            MintCommand::CloseMint { issuer_request_id, reason } => {
-                self.handle_close_mint(issuer_request_id, reason)
-            }
+            MintCommand::CloseMint {
+                issuer_request_id,
+                reason,
+                acknowledged_unresolved_mint_tx_hash,
+            } => self.handle_close_mint(
+                issuer_request_id,
+                reason,
+                acknowledged_unresolved_mint_tx_hash,
+            ),
         }
     }
 }
@@ -1857,8 +1953,18 @@ impl Mint {
             } => {
                 self.apply_mint_retry_started(tx_hash, started_at);
             }
-            MintEvent::MintClosed { issuer_request_id, reason, closed_at } => {
-                *self = Self::Closed { issuer_request_id, reason, closed_at };
+            MintEvent::MintClosed {
+                issuer_request_id,
+                reason,
+                acknowledged_unresolved_mint_tx_hash,
+                closed_at,
+            } => {
+                *self = Self::Closed {
+                    issuer_request_id,
+                    reason,
+                    acknowledged_unresolved_mint_tx_hash,
+                    closed_at,
+                };
             }
         }
     }
@@ -1950,6 +2056,18 @@ pub(crate) enum MintError {
     PendingWalletIntent,
     #[error("Vault: {message}")]
     Vault { message: String },
+    #[error(
+        "Unresolved prepared mint {mint_tx_hash:?} requires explicit operator acknowledgement"
+    )]
+    UnresolvedMintRequiresAcknowledgement { mint_tx_hash: B256 },
+    #[error(
+        "Unresolved mint acknowledgement mismatch: expected {expected:?}, provided {provided:?}"
+    )]
+    UnresolvedMintAcknowledgementMismatch { expected: B256, provided: B256 },
+    #[error(
+        "Unresolved mint acknowledgement {provided:?} was provided, but this mint has no persisted prepared deposit"
+    )]
+    UnexpectedUnresolvedMintAcknowledgement { provided: B256 },
 }
 
 impl From<TokenizedAssetViewError> for MintError {
@@ -2867,6 +2985,108 @@ pub(crate) mod tests {
                 )
             ),
             "a pre-cutover mint must be refused, got {error:?}"
+        );
+    }
+
+    #[test]
+    fn pending_prepared_tx_resolves_from_tx_intended() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mint =
+            replay::<Mint>(events_through_tx_intended(&issuer_request_id))
+                .unwrap()
+                .unwrap();
+        let prepared =
+            mint.pending_prepared_tx().expect("TxIntended holds prepared");
+        assert_eq!(prepared.nonce, 1);
+        assert_eq!(
+            prepared.external_tx_id,
+            format!("mint-{issuer_request_id}")
+        );
+    }
+
+    #[test]
+    fn pending_prepared_tx_resolves_from_tx_submitted_after_intended() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared_tx = PreparedMintTx::valid_for_test(
+            7,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared_tx.hash;
+        let mut events = events_through_tx_intended(&issuer_request_id);
+        // Rewrite intended with known prepared, then submit so apply copies it.
+        if let MintEvent::MintTxIntended { prepared_tx: stored, .. } =
+            &mut events[3]
+        {
+            *stored = prepared_tx;
+        }
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: Utc::now(),
+        });
+        let mint = replay::<Mint>(events).unwrap().unwrap();
+        let prepared = mint
+            .pending_prepared_tx()
+            .expect("TxSubmitted must retain prepared_tx from intended");
+        assert_eq!(prepared.hash, expected_hash);
+        assert_eq!(prepared.nonce, 7);
+    }
+
+    #[test]
+    fn pending_prepared_tx_resolves_failed_from_tx_submitted_chain() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let prepared_tx = PreparedMintTx::valid_for_test(
+            9,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared_tx.hash;
+        let mut events = events_through_tx_intended(&issuer_request_id);
+        if let MintEvent::MintTxIntended { prepared_tx: stored, .. } =
+            &mut events[3]
+        {
+            *stored = prepared_tx;
+        }
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: Utc::now(),
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "reverted".to_string(),
+            failed_at: Utc::now(),
+        });
+        let failed = replay::<Mint>(events).unwrap().unwrap();
+        let prepared = failed
+            .pending_prepared_tx()
+            .expect("MintingFailed must resolve prepared via failed_from");
+        assert_eq!(prepared.hash, expected_hash);
+
+        // After RetryMint the Minting{retry} chain must still see the same hash.
+        let mut after_retry = failed;
+        after_retry.apply_event(MintEvent::MintRetryStarted {
+            issuer_request_id,
+            tx_hash: None,
+            manual_retry_id: None,
+            started_at: Utc::now(),
+        });
+        let prepared_after_retry = after_retry
+            .pending_prepared_tx()
+            .expect("retry Minting must resolve prepared via failed_from");
+        assert_eq!(prepared_after_retry.hash, expected_hash);
+    }
+
+    #[test]
+    fn pending_prepared_tx_none_for_first_minting_attempt() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let mint = replay::<Mint>(events_through_minting(&issuer_request_id))
+            .unwrap()
+            .unwrap();
+        assert!(
+            mint.pending_prepared_tx().is_none(),
+            "first Minting attempt has no prepared identity; prepare is allowed"
         );
     }
 
@@ -4596,5 +4816,206 @@ pub(crate) mod tests {
     fn test_tokenization_request_id_display() {
         let id = TokenizationRequestId::new("alp-456");
         assert_eq!(format!("{id}"), "alp-456");
+    }
+
+    #[tokio::test]
+    async fn close_mint_without_prepared_identity_needs_no_acknowledgement() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let events = TestHarness::<Mint>::with(())
+            .given(events_through_minting(&issuer_request_id))
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed pre-prepare".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+            })
+            .await
+            .events();
+
+        assert!(matches!(
+            events.as_slice(),
+            [MintEvent::MintClosed {
+                issuer_request_id: closed_id,
+                acknowledged_unresolved_mint_tx_hash: None,
+                ..
+            }] if closed_id == &issuer_request_id
+        ));
+    }
+
+    /// A legacy `TxSubmitted { prepared_tx: None }` has no prepared bytes, but
+    /// a hash `tx_id` is still a broadcast identity recovery keeps polling.
+    /// Closing it must not be cheaper than closing an intended mint.
+    #[tokio::test]
+    async fn close_mint_with_legacy_submitted_hash_requires_acknowledgement() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let submitted_hash = B256::random();
+        let mut seed = events_through_minting(&issuer_request_id);
+        seed.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: "ext-legacy".to_string(),
+            tx_id: TxId::Hash(submitted_hash),
+            submitted_at: Utc::now(),
+        });
+
+        let missing = TestHarness::<Mint>::with(())
+            .given(seed.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed legacy submitted".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                missing,
+                LifecycleError::Apply(
+                    MintError::UnresolvedMintRequiresAcknowledgement {
+                        mint_tx_hash
+                    }
+                ) if mint_tx_hash == submitted_hash
+            ),
+            "legacy submitted close without ack must fail, got {missing:?}"
+        );
+
+        let wrong_hash = B256::random();
+        let wrong = TestHarness::<Mint>::with(())
+            .given(seed.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed legacy submitted".to_string(),
+                acknowledged_unresolved_mint_tx_hash: Some(wrong_hash),
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                wrong,
+                LifecycleError::Apply(
+                    MintError::UnresolvedMintAcknowledgementMismatch {
+                        expected,
+                        provided,
+                    }
+                ) if expected == submitted_hash && provided == wrong_hash
+            ),
+            "mismatched ack must fail, got {wrong:?}"
+        );
+
+        let events = TestHarness::<Mint>::with(())
+            .given(seed)
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed legacy submitted".to_string(),
+                acknowledged_unresolved_mint_tx_hash: Some(submitted_hash),
+            })
+            .await
+            .events();
+        assert!(matches!(
+            events.as_slice(),
+            [MintEvent::MintClosed {
+                acknowledged_unresolved_mint_tx_hash: Some(acknowledged),
+                ..
+            }] if acknowledged == &submitted_hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_mint_with_prepared_identity_requires_matching_hash() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let seed = events_through_tx_intended(&issuer_request_id);
+        let prepared_hash = match &seed[3] {
+            MintEvent::MintTxIntended { prepared_tx, .. } => prepared_tx.hash,
+            other => panic!("expected MintTxIntended, got {other:?}"),
+        };
+
+        let missing = TestHarness::<Mint>::with(())
+            .given(seed.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed intended".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                missing,
+                LifecycleError::Apply(
+                    MintError::UnresolvedMintRequiresAcknowledgement {
+                        mint_tx_hash
+                    }
+                ) if mint_tx_hash == prepared_hash
+            ),
+            "missing ack must fail, got {missing:?}"
+        );
+
+        let wrong = TestHarness::<Mint>::with(())
+            .given(seed.clone())
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "wrong hash".to_string(),
+                acknowledged_unresolved_mint_tx_hash: Some(b256!(
+                    "0x1111111111111111111111111111111111111111111111111111111111111111"
+                )),
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                wrong,
+                LifecycleError::Apply(
+                    MintError::UnresolvedMintAcknowledgementMismatch {
+                        expected,
+                        ..
+                    }
+                ) if expected == prepared_hash
+            ),
+            "mismatched ack must fail, got {wrong:?}"
+        );
+
+        let events = TestHarness::<Mint>::with(())
+            .given(seed)
+            .when(MintCommand::CloseMint {
+                issuer_request_id: issuer_request_id.clone(),
+                reason: "operator closed intended".to_string(),
+                acknowledged_unresolved_mint_tx_hash: Some(prepared_hash),
+            })
+            .await
+            .events();
+        assert!(matches!(
+            events.as_slice(),
+            [MintEvent::MintClosed {
+                issuer_request_id: closed_id,
+                acknowledged_unresolved_mint_tx_hash: Some(ack),
+                ..
+            }] if closed_id == &issuer_request_id && *ack == prepared_hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_mint_rejects_unexpected_acknowledgement() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let unexpected = b256!(
+            "0x2222222222222222222222222222222222222222222222222222222222222222"
+        );
+        let error = TestHarness::<Mint>::with(())
+            .given(events_through_minting(&issuer_request_id))
+            .when(MintCommand::CloseMint {
+                issuer_request_id,
+                reason: "ack without intent".to_string(),
+                acknowledged_unresolved_mint_tx_hash: Some(unexpected),
+            })
+            .await
+            .then_expect_error();
+        assert!(
+            matches!(
+                error,
+                LifecycleError::Apply(
+                    MintError::UnexpectedUnresolvedMintAcknowledgement {
+                        provided
+                    }
+                ) if provided == unexpected
+            ),
+            "unexpected ack must fail, got {error:?}"
+        );
     }
 }

--- a/src/mint/recovery.rs
+++ b/src/mint/recovery.rs
@@ -20,7 +20,9 @@ use super::{
 use crate::jobs::{Job, JobQueue, QueuePushError, job_type};
 use crate::receipt_inventory::{ItnReceiptHandler, ReceiptService};
 use crate::tokenized_asset::view::{TokenizedAssetViewError, find_vault};
-use crate::vault::{NetworkVaultServices, TxId, UnconfiguredNetworkError};
+use crate::vault::{
+    MintTxStatus, NetworkVaultServices, TxId, UnconfiguredNetworkError,
+};
 
 /// Dependencies the scheduled mint-recovery worker needs to re-drive a stuck or
 /// failed mint by enqueuing the appropriate per-state job.
@@ -41,8 +43,9 @@ pub(crate) struct MintRecoveryContext {
 /// reconciler. On-chain evidence (`tx_hash`, receipt id, shares) is already
 /// in inventory from the preceding `DiscoverReceipt`; the recovery /
 /// `SubmitMintJob` path loads that receipt and records it via
-/// `RecordExistingMint` (or re-submits only when no receipt exists — the
-/// signer does not dedup on `external_tx_id`).
+/// `RecordExistingMint` (or rebroadcasts / replaces only after burn-parity
+/// classification — never relying on `external_tx_id` for double-mint safety;
+/// the signer does not dedup on it).
 #[derive(Clone)]
 pub(crate) struct MintRecoveryHandler {
     pool: Pool<Sqlite>,
@@ -412,7 +415,12 @@ pub(crate) async fn push_mint_recovery_job(
 /// idempotency key is free to re-enqueue, leaving any active (`Pending`/
 /// `Running`) row so the re-enqueue still dedups against it. Runs on the
 /// event-store pool (same SQLite file as the apalis pool).
-async fn release_terminal_job(
+///
+/// Shared by recovery enqueue helpers and normal-flow jobs (e.g.
+/// [`super::job::SubmitMintJob::enqueue_confirm`]) so a prior `Done` confirm
+/// cannot silently drop a re-enqueue via apalis
+/// `ON CONFLICT(job_type, idempotency_key) DO NOTHING`.
+pub(crate) async fn release_terminal_job(
     pool: &Pool<Sqlite>,
     job_type: &str,
     idempotency_key: &str,
@@ -937,6 +945,35 @@ async fn recover_mint_until_automatic_budget_exhausted(
             // The state is recoverable and due: enqueue the per-state job that
             // advances it, then poll for progress on the next iteration.
             AutomaticRetryDecision::Ready => {
+                // Same inventory gate as Wait/Exhausted for MintingFailed: fail
+                // closed while inventory is unreadable (may free-prepare), and
+                // surface an existing receipt so SubmitMintJob records it.
+                if matches!(&mint, Mint::MintingFailed { .. }) {
+                    match minting_failed_receipt_exists_with_backoff(
+                        ctx,
+                        &mint,
+                        issuer_request_id,
+                        backoff,
+                        &mut receipt_load_failure_backoffs,
+                    )
+                    .await
+                    {
+                        Ok(Some(true)) => {
+                            // Inside the budget loop and falling through to
+                            // another poll, so DEBUG for the same reason the
+                            // fail-closed step below is DEBUG.
+                            debug!(target: "mint", issuer_request_id = %issuer_request_id,
+                                "MintingFailed ready for retry but on-chain receipt exists; driving recovery"
+                            );
+                        }
+                        Ok(Some(false)) => {}
+                        Ok(None) => continue,
+                        Err(reason) => {
+                            return RecoveryConclusion::Abandoned { reason };
+                        }
+                    }
+                }
+
                 no_progress_polls += 1;
                 if no_progress_polls > max_no_progress_polls {
                     warn!(target: "mint", issuer_request_id = %issuer_request_id,
@@ -978,6 +1015,8 @@ enum MintRecoveryStepError {
     AssetView(#[from] TokenizedAssetViewError),
     #[error(transparent)]
     UnconfiguredNetwork(#[from] UnconfiguredNetworkError),
+    #[error(transparent)]
+    ReceiptLookup(#[from] crate::receipt_inventory::ReceiptLookupError),
     #[error("no vault configured for {underlying} on {network}")]
     VaultNotFound { underlying: UnderlyingSymbol, network: Network },
 }
@@ -990,8 +1029,12 @@ struct ResolvedVault {
 
 /// Advances a recoverable mint one step by enqueuing the appropriate per-state
 /// job (or issuing the pure transition that precedes it). The durable jobs
-/// perform the actual I/O; recovery only schedules them. The deterministic
-/// `external_tx_id` keeps a re-submission double-mint-safe.
+/// perform the actual I/O; recovery only schedules them.
+///
+/// After a prepared identity exists, recovery **never** treats `external_tx_id`
+/// as double-mint protection — only exact-hash classification / rebroadcast
+/// (or inventory) is safe. Replacement requires `MinedReverted` or
+/// `ProvablyDead` under the wallet guard.
 async fn drive_one_step(
     ctx: &MintRecoveryContext,
     mint: &Mint,
@@ -1015,19 +1058,18 @@ async fn drive_one_step(
             let vault = resolve_vault(ctx, underlying, *network).await?;
             enqueue_submit(ctx, issuer_request_id, vault).await?;
         }
-        // Retry a failed mint: transition back to Minting (advancing the attempt
-        // counter), then enqueue a fresh submission.
+        // Failed mint: classify any live prepared identity under the wallet
+        // guard before RetryMint. StillMineable / Uncertain never authorize a
+        // fresh prepare; only terminal dead/revert may replace after recheck.
         Mint::MintingFailed { underlying, network, .. } => {
-            ctx.mint_store
-                .send(
-                    issuer_request_id,
-                    MintCommand::RetryMint {
-                        issuer_request_id: issuer_request_id.clone(),
-                    },
-                )
-                .await?;
-            let vault = resolve_vault(ctx, underlying, *network).await?;
-            enqueue_submit(ctx, issuer_request_id, vault).await?;
+            drive_minting_failed_step(
+                ctx,
+                mint,
+                issuer_request_id,
+                underlying,
+                *network,
+            )
+            .await?;
         }
         Mint::TxSubmitted { underlying, network, tx_id, .. } => {
             let vault = resolve_vault(ctx, underlying, *network).await?;
@@ -1042,6 +1084,228 @@ async fn drive_one_step(
         _ => {}
     }
 
+    Ok(())
+}
+
+/// Recovery step for `MintingFailed`. Inventory hits are handled by the
+/// budget loop / SubmitMintJob receipt check; here we gate RetryMint on
+/// observation of any predecessor prepared identity.
+async fn drive_minting_failed_step(
+    ctx: &MintRecoveryContext,
+    mint: &Mint,
+    issuer_request_id: &IssuerMintRequestId,
+    underlying: &UnderlyingSymbol,
+    network: Network,
+) -> Result<(), MintRecoveryStepError> {
+    let vault = resolve_vault(ctx, underlying, network).await?;
+
+    let Some(prepared) = mint.pending_prepared_tx() else {
+        // Post-intent without prepared bytes (legacy TxSubmitted): never
+        // free-prepare a replacement — that is the double-mint hole. Inventory
+        // may still record an existing mint via SubmitMintJob; otherwise only
+        // confirm-poll the known tx_id and leave MintingFailed for ops.
+        if mint.has_unclassifiable_post_intent_identity() {
+            let receipt_exists = match minting_failed_receipt_exists(
+                ctx,
+                mint,
+                issuer_request_id,
+            )
+            .await
+            {
+                Ok(exists) => exists,
+                Err(error) => {
+                    // Lookup failure is not "no receipt": refuse free-prepare
+                    // and fall through to confirm-poll / ops ERROR below.
+                    warn!(
+                        target: "mint",
+                        issuer_request_id = %issuer_request_id,
+                        error = %error,
+                        "Inventory lookup failed for post-submit MintingFailed \
+                         without prepared_tx; fail closed"
+                    );
+                    false
+                }
+            };
+            if receipt_exists {
+                info!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    "MintingFailed post-submit without prepared_tx but inventory \
+                     has receipt; RetryMint so SubmitMintJob can record ExistingMint"
+                );
+                authorize_resubmit(ctx, issuer_request_id, vault).await?;
+                return Ok(());
+            }
+
+            // `has_unclassifiable_post_intent_identity` and
+            // `latest_known_tx_id` read the same `TxSubmitted` predecessor, so
+            // the tx_id is present here and the confirm poll below always runs.
+            // That makes this pass self-recovering, and this step repeats on
+            // every recovery poll — an ERROR per pass would alarm on a system
+            // that is still re-observing. ERROR stays for the accessors
+            // disagreeing, where nothing is left to poll and only an operator
+            // can resolve it.
+            let Some(tx_id) = mint.latest_known_tx_id() else {
+                error!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    "MintingFailed after post-submit identity without \
+                     prepared_tx or a known tx_id; fail closed with nothing \
+                     left to poll (never free-prepare)"
+                );
+                return Ok(());
+            };
+
+            debug!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_id = ?tx_id,
+                "MintingFailed after post-submit identity without prepared_tx; \
+                 fail closed (confirm poll / inventory only; never free-prepare)"
+            );
+            enqueue_confirm(ctx, issuer_request_id, vault, tx_id).await?;
+            return Ok(());
+        }
+
+        // True pre-intent failure (Minting only / never intended): no on-chain
+        // identity — existing retry schedule may prepare a first mint.
+        authorize_resubmit(ctx, issuer_request_id, vault).await?;
+        return Ok(());
+    };
+
+    let vault_service = ctx.vault_services.service(network)?;
+    let owner = match prepared.recover_signer() {
+        Ok(owner) => owner,
+        Err(error) => {
+            // Corrupt identity: fail closed — cannot prove death without a
+            // valid envelope; leave MintingFailed for operator/restart.
+            warn!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                error = %error,
+                "Cannot recover signer from prepared mint; fail closed"
+            );
+            return Ok(());
+        }
+    };
+
+    let wallet_guard = vault_service.lock_wallet().await;
+    let status = match vault_service.classify_mint_tx(owner, &prepared).await {
+        Ok(status) => status,
+        Err(error) => {
+            drop(wallet_guard);
+            warn!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %prepared.hash,
+                nonce = prepared.nonce,
+                error = %error,
+                "Mint recovery classification uncertain; not replacing"
+            );
+            return Ok(());
+        }
+    };
+
+    match status {
+        MintTxStatus::StillMineable => {
+            // Mempool-live / unconfirmed: rebroadcast same prepared hash.
+            // SubmitMintJob classifies again and rebroadcasts without preparing.
+            info!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %prepared.hash,
+                nonce = prepared.nonce,
+                status = ?status,
+                "Mint recovery rebroadcasting existing identity"
+            );
+            drop(wallet_guard);
+            authorize_resubmit(ctx, issuer_request_id, vault).await?;
+        }
+        MintTxStatus::MinedSuccess => {
+            // Receipt exists: observe via confirm while still MintingFailed
+            // (ConfirmMintJob::confirm_while_minting_failed → RecordExistingMint).
+            // Do not re-enter submit — a mined deposit must not rebroadcast.
+            info!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %prepared.hash,
+                nonce = prepared.nonce,
+                "Mint recovery confirming mined success for existing identity"
+            );
+            drop(wallet_guard);
+            enqueue_confirm(
+                ctx,
+                issuer_request_id,
+                vault,
+                TxId::from(prepared.hash),
+            )
+            .await?;
+        }
+        MintTxStatus::MinedReverted | MintTxStatus::ProvablyDead => {
+            // TOCTOU recheck immediately before allowing replacement prepare.
+            let recheck =
+                match vault_service.classify_mint_tx(owner, &prepared).await {
+                    Ok(status) => status,
+                    Err(error) => {
+                        drop(wallet_guard);
+                        warn!(
+                            target: "mint",
+                            issuer_request_id = %issuer_request_id,
+                            tx_hash = %prepared.hash,
+                            error = %error,
+                            "Mint recovery recheck uncertain; not replacing"
+                        );
+                        return Ok(());
+                    }
+                };
+            if !matches!(
+                recheck,
+                MintTxStatus::MinedReverted | MintTxStatus::ProvablyDead
+            ) {
+                drop(wallet_guard);
+                warn!(
+                    target: "mint",
+                    issuer_request_id = %issuer_request_id,
+                    tx_hash = %prepared.hash,
+                    first = ?status,
+                    recheck = ?recheck,
+                    "Mint recovery recheck no longer terminal; not replacing"
+                );
+                return Ok(());
+            }
+
+            info!(
+                target: "mint",
+                issuer_request_id = %issuer_request_id,
+                tx_hash = %prepared.hash,
+                nonce = prepared.nonce,
+                status = ?recheck,
+                "Mint recovery authorizing replacement after terminal dead/revert"
+            );
+            drop(wallet_guard);
+            authorize_resubmit(ctx, issuer_request_id, vault).await?;
+        }
+    }
+
+    Ok(())
+}
+
+/// `RetryMint` + enqueue `SubmitMintJob` — shared by free-prepare-safe and
+/// rebroadcast / replacement-authorized recovery paths under `MintingFailed`.
+async fn authorize_resubmit(
+    ctx: &MintRecoveryContext,
+    issuer_request_id: &IssuerMintRequestId,
+    vault: ResolvedVault,
+) -> Result<(), MintRecoveryStepError> {
+    ctx.mint_store
+        .send(
+            issuer_request_id,
+            MintCommand::RetryMint {
+                issuer_request_id: issuer_request_id.clone(),
+            },
+        )
+        .await?;
+    enqueue_submit(ctx, issuer_request_id, vault).await?;
     Ok(())
 }
 
@@ -1064,21 +1328,21 @@ async fn resolve_vault(
 /// Whether a `MintingFailed` mint already has a discovered receipt — i.e. its
 /// on-chain transaction actually succeeded after the mint was marked failed.
 /// When true, recovery should record the existing mint now rather than wait out
-/// the re-submission backoff. A non-`MintingFailed` state, an unresolved vault,
-/// or a lookup error is treated as "no receipt" so recovery falls back to the
-/// normal retry schedule.
+/// the re-submission backoff. Only a non-`MintingFailed` state answers a
+/// definite "no receipt"; an unresolved vault or an unreadable inventory is
+/// "cannot tell" and must surface as an error. Answering `false` there would
+/// abandon a mint whose deposit already succeeded, since retry exhaustion reads
+/// `false` as proof that nothing was minted.
 async fn minting_failed_receipt_exists(
     ctx: &MintRecoveryContext,
     mint: &Mint,
     issuer_request_id: &IssuerMintRequestId,
-) -> Result<bool, crate::receipt_inventory::ReceiptLookupError> {
+) -> Result<bool, MintRecoveryStepError> {
     let Mint::MintingFailed { underlying, network, .. } = mint else {
         return Ok(false);
     };
 
-    let Ok(vault) = resolve_vault(ctx, underlying, *network).await else {
-        return Ok(false);
-    };
+    let vault = resolve_vault(ctx, underlying, *network).await?;
 
     ctx.receipts
         .find_by_issuer_request_id(
@@ -1088,6 +1352,7 @@ async fn minting_failed_receipt_exists(
         )
         .await
         .map(|receipt| receipt.is_some())
+        .map_err(Into::into)
 }
 
 /// Enqueues a per-state job for a recovering mint, first freeing the mint's
@@ -1177,7 +1442,8 @@ async fn enqueue_callback(
 
 #[cfg(test)]
 mod tests {
-    use alloy::primitives::address;
+    use alloy::primitives::{Address, B256, U256, address};
+    use async_trait::async_trait;
     use chrono::Utc;
     use event_sorcery::test_store;
     use rust_decimal::Decimal;
@@ -1193,9 +1459,110 @@ mod tests {
         ClientId, IssuerMintRequestId, MintEvent, MintExternalTxId, Network,
         Quantity, TokenSymbol, TokenizationRequestId, UnderlyingSymbol,
     };
-    use crate::receipt_inventory::{CqrsReceiptService, ReceiptInventory};
-    use crate::test_utils::log_count_at;
+    use crate::receipt_inventory::{
+        BurnPlan, BurnTrackingError, CqrsReceiptService, MintedReceiptParams,
+        ReceiptInventory, ReceiptLookupError, ReceiptRegistrationError,
+        RecoveredReceipt, Shares,
+    };
+    use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
+    use crate::test_utils::{log_count_at, logs_contain_at};
     use crate::tokenized_asset::{AssetKey, TokenizedAssetCommand};
+    use crate::vault::mock::MockVaultService;
+    use crate::vault::{MintTxStatus, PreparedMintTx, VaultService};
+
+    /// Configurable `ReceiptService` stub for recovery tests. Only
+    /// `find_by_issuer_request_id` is behavior-specific; other methods are
+    /// no-ops so a future trait method needs one edit instead of three.
+    enum ReceiptLookupBehavior {
+        Present,
+        Fails,
+    }
+
+    struct ReceiptLookupStub(ReceiptLookupBehavior);
+
+    #[async_trait]
+    impl ReceiptService for ReceiptLookupStub {
+        async fn register_minted_receipt(
+            &self,
+            _params: MintedReceiptParams,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Ok(())
+        }
+
+        async fn for_burn(
+            &self,
+            _chain_id: u64,
+            _vault: Address,
+            _redemption_issuer_request_id: &IssuerRedemptionRequestId,
+            _shares_to_burn: Shares,
+            _dust: Shares,
+        ) -> Result<BurnPlan, BurnTrackingError> {
+            Ok(BurnPlan {
+                allocations: vec![],
+                total_burn: Shares::ZERO,
+                dust: Shares::ZERO,
+            })
+        }
+
+        async fn reserve_burn(
+            &self,
+            _chain_id: u64,
+            _vault: Address,
+            _redemption_issuer_request_id: IssuerRedemptionRequestId,
+            _burns: Vec<BurnRecord>,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Ok(())
+        }
+
+        async fn release_burn(
+            &self,
+            _chain_id: u64,
+            _vault: Address,
+            _redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Ok(())
+        }
+
+        async fn settle_burn(
+            &self,
+            _chain_id: u64,
+            _vault: Address,
+            _redemption_issuer_request_id: IssuerRedemptionRequestId,
+        ) -> Result<(), ReceiptRegistrationError> {
+            Ok(())
+        }
+
+        async fn reserved_redemptions(
+            &self,
+            _chain_id: u64,
+            _vault: Address,
+        ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
+        {
+            Ok(vec![])
+        }
+
+        async fn find_by_issuer_request_id(
+            &self,
+            _chain_id: u64,
+            _vault: &Address,
+            issuer_request_id: &IssuerMintRequestId,
+        ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError> {
+            match self.0 {
+                ReceiptLookupBehavior::Present => Ok(Some(RecoveredReceipt {
+                    receipt_id: U256::from(1),
+                    tx_hash: B256::ZERO,
+                    shares: U256::from(100),
+                    block_number: 1,
+                })),
+                ReceiptLookupBehavior::Fails => {
+                    Err(ReceiptLookupError::Inconsistent {
+                        issuer_request_id: issuer_request_id.clone(),
+                        receipt_id: U256::from(1).into(),
+                    })
+                }
+            }
+        }
+    }
 
     /// Builds a real event-sorcery [`Store<Mint>`] over a file-backed SQLite
     /// pool shared with an apalis-sqlite pool (so the durable per-state queues
@@ -1267,6 +1634,11 @@ mod tests {
             }
         }
 
+        /// Override the vault service used by recovery (classification mocks).
+        fn with_vault(self, vault: Arc<dyn VaultService>) -> Self {
+            Self { vault_services: network_vault_services(vault), ..self }
+        }
+
         /// Seeds the event store with raw `Mint` events, putting the aggregate
         /// directly into the desired lifecycle state. Mirrors the e2e
         /// setup-phase pattern of writing rows to the `events` table; the
@@ -1322,7 +1694,26 @@ mod tests {
         }
     }
 
-    fn tx_failed_events(
+    /// True pre-intent failure (`Minting` only — never `MintTxIntended` /
+    /// `MintTxSubmitted`). Recovery may free-prepare on RetryMint.
+    fn pre_intent_failed_events(
+        issuer_request_id: &IssuerMintRequestId,
+        failed_at: chrono::DateTime<Utc>,
+    ) -> Vec<MintEvent> {
+        let mut events = minting_events(issuer_request_id);
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "prepare or pre-submit failure".to_string(),
+            failed_at,
+        });
+
+        events
+    }
+
+    /// Legacy post-submit failure: `MintTxSubmitted` without a preceding
+    /// `MintTxIntended`, so `prepared_tx` is `None` on the predecessor.
+    /// Free-prepare is forbidden; recovery must fail closed.
+    fn post_submit_without_prepared_failed_events(
         issuer_request_id: &IssuerMintRequestId,
         failed_at: chrono::DateTime<Utc>,
     ) -> Vec<MintEvent> {
@@ -1334,6 +1725,58 @@ mod tests {
         });
 
         events
+    }
+
+    /// MintingFailed after TxIntended + TxSubmitted so `prepared_tx` is retained
+    /// on the predecessor (load-bearing for rebroadcast vs fresh prepare).
+    fn tx_failed_with_prepared_events(
+        issuer_request_id: &IssuerMintRequestId,
+        failed_at: chrono::DateTime<Utc>,
+        prepared_tx: PreparedMintTx,
+    ) -> Vec<MintEvent> {
+        // failed_at must be after intent/submit so the fixture is causally
+        // ordered (callers often pass Utc::now() - N minutes for backoff).
+        let intended_at = failed_at - chrono::Duration::minutes(2);
+        let submitted_at = failed_at - chrono::Duration::minutes(1);
+        let mut events = minting_events(issuer_request_id);
+        let hash = prepared_tx.hash;
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx,
+            intended_at,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(hash),
+            submitted_at,
+        });
+        events.push(MintEvent::MintingFailed {
+            issuer_request_id: issuer_request_id.clone(),
+            error: "prior confirm uncertain or reverted".to_string(),
+            failed_at,
+        });
+        events
+    }
+
+    async fn count_jobs_for_mint(
+        pool: &Pool<Sqlite>,
+        job_ty: &str,
+        issuer_request_id: &IssuerMintRequestId,
+    ) -> i64 {
+        sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE job_type = ?
+              AND idempotency_key = ?
+            ",
+        )
+        .bind(job_ty)
+        .bind(issuer_request_id.to_string())
+        .fetch_one(pool)
+        .await
+        .unwrap()
     }
 
     fn test_issuer_request_id() -> IssuerMintRequestId {
@@ -1398,7 +1841,7 @@ mod tests {
     async fn scheduled_recovery_backs_off_without_progress() {
         let issuer_request_id = test_issuer_request_id();
         let failed_at = Utc::now() - chrono::Duration::minutes(2);
-        let events = tx_failed_events(&issuer_request_id, failed_at);
+        let events = pre_intent_failed_events(&issuer_request_id, failed_at);
         let fixture = MintRecoveryFixture::new().await;
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
@@ -1436,8 +1879,8 @@ mod tests {
             fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
         assert!(
             matches!(mint, Mint::Minting { .. }),
-            "drive_one_step retries MintingFailed into Minting and re-enqueues \
-             the submission, got: {}",
+            "drive_one_step retries true pre-intent MintingFailed into Minting \
+             and re-enqueues the submission, got: {}",
             mint.state_name()
         );
 
@@ -1637,7 +2080,7 @@ mod tests {
     async fn budget_loop_reports_abandoned_when_no_progress_budget_spent() {
         let issuer_request_id = test_issuer_request_id();
         let failed_at = Utc::now() - chrono::Duration::minutes(2);
-        let events = tx_failed_events(&issuer_request_id, failed_at);
+        let events = pre_intent_failed_events(&issuer_request_id, failed_at);
         let fixture = MintRecoveryFixture::new().await;
         fixture.seed_mint_events(&issuer_request_id, events).await;
 
@@ -1704,109 +2147,6 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn exhausted_retries_with_existing_receipt_keep_driving() {
-        use crate::receipt_inventory::{
-            BurnPlan, BurnTrackingError, MintedReceiptParams,
-            ReceiptLookupError, ReceiptRegistrationError, ReceiptService,
-            RecoveredReceipt, Shares,
-        };
-        use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
-        use alloy::primitives::{B256, U256};
-        use async_trait::async_trait;
-
-        enum ReceiptLookupBehavior {
-            Present,
-            Fails,
-        }
-
-        struct ReceiptLookupStub(ReceiptLookupBehavior);
-
-        #[async_trait]
-        impl ReceiptService for ReceiptLookupStub {
-            async fn register_minted_receipt(
-                &self,
-                _params: MintedReceiptParams,
-            ) -> Result<(), ReceiptRegistrationError> {
-                Ok(())
-            }
-
-            async fn for_burn(
-                &self,
-                _chain_id: u64,
-                _vault: Address,
-                _redemption_issuer_request_id: &IssuerRedemptionRequestId,
-                _shares_to_burn: Shares,
-                _dust: Shares,
-            ) -> Result<BurnPlan, BurnTrackingError> {
-                Ok(BurnPlan {
-                    allocations: vec![],
-                    total_burn: Shares::ZERO,
-                    dust: Shares::ZERO,
-                })
-            }
-
-            async fn reserve_burn(
-                &self,
-                _chain_id: u64,
-                _vault: Address,
-                _redemption_issuer_request_id: IssuerRedemptionRequestId,
-                _burns: Vec<BurnRecord>,
-            ) -> Result<(), ReceiptRegistrationError> {
-                Ok(())
-            }
-
-            async fn release_burn(
-                &self,
-                _chain_id: u64,
-                _vault: Address,
-                _redemption_issuer_request_id: IssuerRedemptionRequestId,
-            ) -> Result<(), ReceiptRegistrationError> {
-                Ok(())
-            }
-
-            async fn settle_burn(
-                &self,
-                _chain_id: u64,
-                _vault: Address,
-                _redemption_issuer_request_id: IssuerRedemptionRequestId,
-            ) -> Result<(), ReceiptRegistrationError> {
-                Ok(())
-            }
-
-            async fn reserved_redemptions(
-                &self,
-                _chain_id: u64,
-                _vault: Address,
-            ) -> Result<Vec<IssuerRedemptionRequestId>, ReceiptLookupError>
-            {
-                Ok(vec![])
-            }
-
-            async fn find_by_issuer_request_id(
-                &self,
-                _chain_id: u64,
-                _vault: &Address,
-                _issuer_request_id: &IssuerMintRequestId,
-            ) -> Result<Option<RecoveredReceipt>, ReceiptLookupError>
-            {
-                match self.0 {
-                    ReceiptLookupBehavior::Present => {
-                        Ok(Some(RecoveredReceipt {
-                            receipt_id: U256::from(1),
-                            tx_hash: B256::ZERO,
-                            shares: U256::from(100),
-                            block_number: 1,
-                        }))
-                    }
-                    ReceiptLookupBehavior::Fails => {
-                        Err(ReceiptLookupError::Inconsistent {
-                            issuer_request_id: _issuer_request_id.clone(),
-                            receipt_id: U256::from(1).into(),
-                        })
-                    }
-                }
-            }
-        }
-
         let issuer_request_id = test_issuer_request_id();
         let failed_at = Utc::now() - chrono::Duration::hours(2);
         let mut events = tx_submitted_events(&issuer_request_id);
@@ -1881,6 +2221,76 @@ mod tests {
                 reason: AbandonReason::FailedToLoadReceipt
             }
         ));
+    }
+
+    /// A vault that cannot be resolved means "cannot tell whether a receipt
+    /// exists", not "no receipt". Reporting `AutomaticRetriesExhausted` there
+    /// would abandon a mint whose deposit may already have succeeded, and an
+    /// abandoned mint is Killed, never requeued, and unrecoverable without an
+    /// operator. The honest conclusion is the unreadable-inventory one.
+    #[traced_test]
+    #[tokio::test]
+    async fn exhausted_retries_with_unresolvable_vault_do_not_report_exhausted()
+    {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::hours(2);
+        // The fixture registers a vault for AAPL/Base only, so a mint on an
+        // unregistered underlying makes `resolve_vault` fail.
+        let mut events = tx_submitted_events(&issuer_request_id);
+        if let Some(MintEvent::Initiated { underlying, token, .. }) =
+            events.first_mut()
+        {
+            *underlying = UnderlyingSymbol::new("MSFT").unwrap();
+            *token = TokenSymbol::new("tMSFT");
+        }
+        for _ in 0..5 {
+            events.push(MintEvent::MintingFailed {
+                issuer_request_id: issuer_request_id.clone(),
+                error: "submission rejected".to_string(),
+                failed_at,
+            });
+        }
+        let fixture = MintRecoveryFixture::new().await;
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let conclusion = recover_mint_until_automatic_budget_exhausted(
+            &fixture.context(),
+            &issuer_request_id,
+            Duration::from_millis(1),
+            3,
+        )
+        .await;
+
+        assert!(
+            matches!(
+                conclusion,
+                RecoveryConclusion::Abandoned {
+                    reason: AbandonReason::FailedToLoadReceipt
+                }
+            ),
+            "an unresolvable vault must abandon as unreadable inventory, not \
+             as retry exhaustion"
+        );
+
+        let test =
+            "exhausted_retries_with_unresolvable_vault_do_not_report_exhausted";
+        assert!(
+            log_count_at!(
+                Level::WARN,
+                &[
+                    test,
+                    "Failed to read receipt inventory after maximum backoffs"
+                ]
+            ) >= 1,
+            "giving up on an unreadable inventory must log the WARN"
+        );
+        assert!(
+            log_count_at!(
+                Level::WARN,
+                &[test, "Automatic mint retries exhausted"]
+            ) == 0,
+            "an unreadable inventory must never be reported as retry exhaustion"
+        );
     }
 
     /// `MintRecoveryJob::perform` returns `Err(AbortError)` when recovery
@@ -2455,5 +2865,720 @@ mod tests {
             "MintingFailed",
             "a refused manual retry must not advance the mint"
         );
+    }
+    /// Uncertain classify must not RetryMint — leave MintingFailed so a second
+    /// deposit is never prepared under observation failure.
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_uncertain_classify_does_not_retry_mint() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        // Replace the default success mock with one that fails classification.
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_classification_failure(),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        drive_one_step(
+            &fixture.context(),
+            &fixture
+                .mint_store
+                .load(&issuer_request_id)
+                .await
+                .unwrap()
+                .unwrap(),
+            &issuer_request_id,
+        )
+        .await
+        .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "uncertain classify must not RetryMint, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            1,
+            "must classify under wallet guard before any retry"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "must not prepare a new mint under uncertain classification"
+        );
+
+        let test = "drive_one_step_uncertain_classify_does_not_retry_mint";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "classification uncertain", "not replacing"]
+        ));
+        // Prepared identity still recoverable for a later successful observe.
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash)
+        );
+    }
+
+    /// StillMineable rebroadcast path: RetryMint + submit reuses same hash
+    /// (pending_prepared_tx), never prepare_mint_tx a different identity.
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_still_mineable_rebroadcasts_same_hash() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_status(MintTxStatus::StillMineable),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "StillMineable recovery RetryMints into Minting for rebroadcast, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash),
+            "rebroadcast path must keep the same prepared hash"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "drive_one_step must not prepare; SubmitMintJob rebroadcasts"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "StillMineable rebroadcast must enqueue SubmitMintJob"
+        );
+    }
+
+    /// ProvablyDead allows RetryMint; SubmitMintJob may prepare a replacement.
+    #[tokio::test]
+    async fn drive_one_step_provably_dead_allows_retry() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_status(MintTxStatus::ProvablyDead),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "ProvablyDead must allow RetryMint, got: {}",
+            mint.state_name()
+        );
+        // Two classify calls: initial + TOCTOU recheck.
+        assert_eq!(vault.mint_classification_call_count(), 2);
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "ProvablyDead replacement path must enqueue SubmitMintJob"
+        );
+    }
+
+    /// TOCTOU: first classify ProvablyDead, recheck StillMineable → no
+    /// RetryMint (identity may still mine; never authorize replacement).
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_toctou_provably_dead_then_still_mineable_no_retry()
+    {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(
+            MockVaultService::new_success().with_mint_tx_status_sequence(vec![
+                MintTxStatus::ProvablyDead,
+                MintTxStatus::StillMineable,
+            ]),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "TOCTOU recheck StillMineable must not RetryMint, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            2,
+            "must classify then recheck under the wallet guard"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "TOCTOU abort must not prepare a replacement"
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash)
+        );
+
+        let test =
+            "drive_one_step_toctou_provably_dead_then_still_mineable_no_retry";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "recheck no longer terminal", "not replacing"]
+        ));
+    }
+
+    /// Restart mid-`TxSubmitted`: recovery re-enqueues confirm for the same
+    /// prepared hash and never prepares a replacement.
+    #[tokio::test]
+    async fn drive_one_step_tx_submitted_restart_reuses_same_hash() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            7,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let now = Utc::now();
+        let mut events = minting_events(&issuer_request_id);
+        events.push(MintEvent::MintTxIntended {
+            issuer_request_id: issuer_request_id.clone(),
+            prepared_tx: prepared,
+            intended_at: now,
+        });
+        events.push(MintEvent::MintTxSubmitted {
+            issuer_request_id: issuer_request_id.clone(),
+            external_tx_id: format!("mint-{issuer_request_id}"),
+            tx_id: TxId::from(expected_hash),
+            submitted_at: now,
+        });
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint_before, Mint::TxSubmitted { .. }),
+            "fixture must start TxSubmitted, got {}",
+            mint_before.state_name()
+        );
+        assert_eq!(
+            mint_before.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash)
+        );
+
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::TxSubmitted { .. }),
+            "restart confirm enqueue must not change state, got {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash),
+            "restart recovery must keep the same prepared hash"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "drive_one_step must only enqueue ConfirmMintJob, not prepare"
+        );
+
+        let confirm_jobs: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE job_type = ?
+              AND idempotency_key = ?
+            ",
+        )
+        .bind(job_type::<ConfirmMintJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&fixture.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            confirm_jobs, 1,
+            "restart must enqueue exactly one confirm job"
+        );
+    }
+
+    /// Post-submit identity without prepared bytes must never free-prepare:
+    /// leave MintingFailed, log ERROR for ops, and enqueue confirm poll only.
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_post_submit_without_prepared_fails_closed() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = post_submit_without_prepared_failed_events(
+            &issuer_request_id,
+            failed_at,
+        );
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            mint_before.pending_prepared_tx().is_none(),
+            "fixture is legacy TxSubmitted without prepared_tx"
+        );
+        assert!(
+            mint_before.has_unclassifiable_post_intent_identity(),
+            "fixture must be recognized as post-intent without prepared bytes"
+        );
+
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "must not RetryMint into free-prepare path, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "must never prepare_mint_tx for unclassifiable post-submit identity"
+        );
+
+        let confirm_jobs: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM Jobs
+            WHERE job_type = ?
+              AND idempotency_key = ?
+            ",
+        )
+        .bind(job_type::<ConfirmMintJob>())
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&fixture.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            confirm_jobs, 1,
+            "fail-closed path must still enqueue confirm poll for known tx_id"
+        );
+
+        // DEBUG, not ERROR: this step repeats on every recovery poll and the
+        // confirm poll above keeps re-observing, so the mint is not stuck
+        // awaiting an operator.
+        let test = "drive_one_step_post_submit_without_prepared_fails_closed";
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[test, "without prepared_tx", "never free-prepare"]
+        ));
+    }
+
+    /// MinedSuccess under wallet-guard recovery keeps the same prepared hash
+    /// and enqueues ConfirmMintJob (not submit) so ExistingMint can be recorded
+    /// without rebroadcasting a mined deposit.
+    #[tokio::test]
+    async fn drive_one_step_mined_success_keeps_same_prepared_hash() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let expected_hash = prepared.hash;
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_status(MintTxStatus::MinedSuccess),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "MinedSuccess must stay MintingFailed for confirm re-observe, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash),
+            "must not prepare a different hash after MinedSuccess classify"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "drive_one_step must not call prepare_mint_tx"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<ConfirmMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "MinedSuccess must enqueue ConfirmMintJob, not SubmitMintJob"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            0,
+            "must not enqueue submit after MinedSuccess"
+        );
+    }
+
+    /// MinedReverted allows RetryMint + SubmitMintJob (replacement after
+    /// terminal death), mirroring ProvablyDead.
+    #[tokio::test]
+    async fn drive_one_step_mined_reverted_allows_retry() {
+        let issuer_request_id = test_issuer_request_id();
+        let prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(
+            MockVaultService::new_success()
+                .with_mint_tx_status(MintTxStatus::MinedReverted),
+        );
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "MinedReverted must allow RetryMint, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            2,
+            "must classify then recheck under the wallet guard"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "MinedReverted replacement path must enqueue SubmitMintJob"
+        );
+    }
+
+    /// Post-submit MintingFailed with inventory receipt: RetryMint so
+    /// SubmitMintJob can record ExistingMint (never free-prepare a new deposit).
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_post_submit_with_inventory_receipt_retries() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = post_submit_without_prepared_failed_events(
+            &issuer_request_id,
+            failed_at,
+        );
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mut ctx = fixture.context();
+        ctx.receipts =
+            Arc::new(ReceiptLookupStub(ReceiptLookupBehavior::Present));
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&ctx, &mint_before, &issuer_request_id).await.unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::Minting { .. }),
+            "inventory-present post-submit must RetryMint into Minting, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "RetryMint must not prepare_mint_tx in recovery; SubmitMintJob records ExistingMint"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "inventory-present path must enqueue SubmitMintJob"
+        );
+
+        let test = "drive_one_step_post_submit_with_inventory_receipt_retries";
+        assert!(logs_contain_at!(
+            Level::INFO,
+            &[test, "has receipt", "RetryMint"]
+        ));
+    }
+
+    /// Inventory lookup Err on post-submit without prepared bytes: refuse
+    /// free-prepare, stay MintingFailed, still enqueue confirm poll.
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_post_submit_inventory_err_fails_closed() {
+        let issuer_request_id = test_issuer_request_id();
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = post_submit_without_prepared_failed_events(
+            &issuer_request_id,
+            failed_at,
+        );
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mut ctx = fixture.context();
+        ctx.receipts =
+            Arc::new(ReceiptLookupStub(ReceiptLookupBehavior::Fails));
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&ctx, &mint_before, &issuer_request_id).await.unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "inventory Err must not RetryMint free-prepare, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "must never prepare_mint_tx when inventory lookup fails"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<ConfirmMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            1,
+            "fail-closed path must still enqueue confirm poll for known tx_id"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            0,
+            "must not enqueue submit when inventory is unreadable"
+        );
+
+        let test = "drive_one_step_post_submit_inventory_err_fails_closed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Inventory lookup failed", "fail closed"]
+        ));
+    }
+
+    /// Corrupt prepared identity: recover_signer fails closed without RetryMint
+    /// or enqueue (cannot prove death without a valid envelope).
+    #[traced_test]
+    #[tokio::test]
+    async fn drive_one_step_recover_signer_failure_fails_closed() {
+        let issuer_request_id = test_issuer_request_id();
+        let mut prepared = PreparedMintTx::valid_for_test(
+            5,
+            format!("mint-{issuer_request_id}"),
+        );
+        // Invalidate hash so validate()/recover_signer fails before RPC.
+        prepared.hash = B256::ZERO;
+        let expected_hash = prepared.hash;
+        let failed_at = Utc::now() - chrono::Duration::minutes(2);
+        let events = tx_failed_with_prepared_events(
+            &issuer_request_id,
+            failed_at,
+            prepared,
+        );
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let fixture =
+            MintRecoveryFixture::new().await.with_vault(vault.clone());
+        fixture.seed_mint_events(&issuer_request_id, events).await;
+
+        let mint_before =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        drive_one_step(&fixture.context(), &mint_before, &issuer_request_id)
+            .await
+            .unwrap();
+
+        let mint =
+            fixture.mint_store.load(&issuer_request_id).await.unwrap().unwrap();
+        assert!(
+            matches!(mint, Mint::MintingFailed { .. }),
+            "recover_signer failure must leave MintingFailed, got: {}",
+            mint.state_name()
+        );
+        assert_eq!(
+            vault.mint_classification_call_count(),
+            0,
+            "must not classify when signer recovery fails"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "must not prepare on corrupt identity"
+        );
+        assert_eq!(
+            count_jobs_for_mint(
+                &fixture.pool,
+                job_type::<SubmitMintJob>(),
+                &issuer_request_id,
+            )
+            .await,
+            0,
+            "must not enqueue submit on corrupt prepared identity"
+        );
+        assert_eq!(
+            mint.pending_prepared_tx().map(|prepared| prepared.hash),
+            Some(expected_hash)
+        );
+
+        let test = "drive_one_step_recover_signer_failure_fails_closed";
+        assert!(logs_contain_at!(
+            Level::WARN,
+            &[test, "Cannot recover signer", "fail closed"]
+        ));
     }
 }

--- a/src/mint/view.rs
+++ b/src/mint/view.rs
@@ -159,6 +159,8 @@ pub(crate) enum MintView {
     Closed {
         issuer_request_id: IssuerMintRequestId,
         reason: String,
+        #[serde(default)]
+        acknowledged_unresolved_mint_tx_hash: Option<B256>,
         closed_at: DateTime<Utc>,
     },
 }
@@ -751,6 +753,7 @@ mod tests {
             &MintView::Closed {
                 issuer_request_id: closed_fields.issuer_request_id,
                 reason: "closed by admin".to_string(),
+                acknowledged_unresolved_mint_tx_hash: None,
                 closed_at: now,
             },
         )

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -9,12 +9,12 @@ use futures::{StreamExt, stream};
 use itertools::Itertools;
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{info, trace};
+use tracing::{error, info, trace, warn};
 
 use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand,
     ReceiptInventoryError, ReceiptSource, Shares, determine_source,
-    send_receipt_inventory_command,
+    load_inventory, send_receipt_inventory_command,
 };
 use crate::bindings::{OffchainAssetReceiptVault, Receipt};
 use crate::mint::IssuerMintRequestId;
@@ -101,6 +101,18 @@ pub(crate) enum BackfillError {
     Aggregate(#[from] AggregateError<ReceiptInventoryError>),
     #[error("Checkpoint error: {0}")]
     Checkpoint(#[from] CheckpointError),
+    /// Inventory could not be loaded while checking an ITN Deposit for
+    /// duplicate `issuer_request_id`. Fail closed before advancing the
+    /// backfill checkpoint so the same block range is retried once inventory
+    /// is readable again.
+    #[error(
+        "ITN inventory unreadable for issuer_request_id {issuer_request_id} \
+         (receipt_id {receipt_id}); refusing discovery and checkpoint advance"
+    )]
+    ItnInventoryUnreadable {
+        issuer_request_id: IssuerMintRequestId,
+        receipt_id: ReceiptId,
+    },
 }
 
 impl<ProviderType, Handler> ReceiptBackfiller<ProviderType, Handler>
@@ -483,6 +495,54 @@ where
             Some(discovery.receipt_information.clone())
         };
 
+        // Inventory is 1:1 on issuer_request_id for ITN mints. A second Deposit
+        // with a different receipt_id / tx_hash for the same request is an
+        // unrecoverable double-mint signal (operator: burn-excess / investigate).
+        // Do not apply DiscoverReceipt — that would insert the duplicate and
+        // overwrite `itn_receipts[issuer_request_id]`. Inventory load failure
+        // also fails closed (skip discovery) so we never invent a second index.
+        if let ReceiptSource::Itn { ref issuer_request_id } = source {
+            match self
+                .detect_duplicate_itn_deposit(
+                    issuer_request_id,
+                    discovery.receipt_id,
+                    discovery.tx_hash,
+                )
+                .await
+            {
+                ItnDepositCheck::Clear => {}
+                ItnDepositCheck::Conflict => {
+                    // The checkpoint advances past this block once the pass
+                    // completes and the range is never re-scanned, so the
+                    // duplicate must be recorded now or it survives only as
+                    // the log line above. `DiscoverReceipt` is still skipped:
+                    // the event records the observation, never tracked balance.
+                    send_receipt_inventory_command(
+                        &self.store,
+                        self.chain_id,
+                        &self.vault,
+                        ReceiptInventoryCommand::RecordConflictingItnDeposit {
+                            issuer_request_id: issuer_request_id.clone(),
+                            discovered_receipt_id: discovery.receipt_id,
+                            discovered_tx_hash: discovery.tx_hash,
+                            discovered_block_number: discovery.block_number,
+                        },
+                    )
+                    .await?;
+
+                    return Ok(ProcessOutcome::Processed);
+                }
+                ItnDepositCheck::Unreadable => {
+                    // Transient inventory failure: stop the pass so the
+                    // checkpoint is not advanced past this block range.
+                    return Err(BackfillError::ItnInventoryUnreadable {
+                        issuer_request_id: issuer_request_id.clone(),
+                        receipt_id: discovery.receipt_id,
+                    });
+                }
+            }
+        }
+
         send_receipt_inventory_command(
             &self.store,
             self.chain_id,
@@ -526,6 +586,63 @@ where
         Ok(ProcessOutcome::Processed)
     }
 
+    /// Check whether a second Deposit/receipt for an already-tracked ITN mint
+    /// id is being discovered. Inventory is 1:1 on `issuer_request_id`, so a
+    /// conflicting receipt id or tx hash is operator-actionable double-mint
+    /// evidence (use `issuer burn-excess` after proving the excess deposit).
+    ///
+    /// Inventory load failure is fail-closed (`Unreadable`): the caller must
+    /// not apply `DiscoverReceipt` without a successful conflict check.
+    async fn detect_duplicate_itn_deposit(
+        &self,
+        issuer_request_id: &IssuerMintRequestId,
+        discovered_receipt_id: ReceiptId,
+        discovered_tx_hash: TxHash,
+    ) -> ItnDepositCheck {
+        let inventory =
+            match load_inventory(&self.store, self.chain_id, &self.vault).await
+            {
+                Ok(inventory) => inventory,
+                Err(error) => {
+                    warn!(
+                        target: "receipt",
+                        issuer_request_id = %issuer_request_id,
+                        discovered_receipt_id = %discovered_receipt_id,
+                        discovered_tx_hash = %discovered_tx_hash,
+                        vault = %self.vault,
+                        chain_id = self.chain_id,
+                        error = %error,
+                        "Failed to load inventory for ITN duplicate-deposit \
+                         check; refusing discovery until inventory is readable"
+                    );
+                    return ItnDepositCheck::Unreadable;
+                }
+            };
+
+        let Some(tracked) = inventory.conflicting_itn_deposit(
+            issuer_request_id,
+            discovered_receipt_id,
+            discovered_tx_hash,
+        ) else {
+            return ItnDepositCheck::Clear;
+        };
+
+        error!(
+            target: "receipt",
+            issuer_request_id = %issuer_request_id,
+            tracked = %tracked,
+            existing_receipt_id = %tracked.receipt_id(),
+            discovered_receipt_id = %discovered_receipt_id,
+            discovered_tx_hash = %discovered_tx_hash,
+            vault = %self.vault,
+            chain_id = self.chain_id,
+            "Duplicate Deposit/receipt for already-tracked issuer_request_id; \
+             operator intervention required (do not mint again; consider burn-excess)"
+        );
+
+        ItnDepositCheck::Conflict
+    }
+
     /// Queries the on-chain balance of a receipt and reconciles the aggregate.
     async fn reconcile_receipt(
         &self,
@@ -558,6 +675,16 @@ where
 
         Ok(())
     }
+}
+
+/// Outcome of the ITN 1:1 deposit conflict check before applying discovery.
+enum ItnDepositCheck {
+    /// No prior ITN receipt, or same identity rediscovery.
+    Clear,
+    /// Second deposit conflicts with inventory — do not DiscoverReceipt.
+    Conflict,
+    /// Inventory could not be loaded — fail closed (do not DiscoverReceipt).
+    Unreadable,
 }
 
 struct FetchedLogs {

--- a/src/receipt_inventory/cmd.rs
+++ b/src/receipt_inventory/cmd.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use super::event::ReceiptSource;
 use super::{ReceiptId, Shares};
+use crate::mint::IssuerMintRequestId;
 use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 
@@ -57,5 +58,16 @@ pub(crate) enum ReceiptInventoryCommand {
         from: Address,
         to: Address,
         tx_hash: Option<TxHash>,
+    },
+    /// Record a second ITN `Deposit` observed for an already-tracked request.
+    ///
+    /// Records the observation only; it never applies the discovery, so the
+    /// 1:1 index is untouched. Idempotent on the duplicate's own identity so a
+    /// re-scanned block range records it once.
+    RecordConflictingItnDeposit {
+        issuer_request_id: IssuerMintRequestId,
+        discovered_receipt_id: ReceiptId,
+        discovered_tx_hash: TxHash,
+        discovered_block_number: u64,
     },
 }

--- a/src/receipt_inventory/event.rs
+++ b/src/receipt_inventory/event.rs
@@ -7,6 +7,44 @@ use crate::mint::IssuerMintRequestId;
 use crate::redemption::{BurnRecord, IssuerRedemptionRequestId};
 use crate::vault::ReceiptInformation;
 
+/// The ITN deposit inventory already tracks for an issuer request.
+///
+/// Inventory is 1:1 on `issuer_request_id`, held as an index into receipt
+/// metadata. Both variants are a tracked identity: an index entry whose
+/// metadata is missing still names the receipt, which is enough to refuse a
+/// second deposit. Reading that case as "nothing tracked" is the one way the
+/// duplicate-deposit gate could fail open.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub(crate) enum TrackedItnDeposit {
+    /// The tracked receipt and the deposit transaction that created it.
+    Receipt { receipt_id: ReceiptId, tx_hash: TxHash },
+    /// The index maps the request to this receipt, but inventory holds no
+    /// metadata for it.
+    IndexOnly { receipt_id: ReceiptId },
+}
+
+impl TrackedItnDeposit {
+    pub(crate) const fn receipt_id(&self) -> ReceiptId {
+        match self {
+            Self::Receipt { receipt_id, .. }
+            | Self::IndexOnly { receipt_id } => *receipt_id,
+        }
+    }
+}
+
+impl std::fmt::Display for TrackedItnDeposit {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Receipt { receipt_id, tx_hash } => {
+                write!(formatter, "receipt {receipt_id} (tx {tx_hash})")
+            }
+            Self::IndexOnly { receipt_id } => {
+                write!(formatter, "receipt {receipt_id} (metadata missing)")
+            }
+        }
+    }
+}
+
 /// Identifies how a receipt was created.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub(crate) enum ReceiptSource {
@@ -83,6 +121,23 @@ pub(crate) enum ReceiptInventoryEvent {
         to: Address,
         tx_hash: Option<TxHash>,
     },
+    /// A second ITN `Deposit` was observed for a request inventory already
+    /// tracks — an excess mint that must be burned, never re-minted.
+    ///
+    /// Recorded rather than only logged because backfill advances its
+    /// checkpoint past the block afterwards and never re-scans it: without an
+    /// event the duplicate survives only as one log line, and remediation
+    /// (`issuer burn-excess`) needs both identities. This event records the
+    /// observation only — `Discovered` is deliberately NOT emitted for the
+    /// duplicate, so inventory stays 1:1 and the second deposit never becomes
+    /// spendable receipt balance.
+    ConflictingItnDepositObserved {
+        issuer_request_id: IssuerMintRequestId,
+        tracked: TrackedItnDeposit,
+        discovered_receipt_id: ReceiptId,
+        discovered_tx_hash: TxHash,
+        discovered_block_number: u64,
+    },
 }
 
 impl DomainEvent for ReceiptInventoryEvent {
@@ -111,6 +166,10 @@ impl DomainEvent for ReceiptInventoryEvent {
             }
             Self::CustodyMigrated { .. } => {
                 "ReceiptInventoryEvent::CustodyMigrated".to_string()
+            }
+            Self::ConflictingItnDepositObserved { .. } => {
+                "ReceiptInventoryEvent::ConflictingItnDepositObserved"
+                    .to_string()
             }
         }
     }

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -13,7 +13,7 @@ use cqrs_es::AggregateError;
 use event_sorcery::{EventSourced, LifecycleError, Nil, SendError, Store};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::future::Future;
 use std::sync::Arc;
 use thiserror::Error;
@@ -30,7 +30,9 @@ pub(crate) use burn_tracking::{
     BurnPlan, BurnTrackingError, ReceiptWithBalance,
 };
 pub(crate) use cmd::ReceiptInventoryCommand;
-pub(crate) use event::{ReceiptInventoryEvent, ReceiptSource};
+pub(crate) use event::{
+    ReceiptInventoryEvent, ReceiptSource, TrackedItnDeposit,
+};
 use reconcile::ReconcileError;
 pub(crate) use vault_key::ReceiptVaultKey;
 
@@ -360,6 +362,9 @@ const fn receipt_inventory_operation(
         ReceiptInventoryCommand::RecordCustodyMigration { .. } => {
             "record_custody_migration"
         }
+        ReceiptInventoryCommand::RecordConflictingItnDeposit { .. } => {
+            "record_conflicting_itn_deposit"
+        }
     }
 }
 
@@ -644,6 +649,11 @@ pub(crate) struct ReceiptInventory {
     /// original one.
     #[serde(default)]
     migrations_recorded: u32,
+    /// Duplicate ITN deposits already recorded, keyed by the duplicate's own
+    /// `(receipt_id, tx_hash)`. These are observations, never tracked balance:
+    /// nothing here is spendable, reservable, or burnable by the bot.
+    #[serde(default)]
+    conflicting_itn_deposits: HashSet<(ReceiptId, TxHash)>,
 }
 
 /// Which wallet holds this vault's receipts.
@@ -756,6 +766,52 @@ impl ReceiptInventory {
         issuer_request_id: &IssuerMintRequestId,
     ) -> Option<ReceiptId> {
         self.itn_receipts.get(issuer_request_id).copied()
+    }
+
+    /// When inventory already tracks an ITN mint id, returns the tracked
+    /// deposit if the discovered deposit conflicts (different receipt or
+    /// different tx). Same-identity rediscovery returns `None`.
+    ///
+    /// An index entry whose receipt metadata is missing returns
+    /// [`TrackedItnDeposit::IndexOnly`], which carries no transaction hash: a
+    /// dangling index is a conflict, not a clear. Reading it as "nothing
+    /// tracked" is the one way this gate could fail open.
+    pub(crate) fn conflicting_itn_deposit(
+        &self,
+        issuer_request_id: &IssuerMintRequestId,
+        discovered_receipt_id: ReceiptId,
+        discovered_tx_hash: TxHash,
+    ) -> Option<TrackedItnDeposit> {
+        let existing_receipt_id =
+            self.itn_receipts.get(issuer_request_id).copied()?;
+        // Rediscovering the tracked receipt is the repair for a dangling index,
+        // not a conflict. It re-inserts the same identity, so the overwrite the
+        // gate below guards against cannot happen. Refusing it instead would
+        // strand the metadata row (nothing else re-inserts it) and record the
+        // real mint as its own excess deposit.
+        if existing_receipt_id == discovered_receipt_id
+            && self
+                .receipts
+                .get(&existing_receipt_id)
+                .is_none_or(|existing| existing.tx_hash == discovered_tx_hash)
+        {
+            return None;
+        }
+        // A dangling index entry is an inconsistency, not an absence. The
+        // tracked identity is still known, which is enough to refuse the second
+        // deposit; reading it as "nothing tracked" would let `apply_event`
+        // overwrite the index with the duplicate — the exact overwrite this
+        // gate exists to prevent.
+        let Some(existing) = self.receipts.get(&existing_receipt_id) else {
+            return Some(TrackedItnDeposit::IndexOnly {
+                receipt_id: existing_receipt_id,
+            });
+        };
+
+        Some(TrackedItnDeposit::Receipt {
+            receipt_id: existing_receipt_id,
+            tx_hash: existing.tx_hash,
+        })
     }
 
     /// Whether the given redemption holds a reservation on any receipt.
@@ -903,6 +959,23 @@ pub(crate) enum ReceiptInventoryError {
          from a wallet rotation. Run `issuer confirm-custody` first."
     )]
     CustodyUnconfirmed { receipt_id: ReceiptId, observed_wallet: Address },
+    #[error(transparent)]
+    DuplicateItnDeposit(Box<DuplicateItnDepositConflict>),
+}
+
+/// Payload for [`ReceiptInventoryError::DuplicateItnDeposit`], boxed so the
+/// error enum stays small for `Result` returns (clippy `result_large_err`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, thiserror::Error)]
+#[error(
+    "Refusing DiscoverReceipt for issuer_request_id {issuer_request_id}: \
+     inventory already tracks {tracked}; discovered conflicting receipt \
+     {discovered_receipt_id} (tx {discovered_tx_hash})"
+)]
+pub(crate) struct DuplicateItnDepositConflict {
+    pub(crate) issuer_request_id: IssuerMintRequestId,
+    pub(crate) tracked: TrackedItnDeposit,
+    pub(crate) discovered_receipt_id: ReceiptId,
+    pub(crate) discovered_tx_hash: TxHash,
 }
 
 impl ReceiptInventory {
@@ -920,6 +993,26 @@ impl ReceiptInventory {
                 receipt_info,
                 receipt_info_bytes,
             } => {
+                // Inventory is 1:1 on issuer_request_id for ITN mints. A second
+                // Deposit with a different receipt_id / tx_hash for the same
+                // request must not overwrite `itn_receipts` (fail closed).
+                if let ReceiptSource::Itn { ref issuer_request_id } = source
+                    && let Some(tracked) = self.conflicting_itn_deposit(
+                        issuer_request_id,
+                        receipt_id,
+                        tx_hash,
+                    )
+                {
+                    return Err(ReceiptInventoryError::DuplicateItnDeposit(
+                        Box::new(DuplicateItnDepositConflict {
+                            issuer_request_id: issuer_request_id.clone(),
+                            tracked,
+                            discovered_receipt_id: receipt_id,
+                            discovered_tx_hash: tx_hash,
+                        }),
+                    ));
+                }
+
                 if self.receipts.contains_key(&receipt_id) {
                     return Ok(vec![]);
                 }
@@ -1122,6 +1215,42 @@ impl ReceiptInventory {
                     tx_hash,
                 }])
             }
+
+            ReceiptInventoryCommand::RecordConflictingItnDeposit {
+                issuer_request_id,
+                discovered_receipt_id,
+                discovered_tx_hash,
+                discovered_block_number,
+            } => {
+                // Only a real conflict is recordable. A caller that re-checks
+                // after the tracked receipt was reconciled away must not turn
+                // an ordinary discovery into a permanent duplicate claim.
+                let Some(tracked) = self.conflicting_itn_deposit(
+                    &issuer_request_id,
+                    discovered_receipt_id,
+                    discovered_tx_hash,
+                ) else {
+                    return Ok(vec![]);
+                };
+
+                // Backfill re-scans the same range after a restart before the
+                // checkpoint advances, so the same duplicate arrives more than
+                // once. Key on the duplicate's own identity.
+                if self
+                    .conflicting_itn_deposits
+                    .contains(&(discovered_receipt_id, discovered_tx_hash))
+                {
+                    return Ok(vec![]);
+                }
+
+                Ok(vec![ReceiptInventoryEvent::ConflictingItnDepositObserved {
+                    issuer_request_id,
+                    tracked,
+                    discovered_receipt_id,
+                    discovered_tx_hash,
+                    discovered_block_number,
+                }])
+            }
         }
     }
 
@@ -1286,6 +1415,16 @@ impl ReceiptInventory {
                     Custody::Held { holder: to, moved_from: Some(from) };
                 self.migrations_recorded =
                     self.migrations_recorded.saturating_add(1);
+            }
+            ReceiptInventoryEvent::ConflictingItnDepositObserved {
+                discovered_receipt_id,
+                discovered_tx_hash,
+                ..
+            } => {
+                // Recorded only. The duplicate never becomes tracked balance,
+                // so neither `receipts` nor `itn_receipts` may change here.
+                self.conflicting_itn_deposits
+                    .insert((discovered_receipt_id, discovered_tx_hash));
             }
         }
     }
@@ -1700,6 +1839,247 @@ mod tests {
         assert!(
             inventory.receipts_with_balance().is_empty(),
             "an empty ReserveBurn must leave the inventory empty"
+        );
+    }
+
+    #[tokio::test]
+    async fn conflicting_itn_deposit_detects_second_receipt_for_same_request() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let first_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let second_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+        let first_receipt = make_receipt_id(1);
+        let second_receipt = make_receipt_id(2);
+
+        let mut inventory = ReceiptInventory::default();
+        drive(
+            &mut inventory,
+            discover_itn_receipt_cmd(
+                first_receipt,
+                make_shares(100),
+                1,
+                first_hash,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await;
+
+        assert_eq!(
+            inventory.conflicting_itn_deposit(
+                &issuer_request_id,
+                first_receipt,
+                first_hash,
+            ),
+            None,
+            "same identity rediscovery is not a conflict"
+        );
+        assert_eq!(
+            inventory.conflicting_itn_deposit(
+                &issuer_request_id,
+                second_receipt,
+                second_hash,
+            ),
+            Some(TrackedItnDeposit::Receipt {
+                receipt_id: first_receipt,
+                tx_hash: first_hash
+            }),
+            "a second receipt for the same issuer_request_id is a conflict"
+        );
+        assert_eq!(
+            inventory.conflicting_itn_deposit(
+                &issuer_request_id,
+                first_receipt,
+                second_hash,
+            ),
+            Some(TrackedItnDeposit::Receipt {
+                receipt_id: first_receipt,
+                tx_hash: first_hash
+            }),
+            "same receipt id with a different tx hash is also a conflict"
+        );
+    }
+
+    /// `DiscoverReceipt` must fail closed when a second ITN deposit conflicts
+    /// with an already-tracked issuer_request_id (different receipt id).
+    #[tokio::test]
+    async fn discover_receipt_rejects_conflicting_itn_deposit() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let first_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let second_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+        let first_receipt = make_receipt_id(1);
+        let second_receipt = make_receipt_id(2);
+
+        let mut inventory = ReceiptInventory::default();
+        drive(
+            &mut inventory,
+            discover_itn_receipt_cmd(
+                first_receipt,
+                make_shares(100),
+                1,
+                first_hash,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await;
+
+        let result = inventory.handle_command(discover_itn_receipt_cmd(
+            second_receipt,
+            make_shares(100),
+            2,
+            second_hash,
+            issuer_request_id.clone(),
+        ));
+
+        match result {
+            Err(ReceiptInventoryError::DuplicateItnDeposit(conflict)) => {
+                assert_eq!(conflict.issuer_request_id, issuer_request_id);
+                assert_eq!(
+                    conflict.tracked,
+                    TrackedItnDeposit::Receipt {
+                        receipt_id: first_receipt,
+                        tx_hash: first_hash
+                    }
+                );
+                assert_eq!(conflict.discovered_receipt_id, second_receipt);
+                assert_eq!(conflict.discovered_tx_hash, second_hash);
+            }
+            other => panic!(
+                "conflicting ITN DiscoverReceipt must be rejected, got: {other:?}"
+            ),
+        }
+        assert_eq!(
+            inventory.find_by_issuer_request_id(&issuer_request_id),
+            Some(first_receipt),
+            "rejected DiscoverReceipt must not overwrite itn_receipts"
+        );
+    }
+
+    /// The 1:1 index outliving its metadata row is the one shape that could
+    /// make the duplicate gate fail open: `None` would read as "nothing
+    /// tracked" and let the second deposit overwrite the index.
+    #[tokio::test]
+    async fn conflicting_itn_deposit_refuses_on_a_dangling_index_entry() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let tracked_receipt = make_receipt_id(1);
+        let tracked_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let discovered_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+
+        let mut inventory = ReceiptInventory::default();
+        drive(
+            &mut inventory,
+            discover_itn_receipt_cmd(
+                tracked_receipt,
+                make_shares(100),
+                1,
+                tracked_hash,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await;
+        inventory.receipts.remove(&tracked_receipt);
+
+        assert_eq!(
+            inventory.conflicting_itn_deposit(
+                &issuer_request_id,
+                make_receipt_id(2),
+                discovered_hash,
+            ),
+            Some(TrackedItnDeposit::IndexOnly { receipt_id: tracked_receipt }),
+            "a dangling index entry is a conflict, not a clear"
+        );
+
+        assert_eq!(
+            inventory.conflicting_itn_deposit(
+                &issuer_request_id,
+                tracked_receipt,
+                tracked_hash,
+            ),
+            None,
+            "rediscovering the tracked receipt repairs the dangling index; \
+             calling it a conflict would strand the metadata row and record \
+             the real mint as its own excess deposit"
+        );
+    }
+
+    /// Backfill checkpoints past the conflicting block and never re-scans it,
+    /// so the duplicate has to survive as an event rather than a log line.
+    #[tokio::test]
+    async fn recording_a_conflicting_itn_deposit_is_durable_and_idempotent() {
+        let issuer_request_id = IssuerMintRequestId::random();
+        let tracked_receipt = make_receipt_id(1);
+        let duplicate_receipt = make_receipt_id(2);
+        let tracked_hash = b256!(
+            "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        );
+        let duplicate_hash = b256!(
+            "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        );
+
+        let mut inventory = ReceiptInventory::default();
+        drive(
+            &mut inventory,
+            discover_itn_receipt_cmd(
+                tracked_receipt,
+                make_shares(100),
+                1,
+                tracked_hash,
+                issuer_request_id.clone(),
+            ),
+        )
+        .await;
+
+        let record = ReceiptInventoryCommand::RecordConflictingItnDeposit {
+            issuer_request_id: issuer_request_id.clone(),
+            discovered_receipt_id: duplicate_receipt,
+            discovered_tx_hash: duplicate_hash,
+            discovered_block_number: 4242,
+        };
+        let events = drive(&mut inventory, record.clone()).await;
+        assert!(
+            matches!(
+                events.as_slice(),
+                [ReceiptInventoryEvent::ConflictingItnDepositObserved {
+                    tracked,
+                    discovered_receipt_id,
+                    discovered_tx_hash,
+                    discovered_block_number: 4242,
+                    ..
+                }] if *tracked == TrackedItnDeposit::Receipt {
+                    receipt_id: tracked_receipt,
+                    tx_hash: tracked_hash,
+                } && *discovered_receipt_id == duplicate_receipt
+                    && *discovered_tx_hash == duplicate_hash
+            ),
+            "both identities must be recorded, got: {events:?}"
+        );
+
+        // A re-scan of the same range before the checkpoint advanced must not
+        // grow the log a pass at a time.
+        assert!(
+            drive(&mut inventory, record).await.is_empty(),
+            "re-observing the same duplicate must be a no-op"
+        );
+
+        // The duplicate is evidence, never spendable balance.
+        assert_eq!(
+            inventory.find_by_issuer_request_id(&issuer_request_id),
+            Some(tracked_receipt),
+            "recording a conflict must not touch the 1:1 index"
+        );
+        assert!(
+            !inventory.receipts.contains_key(&duplicate_receipt),
+            "recording a conflict must not add tracked balance"
         );
     }
 

--- a/src/vault/mock.rs
+++ b/src/vault/mock.rs
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::sync::Notify;
 
 use super::{
-    BurnTxStatus, BurnVerification, MintResult, MultiBurnParams,
+    BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnParams,
     MultiBurnResult, MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
     SubmittedTx, VaultError, VaultService, WalletNonceGuard,
 };
@@ -116,6 +116,13 @@ enum MockBurnTxClassification {
 }
 
 #[cfg(test)]
+#[derive(Clone, Copy)]
+enum MockMintTxClassification {
+    Status(MintTxStatus),
+    RpcError,
+}
+
+#[cfg(test)]
 impl Default for MockVerifyBurn {
     fn default() -> Self {
         Self::Verified {
@@ -167,13 +174,29 @@ pub(crate) struct MockVaultService {
     #[cfg(test)]
     burn_tx_status: Arc<Mutex<MockBurnTxClassification>>,
     #[cfg(test)]
+    mint_tx_status: Arc<Mutex<MockMintTxClassification>>,
+    /// Optional per-call mint classification outcomes (FIFO). When non-empty,
+    /// each `classify_mint_tx` pops the next entry; otherwise
+    /// [`Self::mint_tx_status`] is used. Enables TOCTOU recheck tests.
+    #[cfg(test)]
+    mint_tx_status_sequence: Arc<Mutex<Vec<MockMintTxClassification>>>,
+    #[cfg(test)]
     submitted_burn_txs: Arc<Mutex<Vec<SendableTxWithHash>>>,
     #[cfg(test)]
     burn_classification_call_count: Arc<AtomicUsize>,
     #[cfg(test)]
+    mint_classification_call_count: Arc<AtomicUsize>,
+    #[cfg(test)]
     burn_preparation_call_count: Arc<AtomicUsize>,
     #[cfg(test)]
     replacement_preparation_call_count: Arc<AtomicUsize>,
+    /// Optional sequence of confirm_mint outcomes; when non-empty, each call
+    /// pops the next entry instead of using [`MockBehavior`].
+    #[cfg(test)]
+    confirm_mint_outcomes: Arc<Mutex<Vec<Result<MintResult, VaultError>>>>,
+    /// Optional forced `submit_mint` error (e.g. uncertain broadcast).
+    #[cfg(test)]
+    submit_mint_error: Arc<Mutex<Option<VaultError>>>,
 }
 
 impl MockVaultService {
@@ -210,107 +233,47 @@ impl MockVaultService {
                 MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
             )),
             #[cfg(test)]
+            mint_tx_status: Arc::new(Mutex::new(
+                MockMintTxClassification::Status(MintTxStatus::StillMineable),
+            )),
+            #[cfg(test)]
+            mint_tx_status_sequence: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(test)]
             submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
             #[cfg(test)]
             burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
             #[cfg(test)]
+            mint_classification_call_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
             burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
             #[cfg(test)]
             replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
+            #[cfg(test)]
+            confirm_mint_outcomes: Arc::new(Mutex::new(Vec::new())),
+            #[cfg(test)]
+            submit_mint_error: Arc::new(Mutex::new(None)),
         }
     }
 
     #[cfg(test)]
     pub(crate) fn new_failure() -> Self {
-        Self {
-            behavior: MockBehavior::Failure,
-            mint_delay_ms: 0,
-            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
-            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
-            call_count: Arc::new(AtomicUsize::new(0)),
-            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            pending_mint_result: Arc::new(Mutex::new(None)),
-            pending_burn_result: Arc::new(Mutex::new(None)),
-            last_call: Arc::new(Mutex::new(None)),
-            share_balance: Arc::new(Mutex::new(U256::MAX)),
-            last_multi_burn_params: Arc::new(Mutex::new(None)),
-            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
-            #[cfg(test)]
-            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_outcome: Arc::new(Mutex::new(
-                MockCheckTxOutcome::default(),
-            )),
-            burn_tx_status: Arc::new(Mutex::new(
-                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
-            )),
-            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
-            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
-            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-        }
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::Failure;
+        service
     }
 
     #[cfg(test)]
     pub(crate) fn new_submit_failure() -> Self {
-        Self {
-            behavior: MockBehavior::SubmitFailure,
-            mint_delay_ms: 0,
-            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
-            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
-            call_count: Arc::new(AtomicUsize::new(0)),
-            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            pending_mint_result: Arc::new(Mutex::new(None)),
-            pending_burn_result: Arc::new(Mutex::new(None)),
-            last_call: Arc::new(Mutex::new(None)),
-            share_balance: Arc::new(Mutex::new(U256::MAX)),
-            last_multi_burn_params: Arc::new(Mutex::new(None)),
-            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
-            #[cfg(test)]
-            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_outcome: Arc::new(Mutex::new(
-                MockCheckTxOutcome::default(),
-            )),
-            burn_tx_status: Arc::new(Mutex::new(
-                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
-            )),
-            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
-            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
-            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-        }
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::SubmitFailure;
+        service
     }
 
     #[cfg(test)]
     pub(crate) fn new_confirm_revert() -> Self {
-        Self {
-            behavior: MockBehavior::ConfirmRevert,
-            mint_delay_ms: 0,
-            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
-            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
-            call_count: Arc::new(AtomicUsize::new(0)),
-            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            pending_mint_result: Arc::new(Mutex::new(None)),
-            pending_burn_result: Arc::new(Mutex::new(None)),
-            last_call: Arc::new(Mutex::new(None)),
-            share_balance: Arc::new(Mutex::new(U256::MAX)),
-            last_multi_burn_params: Arc::new(Mutex::new(None)),
-            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
-            #[cfg(test)]
-            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_outcome: Arc::new(Mutex::new(
-                MockCheckTxOutcome::default(),
-            )),
-            burn_tx_status: Arc::new(Mutex::new(
-                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
-            )),
-            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
-            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
-            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-        }
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::ConfirmRevert;
+        service
     }
 
     #[cfg(test)]
@@ -380,64 +343,16 @@ impl MockVaultService {
 
     #[cfg(test)]
     pub(crate) fn new_submit_revert() -> Self {
-        Self {
-            behavior: MockBehavior::SubmitRevert,
-            mint_delay_ms: 0,
-            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
-            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
-            call_count: Arc::new(AtomicUsize::new(0)),
-            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            pending_mint_result: Arc::new(Mutex::new(None)),
-            pending_burn_result: Arc::new(Mutex::new(None)),
-            last_call: Arc::new(Mutex::new(None)),
-            share_balance: Arc::new(Mutex::new(U256::MAX)),
-            last_multi_burn_params: Arc::new(Mutex::new(None)),
-            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
-            #[cfg(test)]
-            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_outcome: Arc::new(Mutex::new(
-                MockCheckTxOutcome::default(),
-            )),
-            burn_tx_status: Arc::new(Mutex::new(
-                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
-            )),
-            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
-            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
-            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-        }
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::SubmitRevert;
+        service
     }
 
     #[cfg(test)]
     pub(crate) fn new_prepare_tx_failure() -> Self {
-        Self {
-            behavior: MockBehavior::PrepareTxFails,
-            mint_delay_ms: 0,
-            wallet_nonce_lock: Arc::new(tokio::sync::Mutex::new(())),
-            wallet_lock_call_count: Arc::new(AtomicUsize::new(0)),
-            call_count: Arc::new(AtomicUsize::new(0)),
-            multi_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            pending_mint_result: Arc::new(Mutex::new(None)),
-            pending_burn_result: Arc::new(Mutex::new(None)),
-            last_call: Arc::new(Mutex::new(None)),
-            share_balance: Arc::new(Mutex::new(U256::MAX)),
-            last_multi_burn_params: Arc::new(Mutex::new(None)),
-            verify_burn: Arc::new(Mutex::new(MockVerifyBurn::default())),
-            #[cfg(test)]
-            verify_burn_call_count: Arc::new(AtomicUsize::new(0)),
-            prepared_tx: Arc::new(Mutex::new(None)),
-            checked_tx_outcome: Arc::new(Mutex::new(
-                MockCheckTxOutcome::default(),
-            )),
-            burn_tx_status: Arc::new(Mutex::new(
-                MockBurnTxClassification::Status(BurnTxStatus::StillMineable),
-            )),
-            submitted_burn_txs: Arc::new(Mutex::new(Vec::new())),
-            burn_classification_call_count: Arc::new(AtomicUsize::new(0)),
-            burn_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-            replacement_preparation_call_count: Arc::new(AtomicUsize::new(0)),
-        }
+        let mut service = Self::new_success();
+        service.behavior = MockBehavior::PrepareTxFails;
+        service
     }
 
     #[cfg(test)]
@@ -510,8 +425,14 @@ impl MockVaultService {
         self.submitted_burn_txs.lock().unwrap().clear();
         self.verify_burn_call_count.store(0, Ordering::Relaxed);
         self.burn_classification_call_count.store(0, Ordering::Relaxed);
+        self.mint_classification_call_count.store(0, Ordering::Relaxed);
         self.burn_preparation_call_count.store(0, Ordering::Relaxed);
         self.replacement_preparation_call_count.store(0, Ordering::Relaxed);
+        *self.mint_tx_status.lock().unwrap() =
+            MockMintTxClassification::Status(MintTxStatus::StillMineable);
+        self.mint_tx_status_sequence.lock().unwrap().clear();
+        self.confirm_mint_outcomes.lock().unwrap().clear();
+        *self.submit_mint_error.lock().unwrap() = None;
     }
 
     #[cfg(test)]
@@ -663,6 +584,53 @@ impl MockVaultService {
     }
 
     #[cfg(test)]
+    pub(crate) fn with_mint_tx_status(self, status: MintTxStatus) -> Self {
+        *self.mint_tx_status.lock().unwrap() =
+            MockMintTxClassification::Status(status);
+        self
+    }
+
+    /// FIFO classification outcomes for successive `classify_mint_tx` calls.
+    #[cfg(test)]
+    pub(crate) fn with_mint_tx_status_sequence(
+        self,
+        statuses: Vec<MintTxStatus>,
+    ) -> Self {
+        *self.mint_tx_status_sequence.lock().unwrap() = statuses
+            .into_iter()
+            .map(MockMintTxClassification::Status)
+            .collect();
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_mint_tx_classification_failure(self) -> Self {
+        *self.mint_tx_status.lock().unwrap() =
+            MockMintTxClassification::RpcError;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_confirm_mint_outcomes(
+        self,
+        outcomes: Vec<Result<MintResult, VaultError>>,
+    ) -> Self {
+        *self.confirm_mint_outcomes.lock().unwrap() = outcomes;
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn with_submit_mint_error(self, error: VaultError) -> Self {
+        *self.submit_mint_error.lock().unwrap() = Some(error);
+        self
+    }
+
+    #[cfg(test)]
+    pub(crate) fn mint_classification_call_count(&self) -> usize {
+        self.mint_classification_call_count.load(Ordering::Relaxed)
+    }
+
+    #[cfg(test)]
     pub(crate) fn set_prepared_tx(&self, sendable_tx: SendableTxWithHash) {
         *self.prepared_tx.lock().unwrap() = Some(sendable_tx);
     }
@@ -784,6 +752,14 @@ impl VaultService for MockVaultService {
         prepared_tx: &PreparedMintTx,
     ) -> Result<SubmittedTx, VaultError> {
         #[cfg(test)]
+        {
+            let forced_error = self.submit_mint_error.lock().unwrap().take();
+            if let Some(error) = forced_error {
+                return Err(error);
+            }
+        }
+
+        #[cfg(test)]
         if matches!(self.behavior, MockBehavior::SubmitFailure) {
             return Err(VaultError::InvalidReceipt);
         }
@@ -796,10 +772,22 @@ impl VaultService for MockVaultService {
 
     async fn confirm_mint(
         &self,
-        _tx_id: &TxId,
+        tx_id: &TxId,
     ) -> Result<MintResult, VaultError> {
+        #[cfg(test)]
+        {
+            let mut outcomes = self
+                .confirm_mint_outcomes
+                .lock()
+                .expect("confirm_mint_outcomes mutex poisoned");
+            if !outcomes.is_empty() {
+                return outcomes.remove(0);
+            }
+        }
+
         match &self.behavior {
             MockBehavior::Success => {
+                let _ = tx_id;
                 let result = self
                     .pending_mint_result
                     .lock()
@@ -838,13 +826,57 @@ impl VaultService for MockVaultService {
                 Ok(result)
             }
             #[cfg(test)]
-            MockBehavior::ConfirmRevert
-            | MockBehavior::ConfirmPending
-            | MockBehavior::WalletLockBlocked { .. }
-            | MockBehavior::ConfirmPendingBlocked { .. }
+            MockBehavior::ConfirmRevert => {
+                Err(VaultError::Reverted { tx_hash: MOCK_MINT_TX_HASH })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPending => {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::ConfirmPendingBlocked { started, release } => {
+                started.notify_one();
+                release.notified().await;
+                Err(VaultError::ConfirmationPending {
+                    tx_id: tx_id.clone(),
+                    message: "receipt polling timed out".to_string(),
+                })
+            }
+            #[cfg(test)]
+            MockBehavior::WalletLockBlocked { .. }
             | MockBehavior::SubmitRevert
             | MockBehavior::PrepareTxFails => Err(VaultError::InvalidReceipt),
         }
+    }
+
+    async fn classify_mint_tx(
+        &self,
+        _owner: Address,
+        _prepared_tx: &PreparedMintTx,
+    ) -> Result<MintTxStatus, VaultError> {
+        #[cfg(test)]
+        {
+            self.mint_classification_call_count.fetch_add(1, Ordering::Relaxed);
+            // One lock at a time: holding the sequence guard while taking the
+            // fallback guard is a nesting a future helper could invert.
+            let queued = {
+                let mut sequence = self.mint_tx_status_sequence.lock().unwrap();
+                (!sequence.is_empty()).then(|| sequence.remove(0))
+            };
+            let classification =
+                queued.unwrap_or_else(|| *self.mint_tx_status.lock().unwrap());
+            return match classification {
+                MockMintTxClassification::Status(status) => Ok(status),
+                MockMintTxClassification::RpcError => {
+                    Err(VaultError::InvalidReceipt)
+                }
+            };
+        }
+        #[cfg(not(test))]
+        Ok(MintTxStatus::StillMineable)
     }
 
     async fn get_share_balance(

--- a/src/vault/mod.rs
+++ b/src/vault/mod.rs
@@ -6,9 +6,9 @@ use alloy::eips::Decodable2718;
 #[cfg(test)]
 use alloy::eips::Encodable2718;
 use alloy::hex::decode;
-use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
 #[cfg(test)]
-use alloy::primitives::{Signature, TxKind};
+use alloy::primitives::TxKind;
+use alloy::primitives::{Address, B256, Bytes, FixedBytes, U256};
 use alloy::providers::SendableTxErr;
 use alloy::rpc::types::{TransactionReceipt, TransactionRequest};
 #[cfg(test)]
@@ -47,8 +47,11 @@ pub(crate) trait VaultService: Send + Sync {
     /// The returned bytes and hash must be persisted before calling
     /// [`VaultService::submit_mint`].
     ///
-    /// Uses a deterministic `external_tx_id` so that resubmitting the same mint
-    /// after a crash triggers transaction duplicate rejection instead of a double-mint.
+    /// `external_tx_id` is a signing-backend correlation id (Fireblocks
+    /// idempotency / Turnkey labeling). It is **not** vault-direct double-mint
+    /// protection — after the first `MintTxIntended`, only exact-hash
+    /// classification / rebroadcast of the persisted prepared bytes (or
+    /// inventory) is safe.
     async fn prepare_mint_tx(
         &self,
         vault: Address,
@@ -69,8 +72,11 @@ pub(crate) trait VaultService: Send + Sync {
 
     /// Confirms a previously submitted mint transaction.
     ///
-    /// Polls the signing backend until the transaction reaches a terminal state,
-    /// then fetches the on-chain receipt and parses the Deposit event.
+    /// Bounded-polls `eth_getTransactionReceipt` as `Option` (never uses
+    /// `PendingTransactionBuilder::get_receipt` as the terminal classifier).
+    /// Terminal outcomes: mined success with a `Deposit` log, mined revert
+    /// (`status=0`), or [`VaultError::ConfirmationPending`] when the poll
+    /// budget is exhausted with no receipt. Provider uncertainty fails closed.
     ///
     /// # Arguments
     ///
@@ -79,6 +85,20 @@ pub(crate) trait VaultService: Send + Sync {
         &self,
         tx_id: &TxId,
     ) -> Result<MintResult, VaultError>;
+
+    /// Classifies whether a persisted signed mint transaction can still land.
+    ///
+    /// Implementations must check the exact hash receipt before comparing the
+    /// owner's finalized nonce. Any provider uncertainty returns an error so
+    /// callers fail closed and keep the persisted transaction live. `Uncertain`
+    /// is expressed as `Err`, never as a success variant.
+    async fn classify_mint_tx(
+        &self,
+        _owner: Address,
+        _prepared_tx: &PreparedMintTx,
+    ) -> Result<MintTxStatus, VaultError> {
+        Ok(MintTxStatus::StillMineable)
+    }
 
     /// Gets the ERC-20 share balance for an address.
     ///
@@ -193,6 +213,19 @@ pub(crate) type WalletNonceGuard = Option<tokio::sync::OwnedMutexGuard<()>>;
 pub(crate) enum BurnTxStatus {
     Mined,
     Reverted,
+    StillMineable,
+    ProvablyDead,
+}
+
+/// Observation of a persisted signed vault-direct mint transaction.
+///
+/// Parallel to [`BurnTxStatus`]. Provider/identity uncertainty is **not** a
+/// variant — callers receive `Err` and must fail closed (no `MintingFailed`, no
+/// replacement).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum MintTxStatus {
+    MinedSuccess,
+    MinedReverted,
     StillMineable,
     ProvablyDead,
 }
@@ -312,7 +345,7 @@ pub(crate) struct PreparedMintTx {
 impl PreparedMintTx {
     /// Verifies that the redundant persisted identity fields describe the
     /// exact signed envelope bytes.
-    pub(crate) fn validate(&self) -> Result<(), VaultError> {
+    pub(crate) fn validate(&self) -> Result<TxEnvelope, VaultError> {
         let envelope = TxEnvelope::decode_2718_exact(&self.tx)?;
         let decoded_hash = *envelope.tx_hash();
         if decoded_hash != self.hash {
@@ -330,7 +363,31 @@ impl PreparedMintTx {
             });
         }
 
-        Ok(())
+        Ok(envelope)
+    }
+
+    /// Like [`Self::validate`], and requires the recovered signer to match
+    /// `owner` (the bot wallet whose nonce is authoritative for death proof).
+    pub(crate) fn validate_for_owner(
+        &self,
+        owner: Address,
+    ) -> Result<TxEnvelope, VaultError> {
+        let envelope = self.validate()?;
+        let signer = envelope.recover_signer()?;
+        if signer != owner {
+            return Err(VaultError::PreparedMintSignerMismatch {
+                expected: owner,
+                decoded: signer,
+            });
+        }
+        Ok(envelope)
+    }
+
+    /// Recovers the signing address from the persisted envelope after
+    /// identity validation. Used when classify needs an owner and the job
+    /// context does not carry the bot address.
+    pub(crate) fn recover_signer(&self) -> Result<Address, VaultError> {
+        Ok(self.validate()?.recover_signer()?)
     }
 
     #[cfg(test)]
@@ -344,7 +401,11 @@ impl PreparedMintTx {
             value: U256::ZERO,
             input: Bytes::new(),
         };
-        let signature = Signature::new(U256::from(1), U256::from(1), false);
+        let signer = PrivateKeySigner::from_bytes(&B256::repeat_byte(1))
+            .expect("test private key should be valid");
+        let signature = signer
+            .sign_hash_sync(&transaction.signature_hash())
+            .expect("test mint transaction should sign");
         let envelope = TxEnvelope::from(transaction.into_signed(signature));
 
         Self {
@@ -354,6 +415,12 @@ impl PreparedMintTx {
             signed_at: Utc::now(),
             external_tx_id,
         }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn signer_for_test(&self) -> Address {
+        self.recover_signer()
+            .expect("test mint transaction signature should recover")
     }
 }
 
@@ -679,6 +746,16 @@ pub(crate) enum VaultError {
     /// held for it must be released.
     #[error("Transaction reverted on-chain: {tx_hash:?}")]
     Reverted { tx_hash: B256 },
+    /// The node's own answers contradict each other: the sender's finalized
+    /// nonce is past this transaction's, so the nonce is permanently spent,
+    /// yet the node still knows the transaction and reports no receipt for
+    /// it. A death proof cannot be read out of an inconsistent node, so this
+    /// is uncertainty, not a terminal identity.
+    #[error(
+        "node reports nonce {nonce} finalized but still knows unmined \
+         transaction {tx_hash:?}"
+    )]
+    ContradictoryDeathSignals { tx_hash: B256, nonce: u64 },
     /// Transaction was mined and succeeded but does not prove the expected
     /// burn — it contains no `Transfer(owner -> 0x0)` of the vault's shares.
     /// The operator-supplied hash cannot terminalize the redemption.
@@ -696,6 +773,10 @@ pub(crate) enum VaultError {
         "Persisted mint transaction nonce {expected} does not match decoded nonce {decoded}"
     )]
     PreparedMintNonceMismatch { expected: u64, decoded: u64 },
+    #[error(
+        "Persisted mint transaction signer {decoded:?} does not match wallet {expected:?}"
+    )]
+    PreparedMintSignerMismatch { expected: Address, decoded: Address },
     #[error(
         "Persisted burn transaction hash {expected:?} does not match decoded hash {decoded:?}"
     )]

--- a/src/vault/service.rs
+++ b/src/vault/service.rs
@@ -20,7 +20,7 @@ use tracing::debug;
 
 use super::rain_meta::OaSchemaCache;
 use super::{
-    BurnTxStatus, BurnVerification, MintResult, MultiBurnResult,
+    BurnTxStatus, BurnVerification, MintResult, MintTxStatus, MultiBurnResult,
     MultiBurnResultEntry, PreparedMintTx, ReceiptInformation,
     SendableTxWithHash, SubmittedTx, TxId, VaultError, VaultService,
     WalletNonceGuard, classify_checked_receipt, verify_burn_in_receipt,
@@ -183,55 +183,202 @@ impl VaultService for RealBlockchainService {
         &self,
         tx_id: &TxId,
     ) -> Result<MintResult, VaultError> {
-        // Fetch receipt from chain using tx hash
+        // Bounded Option poll of eth_getTransactionReceipt — never
+        // PendingTransactionBuilder::get_receipt as the terminal classifier.
+        // Uncertain outcomes surface as ConfirmationPending so jobs fail closed
+        // instead of recording MintingFailed and authorizing a second deposit.
         debug!(target: "vault", tx_hash = %tx_id,
             "Getting mint tx from chain"
         );
 
         let tx_hash = tx_id.to_hash().ok_or(VaultError::InvalidReceipt)?;
 
-        let receipt = PendingTransactionBuilder::new(
-            self.provider.root().clone(),
-            tx_hash,
+        // Overall budget matches the historical 120s PendingTransactionBuilder
+        // timeout; cadence is a simple fixed sleep (no multi-RPC failover).
+        // Wrap the entire poll (including in-flight RPC) so a hanging provider
+        // call cannot exceed the budget and hold an apalis worker slot.
+        const CONFIRM_MINT_TIMEOUT: Duration = Duration::from_secs(120);
+        const CONFIRM_MINT_POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+        let poll = async {
+            loop {
+                let receipt = match self
+                    .provider
+                    .get_transaction_receipt(tx_hash)
+                    .await
+                {
+                    Ok(receipt) => receipt,
+                    Err(error) => {
+                        // Transport / RPC blips are uncertain — never Reverted.
+                        return Err(VaultError::ConfirmationPending {
+                            tx_id: TxId::Hash(tx_hash),
+                            message: error.to_string(),
+                        });
+                    }
+                };
+
+                let Some(receipt) = receipt else {
+                    debug!(target: "vault",
+                        tx_hash = %tx_hash,
+                        "Mint receipt not yet available; polling"
+                    );
+                    tokio::time::sleep(CONFIRM_MINT_POLL_INTERVAL).await;
+                    continue;
+                };
+
+                if receipt.transaction_hash != tx_hash
+                    || receipt.block_number.is_none()
+                {
+                    return Err(VaultError::InvalidReceipt);
+                }
+
+                if !receipt.status() {
+                    debug!(target: "vault",
+                        tx_hash = %tx_hash,
+                        "Mint transaction mined with status=0"
+                    );
+                    return Err(VaultError::Reverted { tx_hash });
+                }
+
+                let (receipt_id, shares_minted, receipt_info_bytes) = receipt
+                    .inner
+                    .logs()
+                    .iter()
+                    .find_map(|log| {
+                        log.log_decode::<OffchainAssetReceiptVault::Deposit>()
+                            .ok()
+                            .map(|decoded| {
+                                let event_data = decoded.data();
+                                (
+                                    event_data.id,
+                                    event_data.shares,
+                                    event_data.receiptInformation.clone(),
+                                )
+                            })
+                    })
+                    .ok_or_else(|| VaultError::EventNotFound { tx_hash })?;
+
+                let block_number =
+                    receipt.block_number.ok_or(VaultError::InvalidReceipt)?;
+
+                debug!(target: "vault",
+                    tx_hash = %tx_hash,
+                    block_number,
+                    receipt_id = %receipt_id,
+                    "Mint transaction confirmed with Deposit"
+                );
+
+                return Ok(MintResult {
+                    tx_hash,
+                    receipt_id,
+                    shares_minted,
+                    gas_used: receipt.gas_used,
+                    block_number,
+                    receipt_info_bytes,
+                });
+            }
+        };
+
+        tokio::time::timeout(CONFIRM_MINT_TIMEOUT, poll).await.unwrap_or_else(
+            |_| {
+                Err(VaultError::ConfirmationPending {
+                    tx_id: TxId::Hash(tx_hash),
+                    message:
+                        "receipt polling budget exhausted without a receipt"
+                            .to_string(),
+                })
+            },
         )
-        .with_timeout(Some(Duration::from_secs(120)))
-        .get_receipt()
-        .await?;
+    }
 
-        // A mined-but-reverted burn consumes no receipts, so it is a definitive
-        // failure distinct from an anomalous missing-Withdraw parse error.
-        if !receipt.status() {
-            return Err(VaultError::Reverted { tx_hash });
-        }
+    async fn classify_mint_tx(
+        &self,
+        owner: Address,
+        prepared_tx: &PreparedMintTx,
+    ) -> Result<MintTxStatus, VaultError> {
+        prepared_tx.validate_for_owner(owner)?;
+        let status = if let Some(receipt) =
+            self.provider.get_transaction_receipt(prepared_tx.hash).await?
+        {
+            if receipt.transaction_hash != prepared_tx.hash
+                || receipt.block_number.is_none()
+            {
+                return Err(VaultError::InvalidReceipt);
+            }
 
-        let (receipt_id, shares_minted, receipt_info_bytes) = receipt
-            .inner
-            .logs()
-            .iter()
-            .find_map(|log| {
-                log.log_decode::<OffchainAssetReceiptVault::Deposit>().ok().map(
-                    |decoded| {
-                        let event_data = decoded.data();
-                        (
-                            event_data.id,
-                            event_data.shares,
-                            event_data.receiptInformation.clone(),
-                        )
+            if receipt.status() {
+                MintTxStatus::MinedSuccess
+            } else {
+                MintTxStatus::MinedReverted
+            }
+        } else {
+            let latest_nonce =
+                self.provider.get_transaction_count(owner).latest().await?;
+            let finalized_nonce =
+                self.provider.get_transaction_count(owner).finalized().await?;
+            let status = if finalized_nonce > prepared_tx.nonce {
+                match self
+                    .provider
+                    .get_transaction_receipt(prepared_tx.hash)
+                    .await?
+                {
+                    Some(receipt) => {
+                        if receipt.transaction_hash != prepared_tx.hash
+                            || receipt.block_number.is_none()
+                        {
+                            return Err(VaultError::InvalidReceipt);
+                        }
+                        if receipt.status() {
+                            MintTxStatus::MinedSuccess
+                        } else {
+                            MintTxStatus::MinedReverted
+                        }
+                    }
+                    // `ProvablyDead` unlocks `RecordMintFailed` and a
+                    // replacement prepare, so it must not rest on a single
+                    // absent receipt: a lagging or load-balanced RPC node can
+                    // answer `None` for a receipt that exists. A node that has
+                    // also forgotten the transaction corroborates the death; a
+                    // node that still knows it is contradicting itself, which
+                    // is uncertainty rather than proof.
+                    None => match self
+                        .provider
+                        .get_transaction_by_hash(prepared_tx.hash)
+                        .await?
+                    {
+                        None => MintTxStatus::ProvablyDead,
+                        Some(_) => {
+                            return Err(
+                                VaultError::ContradictoryDeathSignals {
+                                    tx_hash: prepared_tx.hash,
+                                    nonce: prepared_tx.nonce,
+                                },
+                            );
+                        }
                     },
-                )
-            })
-            .ok_or_else(|| VaultError::EventNotFound { tx_hash })?;
-
-        Ok(MintResult {
-            tx_hash,
-            receipt_id,
-            shares_minted,
-            gas_used: receipt.gas_used,
-            block_number: receipt
-                .block_number
-                .ok_or(VaultError::InvalidReceipt)?,
-            receipt_info_bytes,
-        })
+                }
+            } else {
+                MintTxStatus::StillMineable
+            };
+            debug!(target: "vault",
+                owner = %owner,
+                tx_hash = %prepared_tx.hash,
+                nonce = prepared_tx.nonce,
+                latest_nonce,
+                finalized_nonce,
+                status = ?status,
+                "Classified persisted mint transaction"
+            );
+            return Ok(status);
+        };
+        debug!(target: "vault",
+            owner = %owner,
+            tx_hash = %prepared_tx.hash,
+            nonce = prepared_tx.nonce,
+            status = ?status,
+            "Classified persisted mint transaction"
+        );
+        Ok(status)
     }
 
     async fn get_share_balance(
@@ -639,8 +786,9 @@ mod tests {
     use crate::test_utils::{LocalEvm, logs_contain_at};
     use crate::vault::rain_meta::OaSchemaCache;
     use crate::vault::{
-        BurnRequestOrigin, BurnTxStatus, MultiBurnEntry, MultiBurnParams,
-        ReceiptInformation, SendableTxWithHash, TxId, VaultError, VaultService,
+        BurnRequestOrigin, BurnTxStatus, MintTxStatus, MultiBurnEntry,
+        MultiBurnParams, PreparedMintTx, ReceiptInformation,
+        SendableTxWithHash, TxId, VaultError, VaultService,
     };
 
     const TEST_OA_SCHEMA: &str =
@@ -1028,8 +1176,7 @@ mod tests {
 
         receipt.transaction_hash = prepared.hash;
         asserter.push_success(&prepared.hash);
-        asserter.push_success(&receipt);
-        asserter.push_success(&receipt);
+        asserter.push_success(&Some(receipt));
         let submitted = service.submit_mint(&prepared).await.unwrap();
         assert_eq!(submitted.tx_id, TxId::from(prepared.hash));
 
@@ -1132,8 +1279,7 @@ mod tests {
         let prepared = prepared.unwrap();
         receipt.transaction_hash = prepared.hash;
         asserter.push_success(&prepared.hash);
-        asserter.push_success(&receipt);
-        asserter.push_success(&receipt);
+        asserter.push_success(&Some(receipt));
         let submitted = service.submit_mint(&prepared).await.unwrap();
 
         let result = service.confirm_mint(&submitted.tx_id).await;
@@ -1143,6 +1289,250 @@ mod tests {
         assert!(
             matches!(err, VaultError::EventNotFound { .. }),
             "Expected EventNotFound but got: {err:?}"
+        );
+    }
+
+    fn persisted_mint_tx(nonce: u64) -> PreparedMintTx {
+        PreparedMintTx::valid_for_test(nonce, format!("mint-test-{nonce}"))
+    }
+
+    #[tokio::test]
+    async fn classify_mint_tx_reports_mined_and_reverted_receipts() {
+        for (succeeded, expected) in [
+            (true, MintTxStatus::MinedSuccess),
+            (false, MintTxStatus::MinedReverted),
+        ] {
+            let persisted = persisted_mint_tx(7);
+            let owner = persisted.signer_for_test();
+            let mut receipt =
+                create_empty_receipt(test_vault_address(), persisted.hash);
+            receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+                Receipt {
+                    status: Eip658Value::Eip658(succeeded),
+                    cumulative_gas_used: 0x6100,
+                    logs: vec![],
+                },
+                Bloom::default(),
+            ));
+            let asserter = Asserter::new();
+            asserter.push_success(&receipt);
+            let service = create_service_with_asserter(asserter);
+
+            let status = service
+                .classify_mint_tx(owner, &persisted)
+                .await
+                .expect("receipt should classify");
+
+            assert_eq!(status, expected);
+        }
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn classify_mint_tx_requires_finalized_nonce_to_prove_death() {
+        let persisted = persisted_mint_tx(7);
+        let owner = persisted.signer_for_test();
+
+        for (latest_nonce, finalized_nonce, expected) in [
+            (7, 7, MintTxStatus::StillMineable),
+            (8, 7, MintTxStatus::StillMineable),
+            (8, 8, MintTxStatus::ProvablyDead),
+        ] {
+            let asserter = Asserter::new();
+            asserter.push_success(&Option::<TransactionReceipt>::None);
+            asserter.push_success(&latest_nonce);
+            asserter.push_success(&finalized_nonce);
+            if finalized_nonce > persisted.nonce {
+                asserter.push_success(&Option::<TransactionReceipt>::None);
+                // Death needs the node to have forgotten the transaction too.
+                asserter.push_success(&Option::<RpcTransaction>::None);
+            }
+            let service = create_service_with_asserter(asserter);
+
+            let status = service
+                .classify_mint_tx(owner, &persisted)
+                .await
+                .expect("missing receipt should classify by finalized nonce");
+
+            assert_eq!(status, expected);
+        }
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "Classified persisted mint transaction",
+                "latest_nonce=8",
+                "finalized_nonce=7",
+                "StillMineable"
+            ]
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_mint_tx_refuses_death_while_the_node_still_holds_the_tx()
+    {
+        let persisted = persisted_mint_tx(7);
+        let owner = persisted.signer_for_test();
+        let asserter = Asserter::new();
+        asserter.push_success(&Option::<TransactionReceipt>::None);
+        asserter.push_success(&8u64);
+        asserter.push_success(&8u64);
+        asserter.push_success(&Option::<TransactionReceipt>::None);
+        // A finalized nonce past ours says the nonce is spent, but the node
+        // answering with the transaction says it is not spent by another. One
+        // node cannot have it both ways, so this is not a death proof.
+        asserter.push_success(&Some(rpc_transaction(&persisted.tx, owner)));
+        let service = create_service_with_asserter(asserter);
+
+        let error = service
+            .classify_mint_tx(owner, &persisted)
+            .await
+            .expect_err("contradictory node answers must not prove death");
+
+        assert!(
+            matches!(
+                error,
+                VaultError::ContradictoryDeathSignals { tx_hash, nonce }
+                    if tx_hash == persisted.hash && nonce == persisted.nonce
+            ),
+            "expected ContradictoryDeathSignals, got {error:?}"
+        );
+    }
+
+    #[traced_test]
+    #[tokio::test]
+    async fn classify_mint_tx_rechecks_receipt_after_nonce_advances() {
+        let persisted = persisted_mint_tx(7);
+        let owner = persisted.signer_for_test();
+        let receipt =
+            create_empty_receipt(test_vault_address(), persisted.hash);
+        let asserter = Asserter::new();
+        asserter.push_success(&Option::<TransactionReceipt>::None);
+        asserter.push_success(&8u64);
+        asserter.push_success(&8u64);
+        asserter.push_success(&Some(receipt));
+        let service = create_service_with_asserter(asserter);
+
+        let status = service
+            .classify_mint_tx(owner, &persisted)
+            .await
+            .expect("the second receipt read should win the nonce race");
+
+        assert_eq!(status, MintTxStatus::MinedSuccess);
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &["Classified persisted mint transaction", "MinedSuccess"]
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_mint_tx_rejects_unmined_receipt_shape() {
+        let persisted = persisted_mint_tx(7);
+        let owner = persisted.signer_for_test();
+        let mut receipt =
+            create_empty_receipt(test_vault_address(), persisted.hash);
+        receipt.block_number = None;
+        let asserter = Asserter::new();
+        asserter.push_success(&receipt);
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.classify_mint_tx(owner, &persisted).await;
+
+        assert!(matches!(result, Err(VaultError::InvalidReceipt)));
+    }
+
+    #[tokio::test]
+    async fn classify_mint_tx_rejects_corrupt_persisted_identity_before_rpc() {
+        let mut persisted = persisted_mint_tx(7);
+        persisted.hash = B256::ZERO;
+        let service = create_service_with_asserter(Asserter::new());
+
+        let result =
+            service.classify_mint_tx(test_receiver(), &persisted).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::PreparedMintHashMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn classify_mint_tx_rejects_a_different_signer_before_rpc() {
+        let persisted = persisted_mint_tx(7);
+        let service = create_service_with_asserter(Asserter::new());
+
+        let result = service.classify_mint_tx(Address::ZERO, &persisted).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::PreparedMintSignerMismatch { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn confirm_mint_status_zero_is_reverted() {
+        let persisted = persisted_mint_tx(3);
+        let mut receipt =
+            create_empty_receipt(test_vault_address(), persisted.hash);
+        receipt.inner = ReceiptEnvelope::Eip1559(ReceiptWithBloom::new(
+            Receipt {
+                status: Eip658Value::Eip658(false),
+                cumulative_gas_used: 0x6100,
+                logs: vec![],
+            },
+            Bloom::default(),
+        ));
+        let asserter = Asserter::new();
+        asserter.push_success(&Some(receipt));
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.confirm_mint(&TxId::from(persisted.hash)).await;
+
+        assert!(matches!(
+            result,
+            Err(VaultError::Reverted { tx_hash }) if tx_hash == persisted.hash
+        ));
+    }
+
+    #[tokio::test]
+    async fn confirm_mint_rpc_error_reports_confirmation_pending() {
+        let persisted = persisted_mint_tx(3);
+        let asserter = Asserter::new();
+        // Transport/RPC blips must fail closed as ConfirmationPending (never
+        // Reverted). Direct RPC failure on the first receipt poll avoids the
+        // 120s empty-receipt budget in unit tests.
+        asserter.push_failure_msg("forced transport blip");
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.confirm_mint(&TxId::from(persisted.hash)).await;
+
+        assert!(
+            matches!(result, Err(VaultError::ConfirmationPending { .. })),
+            "expected ConfirmationPending, got {result:?}"
+        );
+    }
+
+    /// Empty receipts until the 120s poll budget expires must surface
+    /// `ConfirmationPending` (never Reverted / MintingFailed). Uses Tokio's
+    /// paused clock so the budget elapses without a real wall-clock wait.
+    #[tokio::test(start_paused = true)]
+    async fn confirm_mint_poll_budget_exhausted_reports_confirmation_pending() {
+        let persisted = persisted_mint_tx(3);
+        let asserter = Asserter::new();
+        // 120s budget / 2s interval ≈ 60 polls; pad past the deadline.
+        for _ in 0..80 {
+            asserter.push_success(&Option::<TransactionReceipt>::None);
+        }
+        let service = create_service_with_asserter(asserter);
+
+        let result = service.confirm_mint(&TxId::from(persisted.hash)).await;
+
+        assert!(
+            matches!(
+                result,
+                Err(VaultError::ConfirmationPending { ref message, .. })
+                    if message.contains("budget exhausted")
+            ),
+            "expected ConfirmationPending budget exhausted, got {result:?}"
         );
     }
 
@@ -1178,10 +1568,10 @@ mod tests {
     }
 
     fn rpc_transaction(
-        persisted: &SendableTxWithHash,
+        encoded_tx: &[u8],
         reported_signer: Address,
     ) -> RpcTransaction {
-        let mut encoded = persisted.tx.as_ref();
+        let mut encoded = encoded_tx;
         let envelope = TxEnvelope::decode_2718(&mut encoded)
             .expect("test transaction should decode");
 
@@ -1207,7 +1597,7 @@ mod tests {
         );
         let owner = persisted.signer_for_test();
         let receiver = test_receiver();
-        let transaction = rpc_transaction(&persisted, owner);
+        let transaction = rpc_transaction(&persisted.tx, owner);
         let receipt = create_multi_withdraw_receipt(
             vault_address,
             persisted.hash,
@@ -1235,7 +1625,7 @@ mod tests {
     async fn verify_burn_tx_rejects_rpc_transaction_for_another_hash() {
         let persisted = persisted_burn_tx(17);
         let owner = persisted.signer_for_test();
-        let transaction = rpc_transaction(&persisted, owner);
+        let transaction = rpc_transaction(&persisted.tx, owner);
         let requested_tx_hash = B256::random();
         let asserter = Asserter::new();
         asserter.push_success(&transaction);
@@ -1252,7 +1642,7 @@ mod tests {
     async fn verify_burn_tx_rejects_rpc_transaction_with_inconsistent_from() {
         let persisted = persisted_burn_tx(17);
         let owner = persisted.signer_for_test();
-        let transaction = rpc_transaction(&persisted, Address::random());
+        let transaction = rpc_transaction(&persisted.tx, Address::random());
         let asserter = Asserter::new();
         asserter.push_success(&transaction);
         let service = create_service_with_asserter(asserter);
@@ -1268,7 +1658,7 @@ mod tests {
     async fn verify_burn_tx_rejects_another_signature_when_rpc_reports_owner() {
         let persisted = persisted_burn_tx(17);
         let owner = Address::random();
-        let transaction = rpc_transaction(&persisted, owner);
+        let transaction = rpc_transaction(&persisted.tx, owner);
         let asserter = Asserter::new();
         asserter.push_success(&transaction);
         let service = create_service_with_asserter(asserter);
@@ -1287,7 +1677,7 @@ mod tests {
     async fn verify_burn_tx_rejects_rpc_receipt_for_another_hash() {
         let persisted = persisted_burn_tx(17);
         let owner = persisted.signer_for_test();
-        let transaction = rpc_transaction(&persisted, owner);
+        let transaction = rpc_transaction(&persisted.tx, owner);
         let receipt =
             create_empty_receipt(test_vault_address(), B256::random());
         let asserter = Asserter::new();

--- a/tests/recovery.rs
+++ b/tests/recovery.rs
@@ -4,7 +4,9 @@ mod harness;
 
 use alloy::network::EthereumWallet;
 use alloy::primitives::{Address, Bytes, U256, b256};
+use alloy::providers::Provider;
 use alloy::signers::local::PrivateKeySigner;
+use alloy::sol_types::SolEvent;
 use httpmock::prelude::*;
 use serde_json::json;
 use sqlx::sqlite::SqlitePoolOptions;
@@ -13,7 +15,9 @@ use tokio::sync::{Mutex, MutexGuard};
 use uuid::{Uuid, uuid};
 
 use harness::alpaca_mocks::{setup_mint_mocks, setup_redemption_mocks};
-use st0x_issuance::bindings::OffchainAssetReceiptVault::OffchainAssetReceiptVaultInstance;
+use st0x_issuance::bindings::OffchainAssetReceiptVault::{
+    self, OffchainAssetReceiptVaultInstance,
+};
 use st0x_issuance::initialize_rocket;
 use st0x_issuance::test_utils::LocalEvm;
 
@@ -1367,6 +1371,475 @@ async fn test_burn_failed_redemption_auto_failed_when_no_balance()
         failed_count, 1,
         "Stuck BurnFailed redemption should have a RedemptionFailed event (auto-failed). \
          Found {failed_count}. Recovery is not auto-failing redemptions with insufficient balance."
+    );
+
+    Ok(())
+}
+
+/// Count vault `Deposit` logs on Anvil (all owners). Used to assert a mint
+/// recovery path never submits a second on-chain deposit.
+async fn count_vault_deposits(
+    provider: &impl Provider,
+    vault_address: Address,
+) -> Result<usize, Box<dyn std::error::Error>> {
+    let vault = OffchainAssetReceiptVaultInstance::new(vault_address, provider);
+    let deposit_logs =
+        provider.get_logs(&vault.Deposit_filter().from_block(0).filter).await?;
+    let mut count = 0usize;
+    for log in &deposit_logs {
+        OffchainAssetReceiptVault::Deposit::decode_log(&log.inner).map_err(
+            |error| format!("failed to decode vault Deposit log: {error}"),
+        )?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Poison a completed mint back to `TxSubmitted` by deleting events after the
+/// latest `MintTxSubmitted` (and clearing snapshots). Event-store-only setup
+/// for double-mint recovery e2e scenarios.
+async fn poison_mint_to_tx_submitted(
+    db_url: &str,
+    issuer_request_id: &str,
+) -> Result<i64, Box<dyn std::error::Error>> {
+    let query_pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+
+    let submitted_sequence: i64 = sqlx::query_scalar(
+        "
+        SELECT sequence
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND event_type = 'MintEvent::MintTxSubmitted'
+        ORDER BY sequence DESC
+        LIMIT 1
+        ",
+    )
+    .bind(issuer_request_id)
+    .fetch_one(&query_pool)
+    .await?;
+
+    sqlx::query(
+        "
+        DELETE FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND sequence > ?
+        ",
+    )
+    .bind(issuer_request_id)
+    .bind(submitted_sequence)
+    .execute(&query_pool)
+    .await?;
+
+    sqlx::query(
+        "
+        DELETE FROM snapshots
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+        ",
+    )
+    .bind(issuer_request_id)
+    .execute(&query_pool)
+    .await?;
+
+    query_pool.close().await;
+    Ok(submitted_sequence)
+}
+
+/// Poison a completed mint to `MintingFailed` after the latest
+/// `MintTxSubmitted` (null-receipt class of production failure).
+async fn poison_mint_to_minting_failed(
+    db_url: &str,
+    issuer_request_id: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let submitted_sequence =
+        poison_mint_to_tx_submitted(db_url, issuer_request_id).await?;
+
+    let query_pool =
+        SqlitePoolOptions::new().max_connections(1).connect(db_url).await?;
+
+    let failed_sequence = submitted_sequence + 1;
+    let failed_payload = json!({
+        "MintingFailed": {
+            "issuer_request_id": issuer_request_id,
+            "error": "Simulated null receipt / uncertain confirmation after mined deposit",
+            "failed_at": (chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339()
+        }
+    });
+    insert_event(
+        &query_pool,
+        "Mint",
+        issuer_request_id,
+        i32::try_from(failed_sequence)?,
+        "MintEvent::MintingFailed",
+        &failed_payload,
+    )
+    .await?;
+
+    query_pool.close().await;
+    Ok(())
+}
+
+/// Production race: first vault deposit mined, confirmation observation was
+/// null / uncertain (RPC `NullResp` / timeout). Pre-fix the bot recorded
+/// `MintingFailed` and prepared a **second** deposit (~1 minute later),
+/// double-minting supply (incident: 0.750 wtPTY).
+///
+/// Correct behaviour:
+/// 1. Uncertain confirm leaves `TxSubmitted` (no `MintingFailed`).
+/// 2. Recovery re-observes the **same** prepared hash and completes callback.
+/// 3. Exactly one on-chain `Deposit` and one `MintTxIntended` for the mint.
+///
+/// This e2e cannot inject a live null receipt from Anvil; it reproduces the
+/// durable mid-flight state after a mined deposit whose confirm never recorded
+/// `TokensMinted` (rollback to `MintTxSubmitted`), then proves restart recovery
+/// finishes without a second deposit.
+#[tokio::test]
+async fn test_mined_deposit_with_unrecorded_confirm_must_not_double_mint()
+-> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir
+        .path()
+        .join("test_mined_deposit_unrecorded_confirm_no_double_mint.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let mint_callback_mock = setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) = setup_redemption_mocks(&mock_alpaca);
+
+    let (config1, _mock_subgraph1) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket1 = initialize_rocket(config1).await?;
+    let client1 = rocket::local::asynchronous::Client::tracked(rocket1).await?;
+
+    harness::seed_tokenized_asset(&client1, evm.vault_address).await;
+    harness::setup_roles(&evm, user_wallet, bot_wallet).await?;
+
+    let link_body = harness::setup_account(&client1, user_wallet).await;
+    let issuer_request_id = harness::perform_mint_and_confirm(
+        &client1,
+        user_wallet,
+        &link_body.client_id.to_string(),
+        "alp-uncertain-confirm-no-double-mint",
+        "50.0",
+    )
+    .await?;
+
+    let user_wallet_instance = EthereumWallet::from(user_signer.clone());
+    let user_provider = create_provider()
+        .wallet(user_wallet_instance)
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let shares_before = harness::wait_for_shares(&vault, user_wallet).await?;
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintCompleted",
+        1,
+    )
+    .await?;
+
+    let deposits_before =
+        count_vault_deposits(&user_provider, evm.vault_address).await?;
+    assert_eq!(
+        deposits_before, 1,
+        "happy-path mint must create exactly one Deposit before rollback"
+    );
+
+    let intended_before = wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintTxIntended",
+        1,
+    )
+    .await?;
+    assert_eq!(intended_before, 1, "happy-path mint must prepare exactly once");
+
+    client1.terminate().await;
+
+    // Setup phase: event-store only. Drop TokensMinted/MintCompleted so the
+    // aggregate is again `TxSubmitted` with the live prepared identity while
+    // the on-chain deposit remains mined — the durable window after uncertain
+    // confirm (or a crash before TokensMinted).
+    let submitted_sequence =
+        poison_mint_to_tx_submitted(&db_url, &issuer_request_id).await?;
+
+    let remaining = sqlx::query_scalar::<_, i64>(
+        "
+        SELECT COUNT(*)
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+        ",
+    )
+    .bind(&issuer_request_id)
+    .fetch_one(
+        &SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?,
+    )
+    .await?;
+    assert_eq!(
+        remaining, submitted_sequence,
+        "rollback must leave the mint at MintTxSubmitted (seq {submitted_sequence})"
+    );
+
+    // Restart: recovery re-enqueues ConfirmMint for the same hash.
+    let (config2, _mock_subgraph2) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket2 = initialize_rocket(config2).await?;
+    let _client2 =
+        rocket::local::asynchronous::Client::tracked(rocket2).await?;
+
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+    // Settle briefly then re-assert exact count so late extra callbacks fail.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        2,
+        "recovery must deliver exactly one additional mint callback (no extras)"
+    );
+
+    let completed_count = wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintCompleted",
+        1,
+    )
+    .await?;
+    assert_eq!(
+        completed_count, 1,
+        "recovery must complete the mint exactly once"
+    );
+
+    let intended_after = sqlx::query_scalar::<_, i64>(
+        "
+        SELECT COUNT(*)
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND event_type = 'MintEvent::MintTxIntended'
+        ",
+    )
+    .bind(&issuer_request_id)
+    .fetch_one(
+        &SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?,
+    )
+    .await?;
+    assert_eq!(
+        intended_after, 1,
+        "recovery must not prepare a second MintTxIntended (same hash only)"
+    );
+
+    let minting_failed_count = sqlx::query_scalar::<_, i64>(
+        "
+        SELECT COUNT(*)
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND event_type = 'MintEvent::MintingFailed'
+        ",
+    )
+    .bind(&issuer_request_id)
+    .fetch_one(
+        &SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?,
+    )
+    .await?;
+    assert_eq!(
+        minting_failed_count, 0,
+        "uncertain/unrecorded confirm recovery must not record MintingFailed"
+    );
+
+    let deposits_after =
+        count_vault_deposits(&user_provider, evm.vault_address).await?;
+    assert_eq!(
+        deposits_after, 1,
+        "must keep exactly one on-chain Deposit; got {deposits_after}"
+    );
+
+    let shares_after = vault.balanceOf(user_wallet).call().await?;
+    assert_eq!(
+        shares_after, shares_before,
+        "share balance must not change (no double mint). \
+         Before: {shares_before}, After: {shares_after}"
+    );
+
+    Ok(())
+}
+
+/// Same production class of failure, but the durable poison state is
+/// `MintingFailed` after a mined deposit (what the old bot wrote when it
+/// treated null receipt as terminal). Recovery must reclassify the live
+/// prepared identity / inventory hit and complete without a second Deposit.
+#[tokio::test]
+async fn test_minting_failed_after_mined_deposit_must_not_double_mint()
+-> Result<(), Box<dyn std::error::Error>> {
+    let _recovery_test_guard = recovery_test_guard().await;
+
+    let evm = LocalEvm::new().await?;
+    let mock_alpaca = MockServer::start();
+
+    let bot_wallet = evm.wallet_address;
+    let user_private_key = b256!(
+        "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+    );
+    let user_signer = PrivateKeySigner::from_bytes(&user_private_key)?;
+    let user_wallet = user_signer.address();
+
+    let temp_dir = tempfile::tempdir()?;
+    let db_path = temp_dir
+        .path()
+        .join("test_minting_failed_after_mined_deposit_no_double_mint.db");
+    let db_url = format!("sqlite:{}?mode=rwc", db_path.display());
+
+    let mint_callback_mock = setup_mint_mocks(&mock_alpaca);
+    let (_redeem_mock, _poll_mock) = setup_redemption_mocks(&mock_alpaca);
+
+    let (config1, _mock_subgraph1) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket1 = initialize_rocket(config1).await?;
+    let client1 = rocket::local::asynchronous::Client::tracked(rocket1).await?;
+
+    harness::seed_tokenized_asset(&client1, evm.vault_address).await;
+    harness::setup_roles(&evm, user_wallet, bot_wallet).await?;
+
+    let link_body = harness::setup_account(&client1, user_wallet).await;
+    let issuer_request_id = harness::perform_mint_and_confirm(
+        &client1,
+        user_wallet,
+        &link_body.client_id.to_string(),
+        "alp-minting-failed-after-mined-no-double",
+        "50.0",
+    )
+    .await?;
+
+    let user_wallet_instance = EthereumWallet::from(user_signer.clone());
+    let user_provider = create_provider()
+        .wallet(user_wallet_instance)
+        .connect(&evm.endpoint)
+        .await?;
+    let vault = OffchainAssetReceiptVaultInstance::new(
+        evm.vault_address,
+        &user_provider,
+    );
+    let shares_before = harness::wait_for_shares(&vault, user_wallet).await?;
+    harness::wait_for_mock_hits(&mint_callback_mock, 1).await?;
+
+    wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintCompleted",
+        1,
+    )
+    .await?;
+
+    let deposits_before =
+        count_vault_deposits(&user_provider, evm.vault_address).await?;
+    assert_eq!(deposits_before, 1);
+
+    client1.terminate().await;
+
+    poison_mint_to_minting_failed(&db_url, &issuer_request_id).await?;
+
+    let (config2, _mock_subgraph2) =
+        harness::create_config_with_db(&db_url, &mock_alpaca, &evm)?;
+    let rocket2 = initialize_rocket(config2).await?;
+    let _client2 =
+        rocket::local::asynchronous::Client::tracked(rocket2).await?;
+
+    harness::wait_for_mock_hits(&mint_callback_mock, 2).await?;
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    assert_eq!(
+        mint_callback_mock.calls_async().await,
+        2,
+        "MintingFailed recovery must deliver exactly one additional callback"
+    );
+
+    let completed_count = wait_for_event_count(
+        &db_url,
+        "Mint",
+        &issuer_request_id,
+        "MintEvent::MintCompleted",
+        1,
+    )
+    .await?;
+    assert_eq!(
+        completed_count, 1,
+        "MintingFailed recovery must complete the mint exactly once"
+    );
+
+    let intended_after = sqlx::query_scalar::<_, i64>(
+        "
+        SELECT COUNT(*)
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND event_type = 'MintEvent::MintTxIntended'
+        ",
+    )
+    .bind(&issuer_request_id)
+    .fetch_one(
+        &SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?,
+    )
+    .await?;
+    assert_eq!(
+        intended_after, 1,
+        "MintingFailed recovery after a mined deposit must not prepare a second intent"
+    );
+
+    // Pins the other poison state: recovery that records a fresh failure and
+    // then completes through inventory would still satisfy the intent count.
+    let minting_failed_after = sqlx::query_scalar::<_, i64>(
+        "
+        SELECT COUNT(*)
+        FROM events
+        WHERE aggregate_type = 'Mint'
+          AND aggregate_id = ?
+          AND event_type = 'MintEvent::MintingFailed'
+        ",
+    )
+    .bind(&issuer_request_id)
+    .fetch_one(
+        &SqlitePoolOptions::new().max_connections(1).connect(&db_url).await?,
+    )
+    .await?;
+    assert_eq!(
+        minting_failed_after, 1,
+        "recovery must not append another MintingFailed to the seeded one"
+    );
+
+    let deposits_after =
+        count_vault_deposits(&user_provider, evm.vault_address).await?;
+    assert_eq!(
+        deposits_after, 1,
+        "must keep exactly one on-chain Deposit after MintingFailed recovery"
+    );
+
+    let shares_after = vault.balanceOf(user_wallet).call().await?;
+    assert_eq!(
+        shares_after, shares_before,
+        "share balance must not change (no double mint)"
     );
 
     Ok(())


### PR DESCRIPTION
## What

- Fail-closes vault-direct mint confirmation and recovery so an uncertain RPC receipt can never authorize a second deposit.
- Rewrites `confirm_mint` to poll `get_transaction_receipt` as `Option` (bounded backoff). Drops `PendingTransactionBuilder::get_receipt` as the terminal classifier.
- Adds `classify_mint_tx` / `MintTxStatus` (burn-parity).
- Fixes prepared-intent resolution so `TxSubmitted.prepared_tx` and the failed_from chain stay available for rebroadcast.
- ConfirmMintJob: uncertain stays `TxSubmitted`; works under `MintingFailed` for legacy re-observe; inventory before terminal fail; wallet lock on rebroadcast/classify.
- Recovery: rebroadcast same bytes under uncertainty; replace only after terminal classify + TOCTOU + inventory under the wallet lock. Legacy post-submit without prepared never free-prepares.
- Mint submit gates on mint + burn + excess unresolved intents. `MintClosed` clears the mint intent gate.
- Submit enqueue_confirm releases terminal Done keys so re-confirm is not silently dropped.
- ERROR when a second Deposit is discovered for an already-mapped issuer request. Anvil e2e for unrecorded confirm / poisoned MintingFailed without a second deposit.

## Why

- Production double-minted 0.750 wtPTY after a null receipt was treated as definitive failure, then recovery submitted a fresh mint.
- After `MintTxIntended` / `MintTxSubmitted`, an inconclusive observation must never authorize a different transaction.
- Tracked in [RAI-1631](https://linear.app/makeitrain/issue/RAI-1631/prevent-vault-direct-mint-recovery-from-double-minting-after-an). Stacked on [RAI-1632](https://linear.app/makeitrain/issue/RAI-1632) (#311).

## How

- Observation model and recovery predicate documented in SPEC (jobs do I/O; aggregate is pure Record*; vault-direct vs orchestrator).
- Uncertain confirm kicks recovery so re-observe is not only the 300s reconciler.
- Three additional lean multi-agent review loops after the first: broadcast no-reload preserve, burn-intent gate, confirm under failed, inventory under lock, MintClosed gate, terminal confirm re-enqueue, TxIntended classify before rebroadcast, SPEC alignment.

## Testing

- Unit matrix for classify/confirm, pending_prepared, fail-closed confirm, StillMineable rebroadcast, TOCTOU, inventory-before-terminal, MintClosed intent, MintingFailed confirm, enqueue_confirm release, TxIntended classify.
- Anvil `tests/recovery.rs`: mined deposit with unrecorded confirm must not double-mint; MintingFailed after mined deposit must not double-mint.
- Clippy clean locally.

## Anything else

- Residual: false ProvablyDead under extreme multi-fault RPC + inventory miss (burn-parity residual). Inventory at submit is last line of defense.
- Orchestrator / PR #300 out of scope.
- Keep minting paused until deploy + collateral checks. Path B burn-excess for the existing 0.750 deficit is #311.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mint recovery across pending, confirmed, reverted, and failed states.
  * Preserves transaction identity during retries and restarts to prevent duplicate deposits.
  * Added fail-closed handling for uncertain confirmations and network results.
  * Added duplicate-deposit detection, operator visibility, and remediation guidance.
  * Supports bounded automatic and manual retries with wallet and nonce safeguards.
  * Mint closure now supports acknowledging unresolved transaction hashes.

* **Documentation**
  * Expanded recovery procedures, wallet-locking guidance, and duplicate-deposit operations documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->