### PR TITLE
test: cover the wallet-intent gates and burn-excess --close

### DIFF
--- a/src/burn_excess/engine.rs
+++ b/src/burn_excess/engine.rs
@@ -2829,4 +2829,287 @@ mod tests {
             store.load(&BurnExcessId::new(deposit_tx)).await.unwrap().unwrap();
         assert!(matches!(state, BurnExcess::Completed { .. }));
     }
+
+    /// `--close` never proves a plan, so it reaches no chain and no signer.
+    /// Constructing the provider without a live node keeps these tests off
+    /// Anvil and makes the "no I/O on the close path" property structural.
+    fn offline_provider() -> impl Provider {
+        ProviderBuilder::new()
+            .connect_http("http://127.0.0.1:1".parse().unwrap())
+    }
+
+    fn close_request(
+        mode: BurnExcessMode,
+        issuer_request_id: IssuerMintRequestId,
+        deposit_tx_hash: B256,
+        receipt_id: U256,
+        funding_tx_hash: Option<B256>,
+        execute: bool,
+    ) -> BurnExcessRequest {
+        BurnExcessRequest {
+            close: true,
+            ..request(
+                mode,
+                issuer_request_id,
+                deposit_tx_hash,
+                receipt_id,
+                funding_tx_hash,
+                execute,
+            )
+        }
+    }
+
+    fn test_bind(
+        issuer_request_id: &IssuerMintRequestId,
+        deposit_tx_hash: B256,
+    ) -> ExcessBurnBind {
+        ExcessBurnBind {
+            issuer_request_id: issuer_request_id.clone(),
+            deposit_tx_hash,
+            receipt_id: U256::from(7u64),
+            shares: excess_shares(),
+            original_recipient: address!(
+                "0xA9C16673F65AE808688cB18952AFE3d9658C808f"
+            ),
+            vault: address!("0xcccccccccccccccccccccccccccccccccccccccc"),
+            network: Network::Base,
+            issuer_wallet: address!(
+                "0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"
+            ),
+        }
+    }
+
+    fn test_funding_log(bind: &ExcessBurnBind) -> FundingTransferId {
+        FundingTransferId {
+            network: bind.network,
+            vault: bind.vault,
+            tx_hash: b256!(
+                "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff1"
+            ),
+            log_index: 2,
+            from: bind.original_recipient,
+            to: bind.issuer_wallet,
+            amount: bind.shares,
+        }
+    }
+
+    /// Seeds an abandoned Path B recovery: the exclusion is permanent, but no
+    /// transaction is signed. This is the state `--close` exists to release.
+    async fn seed_funding_excluded(
+        pool: &Pool<Sqlite>,
+        issuer_request_id: &IssuerMintRequestId,
+        deposit_tx: B256,
+    ) -> Arc<Store<BurnExcess>> {
+        let bind = test_bind(issuer_request_id, deposit_tx);
+        let store = burn_excess_store(pool.clone()).await.unwrap();
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::RecordFundingExclusion {
+                    funding_log_id: test_funding_log(&bind),
+                    bind,
+                    reason: "abandoned path b".into(),
+                    incident_id: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+    }
+
+    #[tokio::test]
+    async fn close_dry_run_records_no_event_and_keeps_the_gate_closed() {
+        let pool = pool().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let deposit_tx = B256::random();
+        let store =
+            seed_funding_excluded(&pool, &issuer_request_id, deposit_tx).await;
+
+        run_burn_excess(
+            &pool,
+            &MockVaultService::new_success(),
+            &offline_provider(),
+            test_bind(&issuer_request_id, deposit_tx).issuer_wallet,
+            close_request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                U256::from(7u64),
+                Some(B256::random()),
+                false,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            matches!(
+                store.load(&BurnExcessId::new(deposit_tx)).await.unwrap(),
+                Some(BurnExcess::FundingExcluded { .. })
+            ),
+            "a dry-run close must not advance the stream"
+        );
+        assert!(
+            has_unresolved_excess_burn_intent(&pool, None).await.unwrap(),
+            "a dry-run close must leave the wallet gate held"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_execute_releases_the_wallet_gate() {
+        let pool = pool().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let deposit_tx = B256::random();
+        let store =
+            seed_funding_excluded(&pool, &issuer_request_id, deposit_tx).await;
+        assert!(
+            has_unresolved_excess_burn_intent(&pool, None).await.unwrap(),
+            "an abandoned Path B recovery must hold the gate before close"
+        );
+
+        run_burn_excess(
+            &pool,
+            &MockVaultService::new_success(),
+            &offline_provider(),
+            test_bind(&issuer_request_id, deposit_tx).issuer_wallet,
+            close_request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                U256::from(7u64),
+                Some(B256::random()),
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap(),
+            Some(BurnExcess::Closed { .. })
+        ));
+        assert!(
+            !has_unresolved_excess_burn_intent(&pool, None).await.unwrap(),
+            "close is the only escape from a stuck stream: it must release \
+             the gate that blocks every mint and redemption burn"
+        );
+    }
+
+    #[tokio::test]
+    async fn close_aborts_when_the_operator_declines() {
+        let pool = pool().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let deposit_tx = B256::random();
+        let store =
+            seed_funding_excluded(&pool, &issuer_request_id, deposit_tx).await;
+
+        let error = run_burn_excess(
+            &pool,
+            &MockVaultService::new_success(),
+            &offline_provider(),
+            test_bind(&issuer_request_id, deposit_tx).issuer_wallet,
+            close_request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                U256::from(7u64),
+                Some(B256::random()),
+                true,
+            ),
+            |_| Ok(false),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(error, BurnExcessEngineError::Aborted),
+            "a declined confirmation must abort, got: {error:?}"
+        );
+        assert!(matches!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap(),
+            Some(BurnExcess::FundingExcluded { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn close_refuses_a_stream_that_was_never_started() {
+        let pool = pool().await;
+        let deposit_tx = B256::random();
+
+        let error = run_burn_excess(
+            &pool,
+            &MockVaultService::new_success(),
+            &offline_provider(),
+            address!("0x3d0CD66EFA66c05d86c3d4316B03eAE87ab9E8aE"),
+            close_request(
+                BurnExcessMode::Internal,
+                IssuerMintRequestId::random(),
+                deposit_tx,
+                U256::from(7u64),
+                None,
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(
+                &error,
+                BurnExcessEngineError::Aggregate(inner)
+                    if matches!(
+                        **inner,
+                        super::super::BurnExcessError::InvalidState { .. }
+                    )
+            ),
+            "closing an uninitialized stream must refuse, got: {error:?}"
+        );
+    }
+
+    /// `ReportOnly` is matched before `close`, so `--close` on a terminal
+    /// stream reports instead of erroring — re-running an ops command must be
+    /// safe.
+    #[tokio::test]
+    async fn close_on_a_closed_stream_is_report_only() {
+        let pool = pool().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        let deposit_tx = B256::random();
+        let store =
+            seed_funding_excluded(&pool, &issuer_request_id, deposit_tx).await;
+        store
+            .send(
+                &BurnExcessId::new(deposit_tx),
+                BurnExcessCommand::CloseExcessBurn {
+                    reason: "already closed".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+        run_burn_excess(
+            &pool,
+            &MockVaultService::new_success(),
+            &offline_provider(),
+            test_bind(&issuer_request_id, deposit_tx).issuer_wallet,
+            close_request(
+                BurnExcessMode::External,
+                issuer_request_id,
+                deposit_tx,
+                U256::from(7u64),
+                Some(B256::random()),
+                true,
+            ),
+            |_| Ok(true),
+        )
+        .await
+        .unwrap();
+
+        assert!(matches!(
+            store.load(&BurnExcessId::new(deposit_tx)).await.unwrap(),
+            Some(BurnExcess::Closed { .. })
+        ));
+    }
 }

--- a/src/mint/job.rs
+++ b/src/mint/job.rs
@@ -24,7 +24,7 @@ use event_sorcery::{SendError, Store};
 use serde::{Deserialize, Serialize};
 use sqlx::{Pool, Sqlite};
 use std::sync::Arc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use super::recovery::{enqueue_scheduled_mint_recovery, release_terminal_job};
 use super::{
@@ -185,6 +185,42 @@ struct ResolvePreparedParams {
 }
 
 impl SubmitMintJob {
+    /// Refuses while another persisted intent holds this signer's nonce domain.
+    ///
+    /// The `active_signer_intents` reservation is network-keyed, so one check
+    /// covers competing mint AND redemption-burn intents on this signer.
+    /// `BurnExcess` holds no reservation row there, so it needs its own check.
+    async fn refuse_behind_wallet_intents(
+        &self,
+        ctx: &SubmitMintContext,
+        network: Network,
+        stage: &'static str,
+    ) -> Result<(), MintJobError> {
+        let unresolved_intent = has_unresolved_signer_intent(
+            &ctx.pool,
+            network,
+            Some(&self.issuer_request_id),
+        )
+        .await?;
+        let unresolved_excess =
+            has_unresolved_excess_burn_intent(&ctx.pool, None).await?;
+        if !unresolved_intent && !unresolved_excess {
+            return Ok(());
+        }
+
+        debug!(target: "mint",
+            issuer_request_id = %self.issuer_request_id,
+            unresolved_intent,
+            unresolved_excess,
+            stage,
+            "Deferring mint behind another persisted wallet intent"
+        );
+
+        Err(MintJobError::UnresolvedWalletIntent {
+            issuer_request_id: self.issuer_request_id.clone(),
+        })
+    }
+
     /// Rebroadcast a legacy `TxIntended` prepared identity under the wallet
     /// lock, after burn-parity classification (aligned with
     /// [`Self::resolve_prepared_for_submit`]).
@@ -204,21 +240,7 @@ impl SubmitMintJob {
         };
 
         let wallet_guard = vault.lock_wallet().await;
-        // Network-keyed reservation: one check covers competing mint AND burn
-        // intents on this signer's nonce domain. BurnExcess holds no
-        // reservation row there, so it needs its own check.
-        if has_unresolved_signer_intent(
-            &ctx.pool,
-            network,
-            Some(&self.issuer_request_id),
-        )
-        .await?
-            || has_unresolved_excess_burn_intent(&ctx.pool, None).await?
-        {
-            return Err(MintJobError::UnresolvedWalletIntent {
-                issuer_request_id: self.issuer_request_id.clone(),
-            });
-        }
+        self.refuse_behind_wallet_intents(ctx, network, "submission").await?;
 
         let owner = match prepared_tx.recover_signer() {
             Ok(owner) => owner,
@@ -447,21 +469,8 @@ impl SubmitMintJob {
             .map(super::MintExternalTxId::into_string);
 
         let wallet_guard = vault.lock_wallet().await;
-        // Network-keyed reservation: one check covers competing mint AND burn
-        // intents on this signer's nonce domain. BurnExcess holds no
-        // reservation row there, so it needs its own check.
-        if has_unresolved_signer_intent(
-            &ctx.pool,
-            params.network,
-            Some(&self.issuer_request_id),
-        )
-        .await?
-            || has_unresolved_excess_burn_intent(&ctx.pool, None).await?
-        {
-            return Err(MintJobError::UnresolvedWalletIntent {
-                issuer_request_id: self.issuer_request_id.clone(),
-            });
-        }
+        self.refuse_behind_wallet_intents(ctx, params.network, "preparation")
+            .await?;
 
         let Some(prepared) = self
             .resolve_prepared_for_submit(
@@ -1939,6 +1948,7 @@ mod tests {
 
     use super::*;
     use crate::alpaca::mock::MockAlpacaService;
+    use crate::burn_excess::BurnExcessEvent;
     use crate::mint::MintEvent;
     use crate::mint::api::test_utils::TestHarness;
     use crate::mint::tests::{
@@ -1995,6 +2005,42 @@ mod tests {
             .await
             .unwrap();
         }
+    }
+
+    /// Seeds an unresolved `BurnExcess` stream so the wallet intent gate sees a
+    /// competing excess-burn recovery. `BurnExcess` holds no
+    /// `active_signer_intents` row, so the gate reads the event stream directly
+    /// and only `event_type` matters — an empty payload is enough.
+    async fn seed_unresolved_excess_burn(
+        pool: &Pool<Sqlite>,
+        event_type: &str,
+    ) {
+        sqlx::query(
+            "
+            INSERT INTO events (
+                aggregate_type,
+                aggregate_id,
+                sequence,
+                event_type,
+                event_version,
+                payload,
+                metadata
+            )
+            VALUES (
+                'BurnExcess',
+                '0x00000000000000000000000000000000000000000000000000000000000000e1',
+                1,
+                ?,
+                '1.0',
+                '{}',
+                '{}'
+            )
+            ",
+        )
+        .bind(event_type)
+        .execute(pool)
+        .await
+        .unwrap();
     }
 
     fn submit_ctx(
@@ -2401,6 +2447,142 @@ mod tests {
             0,
             "the blocked job must not prepare another signed transaction"
         );
+    }
+
+    /// `BurnExcess` holds no `active_signer_intents` reservation, so the
+    /// network-keyed signer-intent query cannot see it. Without the separate
+    /// gate a mint would free-prepare over an excess recovery's nonce.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_from_minting_defers_to_an_unresolved_excess_burn_intent() {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_minting(&issuer_request_id),
+        )
+        .await;
+        // `FundingExcluded` holds no signed transaction yet, and must still
+        // block: its exclusion write is permanent and it will sign against the
+        // same issuer wallet.
+        seed_unresolved_excess_burn(
+            &harness.pool,
+            BurnExcessEvent::FUNDING_EXCLUSION_RECORDED,
+        )
+        .await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        let error = SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .expect_err("an unresolved excess burn must defer minting");
+
+        assert!(
+            matches!(error, MintJobError::UnresolvedWalletIntent { .. }),
+            "expected UnresolvedWalletIntent, got: {error:?}"
+        );
+        assert_eq!(
+            vault.get_call_count(),
+            0,
+            "the blocked job must not prepare a signed transaction"
+        );
+        let intent_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+              AND event_type = 'MintEvent::MintTxIntended'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            intent_count, 0,
+            "a blocked mint must persist no signed intent"
+        );
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "Deferring mint behind another persisted wallet intent",
+                "stage=\"preparation\"",
+                "unresolved_intent=false",
+                "unresolved_excess=true"
+            ]
+        ));
+    }
+
+    /// The rebroadcast path gates too: a persisted mint intent must not go back
+    /// on the wire while an excess recovery is signing against the same wallet.
+    #[traced_test]
+    #[tokio::test]
+    async fn submit_from_tx_intended_defers_to_an_unresolved_excess_burn_intent()
+     {
+        let harness = TestHarness::new().await;
+        let issuer_request_id = IssuerMintRequestId::random();
+        seed_mint_events(
+            &harness.pool,
+            &issuer_request_id,
+            events_through_tx_intended(&issuer_request_id),
+        )
+        .await;
+        seed_unresolved_excess_burn(
+            &harness.pool,
+            BurnExcessEvent::EXCESS_BURN_INTENDED,
+        )
+        .await;
+
+        let vault = Arc::new(MockVaultService::new_success());
+        let ctx = submit_ctx(&harness, vault.clone());
+
+        let error = SubmitMintJob {
+            issuer_request_id: issuer_request_id.clone(),
+            vault: VAULT,
+            chain_id: ANVIL_CHAIN_ID,
+        }
+        .perform(&ctx)
+        .await
+        .expect_err("an unresolved excess burn must defer submission");
+
+        assert!(
+            matches!(error, MintJobError::UnresolvedWalletIntent { .. }),
+            "expected UnresolvedWalletIntent, got: {error:?}"
+        );
+        let submitted_count: i64 = sqlx::query_scalar(
+            "
+            SELECT COUNT(*)
+            FROM events
+            WHERE aggregate_type = 'Mint'
+              AND aggregate_id = ?
+              AND event_type = 'MintEvent::MintTxSubmitted'
+            ",
+        )
+        .bind(issuer_request_id.to_string())
+        .fetch_one(&harness.pool)
+        .await
+        .unwrap();
+        assert_eq!(
+            submitted_count, 0,
+            "a blocked rebroadcast must record no submission"
+        );
+        assert!(logs_contain_at!(
+            Level::DEBUG,
+            &[
+                "Deferring mint behind another persisted wallet intent",
+                "stage=\"submission\"",
+                "unresolved_intent=false",
+                "unresolved_excess=true"
+            ]
+        ));
     }
 
     #[tokio::test]
@@ -3430,32 +3612,38 @@ mod tests {
         let harness = TestHarness::new().await;
         let redemption_id =
             crate::redemption::IssuerRedemptionRequestId::random();
-        sqlx::query(
-            "
-            INSERT INTO events (
-                aggregate_type,
-                aggregate_id,
-                sequence,
-                event_type,
-                event_version,
-                payload,
-                metadata
-            )
-            VALUES (
-                'Redemption',
-                ?,
+        // The reserve trigger requires the stream to carry exactly one
+        // `Detected` event, so a bare `BurnIntended` cannot seed a reservation.
+        for (sequence, event_type, payload) in [
+            (
                 1,
-                'RedemptionEvent::BurnIntended',
-                '1.0',
-                '{}',
-                '{}'
+                "RedemptionEvent::Detected",
+                r#"{"Detected":{"network":"base"}}"#,
+            ),
+            (2, "RedemptionEvent::BurnIntended", "{}"),
+        ] {
+            sqlx::query(
+                "
+                INSERT INTO events (
+                    aggregate_type,
+                    aggregate_id,
+                    sequence,
+                    event_type,
+                    event_version,
+                    payload,
+                    metadata
+                )
+                VALUES ('Redemption', ?, ?, ?, '1.0', ?, '{}')
+                ",
             )
-            ",
-        )
-        .bind(redemption_id.to_string())
-        .execute(&harness.pool)
-        .await
-        .unwrap();
+            .bind(redemption_id.to_string())
+            .bind(sequence)
+            .bind(event_type)
+            .bind(payload)
+            .execute(&harness.pool)
+            .await
+            .unwrap();
+        }
 
         let issuer_request_id = IssuerMintRequestId::random();
         seed_mint_events(

--- a/src/redemption/burn_manager.rs
+++ b/src/redemption/burn_manager.rs
@@ -2300,6 +2300,7 @@ mod tests {
     use rust_decimal::Decimal;
     use sqlx::{SqlitePool, sqlite::SqlitePoolOptions};
     use std::sync::Arc;
+    use std::time::Duration;
     use tracing_test::traced_test;
 
     use super::{
@@ -2307,6 +2308,7 @@ mod tests {
         RecoveryOutcome, Redemption, RedemptionCommand,
         should_release_reserved_burn,
     };
+    use crate::burn_excess::BurnExcessEvent;
     use crate::mint::IssuerMintRequestId;
     use crate::mint::{Quantity, TokenizationRequestId};
     use crate::receipt_inventory::{
@@ -5483,6 +5485,215 @@ mod tests {
         ));
         assert_eq!(vault_mock.replacement_preparation_call_count(), 1);
         assert_eq!(vault_mock.submitted_burn_txs(), vec![replacement_tx]);
+    }
+
+    /// Seeds an unresolved `BurnExcess` stream. The gate reads the event stream
+    /// rather than `active_signer_intents` (`BurnExcess` reserves no row there),
+    /// so only `event_type` matters and an empty payload is enough.
+    async fn seed_unresolved_excess_burn(
+        pool: &SqlitePool,
+        event_type: &str,
+    ) -> Result<(), sqlx::Error> {
+        insert_raw_event(
+            pool,
+            "BurnExcess",
+            "0x00000000000000000000000000000000000000000000000000000000000000e1",
+            1,
+            event_type,
+            "{}",
+        )
+        .await
+    }
+
+    /// A dead burn may only be replaced when nothing else holds this wallet.
+    /// `has_unresolved_signer_intent` cannot see an excess-burn recovery, so
+    /// without the separate gate the replacement would sign over its nonce.
+    #[traced_test]
+    #[tokio::test]
+    async fn provably_dead_replacement_waits_for_an_unresolved_excess_burn() {
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let old_tx = SendableTxWithHash::valid_for_test(
+            4,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let owner = old_tx.signer_for_test();
+        let replacement_tx = SendableTxWithHash::valid_for_test(
+            5,
+            vault,
+            Bytes::from_static(&[0xca, 0xfe]),
+        );
+        let vault_mock = Arc::new(
+            MockVaultService::new_success()
+                .with_burn_tx_status(BurnTxStatus::ProvablyDead)
+                .with_prepared_tx(old_tx),
+        );
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+        harness.add_asset(&UnderlyingSymbol::new("AAPL").unwrap(), vault).await;
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        create_test_redemption_in_burning_state(store, &issuer_request_id)
+            .await;
+        store
+            .send(
+                &issuer_request_id,
+                RedemptionCommand::IntendBurn {
+                    issuer_request_id: issuer_request_id.clone(),
+                    vault,
+                    burns: vec![],
+                    dust_shares: U256::ZERO,
+                    owner,
+                    external_tx_id: None,
+                },
+            )
+            .await
+            .expect("burn intent should persist");
+
+        // `FundingExcluded` holds no signed transaction yet, and must still
+        // block: the exclusion write is already permanent and the stream will
+        // sign against the same issuer wallet.
+        seed_unresolved_excess_burn(
+            pool,
+            BurnExcessEvent::FUNDING_EXCLUSION_RECORDED,
+        )
+        .await
+        .expect("excess burn intent should seed");
+
+        let manager = BurnManager::new_for_tests(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            owner,
+            ANVIL_CHAIN_ID,
+        );
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::SkippedManualIntervention)
+        ));
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 0);
+        assert!(vault_mock.submitted_burn_txs().is_empty());
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::BurnIntended { .. }
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Deferring dead burn replacement",
+                "unresolved_intent=false",
+                "unresolved_excess=true",
+            ]
+        ));
+
+        // Closing the excess stream must free the gate, or an abandoned
+        // recovery would block burns forever.
+        insert_raw_event(
+            pool,
+            "BurnExcess",
+            "0x00000000000000000000000000000000000000000000000000000000000000e1",
+            2,
+            BurnExcessEvent::EXCESS_BURN_CLOSED,
+            "{}",
+        )
+        .await
+        .expect("excess burn intent should resolve");
+        vault_mock.set_prepared_tx(replacement_tx.clone());
+
+        assert!(matches!(
+            manager.recover_single_burning(&issuer_request_id).await,
+            Ok(RecoveryOutcome::Executed)
+        ));
+        assert_eq!(vault_mock.replacement_preparation_call_count(), 1);
+        assert_eq!(vault_mock.submitted_burn_txs(), vec![replacement_tx]);
+    }
+
+    /// The live burn path waits behind an excess recovery rather than racing
+    /// it for the nonce, and resumes once that stream resolves.
+    ///
+    /// Exhausting the full 30-attempt budget is deliberately not asserted here:
+    /// the waits are real one-second sleeps, and paused time cannot stand in
+    /// for them because advancing the clock 30 seconds also trips sqlx's
+    /// 30-second pool acquire timeout.
+    #[traced_test]
+    #[tokio::test]
+    async fn live_burn_waits_for_an_unresolved_excess_burn_then_proceeds() {
+        let vault_mock = Arc::new(MockVaultService::new_success());
+        let harness = TestHarness::with_vault_mock(vault_mock.clone()).await;
+        let TestHarness { store, receipt_service, pool, .. } = &harness;
+
+        let vault = address!("0xcccccccccccccccccccccccccccccccccccccccc");
+        let underlying = UnderlyingSymbol::new("AAPL").unwrap();
+        harness.add_asset(&underlying, vault).await;
+        harness
+            .discover_receipt(
+                vault,
+                uint!(42_U256),
+                uint!(100_000000000000000000_U256),
+            )
+            .await;
+
+        seed_unresolved_excess_burn(
+            pool,
+            BurnExcessEvent::EXCESS_BURN_INTENDED,
+        )
+        .await
+        .expect("excess burn intent should seed");
+
+        let manager = BurnManager::new_for_tests(
+            vault_mock.clone(),
+            pool.clone(),
+            store.clone(),
+            receipt_service.clone(),
+            TEST_WALLET,
+            ANVIL_CHAIN_ID,
+        );
+
+        let issuer_request_id = IssuerRedemptionRequestId::random();
+        let aggregate =
+            create_test_redemption_in_burning_state(store, &issuer_request_id)
+                .await;
+
+        // Resolve the excess stream while the burn is parked in the wait loop,
+        // so the test also proves the gate releases instead of only blocking.
+        let releasing_pool = pool.clone();
+        let release = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(1_500)).await;
+            insert_raw_event(
+                &releasing_pool,
+                "BurnExcess",
+                "0x00000000000000000000000000000000000000000000000000000000000000e1",
+                2,
+                BurnExcessEvent::EXCESS_BURN_CLOSED,
+                "{}",
+            )
+            .await
+            .expect("excess burn intent should resolve");
+        });
+
+        manager
+            .handle_burning_started(&issuer_request_id, &aggregate)
+            .await
+            .expect("the burn must proceed once the excess stream resolves");
+        release.await.unwrap();
+
+        assert_eq!(
+            vault_mock.get_multi_burn_call_count(),
+            1,
+            "the burn must reach the chain exactly once, after the wait"
+        );
+        assert!(matches!(
+            load_aggregate(store, &issuer_request_id).await,
+            Redemption::Completed { .. }
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &[
+                "Waiting for an earlier wallet intent",
+                "unresolved_intent=false",
+                "unresolved_excess=true",
+            ]
+        ));
     }
 
     #[tokio::test]


### PR DESCRIPTION
<!-- Thanks for your Pull Request, please read the contributing guidelines before submitting. -->

## Motivation

- #311 shipped the excess-burn wallet gate and `burn-excess --close` with no test on either. The gate stops a mint or a redemption burn from signing over an excess recovery's nonce. `--close` is the only way out of a stuck `FundingExcluded` stream. That stream blocks every mint and every redemption burn on every network while it stays open.
- A mint blocked by the gate logged nothing. `MintJobError::UnresolvedWalletIntent` only carries the mint request id, so during an incident it points at the mint when the real cause can be an excess-burn stream, possibly on another network.
- `submit_mint_job_waits_for_unresolved_burn_intent` fails on `main` at `2ee262f`. It seeds a bare `RedemptionEvent::BurnIntended`, and the reserve trigger needs one `Detected` event on that stream.
- Follow-up to [RAI-1632](https://linear.app/makeitrain/issue/RAI-1632) (#311) and [RAI-1631](https://linear.app/makeitrain/issue/RAI-1631) (#312).

## Solution

- Extract `SubmitMintJob::refuse_behind_wallet_intents`. Both gate sites (`submit_from_tx_intended` and `submit_from_minting`) had the same check copied. The helper now logs `unresolved_intent`, `unresolved_excess`, and `stage` when it refuses, which is what `burn_manager` already reports.
- `src/mint/job.rs`, two tests, one per gate site. `submit_from_minting_defers_to_an_unresolved_excess_burn_intent` proves an unresolved `FundingExcluded` stream stops the prepare and writes no `MintTxIntended`. `submit_from_tx_intended_defers_to_an_unresolved_excess_burn_intent` proves the rebroadcast path stops too and writes no `MintTxSubmitted`.
- `src/redemption/burn_manager.rs`, two tests. `provably_dead_replacement_waits_for_an_unresolved_excess_burn` covers the dead-burn replacement gate. `live_burn_waits_for_an_unresolved_excess_burn_then_proceeds` covers the live wait loop. Both then close the excess stream and check the work resumes, so an abandoned recovery cannot look the same as a permanently stuck one.
- `src/burn_excess/engine.rs`, five `--close` tests. A dry run writes no event and holds the gate. `--execute` closes the stream and releases the gate. A declined confirmation aborts and leaves the stream alone. An uninitialized stream refuses with `InvalidState`. A terminal stream is report only, so a repeated ops command is safe.
- Fix `submit_mint_job_waits_for_unresolved_burn_intent`. It now seeds `Detected` then `BurnIntended`, which is the pattern `burn_manager` tests already use. This is unrelated to the rest, but the branch cannot go green without it.

Two notes on the tests:

The `--close` tests build the provider without a node, because the close path reaches no chain and no signer. That keeps them off Anvil and they run in under half a second.

`live_burn_waits_for_an_unresolved_excess_burn_then_proceeds` does not assert the full 30 attempt budget. The waits are real one second sleeps. Paused time cannot replace them, because advancing the clock 30 seconds also trips the sqlx pool acquire timeout. The test asserts wait then resume instead, and takes about 2 seconds. There is a comment on the test that says this.

I checked the gate tests are not vacuous. I dropped `|| unresolved_excess` from the production check, confirmed the test fails, then put it back.

## Checks

<!-- It's important you've done these, or your PR will not be considered for review -->

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.issuance/pr/322"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788720476&installation_model_id=19370&pr_number=322&repository=ST0x-Technology%2Fst0x.issuance&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.issuance%2Fpull%2F322&signature=ae779306f603bb97a8c38926aa1748f1adbf106a87f758aced73f3e9b5aab992"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
