### PR TITLE
feat: resolve the infra age identity from 1Password via SSH_IDENTITY_OP

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -10,3 +10,5 @@ watch_file flake.lock
 watch_file flake.nix
 
 use flake . --verbose --show-trace
+
+source_env_if_exists .envrc.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .direnv/
+.envrc.local
 .DS_Store
 .idea/
 target/

--- a/deploy.nix
+++ b/deploy.nix
@@ -241,19 +241,25 @@ in
           envInfraPkgs = infraPkgs.perEnv.${env};
 
           deployPreamble = ''
-            # parseIdentity (inside resolveHost) redefines this. The no-op keeps
-            # the EXIT trap from failing with exit 127 -- masking the real exit
-            # code -- when DEPLOY_HOST is pre-set and resolveHost never runs.
-            _cleanup_identity() { :; }
+            # Ahead of the DEPLOY_HOST branch, so the identity flags are
+            # consumed off "$@" whichever way the host is resolved -- otherwise
+            # they reach `deploy` (or bind $profile in the prelude below).
+            ${infraPkgs.parseIdentity}
 
             if [ -n "''${DEPLOY_HOST:-}" ]; then
               host_ip="$DEPLOY_HOST"
               echo "Using pre-set DEPLOY_HOST=$host_ip"
+              # An op:// identity is materialized for decryption alone, which
+              # this branch skips -- so no key file exists and the agent really
+              # is the credential.
+              if [ -n "''${SSH_IDENTITY_OP:-}" ] && [ -z "$ssh_identity" ]; then
+                echo "WARNING: SSH_IDENTITY_OP is set but DEPLOY_HOST skips decryption; relying on the 1Password SSH agent for authentication" >&2
+              fi
             else
               # Resolves the droplet IP from the encrypted per-env cache
               # (infra/.remote-${env}.age), decryptable by every key in
               # roles.${env}.ssh -- including the CI deploy key.
-              ${envInfraPkgs.resolveHost}
+              ${envInfraPkgs.resolveHostBody}
             fi
 
             # Pin the host key from keys.nix so SSH verifies it during
@@ -263,13 +269,15 @@ in
             ssh-keygen -R "$host_ip" >/dev/null 2>&1 || true
             echo "$host_ip ${hostKey}" >> "$HOME/.ssh/known_hosts"
 
-            identity="''${SSH_IDENTITY:-$HOME/.ssh/id_ed25519}"
             ssh_flag=""
-            if [ "$identity" != "$HOME/.ssh/id_ed25519" ]; then
-              export NIX_SSHOPTS="-i $identity"
-              ssh_flag="--ssh-opts=-i $identity"
+            # The bare default key is left unpinned: -i replaces ssh's default
+            # IdentityFile list, so pinning it would lock out an operator whose
+            # login key is another default. Agent keys are unaffected -- ssh
+            # still offers them unless IdentitiesOnly=yes.
+            if [ -n "$ssh_identity" ] && [ "$ssh_identity" != "$HOME/.ssh/id_ed25519" ]; then
+              export NIX_SSHOPTS="-i $ssh_identity"
+              ssh_flag="--ssh-opts=-i $ssh_identity"
             fi
-            trap _cleanup_identity EXIT
           '';
 
           mkDeployScript =

--- a/docs/nixos-provisioning.md
+++ b/docs/nixos-provisioning.md
@@ -20,14 +20,87 @@ are **kebab-case**.
 
 ```bash
 # from repo root — either:
-nix run .#tfEditVars -- -i "$SSH_IDENTITY"
+nix run .#tfEditVars
 # or:
 nix develop
-tf-edit-vars -i "$SSH_IDENTITY"
+tf-edit-vars
 ```
 
