### PR TITLE
Move `MintAuthorizationRequest`/`Response` DTOs to shared `st0x-issuance-dto` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5801,6 +5801,7 @@ dependencies = [
 name = "st0x-issuance-client"
 version = "0.1.0"
 dependencies = [
+ "alloy-primitives",
  "httpmock",
  "reqwest",
  "serde_json",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -10,6 +10,7 @@ thiserror = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+alloy-primitives = { workspace = true }
 httpmock = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }

--- a/crates/client/src/lib.rs
+++ b/crates/client/src/lib.rs
@@ -19,7 +19,10 @@
 
 use reqwest::StatusCode;
 use reqwest::redirect::Policy;
-use st0x_issuance_dto::{TokenizedAssetStatusResponse, UnderlyingSymbol};
+use st0x_issuance_dto::{
+    MintAuthorizationRequest, MintAuthorizationResponse,
+    TokenizedAssetStatusResponse, UnderlyingSymbol,
+};
 use std::time::Duration;
 use url::Url;
 
@@ -130,10 +133,73 @@ impl IssuanceClient {
             status => Err(ClientError::Status { status, url }),
         }
     }
+
+    /// Delivers a signed `MintAuthV1` recipient authorization for the mint
+    /// correlated by `tokenization_request_id`, via
+    /// `POST /internal/mints/<tokenization_request_id>/authorization`
+    /// (RAI-1243). A retried delivery MUST reuse the same
+    /// `MintAuthorizationRequest` byte-identically — the nonce is fixed per
+    /// mint, and the server treats an identical redelivery as an idempotent
+    /// `200`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ClientError`] on URL/transport failures, and every non-`200`
+    /// status as [`ClientError::Status`] for the caller to map. The server's
+    /// contract: `404` — no mint exists yet for the tokenization request
+    /// (retryable: the mint's Alpaca-side initiation may not have reached
+    /// the issuance bot yet); `409` — a conflicting authorization is already
+    /// recorded, or the mint has advanced past intent; `422` — the mint is
+    /// vault-direct, the signer does not recover to the recipient, or the
+    /// nonce is already consumed on-chain; `502` — the server's on-chain
+    /// validation read failed (retryable).
+    pub async fn deliver_mint_authorization(
+        &self,
+        tokenization_request_id: &str,
+        authorization: &MintAuthorizationRequest,
+    ) -> Result<MintAuthorizationResponse, ClientError> {
+        // Segment-appended (never `Url::join`ed) for the same reasons as
+        // `tokenized_asset_status`: preserve a base path prefix and
+        // percent-encode a path-significant character in the id into one
+        // segment instead of corrupting the route.
+        let mut url = self.base_url.clone();
+        url.path_segments_mut()
+            .map_err(|()| ClientError::NotABase {
+                base: self.base_url.clone(),
+            })?
+            .pop_if_empty()
+            .extend([
+                "internal",
+                "mints",
+                tokenization_request_id,
+                "authorization",
+            ]);
+
+        let response = self
+            .http
+            .post(url.clone())
+            .header(API_KEY_HEADER, &self.api_key)
+            .json(authorization)
+            .send()
+            .await?;
+
+        match response.status() {
+            StatusCode::OK => {
+                response.json().await.map_err(ClientError::ParseResponse)
+            }
+            // No `Ok(None)` mapping here, unlike `tokenized_asset_status`:
+            // for a delivery, a 404 is a retryable race (the mint is not
+            // initiated yet), not a benign "asset unknown" — collapsing it
+            // into a non-error would hide the state the caller must retry
+            // on. The URL never carries the API key (it is a header).
+            status => Err(ClientError::Status { status, url }),
+        }
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    use alloy_primitives::{B256, Bytes};
     use httpmock::prelude::*;
     use serde_json::json;
     use st0x_issuance_dto::{TokenizedAssetStatus, VaultModeTag};
@@ -310,6 +376,153 @@ mod tests {
 
         mock.assert();
         assert_eq!(status.status, TokenizedAssetStatus::Enabled);
+    }
+
+    fn test_authorization() -> MintAuthorizationRequest {
+        MintAuthorizationRequest {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from(vec![0xab, 0xcd]),
+        }
+    }
+
+    #[tokio::test]
+    async fn deliver_mint_authorization_posts_hex_body_and_parses_response() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/internal/mints/tok-123/authorization")
+                .header(API_KEY_HEADER, "test-key")
+                .json_body(json!({
+                    "nonce": "0x0707070707070707070707070707070707070707070707070707070707070707",
+                    "signature": "0xabcd"
+                }));
+            then.status(200).json_body(json!({
+                "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+                "status": "authorized"
+            }));
+        });
+
+        let response = client_for(&server)
+            .deliver_mint_authorization("tok-123", &test_authorization())
+            .await
+            .expect("delivery succeeds");
+
+        mock.assert();
+        assert_eq!(
+            response.issuer_request_id,
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(response.status, "authorized");
+    }
+
+    /// An empty signature (`"0x"`) is a valid delivery for contract
+    /// recipients — the client must send it as `"0x"`, not omit or reshape
+    /// the field.
+    #[tokio::test]
+    async fn deliver_mint_authorization_sends_empty_signature_as_0x() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/internal/mints/tok-123/authorization")
+                .json_body_includes(r#"{"signature":"0x"}"#);
+            then.status(200).json_body(json!({
+                "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+                "status": "authorized"
+            }));
+        });
+
+        client_for(&server)
+            .deliver_mint_authorization(
+                "tok-123",
+                &MintAuthorizationRequest {
+                    nonce: B256::repeat_byte(0x07),
+                    signature: Bytes::new(),
+                },
+            )
+            .await
+            .expect("delivery succeeds");
+
+        mock.assert();
+    }
+
+    // The server's delivery contract distinguishes retryable races (404: the
+    // mint is not initiated yet; 502: on-chain validation read failed) from
+    // terminal rejections (409 conflict, 422 invalid) purely by status. The
+    // client must surface EVERY non-200 as `Status` with the exact code —
+    // in particular 404 must NOT collapse into a benign `None` the way the
+    // status endpoint's does, or the caller would lose the retry signal.
+    #[tokio::test]
+    async fn deliver_mint_authorization_surfaces_each_contract_status() {
+        for code in [404u16, 409, 422, 502] {
+            let server = MockServer::start_async().await;
+            let mock = server.mock(|when, then| {
+                when.method(POST).path("/internal/mints/tok-123/authorization");
+                then.status(code);
+            });
+
+            let err = client_for(&server)
+                .deliver_mint_authorization("tok-123", &test_authorization())
+                .await
+                .expect_err("a non-200 must surface as an error");
+
+            mock.assert();
+            assert!(
+                matches!(
+                    err,
+                    ClientError::Status { status, .. } if status.as_u16() == code
+                ),
+                "expected Status({code}), got {err:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn deliver_mint_authorization_errors_on_malformed_body() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/internal/mints/tok-123/authorization");
+            then.status(200).body("not json");
+        });
+
+        let err = client_for(&server)
+            .deliver_mint_authorization("tok-123", &test_authorization())
+            .await
+            .expect_err("a malformed 200 body must surface as a parse error");
+
+        mock.assert();
+        assert!(
+            matches!(err, ClientError::ParseResponse(_)),
+            "expected ParseResponse, got {err:?}"
+        );
+    }
+
+    /// Same URL-building contract as the status endpoint: a base path prefix
+    /// survives, and a path-significant character in the tokenization id is
+    /// percent-encoded into a single segment instead of corrupting the
+    /// route (which would 404 and masquerade as the initiation race).
+    #[tokio::test]
+    async fn deliver_mint_authorization_builds_prefixed_encoded_paths() {
+        let server = MockServer::start_async().await;
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/internal/mints/tok%2F123/authorization");
+            then.status(200).json_body(json!({
+                "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+                "status": "authorized"
+            }));
+        });
+
+        let base = Url::parse(&format!("{}/api/", server.base_url()))
+            .expect("valid prefixed base URL");
+        let client =
+            IssuanceClient::new(base, "test-key").expect("client builds");
+
+        client
+            .deliver_mint_authorization("tok/123", &test_authorization())
+            .await
+            .expect("delivery succeeds");
+
+        mock.assert();
     }
 
     // The freeze-gating contract is "only 404 -> None; every other status ->