-Identity: `export SSH_IDENTITY=~/.ssh/id_ed25519`, or pass `-i`, or
-`--op 'op://vault/item'`.
+### Identity resolution
+
+`tf*`, `{env}Remote`, `{env}Service*`, `bootstrap`, `rekey`, `secret`, and the
+deploy scripts all resolve one decryption identity through the same precedence:
+`--op <uri>` (+ `--op-account <acct>`, accepted only alongside `--op`) >
+`-i <key>` > `$SSH_IDENTITY` > `$SSH_IDENTITY_OP` (+ optional
+`$SSH_IDENTITY_OP_ACCOUNT`) > `~/.ssh/id_ed25519`. Every command in this doc is
+shown bare — pass one of the flags, as the first argument, only to override the
+default. With an `op://` source the key file is materialized for decryption only
+and is never passed to `ssh -i`, so SSH itself authenticates through the
+1Password SSH agent. `bootstrap` is the exception: it provisions a fresh
+droplet, and both `nixos-anywhere` and its pre/post-install SSH probes need a
+concrete key path, so bootstrap does pass the materialized key as `ssh -i` /
+`IdentityFile=` for the lifetime of that command.
+
+For every command but `bootstrap`, SSH access therefore requires the 1Password
+SSH agent to be serving a key that is present in the server's `authorized_keys`
+— the `op://` item used for decryption does not have to be that SSH key, and
+cannot be when it holds an age identity.
+
+An SSH agent cannot substitute for any of this: age decryption needs the raw
+private key for key agreement with the recipient, and the SSH agent protocol
+exposes only a sign operation, no way to derive a shared secret from the key it
+holds. `DEPLOY_HOST=<ip>` deploys are the one exception (see "Deploy" below) —
+they skip decryption entirely, so `SSH_IDENTITY_OP` has no effect there and an
+`op://` source leaves the 1Password SSH agent as the only credential. A file
+identity (`-i <key>` or `$SSH_IDENTITY`) is still passed to ssh as `-i`.
+
+**Recommended setup:** put your 1Password identity in the gitignored
+`.envrc.local` (sourced by `.envrc`; run `direnv allow` once after creating or
+editing it):
+
+```bash
+echo "export SSH_IDENTITY_OP='op://<vault>/<item>/private key'" >> .envrc.local
+# optional, only if the item is not in your default 1Password account:
+echo "export SSH_IDENTITY_OP_ACCOUNT=<account>" >> .envrc.local
+direnv allow
+```
+
+The bare field URI above is right for an item that stores the key in a **text
+field**. For a 1Password **SSH key** item, append `?ssh-format=openssh` —
+without it `op read` serves the key as PKCS#8, which `rage` cannot parse (see
+the
+[`op read` reference](https://developer.1password.com/docs/cli/reference/commands/read)).
+The tooling checks the fetched key's format and says so if it is wrong.
+
+**Caching:** no key material is ever cached. Every `--op`/`SSH_IDENTITY_OP`
+resolution is a fresh `op read` into a `0600` temp file that is deleted when the
+command exits, Ctrl-C included: every command resolves the key in its shell
+wrapper, where an EXIT trap owns the removal. That resolution is also lazy — it
+only happens the moment a command actually needs to decrypt something, so a
+command that never decrypts never calls `op` and is never prompted. What IS
+cached is the **decrypted droplet IP** (`{env}Remote`, `{env}Service*`,
+`{env}DbReset` and the deploy scripts): `0600` inside a `0700` per-user runtime
+directory (`$XDG_RUNTIME_DIR`, else `$TMPDIR`, else `~/.cache`), keyed by the
+sha256 of `infra/.remote-{env}.age` itself. `tf-apply` and `tf-destroy` rewrite
+that file on exit, so every one of them changes the hash and is an automatic,
+exact cache miss — there is nothing to clear by hand. (`rekey` does not: it
+re-encrypts the secrets in `secret/secrets.nix`, which never include the
+remote-IP caches.)
+
+**Prompt model:** `{env}Remote`-style commands prompt `op` at most once per IP
+rotation (cache hits skip identity resolution entirely); `tf*`, `rekey`,
+`tf-edit-vars`, `secret` and `bootstrap` prompt once per invocation, since they
+always decrypt. SSH authentication for the remote/service/deploy scripts goes
+through the 1Password SSH agent whenever the identity came from an `op://`
+source (`-i` is then never passed to ssh) — the agent's own approval/biometric
+settings are the knob for how often you are prompted for a fresh SSH connection.
+`bootstrap` is the exception noted above: it passes the materialized key as `-i`
+/ `IdentityFile=`, so it prompts `op` up front and that key is the one offered
+first. The agent is not locked out — `-i` only replaces ssh's default identity
+files, and agent keys are still offered unless `IdentitiesOnly=yes`. One caveat:
+the ambient `op` signed-in account is not part of the IP cache key when
+`--account`/`SSH_IDENTITY_OP_ACCOUNT` is omitted, so switching accounts reuses a
+cached IP the same as before.
 
 Service secrets encrypt to `roles.{env}.service` (`st0x-op` + `host-{env}`). Use
 the **st0x-op private key** as `-i` when creating service secrets unless you
@@ -57,9 +130,9 @@ Bootstrap overwrites each `host-{env}` with the real key and runs `ragenix -r`.
 
 Per environment (`staging`, then `prod`):
 
-| File                                              | Contents                                  |
-| ------------------------------------------------- | ----------------------------------------- |
-| `secret/st0x-issuance-{env}.env.age`              | Service env (from `.env.secrets.example`) |
+| File                                 | Contents                                  |
+| ------------------------------------ | ----------------------------------------- |
+| `secret/st0x-issuance-{env}.env.age` | Service env (from `.env.secrets.example`) |
 
 Shared:
 
@@ -70,9 +143,9 @@ Shared:
 ```bash
 cp infra/terraform.tfvars.example infra/terraform.tfvars
 $EDITOR infra/terraform.tfvars
-nix run .#tfEditVars -- -i "$SSH_IDENTITY"
+nix run .#tfEditVars
 
-nix run .#rekey -- -i "$SSH_IDENTITY"
+nix run .#rekey
 git add secret/*.age infra/terraform.tfvars.age keys.nix
 git commit -m "ops: encrypted secrets for provisioning"
 ```
@@ -84,9 +157,9 @@ git commit -m "ops: encrypted secrets for provisioning"
 Creates **both** prod and staging modules by default.
 
 ```bash
-nix run .#tfInit -- -i "$SSH_IDENTITY"
-nix run .#tfPlan -- -i "$SSH_IDENTITY" -target=module.staging   # staging only
-nix run .#tfApply -- -i "$SSH_IDENTITY"
+nix run .#tfInit
+nix run .#tfPlan -- -target=module.staging   # staging only
+nix run .#tfApply
 git add infra/terraform.tfstate.age && git commit -m "ops: terraform state"
 ```
 
@@ -103,8 +176,8 @@ Requires TCP 22 on the DigitalOcean cloud firewall (for the Ubuntu image and
 NixOS accepts operator/CI SSH on the public IP with key-only auth.
 
 ```bash
-nix run .#bootstrap -- -i "$SSH_IDENTITY" staging
-nix run .#bootstrap -- -i "$SSH_IDENTITY" prod
+nix run .#bootstrap -- staging
+nix run .#bootstrap -- prod
 ```
 
 **Trust-on-first-use caveat:** the first SSH connection to the fresh droplet is
@@ -133,11 +206,14 @@ git commit -m "ops: bootstrap host keys + rekey"
 ## Deploy
 
 The deploy scripts resolve the droplet IP from `infra/.remote-{env}.age` and pin
-the host key from `keys.nix`; `DEPLOY_HOST=<ip>` overrides resolution.
+the host key from `keys.nix`; `DEPLOY_HOST=<ip>` overrides resolution. With
+`DEPLOY_HOST` set, no `.remote-{env}.age` decryption happens, so
+`SSH_IDENTITY_OP` is ignored — the 1Password SSH agent alone must cover the
+connection.
 
 ```bash
-nix run .#stagingDeployAll -- -i "$SSH_IDENTITY"
-nix run .#prodDeployAll -- -i "$SSH_IDENTITY"
+nix run .#stagingDeployAll
+nix run .#prodDeployAll
 ```
 
 ---

--- a/flake.nix
+++ b/flake.nix
@@ -308,7 +308,6 @@
                 ];
               text = ''
                 ${infraPkgs.parseIdentity}
-                trap _cleanup_identity EXIT
 
                 env="''${1:?usage: bootstrap [-i identity] <prod|staging>}"
                 shift
@@ -325,6 +324,10 @@
                     exit 1 ;;
                 esac
 
+                # bootstrap.nu needs a concrete key path, so resolve one here
+                # -- after argv validation, so a usage error never prompts.
+                _require_identity
+
                 # No exec: replacing the shell would skip the EXIT trap and
                 # leak the 1Password temp identity file.
                 export env flake_config host_key_field identity
@@ -338,18 +341,33 @@
                 ragenixPkg
                 pkgs.nushell
                 pkgs.coreutils
+                infraPkgs.opIdentity
               ];
               text = ''
-                exec nu ${./scripts/secret.nu} "$@"
+                ${infraPkgs.parseIdentity}
+                # Resolved here rather than in nushell, which cannot trap
+                # SIGINT: Ctrl-C while $EDITOR is open would otherwise leave the
+                # 1Password temp key on disk. No exec, for the same reason:
+                # replacing the shell would skip the EXIT trap that removes it.
+                #
+                # Handed over as --identity, not $SSH_IDENTITY: nushell's $env
+                # lookup is case-insensitive, so the ssh_identity parseIdentity
+                # exports would shadow it. An --identity/-i the operator passes
+                # after the file still wins -- nushell takes the last flag.
+                _require_identity
+                nu ${./scripts/secret.nu} --identity "$identity" "$@"
               '';
             };
 
             rekey = pkgs.writeShellApplication {
               name = "rekey";
-              runtimeInputs = [ ragenixPkg ];
+              runtimeInputs = [
+                ragenixPkg
+                pkgs.coreutils
+              ];
               text = ''
                 ${infraPkgs.parseIdentity}
-                trap _cleanup_identity EXIT
+                _require_identity
                 ${rekeySecrets}
               '';
             };

--- a/infra/.gitignore
+++ b/infra/.gitignore
@@ -1,6 +1,9 @@
 *.tfstate
 *.tfstate.backup
+# `??????` matches mktemp residue only, so terraform.tfvars.example stays tracked
+terraform.tfstate.??????
 terraform.tfvars
+terraform.tfvars.??????
 tfplan
 .terraform/
 .remote-*

--- a/infra/default.nix
+++ b/infra/default.nix
@@ -6,14 +6,20 @@
 }:
 
 let
+  opIdentity = import ./op-identity.nix { inherit pkgs; };
+
   buildInputs = [
     pkgs.terraform
     pkgs.rage
     pkgs.jq
+    pkgs.coreutils
     ragenix.packages.${system}.default
   ];
 
-  sshBuildInputs = [ pkgs.rage ];
+  sshBuildInputs = [
+    pkgs.rage
+    pkgs.coreutils
+  ];
 
   tfPlanFile = "infra/tfplan";
 
@@ -24,15 +30,19 @@ let
       agePath = "${file}.age";
       decrypt = ''
         if [ -f ${file}.age ]; then
-          if [ -z "''${identity:-}" ]; then
-            echo "ERROR: decrypting ${file}.age requires an identity. Options:" >&2
-            echo "  -i <path>                    explicit key" >&2
-            echo "  SSH_IDENTITY=<path>          env var" >&2
-            echo "  --op op://vault/item         1Password CLI" >&2
-            echo "  ~/.ssh/id_ed25519            default key" >&2
+          _require_identity
+          # Decrypted to a temp file and renamed only on success, so a failed
+          # decryption can never leave a truncated file at the real path --
+          # otherwise a zero-byte terraform.tfstate here would get
+          # re-encrypted over terraform.tfstate.age by the EXIT trap.
+          _decrypt_tmp=$(mktemp ${file}.XXXXXX)
+          _decrypt_tmpfiles+=("$_decrypt_tmp")
+          if rage -d -i "$identity" ${file}.age > "$_decrypt_tmp"; then
+            mv "$_decrypt_tmp" ${file}
+          else
+            rm -f "$_decrypt_tmp"
             exit 1
           fi
-          rage -d -i "$identity" ${file}.age > ${file}
         fi
       '';
       encrypt = ''
@@ -67,56 +77,151 @@ let
     }) environments
   );
 
-  # Callers must invoke _cleanup_identity in their own cleanup/on_exit,
-  # or call it explicitly before exec, to remove the temporary key file.
+  # Callers must invoke _cleanup_identity in their own cleanup/on_exit, or
+  # call it explicitly before exec, to remove the ephemeral files.
+  #
+  # Two variables, because the identity plays two unrelated roles. $identity is
+  # the key rage decrypts with; $ssh_identity is the key file ssh/deploy-rs may
+  # present with -i. File-path sources (-i, $SSH_IDENTITY, ~/.ssh/id_ed25519)
+  # set both, here at parse time: it costs nothing and never prompts. A
+  # 1Password source sets only $identity, and only lazily, at the first
+  # _require_identity call -- so a command that never decrypts (e.g. a host-IP
+  # cache hit in resolveHost) never touches 1Password, and ssh authenticates
+  # through the 1Password SSH agent whether the cache was warm or cold.
   parseIdentity = ''
     set -eo pipefail
 
     _identity_tmpfile=""