--- a/crates/dto/src/lib.rs
+++ b/crates/dto/src/lib.rs
@@ -9,7 +9,7 @@
 use std::path::Path;
 use std::str::FromStr;
 
-use alloy_primitives::Address;
+use alloy_primitives::{Address, B256, Bytes};
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
@@ -350,6 +350,45 @@ pub struct TokenizedAssetStatusResponse {
     pub vault_mode: VaultModeTag,
 }
 
+/// Request body of `POST /internal/mints/<tokenization_request_id>/authorization`.
+///
+/// The liquidity bot's signed `MintAuthV1` recipient authorization for one
+/// orchestrator-mode mint, correlated by the path's `tokenization_request_id`
+/// which is the only mint identifier the liquidity bot holds.
+///
+/// Internal service-to-service wire type deliberately not exported to the
+/// dashboard TypeScript bindings (no `TS` derive) — the dashboard never
+/// sees this channel.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct MintAuthorizationRequest {
+    /// Recipient-chosen random 32-byte nonce, hex-encoded. Fixed per mint:
+    /// a retried delivery MUST carry the same nonce byte-identically.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
+    pub nonce: B256,
+    /// EIP-712 `MintAuthV1` signature over `(token, to, amount, nonce)` by
+    /// the recipient wallet key, hex-encoded. May be `"0x"` (empty) for
+    /// contract recipients authorized via the orchestrator's
+    /// `authorizeMint` callback.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
+    pub signature: Bytes,
+}
+
+/// Response body of a successful (`200`) mint-authorization delivery.
+///
+/// Internal service-to-service wire type; not exported to the dashboard
+/// bindings (see [`MintAuthorizationRequest`]).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
+pub struct MintAuthorizationResponse {
+    /// The issuance bot's own id for the resolved mint. Opaque to callers —
+    /// informational only; the wire correlation key remains the
+    /// `tokenization_request_id`.
+    pub issuer_request_id: String,
+    /// `"authorized"` on success.
+    pub status: String,
+}
+
 /// One entry in the `GET /tokenized-assets` list.
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 pub struct TokenizedAssetResponse {
@@ -597,6 +636,59 @@ mod tests {
         assert_eq!(response.underlying, UnderlyingSymbol::new("SGOV").unwrap());
         assert_eq!(response.status, TokenizedAssetStatus::Enabled);
         assert_eq!(response.vault_mode, VaultModeTag::VaultDirect);
+    }
+
+    /// The authorization wire shape is the cross-repo contract the liquidity
+    /// bot signs against — pin it to exact JSON literals (hex-encoded
+    /// `nonce`/`signature`), not just a round-trip, so a field rename or
+    /// encoding change fails here.
+    #[test]
+    fn mint_authorization_request_pins_hex_wire_format() {
+        let request = MintAuthorizationRequest {
+            nonce: B256::repeat_byte(0x07),
+            signature: Bytes::from(vec![0xab, 0xcd]),
+        };
+
+        let wire = json!({
+            "nonce": "0x0707070707070707070707070707070707070707070707070707070707070707",
+            "signature": "0xabcd"
+        });
+        assert_eq!(serde_json::to_value(&request).unwrap(), wire);
+        assert_eq!(
+            serde_json::from_value::<MintAuthorizationRequest>(wire).unwrap(),
+            request
+        );
+    }
+
+    /// `"0x"` is a valid signature on the wire: contract recipients
+    /// authorize via the orchestrator's `authorizeMint` callback and send an
+    /// empty signature (SPEC "Recipient Authorization", staged scope).
+    #[test]
+    fn mint_authorization_request_accepts_empty_signature() {
+        let request: MintAuthorizationRequest = serde_json::from_value(json!({
+            "nonce": "0x0707070707070707070707070707070707070707070707070707070707070707",
+            "signature": "0x"
+        }))
+        .unwrap();
+
+        assert!(request.signature.is_empty());
+    }
+
+    #[test]
+    fn mint_authorization_response_round_trips_wire_format() {
+        let wire = json!({
+            "issuer_request_id": "550e8400-e29b-41d4-a716-446655440000",
+            "status": "authorized"
+        });
+
+        let response: MintAuthorizationResponse =
+            serde_json::from_value(wire.clone()).unwrap();
+        assert_eq!(
+            response.issuer_request_id,
+            "550e8400-e29b-41d4-a716-446655440000"
+        );
+        assert_eq!(response.status, "authorized");
+        assert_eq!(serde_json::to_value(&response).unwrap(), wire);
     }
 
     /// A response from a server that predates `vault_mode` still parses —

--- a/src/mint/api/authorize.rs
+++ b/src/mint/api/authorize.rs
@@ -1,4 +1,3 @@
-use alloy::primitives::{B256, Bytes};
 use apalis_sqlite::SqlitePool as ApalisSqlitePool;
 use cqrs_es::AggregateError;
 use event_sorcery::{LifecycleError, Store};
@@ -6,8 +5,8 @@ use rocket::http::{ContentType, Status};
 use rocket::post;
 use rocket::response::{self, Responder};
 use rocket::serde::json::Json;
-use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
+use st0x_issuance_dto::{MintAuthorizationRequest, MintAuthorizationResponse};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -25,28 +24,6 @@ use crate::tokenized_asset::view::find_vault;
 use crate::vault::{
     MintAuthorization, MintedLogQuery, NetworkVaultServices, VaultError,
 };
-
-/// Wire shape of the liquidity bot's mint-authorization delivery
-/// (RAI-1243). The signature is opaque bytes; `"0x"` (empty) is valid input
-/// for recipients authorized via the orchestrator's `authorizeMint`
-/// callback.
-#[derive(Debug, Deserialize, utoipa::ToSchema)]
-pub(crate) struct MintAuthorizationRequest {
-    /// Recipient-chosen random 32-byte nonce, hex-encoded.
-    #[schema(value_type = String)]
-    pub(crate) nonce: B256,
-    /// EIP-712 `MintAuthV1` signature over `(token, to, amount, nonce)` by
-    /// the recipient wallet key, hex-encoded; may be `"0x"`.
-    #[schema(value_type = String)]
-    pub(crate) signature: Bytes,
-}
-
-#[derive(Debug, Serialize, utoipa::ToSchema)]
-pub(crate) struct MintAuthorizationResponse {
-    #[schema(value_type = String)]
-    pub(crate) issuer_request_id: IssuerMintRequestId,
-    pub(crate) status: String,
-}
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum MintAuthorizationApiError {
@@ -308,7 +285,7 @@ pub(crate) async fn authorize_mint(
         )
         .await;
         return Ok(Json(MintAuthorizationResponse {
-            issuer_request_id,
+            issuer_request_id: issuer_request_id.to_string(),
             status: "authorized".to_string(),
         }));
     }
@@ -386,7 +363,7 @@ pub(crate) async fn authorize_mint(
         .await;
 
     Ok(Json(MintAuthorizationResponse {
-        issuer_request_id,
+        issuer_request_id: issuer_request_id.to_string(),
         status: "authorized".to_string(),
     }))
 }

--- a/src/mint/api/mod.rs
+++ b/src/mint/api/mod.rs
@@ -22,10 +22,7 @@ mod initiate;
 #[cfg(test)]
 pub(crate) mod test_utils;
 
-pub(crate) use authorize::{
-    __path_authorize_mint, MintAuthorizationRequest, MintAuthorizationResponse,
-    authorize_mint,
-};
+pub(crate) use authorize::{__path_authorize_mint, authorize_mint};
 pub(crate) use confirm::confirm_journal;
 pub(crate) use initiate::initiate_mint;
 

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -50,8 +50,8 @@ expressed as an OpenAPI scheme."
         crate::account::api::RegisterAccountResponse,
         crate::account::api::WhitelistWalletRequest,
         crate::account::api::WhitelistWalletResponse,
-        crate::mint::api::MintAuthorizationRequest,
-        crate::mint::api::MintAuthorizationResponse,
+        st0x_issuance_dto::MintAuthorizationRequest,
+        st0x_issuance_dto::MintAuthorizationResponse,
         crate::admin::AggregateKind,
         crate::admin::ReprocessResponse,
         crate::admin::StuckAggregate,
@@ -208,10 +208,10 @@ mod tests {
             serde_json::json!(["enabled", "frozen"])
         );
 
-        // The authorization DTOs carry `schema(value_type = String)` over
-        // `B256`/`Bytes`/`IssuerMintRequestId`; the overrides must hold so
-        // the schema advertises the 0x-hex strings the liquidity bot sends
-        // rather than alloy's internal representations.
+        // The authorization request DTO carries `schema(value_type = String)`
+        // over `B256`/`Bytes`; the overrides must hold so the schema
+        // advertises the 0x-hex strings the liquidity bot sends rather than
+        // alloy's internal representations.
         assert_eq!(
             schemas["MintAuthorizationRequest"]["properties"]["nonce"]["type"],
             "string"


### PR DESCRIPTION
## Motivation

The `MintAuthorizationRequest` and `MintAuthorizationResponse` types were defined locally inside the issuance bot's `authorize.rs` handler, making them inaccessible to the liquidity bot's client crate. The client needed these types to deliver signed `MintAuthV1` recipient authorizations to `POST /internal/mints/<tokenization_request_id>/authorization`, but had no way to reference them without duplicating the definitions.

## Solution

`MintAuthorizationRequest` and `MintAuthorizationResponse` are promoted from the internal `authorize.rs` module into `st0x_issuance_dto`, becoming the shared wire types for both sides of the service-to-service channel. The server-side handler now imports them from the DTO crate and converts `IssuerMintRequestId` to `String` when constructing responses to match the now-generic `issuer_request_id: String` field. The OpenAPI schema registration is updated to reference the DTO crate types directly.

`IssuanceClient` gains a `deliver_mint_authorization` method that `POST`s a `MintAuthorizationRequest` to the authorization endpoint, using the same path-segment URL construction as the existing status endpoint to preserve base path prefixes and percent-encode path-significant characters in the tokenization request ID. Every non-`200` response is surfaced as `ClientError::Status` — including `404`, which is a retryable race condition (mint not yet initiated) rather than a benign "not found" that should collapse to `None`.

Tests cover the happy path with exact hex wire format assertions, empty-signature delivery (`"0x"`), all four contract status codes (`404`, `409`, `422`, `502`) surfacing as errors, malformed response body handling, and prefixed/encoded URL construction.  
  
Issuance part of [RAI-1243](https://linear.app/makeitrain/issue/RAI-1243/liquidity-bot-sign-and-deliver-mintauthv1-for-orchestrator-mode-mints)  
Closes [RAI-1673](https://linear.app/makeitrain/issue/RAI-1673/mint-authorization-request-for-dto-and-client-issuance-side)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for submitting signed mint authorization data.
  * Added structured mint authorization responses, including request identifiers and authorization status.
  * Improved support for encoded authorization endpoints and empty signatures.

* **Bug Fixes**
  * Non-successful authorization responses, including not-found errors, are now reported consistently.
  * Improved handling of malformed authorization responses and request serialization.
  * Authorization responses now consistently provide request identifiers for reliable tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->