-    # The guard must not be `[ -n ... ] && rm`: as the last command of an EXIT
-    # trap, its exit 1 (no tmpfile) would override the script's exit code.
-    _cleanup_identity() { if [ -n "$_identity_tmpfile" ]; then rm -f "$_identity_tmpfile"; fi; }
+    _decrypt_tmpfiles=()
+    # The guards must not be `[ -n ... ] && rm`: as the last command of an EXIT
+    # trap, an exit 1 (nothing to remove) would override the script's exit code.
+    _cleanup_identity() {
+      if [ -n "$_identity_tmpfile" ]; then rm -f "$_identity_tmpfile"; fi
+      if [ ''${#_decrypt_tmpfiles[@]} -gt 0 ]; then rm -f "''${_decrypt_tmpfiles[@]}"; fi
+    }
+
+    _identity_from_op() {
+      identity="$(${opIdentity}/bin/op-identity "$@")"
+      _identity_tmpfile="$identity"
+    }
+
+    # A value starting with `-` is the next flag, not a value: rejecting it
+    # here beats an opaque failure inside `op read` or `rage` layers down.
+    _require_flag_value() {
+      case "''${2:-}" in
+        "" | -*)
+          echo "ERROR: $1" >&2
+          exit 1
+          ;;
+      esac
+    }
+
+    identity=""
+    # Exported rather than plain-assigned: the scripts that only decrypt never
+    # read it back, and an unread plain assignment fails their shellcheck gate.
+    export ssh_identity=""
+    _identity_source=""
+    _identity_op_args=()
 
     if [ "''${1:-}" = "--op" ]; then
-      if [ -z "''${2:-}" ]; then
-        echo "ERROR: --op requires an op:// URI" >&2
-        exit 1
-      fi
+      _require_flag_value "--op requires an op:// URI" "''${2:-}"
       _op_uri="$2"
       shift 2
-      _op_args=()
+      _identity_op_args=("$_op_uri")
       if [ "''${1:-}" = "--op-account" ]; then
-        if [ -z "''${2:-}" ]; then
-          echo "ERROR: --op-account requires an account" >&2
-          exit 1
-        fi
-        _op_args+=(--account "$2")
+        _require_flag_value "--op-account requires an account" "''${2:-}"
+        _identity_op_args+=(--account "$2")
         shift 2
       fi
-      _identity_tmpfile="$(mktemp)"
-      chmod 600 "$_identity_tmpfile"
-      _op="$(command -v op 2>/dev/null || echo /opt/homebrew/bin/op)"
-      if [ ! -x "$_op" ]; then
-        echo "ERROR: 1Password CLI (op) not found" >&2
-        exit 1
-      fi
-      "$_op" read "$_op_uri" "''${_op_args[@]}" > "$_identity_tmpfile"
-      identity="$_identity_tmpfile"
+      _identity_source="op"
+    elif [ "''${1:-}" = "--op-account" ]; then
+      # Only ever a modifier of --op. Left in "$@" it would reach the downstream
+      # command (an ssh remote command, a deploy profile name) as an argument.
+      echo "ERROR: --op-account requires --op" >&2
+      exit 1
     elif [ "''${1:-}" = "-i" ]; then
-      if [ -z "''${2:-}" ]; then
-        echo "ERROR: identity is empty -- pass -i <path> or set a default" >&2
-        exit 1
-      fi
+      _require_flag_value "identity is empty -- pass -i <path> or set a default" "''${2:-}"
       identity="$2"
+      ssh_identity="$2"
       shift 2
     elif [ -n "''${SSH_IDENTITY:-}" ]; then
       identity="$SSH_IDENTITY"
-    elif [ -f "$HOME/.ssh/id_ed25519" ]; then
+      ssh_identity="$SSH_IDENTITY"
+    elif [ -n "''${SSH_IDENTITY_OP:-}" ]; then
+      _identity_op_args=("$SSH_IDENTITY_OP")
+      if [ -n "''${SSH_IDENTITY_OP_ACCOUNT:-}" ]; then
+        _identity_op_args+=(--account "$SSH_IDENTITY_OP_ACCOUNT")
+      fi
+      _identity_source="op"
+    elif [ -n "''${HOME:-}" ] && [ -f "$HOME/.ssh/id_ed25519" ]; then
       identity="$HOME/.ssh/id_ed25519"
-    else
-      echo "ERROR: no identity found -- pass -i <path>, set SSH_IDENTITY, or use --op" >&2
-      exit 1
+      ssh_identity="$HOME/.ssh/id_ed25519"
     fi
+
+    # Idempotent: a non-empty $identity short-circuits every call after the
+    # first, so decrypting several files in one script (e.g. tfvars then
+    # tfstate) only ever prompts once.
+    _require_identity() {
+      if [ -n "$identity" ]; then
+        return 0
+      fi
+      if [ "$_identity_source" = "op" ]; then
+        _identity_from_op "''${_identity_op_args[@]}"
+      else
+        echo "ERROR: no identity found -- pass -i <path>, set SSH_IDENTITY or SSH_IDENTITY_OP, or use --op" >&2
+        echo "  an SSH agent alone cannot decrypt age files: the agent protocol signs, it does not do key agreement" >&2
+        exit 1
+      fi
+    }
+
+    trap _cleanup_identity EXIT
+  '';
+
+  # Caches the decrypted droplet IP (never key material) so the frequent
+  # {env}Remote / {env}Service* / {env}DbReset commands skip both the age
+  # decrypt and identity resolution on a hit -- see resolveHost below, which
+  # keys entries by the ciphertext's hash, so any rewrite of
+  # infra/.remote-{env}.age (tf-apply and tf-destroy re-encrypt it on exit) is
+  # an automatic, exact invalidation.
+  hostIpCacheLib = ''
+    _host_ip_cache_dir() {
+      if [ -n "''${XDG_RUNTIME_DIR:-}" ]; then
+        printf '%s/st0x-host-ip\n' "$XDG_RUNTIME_DIR"
+      elif [ -n "''${TMPDIR:-}" ]; then
+        printf '%s/st0x-host-ip\n' "$TMPDIR"
+      else
+        printf '%s/.cache/st0x-host-ip\n' "''${HOME:-}"
+      fi
+    }
+
+    # The umask subshell creates the directory 0700 in one step, leaving no
+    # window at the ambient mode; a directory that already existed keeps its own
+    # mode, so tighten that separately. -L runs before -O because -O follows
+    # symlinks -- a planted link would otherwise hand a foreign directory our
+    # writes.
+    _ensure_host_ip_cache_dir() {
+      local cache_dir
+      cache_dir=$(_host_ip_cache_dir)
+      if ! (umask 077 && mkdir -p "$cache_dir") 2>/dev/null; then
+        echo "WARNING: cannot create cache directory $cache_dir -- continuing without the host-IP cache" >&2
+        return 1
+      fi
+      if [ -L "$cache_dir" ] || [ ! -O "$cache_dir" ]; then
+        echo "WARNING: cache directory $cache_dir is a symlink or not owned by the current user -- continuing without the host-IP cache" >&2
+        return 1
+      fi
+      chmod 700 "$cache_dir" 2>/dev/null || true
+      printf '%s\n' "$cache_dir"
+    }
+
+    # One shape rule for both ends of the cache, so a value the decrypt path
+    # accepts can never be silently rejected on read-back (a permanent miss).
+    _is_host_ip() {
+      case "''${1:-}" in
+        "" | *[!0-9.]*) return 1 ;;
+        *) return 0 ;;
+      esac
+    }
   '';
 
   cleanup = "rm -f ${state.path} ${state.path}.backup ${vars.path}";
@@ -169,20 +274,65 @@ let
       remoteFile = remoteFiles.${env};
       sshInputs = sshBuildInputs ++ [ pkgs.openssh ];
 
+      # Split from resolveHost so a caller can validate argv between the two:
+      # parseIdentity only reads flags; this half decrypts and can prompt.
+      resolveHostBody = ''
+        ${hostIpCacheLib}
+
+        _host_ip_dir=""
+        _host_ip_entry=""
+        host_ip=""
+        if _host_ip_dir=$(_ensure_host_ip_cache_dir) && [ -f ${remoteFile.agePath} ]; then
+          # The hash names the entry, so a failure to read the ciphertext leaves
+          # $_host_ip_entry empty: no read, no write-back, command unaffected.
+          if _host_ip_age_hash=$(sha256sum ${remoteFile.agePath} 2>/dev/null | cut -d' ' -f1) &&
+            [ -n "$_host_ip_age_hash" ]; then
+            _host_ip_entry="$_host_ip_dir/${env}-$_host_ip_age_hash"
+            # An absent or concurrently evicted entry is a miss, not an error, so
+            # the read itself must never be fatal.
+            _host_ip_cached=$(cat "$_host_ip_entry" 2>/dev/null || true)
+            if _is_host_ip "$_host_ip_cached"; then
+              host_ip="$_host_ip_cached"
+            fi
+          else
+            echo "WARNING: cannot hash ${remoteFile.agePath} -- continuing without the host-IP cache" >&2
+          fi
+        fi
+
+        if [ -z "$host_ip" ]; then
+          ${remoteFile.decrypt}
+          # The check below names the ciphertext to fix; a `cat` error would not.
+          host_ip=$(cat ${remoteFile.path} 2>/dev/null || true)
+          rm -f ${remoteFile.path}
+          if ! _is_host_ip "$host_ip"; then
+            echo "ERROR: could not resolve ${env} host from ${remoteFile.agePath}" >&2
+            exit 1
+          fi
+          if [ -n "$_host_ip_entry" ]; then
+            # A cache write must never fail the command -- the host is already
+            # resolved. Chained because bash ignores errexit left of `||`: an
+            # unchained partial write would still be renamed into place and
+            # served later as a truncated IP. The umask covers a temp recreated
+            # by the redirect after a concurrent run's eviction glob removed it.
+            (
+              umask 077
+              rm -f "$_host_ip_dir/${env}"-* "$_host_ip_dir/${env}".*
+              _host_ip_tmp=$(mktemp "$_host_ip_dir/${env}.XXXXXX") &&
+                printf '%s\n' "$host_ip" > "$_host_ip_tmp" &&
+                mv "$_host_ip_tmp" "$_host_ip_entry"
+            ) 2>/dev/null || echo "WARNING: could not write host-IP cache entry -- continuing" >&2
+          fi
+        fi
+      '';
+
       resolveHost = ''
         ${parseIdentity}
-        ${remoteFile.decrypt}
-        host_ip=$(cat ${remoteFile.path})
-        rm -f ${remoteFile.path}
-        if [ -z "$host_ip" ]; then
-          echo "ERROR: could not resolve ${env} host from ${remoteFile.agePath}" >&2
-          exit 1
-        fi
+        ${resolveHostBody}
       '';
 
       requireDecryptedSecrets = ''
         # shellcheck disable=SC2029
-        ssh ''${identity:+-i "$identity"} "root@$host_ip" '
+        ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" '
           activate=/nix/var/nix/profiles/per-service/st0x-issuance/deploy-rs-activate
           if [ ! -f /run/agenix/st0x-issuance.env ]; then
             echo "Decrypted secrets missing (tmpfs cleared after reboot); trying to re-run service activation to restore them..." >&2
@@ -199,7 +349,7 @@ let
 
     in
     {
-      inherit resolveHost;
+      inherit resolveHost resolveHostBody;
 
       "${env}Remote" = pkgs.writeShellApplication {
         name = "${env}-remote";
@@ -208,7 +358,7 @@ let
           ${resolveHost}
           trap _cleanup_identity EXIT
           # shellcheck disable=SC2029
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" "$@"
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" "$@"
         '';
       };
 
@@ -220,9 +370,9 @@ let
           trap _cleanup_identity EXIT
           ${requireDecryptedSecrets}
           echo "Starting st0x-issuance on ${env}..."
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" \
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" \
             "mkdir -p /run/st0x && touch /run/st0x/st0x-issuance.ready && systemctl start st0x-issuance"
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" systemctl is-active st0x-issuance
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" systemctl is-active st0x-issuance
         '';
       };
 
@@ -233,7 +383,7 @@ let
           ${resolveHost}
           trap _cleanup_identity EXIT
           echo "Stopping st0x-issuance on ${env}..."
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" \
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" \
             "systemctl stop st0x-issuance && rm -f /run/st0x/st0x-issuance.ready"
           echo "Stopped."
         '';
@@ -247,17 +397,17 @@ let
           trap _cleanup_identity EXIT
           ${requireDecryptedSecrets}
           echo "Restarting st0x-issuance on ${env}..."
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" \
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" \
             "mkdir -p /run/st0x && touch /run/st0x/st0x-issuance.ready && systemctl restart st0x-issuance"
-          ssh ''${identity:+-i "$identity"} "root@$host_ip" systemctl is-active st0x-issuance
+          ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" systemctl is-active st0x-issuance
         '';
       };
 
       "${env}DbReset" = pkgs.writeShellApplication {
         name = "${env}-db-reset";
-        runtimeInputs = sshInputs;
+        runtimeInputs = sshInputs ++ [ pkgs.gnugrep ];
         text = ''
-          ${resolveHost}
+          ${parseIdentity}
           trap _cleanup_identity EXIT
 
           stay_stopped=false
@@ -279,9 +429,12 @@ let
             exit 1
           fi
 
+          # After the refusal above, so a usage error never decrypts or prompts.
+          ${resolveHostBody}
+
           ssh_remote() {
             # shellcheck disable=SC2029
-            ssh ''${identity:+-i "$identity"} "root@$host_ip" "$@"
+            ssh ''${ssh_identity:+-i "$ssh_identity"} "root@$host_ip" "$@"
           }
 
           _restart_service() {
@@ -332,15 +485,30 @@ let
     }) environments
   );
 
-  perEnv = builtins.mapAttrs (_: result: { inherit (result) resolveHost; }) envResults;
+  perEnv = builtins.mapAttrs (_: result: {
+    inherit (result) resolveHost resolveHostBody;
+  }) envResults;
 
   envPkgs = builtins.foldl' (
-    acc: env: acc // builtins.removeAttrs envResults.${env} [ "resolveHost" ]
+    acc: env:
+    acc
+    // builtins.removeAttrs envResults.${env} [
+      "resolveHost"
+      "resolveHostBody"
+    ]
   ) { } environments;
 
 in
 {
-  inherit buildInputs sshBuildInputs parseIdentity;
+  # Deliberately not a member of `packages`: that attrset becomes flake
+  # packages, and op-identity's contract is to leave a private key on disk for
+  # its caller to delete -- there is no caller behind `nix run`.
+  inherit
+    buildInputs
+    sshBuildInputs
+    parseIdentity
+    opIdentity
+    ;
 
   inherit perEnv;
 

--- a/infra/op-identity.nix
+++ b/infra/op-identity.nix
@@ -1,0 +1,114 @@
+# Resolves a 1Password identity URI to a 0600 temp file containing the raw
+# key and prints that file's path -- the whole stdout contract. Always
+# ephemeral: one `op read` per call, caller deletes the file when done. The
+# shared implementation behind both `parseIdentity` (bash, infra/default.nix)
+# and `resolve-identity` (nushell, scripts/secret.nu) so there is one `op
+# read` code path, not two.
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "op-identity";
+  runtimeInputs = [ pkgs.coreutils ];
+  text = ''
+    usage() {
+      echo "Usage: op-identity <op://vault/item[/field]> [--account <account>]" >&2
+      exit 1
+    }
+
+    # `op read` is redirected straight to $fetch_dest, never captured via
+    # $( ) -- its stdout must not contaminate this tool's own stdout contract,
+    # and any TTY prompt it issues must still reach the terminal.
+    fetch_key() {
+      fetch_uri="$1"
+      fetch_account="$2"
+      fetch_dest="$3"
+      op_args=("$fetch_uri")
+      if [ -n "$fetch_account" ]; then
+        op_args+=(--account "$fetch_account")
+      fi
+      if ! "$op_path" read "''${op_args[@]}" > "$fetch_dest"; then
+        rm -f "$fetch_dest"
+        echo "ERROR: op read failed for $fetch_uri" >&2
+        exit 1
+      fi
+      # `op read` exits 0 for a field that exists but holds nothing, which is a
+      # different operator mistake than a wrong key format.
+      if [ ! -s "$fetch_dest" ]; then
+        rm -f "$fetch_dest"
+        echo "ERROR: op read returned no data for $fetch_uri" >&2
+        exit 1
+      fi
+      # The accepted classes are the non-interactive ones rage's identity
+      # parsers take: an OpenSSH or PKCS#1 RSA PEM private key (age crate,
+      # src/ssh/identity.rs) or an age identity file, whose reader skips blank
+      # and `#` comment lines around the AGE-SECRET-KEY-1 body (age crate,
+      # src/identity.rs) -- hence classifying the first substantive line,
+      # CRLF-tolerant, rather than line 1. 1Password serves an SSH-key item's
+      # "private key" field as PKCS#8
+      # (-----BEGIN PRIVATE KEY-----) unless the URI asks for OpenSSH. Never
+      # echo the line. Passphrase-encrypted age identity files, which rage also
+      # accepts, are deliberately excluded: this tool's contract is a key file
+      # the caller can use non-interactively, and one of those would surface a
+      # rage passphrase prompt layers down instead.
+      fetch_header=""
+      while IFS= read -r fetch_line || [ -n "$fetch_line" ]; do
+        fetch_line="''${fetch_line%$'\r'}"
+        case "$fetch_line" in
+          "" | "#"*) continue ;;
+        esac
+        fetch_header="$fetch_line"
+        break
+      done < "$fetch_dest"
+      case "$fetch_header" in
+        "-----BEGIN OPENSSH PRIVATE KEY-----" | "-----BEGIN RSA PRIVATE KEY-----" | AGE-SECRET-KEY-1*) ;;
+        *)
+          rm -f "$fetch_dest"
+          echo "ERROR: $fetch_uri did not return a key rage can read" >&2
+          echo "  1Password serves SSH-key items as PKCS#8 by default -- append ?ssh-format=openssh to the op:// URI" >&2
+          exit 1
+          ;;
+      esac
+    }
+
+    # Re-raises after removing the temp key, so a signalled run terminates with
+    # the conventional 128+signal status instead of surviving into the caller's
+    # error path.
+    on_signal() {
+      rm -f "$tmp"
+      trap - "$1"
+      kill -s "$1" "$$"
+    }
+
+    uri="''${1:-}"
+    [ -n "$uri" ] || usage
+    shift
+
+    account=""
+    if [ "''${1:-}" = "--account" ]; then
+      account="''${2:-}"
+      [ -n "$account" ] || usage
+      shift 2
+    fi
+    [ "$#" -eq 0 ] || usage
+
+    # Before mktemp, so a missing op needs no temp-file cleanup.
+    op_path=$(command -v op || true)
+    if [ -z "$op_path" ] && [ -x /opt/homebrew/bin/op ]; then
+      op_path=/opt/homebrew/bin/op
+    fi
+    if [ -z "$op_path" ] || [ ! -x "$op_path" ]; then
+      echo "ERROR: 1Password CLI (op) not found" >&2
+      exit 1
+    fi
+
+    tmp=$(mktemp)
+    # Not an EXIT trap: the file is the deliverable, so the trap only covers the
+    # window before the caller learns the path and takes over deletion.
+    trap 'on_signal INT' INT
+    trap 'on_signal TERM' TERM
+    trap 'on_signal HUP' HUP
+    fetch_key "$uri" "$account" "$tmp"
+    trap - INT TERM HUP
+    printf '%s\n' "$tmp"
+  '';
+}

--- a/scripts/secret.nu
+++ b/scripts/secret.nu
@@ -6,42 +6,34 @@
 # "missing file" error instead of the old positional `$1`/`$2` fall-through
 # that crashed on an unbound `$HOME`.
 
+# op-identity prints one line: the path of an ephemeral key file this caller
+# now owns and must delete.
+def read-op-identity [uri: string, account: string] {
+  let args = if ($account | is-not-empty) { [$uri "--account" $account] } else { [$uri] }
+  # Not `complete`: it buffers stderr too, so an interactive 1Password prompt
+  # would stay invisible until op gave up. Assigning the bare external call
+  # captures stdout only, leaves stderr on the terminal, and still raises on a
+  # non-zero exit. Not wrapped in try/catch either: op-identity already prints a
+  # specific `ERROR:` line for every failure branch, so a wrapper would only
+  # restate nushell's "non-zero exit code" on top of it.
+  let out = (^op-identity ...$args)
+  let path = ($out | lines | get 0)
+  { path: $path, tmpfile: $path }
+}
+
 # Resolves the age/SSH identity used to decrypt, mirroring the deploy tooling's
 # precedence: --op (1Password) > --identity/-i > $SSH_IDENTITY >
-# ~/.ssh/id_ed25519. Returns the key path plus an optional temp file the caller
-# must delete once both ragenix calls are done.
-# Returns a `{ path, tmpfile }` record; `tmpfile` is "" unless the key came from
-# 1Password, in which case it is the temp file the caller must delete.
+# $SSH_IDENTITY_OP (1Password) > ~/.ssh/id_ed25519. Returns a
+# `{ path, tmpfile }` record; `tmpfile` is "" for a caller-supplied key that
+# must NOT be deleted, and the ephemeral 1Password key to delete once both
+# ragenix calls are done otherwise.
 def resolve-identity [
   --identity: string
   --op: string
   --op-account: string
 ] {
   if ($op | is-not-empty) {
-    let found = (which op)
-    let op_bin = if ($found | is-not-empty) { $found.0.path } else { "/opt/homebrew/bin/op" }
-    if not ($op_bin | path exists) {
-      error make --unspanned {
-        msg: "1Password CLI (op) not found -- install it or pass -i <key> instead"
-      }
-    }
-
-    # mktemp creates the file 0600; chmod again so a key never lands group/other
-    # readable even if save were to recreate it.
-    let tmp = (mktemp --tmpdir "secret-identity-XXXXXX")
-    ^chmod 600 $tmp
-
-    let op_args = if ($op_account | is-not-empty) { ["--account" $op_account] } else { [] }
-    let read = (do { ^$op_bin read $op ...$op_args } | complete)
-    if $read.exit_code != 0 {
-      rm --force $tmp
-      error make --unspanned {
-        msg: $"reading identity from 1Password failed: ($read.stderr | str trim)"
-      }
-    }
-
-    $read.stdout | save --raw --force $tmp
-    return { path: $tmp, tmpfile: $tmp }
+    return (read-op-identity $op ($op_account | default ""))
   }
 
   if ($identity | is-not-empty) {
@@ -59,6 +51,11 @@ def resolve-identity [
     return { path: $ssh_identity, tmpfile: "" }
   }
 
+  let op_uri = ($env.SSH_IDENTITY_OP? | default "")
+  if ($op_uri | is-not-empty) {
+    return (read-op-identity $op_uri ($env.SSH_IDENTITY_OP_ACCOUNT? | default ""))
+  }
+
   # Guard $HOME: under nushell it is simply absent rather than an "unbound
   # variable" crash, but a missing HOME must still fall through to a clear error
   # rather than probing a bogus "/.ssh/id_ed25519".
@@ -72,10 +69,14 @@ def resolve-identity [
 
   error make --unspanned {
     msg: ("no decryption identity available -- pass one of:\n"
-      + "  -i <key>              explicit age/SSH private key\n"
-      + "  --op op://vault/item  read the key from 1Password\n"
-      + "  SSH_IDENTITY=<key>    environment variable\n"
-      + "  ~/.ssh/id_ed25519     default key")
+      + "  -i <key>               explicit age/SSH private key\n"
+      + "  --op op://vault/item   read the key from 1Password\n"
+      + "  SSH_IDENTITY=<key>     environment variable\n"
+      + "  SSH_IDENTITY_OP=<uri>  read the key from 1Password (env form)\n"
+      + "  ~/.ssh/id_ed25519      default key\n"
+      + "An SSH agent cannot substitute for any of these: age decryption needs "
+      + "the raw private key for key agreement, and the agent protocol only "
+      + "signs.")
   }
 }
 
@@ -96,34 +97,44 @@ def main [
 ] {
   let identity = (resolve-identity --identity $identity --op $op --op-account $op_account)
 
-  let before = (file-hash $file)
-
-  # ragenix -e launches $EDITOR, so run it directly to inherit the terminal --
-  # capturing it via `complete` would break the interactive editor. try/catch
-  # guarantees the 1Password temp key is removed even when the edit fails.
+  # One outer catch around everything past resolve-identity, so no failure path
+  # can leave the 1Password temp key on disk. A signal is not a failure path:
+  # nushell cannot trap SIGINT, so a key resolved here is only removed if the
+  # catch still gets to run. The packaged `secret` (flake.nix) does not rely on
+  # that -- it resolves the key in its bash wrapper, passes it as --identity,
+  # and lets a bash EXIT trap own the removal.
   try {
-    ^ragenix --rules ./secret/secrets.nix -i $identity.path -e $file
+    let before = (file-hash $file)
+
+    # ragenix -e launches $EDITOR, so run it directly to inherit the terminal --
+    # capturing it via `complete` would break the interactive editor.
+    try {
+      ^ragenix --rules ./secret/secrets.nix -i $identity.path -e $file
+    } catch {|err|
+      error make --unspanned { msg: $"failed to edit ($file): ($err.msg)" }
+    }
+
+    let after = (file-hash $file)
+
+    if $before != $after {
+      print $"($file) changed -- rekeying all recipients"
+      try {
+        ^ragenix --rules ./secret/secrets.nix -i $identity.path -r
+      } catch {|err|
+        error make --unspanned {
+          msg: ($"rekey failed: ($err.msg)\n"
+            + $"WARNING: ($file) may not be encrypted for every recipient yet -- "
+            + "re-run this command to finish rekeying before deploying.")
+        }
+      }
+    } else {
+      print $"($file) unchanged -- skipping rekey"
+    }
   } catch {|err|
     cleanup-identity $identity
-    error make --unspanned { msg: $"failed to edit ($file): ($err.msg)" }
-  }
-
-  let after = (file-hash $file)
-
-  if $before != $after {
-    print $"($file) changed -- rekeying all recipients"
-    try {
-      ^ragenix --rules ./secret/secrets.nix -i $identity.path -r
-    } catch {|err|
-      cleanup-identity $identity
-      error make --unspanned {
-        msg: ($"rekey failed: ($err.msg)\n"
-          + $"WARNING: ($file) may not be encrypted for every recipient yet -- "
-          + "re-run this command to finish rekeying before deploying.")
-      }
-    }
-  } else {
-    print $"($file) unchanged -- skipping rekey"
+    # Re-raised with the original's help text: nushell keeps the offending path
+    # or reason there, and a bare `msg` would drop it.
+    error make --unspanned { msg: $err.msg, help: ($err.json | from json).help? }
   }
 
   cleanup-identity $identity


### PR DESCRIPTION
## Motivation

- The infra commands resolve one identity and use it for two jobs: `rage -d` on the encrypted droplet IP, and `ssh -i`. `rage` cannot use the 1Password SSH agent, cause the agent protocol only signs, and age decryption needs the raw key for key agreement.
- `SSH_IDENTITY` only accepts a file path. An operator whose keys live only in 1Password has no working bare invocation, only an explicit `--op` per command.
- Every `op read` costs an interactive 1Password approval. So the fix must not route every command through `op read` on every invocation, or the tooling becomes a prompt farm.
- This broke silently at #313: the rotation re-keyed the age files, and anyone with a stale `~/.ssh/id_ed25519` got `No matching keys found` with no hint. Closes [RAI-1683](https://linear.app/makeitrain/issue/RAI-1683/resolve-the-infra-toolings-age-identity-from-1password-via-ssh).

## Solution

The design rule: a 1Password key is for decryption only, and the only thing cached on disk is the decrypted droplet IP. Key material is never cached, never passed to `ssh -i` (SSH goes through the 1Password SSH agent), and only exists as a `0600` temp file that an EXIT trap deletes.

- `SSH_IDENTITY_OP` (+ `SSH_IDENTITY_OP_ACCOUNT`) joins the precedence chain: `--op` > `-i` > `$SSH_IDENTITY` > `$SSH_IDENTITY_OP` > `~/.ssh/id_ed25519`. Recommended home is the gitignored `.envrc.local`, sourced by `.envrc`.
- New `infra/op-identity.nix`: the single `op read` path shared by bash (`parseIdentity`) and nushell (`scripts/secret.nu`). It validates the fetched key's header, cause 1Password serves SSH-key items as PKCS#8 by default and `rage` cannot parse that. The error tells you to append `?ssh-format=openssh`.
- Resolution is lazy for op sources: `parseIdentity` records the source, and `_require_identity` materializes the key at the first decrypt. A command that never decrypts never calls `op` and never prompts.
- Host-IP cache: `{env}Remote`, `{env}Service*`, `{env}DbReset`, and the deploy scripts cache the decrypted IP (`0600` in a `0700` runtime dir), keyed by the sha256 of `infra/.remote-{env}.age`. `tf-apply`/`tf-destroy` rewrite that file, so rotation is an exact, automatic cache miss. A warm cache means zero `op` calls and `ssh` without `-i`. Cache failures warn and degrade to uncached, they never abort a command.
- `bootstrap` is the one exception to the ssh rule: `nixos-anywhere` and its install probes need a concrete key path, so it does pass the materialized key as `-i`. The docs say so.
- Fixed on the way: `rage -d ... > file` truncated the target before decrypting, so a failed decrypt in `tf-apply` re-encrypted a zero-byte `terraform.tfstate` over `terraform.tfstate.age`. Decryption now goes to a temp file and renames only on success.
- `deploy.nix` no longer clobbers the resolved identity, and the `DEPLOY_HOST` branch now consumes identity flags instead of forwarding them to `deploy` as argv.
- `secret` resolves the key in its bash wrapper so a bash EXIT trap owns the removal. Nushell cannot trap SIGINT, so Ctrl-C in `$EDITOR` used to leak the temp key.

No committed tests: this is bash generated from Nix, and the repo has no shell test harness. Verified by `nix build` of every infra/deploy/flake attr (shellcheck runs inside `writeShellApplication`) plus stub-`op` smoke runs of the generated scripts: cache hit/miss, precedence order, flag guards, signal cleanup, PKCS#8 rejection, and both deploy branches. The real `op` was never invoked.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [ ] added comprehensive test coverage for any changes in logic (no shell harness in the repo, see the note above)
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined SSH identity resolution using command-line options, environment variables, default keys, and 1Password references.
  - Added a helper for securely retrieving supported identities from 1Password.
  - Added safer host-resolution caching and temporary key handling.

- **Bug Fixes**
  - Improved deployment behavior when a host is supplied directly.
  - Added validation and clearer warnings for invalid or unavailable identities.
  - Improved cleanup and failure handling during secret editing and rekeying.

- **Documentation**
  - Updated provisioning and deployment guidance to reflect the unified identity workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->