### PR TITLE
Add `move-receipts` and `confirm-custody` CLI commands with ERC-165 contract corroboration and post-migration reconciliation skip

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1197,12 +1197,44 @@ against the local SQLite store, and is where future issuer actions (e.g. `mint`,
   before cutover (`orchestrator.mint`, `orchestrator.burn`, `vault.approve`,
   `receipt.safeBatchTransferFrom`), so a policy gap surfaces as a named signing
   refusal instead of during the pilot's first live mint.
+- `issuer move-receipts <UNDERLYING>` — moves one vault's tracked deposit
+  receipts to a corroborated destination through the Turnkey signer, driving the
+  receipt-moving engine (see "Receipt custody"). The destination is stated by
+  exactly one of two mutually exclusive flags: `--to-configured-orchestrator`
+  reads `[orchestrator].address` from `--config` (the cutover path — the
+  orchestrator address is never typed), while `--to <ADDRESS>` states an
+  explicit destination (the wallet-rotation path). `--to` naming the configured
+  orchestrator address is refused: the cutover path must state it through the
+  config flag, so a hand-typed orchestrator address never enters the flow.
+  Either way the stated address only becomes reachable as a transfer destination
+  through the corroboration witness described under "Receipt custody". Before
+  anything is signed the command verifies the deployment hold is armed (the hold
+  file present and the readiness marker absent — the engine's projection
+  rebuilds must not race a running service), verifies the bot wallet's native
+  balance covers a fixed transfer-gas ceiling at the current gas price (no
+  per-transaction estimate — estimating a transfer of receipts the destination
+  does not hold yet would revert), corroborates the destination, and then
+  prompts with the asset, vault, holder, destination and its corroborated kind,
+  and the tracked receipt count — the operator confirms what was proven, not
+  what was typed. A re-run after a completed move reports the already-migrated
+  observation distinctly and submits nothing.
+- `issuer confirm-custody <UNDERLYING>` — verifies on-chain that the Turnkey bot
+  wallet holds exactly every tracked receipt balance for the asset's vault, then
+  records it as the inventory's custody holder. The rollback counterpart of
+  `move-receipts`: after an `EMERGENCY_ROLE` `withdrawReceipt` returns a token's
+  receipts to the bot wallet, recorded custody still names the old destination,
+  so reconciliation stays skipped until this re-confirmation. The holder is
+  always the Turnkey wallet (`TURNKEY_ADDRESS`) — never typed — and it cannot be
+  recorded wrongly: a wallet that does not hold every tracked balance is refused
+  with the first mismatch. Requires the deployment hold armed (the engine's
+  quiescence gates and projection rebuilds must not race a running service);
+  signs nothing and submits nothing on-chain.
 
-`burn-excess` is listing/network-scoped and takes
-`--network` / `--chain-id` (cross-checked against the RPC-reported chain); its
-RPC endpoint is **not** a CLI flag — it uses the service environment for that
-network (`CHAIN_<NETWORK>_RPC_URL`, with legacy `RPC_URL` as Base fallback), the
-same secrets the long-running bot loads.
+`burn-excess` is listing/network-scoped and takes `--network` / `--chain-id`
+(cross-checked against the RPC-reported chain); its RPC endpoint is **not** a
+CLI flag — it uses the service environment for that network
+(`CHAIN_<NETWORK>_RPC_URL`, with legacy `RPC_URL` as Base fallback), the same
+secrets the long-running bot loads.
 
 ### Burn excess shares
 
@@ -1367,27 +1399,54 @@ addresses as free-form operator targets):**
 | Receipt ID              | `7`                                                                  |
 | Shares                  | `0.750` (`750000000000000000` raw)                                   |
 
-The orchestrator onboarding subcommands (`orchestrator-preflight`,
-`approve-orchestrator`, `verify-orchestrator-signing`) take the same network
-flags plus `--config` (the TOML configuration file; its `[orchestrator].address`
-is the only source of the orchestrator address — never typed) and require the
-`TURNKEY_*` group: the readiness facts they verify or establish are keyed to the
-Turnkey bot wallet, so a local-key signer is refused. See
-`docs/runbooks/orchestrator-onboarding.md` for the ordered procedure.
+The orchestrator onboarding and custody subcommands (`orchestrator-preflight`,
+`approve-orchestrator`, `verify-orchestrator-signing`, `move-receipts`,
+`confirm-custody`) take the same network flags and require the `TURNKEY_*`
+group: the facts they verify or establish are keyed to the Turnkey bot wallet,
+so a local-key signer is refused. All but `confirm-custody` also take `--config`
+(the TOML configuration file; its `[orchestrator].address` is the only source of
+the orchestrator address — never typed); `confirm-custody` involves no
+orchestrator address at all. See `docs/runbooks/orchestrator-onboarding.md` for
+the ordered onboarding and per-asset cutover procedures.
 
 ### Receipt custody
 
-The receipt-moving engine is vendor-neutral and deliberately has no operator
-entry point. It remains reusable library code until
-[RAI-1681](https://linear.app/makeitrain/issue/RAI-1681) supplies a dedicated
-driver with a signing provider and stated destination. The engine and custody
+The receipt-moving engine is vendor-neutral; its operator driver is
+`issuer move-receipts`
+([RAI-1681](https://linear.app/makeitrain/issue/RAI-1681)), which supplies the
+Turnkey signing provider and the stated destination. The engine and custody
 state are exercised by end-to-end tests in `tests/receipt_custody.rs`.
 
 An ERC-1155 transfer to a wrong address is final — no counterparty, no recovery,
-and the receipts back tokens that are still outstanding. The engine therefore
-requires a `CorroboratedRecipient` witness before a transfer can be reached. The
-witness refuses the zero address, the current holder itself, and a destination
-with neither transaction history nor native balance on the target chain.
+and the receipts back tokens that are still outstanding. **The destination
+safety guarantee**: a destination is reachable as a transfer target only through
+a `CorroboratedRecipient` witness the transfer cannot be constructed without,
+and the corroboration is as strong as the kind of address it names. The witness
+first refuses the zero address and the current holder itself, then splits on
+what the chain says the address is:
+
+- **Externally owned account** (no deployed code): refused unless the chain has
+  independent evidence it exists — transaction history or native balance. An
+  address with neither is precisely what a fat-fingered address looks like,
+  since the odds of a typo landing on a used address are negligible. Both
+  legitimate EOA destinations clear it: an incoming signing wallet has to be
+  funded for gas before it can run the service, and a prior signing wallet has
+  already been active on-chain.
+- **Contract** (non-empty code): a deployed contract passes the EOA evidence for
+  the wrong reason — deployment proves nothing about its ability to receive
+  receipts, and ERC-1155 `safeTransferFrom` / `safeBatchTransferFrom` revert
+  unless the recipient implements the receiver hooks. So a contract destination
+  is refused unless it proves ERC-1155 receiver support up front via ERC-165
+  (`supportsInterface(IERC1155Receiver)` returning true; a revert or a false — a
+  bare ERC-20, say — is a refusal). Receiver support must be proven before
+  submitting, never discovered by a revert. The `ST0xOrchestrator` clears this:
+  it implements the receiver hooks (its receiver lowers the per-token burn
+  pointer when a receipt arrives below it, which is the documented migration
+  path) and answers ERC-165.
+
+The witness records which kind it corroborated, so the driver's confirmation
+prompt and the audit trail state the destination's proven kind rather than
+assuming one.
 
 `VaultIdentity` is also a corroborated witness rather than a caller-assembled
 tuple. Its network must name the requested chain, the provider must report that
@@ -1432,12 +1491,15 @@ cross-checked against on-chain balances, the vault's certification and
 owner-freeze gates are re-read immediately before submission, and a completed
 move observed again is recorded idempotently instead of being re-transferred
 (`AlreadyMigrated`). A single transfer is limited to the 14-receipt batch size
-proven in production; larger inventories refuse until a future driver supplies
-resumable chunking. That driver must verify the deployment hold, bind the
-signing provider to the recorded holder, and add destination-type-specific proof
-of control and gas readiness before the generic engine is invoked. Use
-`docs/runbooks/deploy-hold.md` when the service must remain stopped across a
-deploy.
+proven in production; larger inventories refuse until resumable chunking exists
+(expected for the full rollout's high-volume assets, not the pilot). The
+`move-receipts` driver performs the outside-the-engine checks before the generic
+engine is invoked: it verifies the deployment hold is armed (hold file present,
+readiness marker absent — see `docs/runbooks/deploy-hold.md`), binds the signing
+provider to the Turnkey bot wallet (which the engine then independently
+corroborates against recorded aggregate custody as the stated holder), verifies
+the wallet's native balance covers a fixed transfer-gas ceiling at the current
+gas price, and corroborates the destination by kind as described above.
 
 Custody is therefore part of the `ReceiptInventory` aggregate's own state,
 maintained by two events. `CustodyConfirmed { holder }` records the wallet the
@@ -1458,16 +1520,38 @@ every balance reading carries the wallet it was taken against, and the handler
 refuses readings from any wallet other than the recorded holder — and refuses a
 destructive zero reading outright while no holder has ever been confirmed.
 Custody is confirmed automatically when startup reconciliation reads every
-tracked balance without error; `confirm_custody_holder` remains available to a
-future custody driver for holders that are not the signing wallet. Confirmation
-is not retried periodically: after a startup read failure, correct the cause and
-restart the service. Every balance reader goes through this handler, so no code
-path can apply a wrong-wallet reading. The refusal is per vault and writes
-nothing: the service keeps serving vaults whose custody matches while a
-displaced vault fails loudly at ERROR. A pass that cannot read every balance
-confirms nothing, so one flaky call cannot disarm the guard. An empty inventory
-also confirms no custody and leaves the vault `Unobserved`; confirmation
-requires at least one tracked receipt to be read successfully.
+tracked balance without error; `issuer confirm-custody` drives the same
+`confirm_custody_holder` verification manually when automatic confirmation
+cannot run (the rollback path below). Confirmation is not retried periodically:
+after a startup read failure, correct the cause and restart the service. Every
+balance reader goes through this handler, so no code path can apply a
+wrong-wallet reading. The refusal is per vault and writes nothing: the service
+keeps serving vaults whose custody matches while a displaced vault fails loudly
+at ERROR. A pass that cannot read every balance confirms nothing, so one flaky
+call cannot disarm the guard. An empty inventory also confirms no custody and
+leaves the vault `Unobserved`; confirmation requires at least one tracked
+receipt to be read successfully.
+
+**Custody moved by a recorded migration is expected, not displacement.** After
+`move-receipts` lands, the vault's recorded holder is the destination (e.g. the
+orchestrator), which is not the signing wallet — and that state persists until
+the receipt-inventory subsystem retires
+([RAI-1223](https://linear.app/makeitrain/issue/RAI-1223)). The periodic
+reconciliation and backfill paths therefore skip balance reads for a vault whose
+recorded custody holder differs from the signing wallet **when a recorded
+`CustodyMigrated` from the signing wallet explains the mismatch**, logging the
+skip once at INFO — dispatching those readings would only manufacture
+`CustodyDisplaced` errors for a state the operator deliberately created. A
+holder mismatch with no recorded migration explaining it is true displacement
+and still fails loudly at ERROR.
+
+The skip also defines the rollback recovery: after an `EMERGENCY_ROLE`
+`withdrawReceipt` returns a token's receipts to the bot wallet, recorded custody
+still names the orchestrator, so reconciliation keeps skipping the vault (and
+cannot auto-confirm, since it never reads). The operator runs
+`issuer confirm-custody` — which verifies the bot wallet holds exactly every
+tracked balance and records it as holder — and reconciliation resumes normally
+on the next startup.
 
 Freeze, unfreeze, and status address the `Underlying` aggregate, so they take no
 network argument: one freeze covers every listing of the underlying. The CLI

--- a/nix/st0x-deploy.nix
+++ b/nix/st0x-deploy.nix
@@ -24,5 +24,7 @@ in
     ST0X_STOX_RECEIPT_VAULT_ABI = "${abi}/out/StoxReceiptVault.sol/StoxReceiptVault.json";
     ST0X_STOX_OARV_BEACON_SET_DEPLOYER_ABI = "${abi}/out/StoxOffchainAssetReceiptVaultBeaconSetDeployer.sol/StoxOffchainAssetReceiptVaultBeaconSetDeployer.json";
     IERC1271_ABI = "${abi}/out/IERC1271.sol/IERC1271.json";
+    IERC165_ABI = "${abi}/out/IERC165.sol/IERC165.json";
+    IERC1155_RECEIVER_ABI = "${abi}/out/IERC1155Receiver.sol/IERC1155Receiver.json";
   };
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -49,3 +49,17 @@ sol!(
     IERC1271,
     env!("IERC1271_ABI")
 );
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IERC165,
+    env!("IERC165_ABI")
+);
+
+sol!(
+    #![sol(all_derives = true, rpc)]
+    #[derive(serde::Serialize, serde::Deserialize)]
+    IERC1155Receiver,
+    env!("IERC1155_RECEIVER_ABI")
+);

--- a/src/receipt_inventory/backfill.rs
+++ b/src/receipt_inventory/backfill.rs
@@ -244,15 +244,38 @@ where
                 })
             })?;
 
-        // Process reconciliation events (Withdraw + outbound transfers)
+        // Process reconciliation events (Withdraw + outbound transfers).
+        // Once a recorded migration moved this vault's custody away from the
+        // signing wallet, `balanceOf(bot_wallet)` readings mean nothing and
+        // could only be refused as `CustodyDisplaced` — the migration's own
+        // outbound transfers land here on post-cutover catch-up, so they are
+        // skipped at INFO until the subsystem retires (RAI-1223). The
+        // discovery path above needs no gate: a zero balance returns before
+        // any command is dispatched.
         let unique_reconciliation_ids: Vec<_> =
             all_reconciliation_ids.into_iter().unique().collect();
 
-        let reconciled_count = u64::try_from(unique_reconciliation_ids.len())?;
-
-        for receipt_id in unique_reconciliation_ids {
-            self.reconcile_receipt(receipt_id).await?;
-        }
+        let reconciled_count = if unique_reconciliation_ids.is_empty() {
+            0
+        } else if load_inventory(&self.store, self.chain_id, &self.vault)
+            .await?
+            .custody()
+            .moved_away_from(self.bot_wallet)
+        {
+            info!(target: "receipt", vault = %self.vault,
+                wallet = %self.bot_wallet,
+                skipped = unique_reconciliation_ids.len(),
+                "Custody recorded at a migrated destination; skipping \
+                 outbound-transfer reconciliation"
+            );
+            0
+        } else {
+            let reconciled = u64::try_from(unique_reconciliation_ids.len())?;
+            for receipt_id in unique_reconciliation_ids {
+                self.reconcile_receipt(receipt_id).await?;
+            }
+            reconciled
+        };
 
         advance_receipt_backfill(
             &self.pool,
@@ -1694,6 +1717,127 @@ mod tests {
             inventory.receipts_with_balance().is_empty(),
             "No receipts should be discovered from outbound/mint transfers"
         );
+    }
+
+    /// Post-cutover catch-up sees the migration's own outbound transfers.
+    /// Once recorded custody moved away from the signing wallet, those
+    /// reconciliation readings are skipped at INFO instead of manufacturing
+    /// `CustodyDisplaced` refusals — the mocked provider deliberately serves
+    /// no `balanceOf` response, so a dispatched reading would fail the test.
+    #[tokio::test]
+    #[traced_test]
+    async fn backfill_skips_outbound_reconciliation_for_a_migrated_vault() {
+        let (receipt_contract, bot_wallet, vault) = test_addresses();
+        let destination =
+            address!("0x5555555555555555555555555555555555555555");
+        let (store, pool) = setup_store().await;
+
+        let receipt_id = U256::from(7);
+        let tx_hash = b256!(
+            "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        );
+
+        let key = ReceiptVaultKey::new(ANVIL_CHAIN_ID, vault);
+        store
+            .send(
+                &key,
+                ReceiptInventoryCommand::DiscoverReceipt {
+                    receipt_id: ReceiptId::from(receipt_id),
+                    balance: Shares::from(U256::from(100)),
+                    block_number: 1,
+                    tx_hash,
+                    source: ReceiptSource::External,
+                    receipt_info: None,
+                    receipt_info_bytes: None,
+                },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &key,
+                ReceiptInventoryCommand::ConfirmCustody { holder: bot_wallet },
+            )
+            .await
+            .unwrap();
+        store
+            .send(
+                &key,
+                ReceiptInventoryCommand::RecordCustodyMigration {
+                    from: bot_wallet,
+                    to: destination,
+                    tx_hash: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // The migration's own outbound transfer, observed on catch-up.
+        let outbound_log =
+            create_transfer_single_log(TransferSingleLogParams {
+                receipt_contract,
+                operator: bot_wallet,
+                from: bot_wallet,
+                to: destination,
+                id: receipt_id,
+                value: U256::from(100),
+                tx_hash,
+                block_number: 100,
+            });
+
+        let asserter = Asserter::new();
+        // Discovery queries: Deposit, inbound TransferSingle, inbound
+        // TransferBatch — all empty.
+        for _ in 0..3 {
+            asserter.push_success(&Vec::<Log>::new());
+        }
+        // Reconciliation queries: Withdraw empty, outbound TransferSingle
+        // carries the migration transfer, outbound TransferBatch empty.
+        asserter.push_success(&Vec::<Log>::new());
+        asserter.push_success(&vec![outbound_log]);
+        asserter.push_success(&Vec::<Log>::new());
+        // Deliberately NO balanceOf response.
+
+        let provider = ProviderBuilder::new()
+            .wallet(EthereumWallet::from(PrivateKeySigner::random()))
+            .connect_mocked_client(asserter);
+
+        let backfiller = ReceiptBackfiller::new(ReceiptBackfillDeps {
+            provider,
+            receipt_contract,
+            bot_wallet,
+            chain_id: ANVIL_CHAIN_ID,
+            network: Network::Base,
+            vault,
+            store: store.clone(),
+            pool: pool.clone(),
+            handler: NoOpItnHandler,
+        });
+
+        let result = backfiller.backfill_receipts(0, 200).await.unwrap();
+
+        assert_eq!(
+            result.reconciled_count, 0,
+            "the migrated vault's outbound reconciliation must be skipped"
+        );
+
+        let inventory =
+            load_inventory(&store, ANVIL_CHAIN_ID, &vault).await.unwrap();
+        assert_eq!(
+            inventory.receipts_with_balance().len(),
+            1,
+            "the migrated inventory must survive the pass intact"
+        );
+        assert_eq!(
+            inventory.custody().holder(),
+            Some(destination),
+            "the skip must not touch recorded custody"
+        );
+
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["skipping", "outbound-transfer reconciliation"]
+        ));
     }
 
     #[tokio::test]

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -6,8 +6,10 @@
 //! at the old address: the new wallet holds shares it cannot redeem because the
 //! matching receipt sits elsewhere. Custody has to follow the rotation.
 //!
-//! The vendor-neutral engine deliberately has no operator entry point. A new
-//! operational driver will be introduced with the next signer migration.
+//! The vendor-neutral engine's operator driver is `issuer move-receipts`
+//! (`src/tokenized_asset/cli.rs`), which supplies the Turnkey signing
+//! provider and the kind-corroborated destination, and performs the
+//! outside-the-engine checks (deploy hold, gas readiness, confirmation).
 //!
 //! **The issuer service must be stopped before this runs.** Startup
 //! reconciliation reads `balanceOf(bot_wallet)` for every tracked receipt
@@ -23,6 +25,7 @@
 use alloy::eips::BlockId;
 use alloy::primitives::{Address, B256, Bytes, U256};
 use alloy::providers::{PendingTransactionError, Provider};
+use alloy::sol_types::SolCall;
 use async_trait::async_trait;
 use event_sorcery::StoreBuilder;
 use itertools::izip;
@@ -35,7 +38,9 @@ use super::{
     ReceiptId, ReceiptInventory, ReceiptInventoryCommand, Shares,
     SharesOverflow, load_inventory, send_receipt_inventory_command,
 };
-use crate::bindings::{OffchainAssetReceiptVault, Receipt};
+use crate::bindings::{
+    IERC165, IERC1155Receiver, OffchainAssetReceiptVault, Receipt,
+};
 use crate::mint::{Mint, find_stuck as find_stuck_mints};
 use crate::prepare_event_sourced_startup;
 use crate::redemption::view::{
@@ -53,6 +58,33 @@ use crate::tokenized_asset::{Network, TokenizedAsset, UnderlyingSymbol};
 /// bound is safer than submitting an irreversible transaction with unverified
 /// gas behaviour.
 const MAX_RECEIPTS_PER_TRANSFER: usize = 14;
+
+/// EIP-165 defines an interface's id as the XOR of all its function
+/// selectors. Deriving it from the bound receiver-hook signatures (the very
+/// functions an ERC-1155 transfer calls) means it can never drift from what
+/// is actually probed — `0x4e2312e0` for `IERC1155Receiver`.
+const ERC1155_RECEIVER_INTERFACE_ID: [u8; 4] = xor_selectors(
+    IERC1155Receiver::onERC1155ReceivedCall::SELECTOR,
+    IERC1155Receiver::onERC1155BatchReceivedCall::SELECTOR,
+);
+
+/// ERC-165's own interface id. `supportsInterface(bytes4)` is the
+/// interface's only function, so the id IS its selector (`0x01ffc9a7`).
+const ERC165_INTERFACE_ID: [u8; 4] = IERC165::supportsInterfaceCall::SELECTOR;
+
+/// EIP-165 requires a compliant contract to answer `false` for
+/// `0xffffffff`; answering `true` unmasks a fallback that affirms
+/// everything, whose answers prove nothing.
+const ERC165_INVALID_INTERFACE_ID: [u8; 4] = [0xff; 4];
+
+const fn xor_selectors(first: [u8; 4], second: [u8; 4]) -> [u8; 4] {
+    [
+        first[0] ^ second[0],
+        first[1] ^ second[1],
+        first[2] ^ second[2],
+        first[3] ^ second[3],
+    ]
+}
 
 /// Refuses unless the deployment is quiescent: no burn reserved against this
 /// vault's receipts, and no mint or redemption anywhere between initiation and
@@ -458,6 +490,32 @@ enum MigrationRefusal {
     )]
     RecipientUnknownToChain { recipient: Address, chain_id: u64 },
 
+    #[error(
+        "recipient {recipient} is a contract that answers \
+         supportsInterface(IERC1155Receiver) = false: it states it cannot \
+         receive ERC-1155 transfers, so the receipt transfer would revert"
+    )]
+    RecipientContractRefusesReceipts { recipient: Address },
+
+    #[error(
+        "recipient {recipient} is a contract whose ERC-165 answers are \
+         inconsistent (a compliant responder answers true for ERC-165 itself \
+         and false for 0xffffffff), so its receiver-support claim proves \
+         nothing; receipts only move to a contract whose support is proven"
+    )]
+    RecipientErc165Inconsistent { recipient: Address },
+
+    #[error(
+        "recipient {recipient} is a contract that does not answer ERC-165 \
+         supportsInterface, so ERC-1155 receiver support cannot be proven \
+         before an irreversible transfer"
+    )]
+    RecipientReceiverSupportUnproven {
+        recipient: Address,
+        #[source]
+        source: Box<alloy::contract::Error>,
+    },
+
     #[error(transparent)]
     SharesOverflow(#[from] SharesOverflow),
 
@@ -675,39 +733,78 @@ pub enum MigrationOutcome {
     },
 }
 
-/// A destination the chain itself has seen, paired with the caller's stated
-/// current holder.
+/// Which kind of address a destination was proven to be.
+///
+/// Deciding which corroboration it had to clear. Recorded on the witness so
+/// the driver's confirmation prompt and the audit trail state what was proven
+/// rather than assuming one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecipientKind {
+    /// No deployed code; corroborated by on-chain history (transaction
+    /// count or native balance).
+    ExternallyOwned,
+    /// Deployed code that proves ERC-1155 receiver support through a
+    /// consistent ERC-165 responder.
+    Erc1155Receiver,
+}
+
+impl fmt::Display for RecipientKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExternallyOwned => {
+                write!(formatter, "externally owned account")
+            }
+            Self::Erc1155Receiver => {
+                write!(formatter, "ERC-1155-receiving contract")
+            }
+        }
+    }
+}
+
+/// A destination the chain itself has corroborated, paired with the caller's
+/// stated current holder.
 ///
 /// Existence proves only the destination and chain were corroborated by
-/// [`CorroboratedRecipient::verify`]. The stated holder is checked against the
-/// inventory's recorded custody before any transfer. An ERC-1155 transfer is
-/// final and has no counterparty to ask for it back, so a mistyped destination
-/// is not a recoverable mistake.
+/// [`CorroboratedRecipient::verify`] — with a corroboration as strong as the
+/// kind of address the destination is (see [`RecipientKind`]). The stated
+/// holder is checked against the inventory's recorded custody before any
+/// transfer. An ERC-1155 transfer is final and has no counterparty to ask
+/// for it back, so a mistyped destination is not a recoverable mistake.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct CorroboratedRecipient {
     chain_id: u64,
     holder: Address,
     recipient: Address,
+    kind: RecipientKind,
 }
 
 impl CorroboratedRecipient {
-    /// Confirms `recipient` differs from `holder` and that the chain has
-    /// independent evidence the destination exists.
+    /// Confirms `recipient` differs from `holder` and corroborates it by
+    /// what the chain says it is.
     ///
-    /// An address that has never sent a transaction and holds no native balance
-    /// has no on-chain existence at all — which is precisely what a
-    /// fat-fingered address looks like, since the odds of a typo landing on a
-    /// used address are negligible. Both legitimate destinations clear it: the
-    /// incoming signing wallet has to be funded for gas before it can run the
-    /// service, while a prior signing wallet has already been active on-chain.
+    /// An address with no deployed code is an externally owned account and
+    /// must have on-chain history: an address that has never sent a
+    /// transaction and holds no native balance has no on-chain existence at
+    /// all — precisely what a fat-fingered address looks like, since the
+    /// odds of a typo landing on a used address are negligible. Both
+    /// legitimate EOA destinations clear it: an incoming signing wallet has
+    /// to be funded for gas before it can run the service, while a prior
+    /// signing wallet has already been active on-chain.
+    ///
+    /// An address with deployed code clears the EOA evidence for the wrong
+    /// reason — deployment proves nothing about receiving ERC-1155 — so a
+    /// contract must instead prove receiver support up front, through a
+    /// consistent ERC-165 responder affirming `IERC1155Receiver`. Receiver
+    /// support is proven before submitting, never discovered by a revert.
     ///
     /// The error type is erased to `anyhow` for the same reason as
     /// [`migrate_vault_receipts`]: [`MigrationRefusal`] stays crate-internal.
     ///
     /// # Errors
     ///
-    /// Returns an error for the zero address, the current holder, and when the
-    /// chain has no record of the address at all.
+    /// Returns an error for the zero address, the current holder, an EOA the
+    /// chain has no record of, and a contract that does not prove ERC-1155
+    /// receiver support.
     pub async fn verify<P: Provider>(
         provider: &P,
         holder: Address,
@@ -728,25 +825,18 @@ impl CorroboratedRecipient {
         let chain_id =
             provider.get_chain_id().await.map_err(ReceiptCustodyError::from)?;
 
-        let nonce = provider
-            .get_transaction_count(recipient)
+        let code = provider
+            .get_code_at(recipient)
             .await
             .map_err(ReceiptCustodyError::from)?;
 
-        let balance = provider
-            .get_balance(recipient)
-            .await
-            .map_err(ReceiptCustodyError::from)?;
+        let kind = if code.is_empty() {
+            corroborate_externally_owned(provider, recipient, chain_id).await?
+        } else {
+            corroborate_erc1155_receiver(provider, recipient).await?
+        };
 
-        if nonce == 0 && balance.is_zero() {
-            return Err(MigrationRefusal::RecipientUnknownToChain {
-                recipient,
-                chain_id,
-            }
-            .into());
-        }
-
-        Ok(Self { chain_id, holder, recipient })
+        Ok(Self { chain_id, holder, recipient, kind })
     }
 
     const fn address(self) -> Address {
@@ -760,6 +850,103 @@ impl CorroboratedRecipient {
     const fn chain_id(self) -> u64 {
         self.chain_id
     }
+
+    /// The kind of address the destination was proven to be.
+    #[must_use]
+    pub const fn kind(self) -> RecipientKind {
+        self.kind
+    }
+}
+
+/// The EOA corroboration: refused unless the chain has independent evidence
+/// the address exists — transaction history or native balance.
+async fn corroborate_externally_owned<P: Provider>(
+    provider: &P,
+    recipient: Address,
+    chain_id: u64,
+) -> anyhow::Result<RecipientKind> {
+    let nonce = provider
+        .get_transaction_count(recipient)
+        .await
+        .map_err(ReceiptCustodyError::from)?;
+
+    let balance = provider
+        .get_balance(recipient)
+        .await
+        .map_err(ReceiptCustodyError::from)?;
+
+    if nonce == 0 && balance.is_zero() {
+        return Err(MigrationRefusal::RecipientUnknownToChain {
+            recipient,
+            chain_id,
+        }
+        .into());
+    }
+
+    Ok(RecipientKind::ExternallyOwned)
+}
+
+/// The contract corroboration: a consistent ERC-165 responder affirming
+/// `IERC1155Receiver`.
+///
+/// Consistency first (EIP-165's own detection procedure): the responder must
+/// affirm ERC-165 itself and deny `0xffffffff` — a fallback that affirms
+/// everything proves nothing — and only then is its answer for the receiver
+/// interface trusted.
+async fn corroborate_erc1155_receiver<P: Provider>(
+    provider: &P,
+    recipient: Address,
+) -> anyhow::Result<RecipientKind> {
+    let responder = IERC165::new(recipient, provider);
+
+    let affirms_erc165 = responder
+        .supportsInterface(ERC165_INTERFACE_ID.into())
+        .call()
+        .await
+        .map_err(|source| {
+            MigrationRefusal::RecipientReceiverSupportUnproven {
+                recipient,
+                source: Box::new(source),
+            }
+        })?;
+
+    let affirms_invalid = responder
+        .supportsInterface(ERC165_INVALID_INTERFACE_ID.into())
+        .call()
+        .await
+        .map_err(|source| {
+            MigrationRefusal::RecipientReceiverSupportUnproven {
+                recipient,
+                source: Box::new(source),
+            }
+        })?;
+
+    if !affirms_erc165 || affirms_invalid {
+        return Err(MigrationRefusal::RecipientErc165Inconsistent {
+            recipient,
+        }
+        .into());
+    }
+
+    let supports_receiver = responder
+        .supportsInterface(ERC1155_RECEIVER_INTERFACE_ID.into())
+        .call()
+        .await
+        .map_err(|source| {
+            MigrationRefusal::RecipientReceiverSupportUnproven {
+                recipient,
+                source: Box::new(source),
+            }
+        })?;
+
+    if !supports_receiver {
+        return Err(MigrationRefusal::RecipientContractRefusesReceipts {
+            recipient,
+        }
+        .into());
+    }
+
+    Ok(RecipientKind::Erc1155Receiver)
 }
 
 impl std::fmt::Display for CorroboratedRecipient {
@@ -808,6 +995,29 @@ pub async fn migrate_vault_receipts<P: Provider + Clone + Send + Sync>(
         OnchainReceiptCustody::resolve(provider, identity.vault).await?;
 
     execute_migration(pool, &custody, identity, recipient).await
+}
+
+/// Tracked receipts with balance for this vault, for the driver's
+/// confirmation prompt.
+///
+/// Informational only: [`migrate_vault_receipts`]
+/// re-derives its own holdings under the quiescence gates before anything
+/// moves, so this count gates nothing.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened or the inventory fails to
+/// load.
+pub async fn tracked_receipt_count(
+    pool: &Pool<Sqlite>,
+    chain_id: u64,
+    vault: Address,
+) -> anyhow::Result<usize> {
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+
+    Ok(inventory.receipts_with_balance().len())
 }
 
 /// Verified identity of the vault a custody operation addresses.
@@ -1265,6 +1475,33 @@ pub async fn recorded_migration_origin(
         anyhow::anyhow!(
             "vault {vault} on chain {chain_id} has no recorded custody \
              migration to reverse"
+        )
+    })
+}
+
+/// The wallet currently recorded as holding the vault's receipts.
+///
+/// The narrow read path for verifying custody state from outside the crate
+/// (e.g. after a `confirm-custody` re-confirmation): the confirmation's
+/// return value counts verified balances, while this reads the holder the
+/// aggregate actually persisted.
+///
+/// # Errors
+///
+/// Returns an error if the store cannot be opened or custody has never been
+/// observed for this vault.
+pub async fn recorded_custody_holder(
+    pool: &Pool<Sqlite>,
+    chain_id: u64,
+    vault: Address,
+) -> anyhow::Result<Address> {
+    let store =
+        StoreBuilder::<ReceiptInventory>::new(pool.clone()).build(()).await?;
+    let inventory = load_inventory(&store, chain_id, &vault).await?;
+
+    inventory.custody().holder().ok_or_else(|| {
+        anyhow::anyhow!(
+            "vault {vault} on chain {chain_id} has no recorded custody holder"
         )
     })
 }
@@ -2919,9 +3156,20 @@ mod tests {
     /// something other than what the operator typed.
     mod recipient_corroboration {
         use alloy::providers::ProviderBuilder;
+        use alloy::providers::ext::AnvilApi;
 
         use super::*;
         use crate::test_utils::LocalEvm;
+
+        /// Runtime bytecode returning 32 bytes ending in `0x01` for ANY
+        /// call: a fallback that affirms every interface, which EIP-165's
+        /// `0xffffffff` probe exists to unmask.
+        const AFFIRMS_EVERYTHING: [u8; 10] =
+            [0x60, 0x01, 0x60, 0x00, 0x52, 0x60, 0x20, 0x60, 0x00, 0xf3];
+
+        /// Runtime bytecode that is the INVALID opcode: every call reverts,
+        /// like a contract with no fallback and no ERC-165.
+        const REVERTS_EVERY_CALL: [u8; 1] = [0xfe];
 
         #[tokio::test]
         async fn the_current_holder_cannot_be_its_own_destination() {
@@ -2998,7 +3246,9 @@ mod tests {
             );
         }
 
-        /// A funded destination distinct from the holder clears the gate.
+        /// A funded destination distinct from the holder clears the gate,
+        /// and the witness records what was proven: an externally owned
+        /// account.
         #[tokio::test]
         async fn a_funded_wallet_is_corroborated() {
             let evm = LocalEvm::new().await.unwrap();
@@ -3014,6 +3264,139 @@ mod tests {
             .unwrap();
 
             assert_eq!(corroborated.address(), evm.wallet_address);
+            assert_eq!(corroborated.kind(), RecipientKind::ExternallyOwned);
+        }
+
+        /// The orchestrator is the one contract destination the migration
+        /// exists for: a consistent ERC-165 responder affirming
+        /// `IERC1155Receiver`, corroborated as such.
+        #[tokio::test]
+        async fn the_orchestrator_is_corroborated_as_a_receiver() {
+            let evm = LocalEvm::new().await.unwrap();
+            let orchestrator = evm.deploy_orchestrator().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+
+            let corroborated = CorroboratedRecipient::verify(
+                &provider,
+                evm.wallet_address,
+                orchestrator,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(corroborated.address(), orchestrator);
+            assert_eq!(corroborated.kind(), RecipientKind::Erc1155Receiver);
+        }
+
+        /// The vault's receipt contract is a genuine, consistent ERC-165
+        /// responder (an ERC-1155 token) that is NOT an ERC-1155 receiver —
+        /// transfers to it would revert, so it must be refused on its own
+        /// answer, before any transaction exists.
+        #[tokio::test]
+        async fn a_contract_that_answers_false_for_receiver_support_is_refused()
+        {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let receipt_contract: Address =
+                OffchainAssetReceiptVault::new(evm.vault_address, &provider)
+                    .receipt()
+                    .call()
+                    .await
+                    .unwrap()
+                    .0
+                    .into();
+
+            let error = CorroboratedRecipient::verify(
+                &provider,
+                evm.wallet_address,
+                receipt_contract,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(MigrationRefusal::RecipientContractRefusesReceipts {
+                        recipient,
+                    }) if *recipient == receipt_contract
+                ),
+                "a non-receiver contract must be refused on its ERC-165 \
+                 answer, got: {error:?}"
+            );
+        }
+
+        /// A fallback answering true for everything claims `0xffffffff` too,
+        /// which a compliant ERC-165 responder must deny — its answers prove
+        /// nothing, so its receiver-support claim is not trusted.
+        #[tokio::test]
+        async fn a_contract_affirming_every_interface_is_refused() {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let stub = Address::random();
+            provider
+                .anvil_set_code(stub, AFFIRMS_EVERYTHING.to_vec().into())
+                .await
+                .unwrap();
+
+            let error = CorroboratedRecipient::verify(
+                &provider,
+                evm.wallet_address,
+                stub,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(MigrationRefusal::RecipientErc165Inconsistent {
+                        recipient,
+                    }) if *recipient == stub
+                ),
+                "an affirm-everything fallback proves nothing and must be \
+                 refused, got: {error:?}"
+            );
+        }
+
+        /// A contract that reverts every call (no ERC-165 at all) cannot
+        /// prove receiver support, so it is refused before any transaction —
+        /// never discovered by the transfer's own revert.
+        #[tokio::test]
+        async fn a_contract_without_erc165_is_refused_as_unproven() {
+            let evm = LocalEvm::new().await.unwrap();
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let stub = Address::random();
+            provider
+                .anvil_set_code(stub, REVERTS_EVERY_CALL.to_vec().into())
+                .await
+                .unwrap();
+
+            let error = CorroboratedRecipient::verify(
+                &provider,
+                evm.wallet_address,
+                stub,
+            )
+            .await
+            .unwrap_err();
+
+            assert!(
+                matches!(
+                    error.downcast_ref::<MigrationRefusal>(),
+                    Some(
+                        MigrationRefusal::RecipientReceiverSupportUnproven {
+                            recipient,
+                            ..
+                        }
+                    ) if *recipient == stub
+                ),
+                "receiver support must be proven before submitting, never \
+                 discovered by a revert, got: {error:?}"
+            );
         }
 
         #[test]

--- a/src/receipt_inventory/mod.rs
+++ b/src/receipt_inventory/mod.rs
@@ -684,6 +684,24 @@ impl Custody {
             Self::Held { moved_from, .. } => *moved_from,
         }
     }
+
+    /// True when a recorded migration moved custody away from `wallet`:
+    /// another holder is on record, and the recorded origin is `wallet`.
+    ///
+    /// This is the expected state after a deliberate custody move (receipts
+    /// sitting in the orchestrator during the cutover, until RAI-1223
+    /// retires the subsystem), not displacement — balance readers skip such
+    /// a vault instead of taking readings against `wallet` that can only be
+    /// refused as `CustodyDisplaced`. A holder mismatch with no recorded
+    /// migration from `wallet` stays displacement and fails loudly.
+    pub(crate) fn moved_away_from(&self, wallet: Address) -> bool {
+        match self {
+            Self::Unobserved => false,
+            Self::Held { holder, moved_from } => {
+                *holder != wallet && *moved_from == Some(wallet)
+            }
+        }
+    }
 }
 
 impl ReceiptInventory {

--- a/src/receipt_inventory/reconcile.rs
+++ b/src/receipt_inventory/reconcile.rs
@@ -86,6 +86,28 @@ where
         let inventory =
             load_inventory(&self.store, self.chain_id, &self.vault).await?;
 
+        // A recorded migration moved this vault's custody away from the
+        // signing wallet (receipts sit at the destination — the
+        // orchestrator, during the cutover): readings taken against this
+        // wallet mean nothing and could only be refused as
+        // `CustodyDisplaced` for a state the operator deliberately created.
+        // Skipped at INFO until the subsystem retires (RAI-1223). A holder
+        // mismatch with NO recorded migration from this wallet is true
+        // displacement and still fails loudly below.
+        if inventory.custody().moved_away_from(self.bot_wallet) {
+            info!(target: "receipt", vault = %self.vault,
+                wallet = %self.bot_wallet,
+                holder = ?inventory.custody().holder(),
+                "Custody recorded at a migrated destination; skipping \
+                 balance reconciliation"
+            );
+            return Ok(ReconcileResult {
+                checked: 0,
+                mismatches: 0,
+                errors: 0,
+            });
+        }
+
         let receipts: Vec<_> = inventory
             .receipts_with_balance()
             .into_iter()
@@ -823,6 +845,161 @@ mod tests {
                     "receipt_count=2"
                 ]
             ));
+        }
+
+        /// Records a completed migration the way the engine does, so the
+        /// expected-elsewhere skip is tested against real recorded state.
+        async fn seed_migration(
+            store: &Arc<Store<ReceiptInventory>>,
+            vault: Address,
+            from: Address,
+            to: Address,
+        ) {
+            send_receipt_inventory_command(
+                store,
+                ANVIL_CHAIN_ID,
+                &vault,
+                ReceiptInventoryCommand::RecordCustodyMigration {
+                    from,
+                    to,
+                    tx_hash: None,
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        /// After a recorded migration moved custody away (receipts sitting
+        /// in the orchestrator during cutover), zero readings against the
+        /// signing wallet are the EXPECTED state until RAI-1223 retires the
+        /// subsystem — the vault is skipped quietly at INFO instead of
+        /// manufacturing a `CustodyDisplaced` error every pass.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_recorded_migration_away_is_skipped_quietly() {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let vault_contract =
+                crate::bindings::OffchainAssetReceiptVault::new(
+                    evm.vault_address,
+                    &provider,
+                );
+            let receipt_contract =
+                Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+            let balance = U256::from(100) * U256::from(10).pow(U256::from(18));
+            seed_receipt(&store, evm.vault_address, uint!(0xaa_U256), balance)
+                .await;
+            seed_receipt(&store, evm.vault_address, uint!(0xbb_U256), balance)
+                .await;
+
+            seed_custody(&store, evm.vault_address, evm.wallet_address).await;
+            let destination = Address::random();
+            seed_migration(
+                &store,
+                evm.vault_address,
+                evm.wallet_address,
+                destination,
+            )
+            .await;
+
+            let reconciler = ReceiptReconciler::new(
+                provider,
+                receipt_contract,
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let result = reconciler.reconcile().await.unwrap();
+
+            assert_eq!(result.checked, 0, "no balances may be read");
+            assert_eq!(result.mismatches, 0);
+            assert_eq!(result.errors, 0);
+
+            let inventory =
+                load_inventory(&store, ANVIL_CHAIN_ID, &evm.vault_address)
+                    .await
+                    .unwrap();
+            assert_eq!(
+                inventory.receipts_with_balance().len(),
+                2,
+                "the migrated inventory must survive the pass intact"
+            );
+            assert_eq!(
+                inventory.custody().holder(),
+                Some(destination),
+                "the skip must not re-confirm custody at the signing wallet"
+            );
+
+            assert!(logs_contain_at!(
+                tracing::Level::INFO,
+                &["skipping", "balance reconciliation"]
+            ));
+            assert!(
+                !logs_contain("Refusing to deplete"),
+                "an expected state must not be reported as displacement"
+            );
+        }
+
+        /// `moved_from` names one specific origin: a migration recorded from
+        /// some OTHER wallet explains nothing about this signing wallet's
+        /// zero readings, so the pass still refuses as displacement.
+        #[traced_test]
+        #[tokio::test]
+        async fn a_migration_from_another_wallet_does_not_excuse_the_mismatch()
+        {
+            let evm = LocalEvm::new().await.unwrap();
+            let store = setup_store().await;
+
+            let provider =
+                ProviderBuilder::new().connect(&evm.endpoint).await.unwrap();
+            let vault_contract =
+                crate::bindings::OffchainAssetReceiptVault::new(
+                    evm.vault_address,
+                    &provider,
+                );
+            let receipt_contract =
+                Address::from(vault_contract.receipt().call().await.unwrap().0);
+
+            let balance = U256::from(100) * U256::from(10).pow(U256::from(18));
+            seed_receipt(&store, evm.vault_address, uint!(0xaa_U256), balance)
+                .await;
+
+            let unrelated_origin = Address::random();
+            let destination = Address::random();
+            seed_custody(&store, evm.vault_address, unrelated_origin).await;
+            seed_migration(
+                &store,
+                evm.vault_address,
+                unrelated_origin,
+                destination,
+            )
+            .await;
+
+            let reconciler = ReceiptReconciler::new(
+                provider,
+                receipt_contract,
+                evm.wallet_address,
+                ANVIL_CHAIN_ID,
+                evm.vault_address,
+                store.clone(),
+            );
+
+            let error = reconciler.reconcile().await.unwrap_err();
+
+            assert!(
+                matches!(
+                    error,
+                    ReconcileError::CustodyDisplaced { receipt_count: 1, .. }
+                ),
+                "an unexplained mismatch must stay displacement, got: \
+                 {error:?}"
+            );
         }
 
         /// Only the depletion is refused, not the whole cutover: once custody

--- a/src/tokenized_asset/cli.rs
+++ b/src/tokenized_asset/cli.rs
@@ -1,4 +1,4 @@
-use alloy::primitives::{Address, B256};
+use alloy::primitives::{Address, B256, U256};
 use alloy::providers::{Provider, ProviderBuilder};
 use clap::{Args, Parser, Subcommand};
 use event_sorcery::{
@@ -27,6 +27,10 @@ use crate::config::{
     VaultMode, VaultModeConfig, load_vault_mode_config, setup_tracing,
 };
 use crate::prepare_event_sourced_startup;
+use crate::receipt_inventory::migration::{
+    CorroboratedRecipient, MigrationOutcome, VaultIdentity,
+    confirm_custody_holder, migrate_vault_receipts, tracked_receipt_count,
+};
 use crate::redemption::IssuerRedemptionRequestId;
 use crate::redemption::force_complete::{
     VerifiedCompletion, ensure_burn_unclaimed, landed_burn_evidence,
@@ -126,6 +130,31 @@ enum IssuerCommand {
     /// touch the operator's database — connecting runs any pending
     /// migrations and projection catch-up before the vault lookup.
     VerifyOrchestratorSigning(Box<VerifyOrchestratorSigningArgs>),
+    /// Moves one vault's tracked deposit receipts to a corroborated
+    /// destination through the Turnkey signer, driving the receipt-moving
+    /// engine (quiescence gates, tracked-vs-chain agreement, per-identifier
+    /// gain verification, idempotent re-runs). The destination is stated by
+    /// exactly one of --to-configured-orchestrator (read from the config,
+    /// never typed — the cutover path) or --to <ADDRESS> (the
+    /// wallet-rotation path); either way it only becomes reachable through
+    /// the kind-aware corroboration witness (EOA: on-chain history;
+    /// contract: proven ERC-1155 receiver support). Requires the deployment
+    /// hold armed and the service stopped (docs/runbooks/deploy-hold.md),
+    /// and the bot wallet funded for the transfer gas.
+    MoveReceipts(Box<MoveReceiptsArgs>),
+    /// Verifies on-chain that the Turnkey bot wallet holds exactly every
+    /// tracked receipt balance for the asset's vault, then records it as
+    /// the inventory's custody holder. The rollback counterpart of
+    /// move-receipts: after an EMERGENCY_ROLE withdrawReceipt returns a
+    /// token's receipts to the bot wallet, recorded custody still names the
+    /// old destination and reconciliation stays skipped until this
+    /// re-confirmation. The holder is always the Turnkey wallet — never
+    /// typed — and cannot be recorded wrongly: a wallet that does not hold
+    /// every tracked balance is refused with the first mismatch. Requires
+    /// the deployment hold armed and the service stopped
+    /// (docs/runbooks/deploy-hold.md); signs nothing and submits nothing
+    /// on-chain.
+    ConfirmCustody(Box<ConfirmCustodyArgs>),
 }
 
 #[derive(Args)]
@@ -320,6 +349,110 @@ struct VerifyOrchestratorSigningArgs {
     database_max_connections: u32,
 }
 
+/// Exactly one destination statement, enforced by clap: every field is a
+/// member of one required, mutually exclusive group.
+#[derive(Args)]
+#[group(required = true, multiple = false)]
+struct MoveDestination {
+    /// Explicit destination address — the wallet-rotation path. Refused if
+    /// it names the configured [orchestrator].address: the cutover path
+    /// must read the orchestrator from the config, never a typed address.
+    #[arg(long)]
+    to: Option<Address>,
+
+    /// Read the destination from [orchestrator].address in --config — the
+    /// cutover path, keeping the orchestrator address never-typed.
+    #[arg(long)]
+    to_configured_orchestrator: bool,
+}
+
+#[derive(Args)]
+struct MoveReceiptsArgs {
+    /// Underlying symbol whose vault's receipts move, e.g. RKLB.
+    /// Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    #[clap(flatten)]
+    destination: MoveDestination,
+
+    /// TOML config file; its `[orchestrator].address` is the only source of
+    /// the orchestrator address, matching what the deployed service
+    /// resolves.
+    #[arg(long, env = "CONFIG")]
+    config: PathBuf,
+
+    /// Network whose vault the receipts move on.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
+#[derive(Args)]
+struct ConfirmCustodyArgs {
+    /// Underlying symbol whose vault's custody is confirmed, e.g. RKLB.
+    /// Upper-cased like [`AssetArgs`].
+    #[arg(value_parser = |value: &str| UnderlyingSymbol::new(value.to_ascii_uppercase()))]
+    underlying: UnderlyingSymbol,
+
+    /// Network whose vault the custody is confirmed on.
+    #[arg(long, value_parser = Network::from_str)]
+    network: Network,
+
+    /// RPC endpoint for the network — the service's own `RPC_URL`.
+    #[arg(long, env = "RPC_URL")]
+    rpc_url: Url,
+
+    /// Chain this must run against, cross-checked against the chain the RPC
+    /// reports.
+    #[arg(long)]
+    chain_id: u64,
+
+    #[clap(flatten)]
+    signer: SignerEnv,
+
+    #[arg(
+        long = "database-url",
+        env = "DATABASE_URL",
+        default_value = DEFAULT_DATABASE_URL,
+        value_parser = parse_sqlite_url
+    )]
+    database_url: String,
+    #[arg(
+        long,
+        env = "DATABASE_MAX_CONNECTIONS",
+        default_value_t = DEFAULT_DATABASE_MAX_CONNECTIONS,
+        value_parser = clap::value_parser!(u32).range(1..)
+    )]
+    database_max_connections: u32,
+}
+
 #[derive(Args)]
 struct AssetArgs {
     /// Underlying symbol, e.g. SGOV. Upper-cased so `"sgov"` resolves to the
@@ -369,6 +502,22 @@ impl IssuerCli {
             }
             IssuerCommand::VerifyOrchestratorSigning(args) => {
                 run_verify_orchestrator_signing(*args).await
+            }
+            IssuerCommand::MoveReceipts(args) => {
+                run_move_receipts(
+                    *args,
+                    Path::new(DEPLOY_RUNTIME_DIR),
+                    prompt_confirm,
+                )
+                .await
+            }
+            IssuerCommand::ConfirmCustody(args) => {
+                run_confirm_custody(
+                    *args,
+                    Path::new(DEPLOY_RUNTIME_DIR),
+                    prompt_confirm,
+                )
+                .await
             }
         }
     }
@@ -698,6 +847,276 @@ async fn run_verify_orchestrator_signing(
         proofs.len(),
         args.underlying
     );
+
+    Ok(())
+}
+
+/// The runtime directory of the deploy-hold protocol
+/// (docs/runbooks/deploy-hold.md); [`run_move_receipts`] verifies the hold
+/// there before an irreversible custody move.
+const DEPLOY_RUNTIME_DIR: &str = "/run/st0x";
+const DEPLOY_HOLD_FILE: &str = "st0x-issuance.hold";
+const DEPLOY_READY_FILE: &str = "st0x-issuance.ready";
+
+/// Gas ceiling for one receipt-batch transfer, used only to fail the move
+/// actionably BEFORE corroboration and prompting when the bot wallet cannot
+/// pay for it. Deliberately a generous upper bound for the engine's
+/// 14-receipt batch cap — a transfer that somehow needed more would fail at
+/// submission with the engine's own error, not silently proceed.
+const MOVE_RECEIPTS_GAS_CEILING: u64 = 3_000_000;
+
+/// Moves one vault's tracked receipts to a corroborated destination through
+/// the Turnkey signer. Everything outside the engine happens here, in order:
+/// destination resolution (config-read or stated, never a typed orchestrator
+/// address), the Turnkey-only signer requirement, the deploy-hold check, gas
+/// readiness, kind-aware destination corroboration, and the confirmation
+/// prompt stating what was proven. The engine then re-verifies identity,
+/// custody, quiescence, and balances before anything is submitted.
+async fn run_move_receipts(
+    args: MoveReceiptsArgs,
+    runtime_dir: &Path,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    let configured_orchestrator =
+        load_vault_mode_config(&args.config)?.orchestrator_address();
+    let destination = match (
+        args.destination.to,
+        args.destination.to_configured_orchestrator,
+    ) {
+        (None, true) => configured_orchestrator.ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} has no [orchestrator].address to move receipts to; add \
+                 the section, or state a wallet destination with --to",
+                args.config.display()
+            )
+        })?,
+        (Some(stated), false) => {
+            if configured_orchestrator == Some(stated) {
+                anyhow::bail!(
+                    "--to {stated} is the configured [orchestrator].address; \
+                     use --to-configured-orchestrator so the cutover \
+                     destination is read from {}, never typed",
+                    args.config.display()
+                );
+            }
+            stated
+        }
+        // Unreachable through clap (the destination group is required and
+        // mutually exclusive), but a refusal keeps this total without a
+        // panic path.
+        _ => anyhow::bail!(
+            "state exactly one destination: --to <ADDRESS> or \
+             --to-configured-orchestrator"
+        ),
+    };
+
+    let SignerConfig::Turnkey(turnkey_config) = args.signer.into_config()?
+    else {
+        anyhow::bail!(
+            "move-receipts requires the Turnkey signer configuration"
+        );
+    };
+    let bot = turnkey_config.settings.address;
+
+    verify_deploy_hold(runtime_dir)?;
+
+    println!("Using database: {}", args.database_url);
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let resolved = resolve_turnkey_signer(&turnkey_config, chain_id)?;
+    let provider = ProviderBuilder::new()
+        .with_chain_id(chain_id)
+        .wallet(resolved.wallet)
+        .connect(args.rpc_url.as_str())
+        .await?;
+
+    verify_gas_readiness(&provider, bot).await?;
+
+    let recipient =
+        CorroboratedRecipient::verify(&provider, bot, destination).await?;
+    let identity = VaultIdentity::verify(
+        &admin.pool,
+        &provider,
+        args.network,
+        chain_id,
+        vault,
+        &args.underlying,
+    )
+    .await?;
+    let receipts = tracked_receipt_count(&admin.pool, chain_id, vault).await?;
+
+    if !confirm(&format!(
+        "Move {receipts} tracked receipt(s) of {} vault {vault} from Turnkey \
+         wallet {bot} to {destination} ({})?",
+        args.underlying,
+        recipient.kind(),
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    match migrate_vault_receipts(&admin.pool, provider, identity, recipient)
+        .await?
+    {
+        MigrationOutcome::Migrated { transaction, receipts } => println!(
+            "Moved {receipts} receipt(s) of {} vault {vault} to \
+             {destination} in {transaction}.",
+            args.underlying
+        ),
+        MigrationOutcome::AlreadyMigrated { receipts } => println!(
+            "Already migrated: {destination} holds all {receipts} tracked \
+             receipt(s) of {} vault {vault}; nothing was submitted.",
+            args.underlying
+        ),
+    }
+
+    Ok(())
+}
+
+/// Verifies the deploy hold is armed: hold file present, readiness marker
+/// absent. The engine rebuilds projections and reads quiescence from the
+/// same store the service writes, so a running service — or a deploy that
+/// could restart one mid-move — must be excluded before an irreversible
+/// custody move. The file checks are the machine-checkable half of the
+/// protocol; stopping the unit is the runbook's job.
+fn verify_deploy_hold(runtime_dir: &Path) -> anyhow::Result<()> {
+    let hold = runtime_dir.join(DEPLOY_HOLD_FILE);
+    if !hold.exists() {
+        anyhow::bail!(
+            "deployment hold is not armed: {} does not exist; arm the hold \
+             and stop the service (docs/runbooks/deploy-hold.md) before \
+             moving receipts",
+            hold.display()
+        );
+    }
+
+    let ready = runtime_dir.join(DEPLOY_READY_FILE);
+    if ready.exists() {
+        anyhow::bail!(
+            "readiness marker {} still exists, so a deploy could restart the \
+             service mid-move; remove it when arming the hold \
+             (docs/runbooks/deploy-hold.md)",
+            ready.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Re-records the Turnkey bot wallet as a vault's custody holder after its
+/// receipts returned there (the `move-receipts` rollback path). Purely
+/// verify-and-record: the engine refuses unless the wallet holds exactly
+/// every tracked balance on-chain, and requires the same quiescence as a
+/// migration, so the checks here are only the ones outside the engine — the
+/// Turnkey-only holder source and the deploy hold. Nothing is signed, so no
+/// signing provider is built.
+async fn run_confirm_custody(
+    args: ConfirmCustodyArgs,
+    runtime_dir: &Path,
+    confirm: impl Fn(&str) -> io::Result<bool>,
+) -> anyhow::Result<()> {
+    if args.chain_id != args.network.chain_id() {
+        anyhow::bail!(
+            "--network {} is chain {} but --chain-id is {}",
+            args.network,
+            args.network.chain_id(),
+            args.chain_id
+        );
+    }
+
+    let SignerConfig::Turnkey(turnkey_config) = args.signer.into_config()?
+    else {
+        anyhow::bail!(
+            "confirm-custody requires the Turnkey signer configuration"
+        );
+    };
+    let bot = turnkey_config.settings.address;
+
+    verify_deploy_hold(runtime_dir)?;
+
+    println!("Using database: {}", args.database_url);
+    let admin =
+        AssetAdmin::connect(&args.database_url, args.database_max_connections)
+            .await?;
+    let vault = find_vault(&admin.pool, &args.underlying, &args.network)
+        .await?
+        .ok_or_else(|| AssetAdminError::NotFound {
+            underlying: args.underlying.clone(),
+        })?;
+
+    let chain_id = verified_chain_id(&args.rpc_url, args.chain_id).await?;
+    let provider =
+        ProviderBuilder::new().connect(args.rpc_url.as_str()).await?;
+
+    let identity = VaultIdentity::verify(
+        &admin.pool,
+        &provider,
+        args.network,
+        chain_id,
+        vault,
+        &args.underlying,
+    )
+    .await?;
+    let receipts = tracked_receipt_count(&admin.pool, chain_id, vault).await?;
+
+    if !confirm(&format!(
+        "Confirm custody of {receipts} tracked receipt(s) of {} vault \
+         {vault} at Turnkey wallet {bot}? Recording only succeeds if the \
+         wallet holds every tracked balance on-chain.",
+        args.underlying
+    ))? {
+        anyhow::bail!("aborted by operator");
+    }
+
+    let confirmed =
+        confirm_custody_holder(&admin.pool, provider, identity, bot).await?;
+
+    println!(
+        "Confirmed custody of {confirmed} receipt(s) of {} vault {vault} at \
+         {bot}.",
+        args.underlying
+    );
+
+    Ok(())
+}
+
+/// Fails actionably when the bot wallet cannot pay for the transfer at the
+/// current gas price, before anything is corroborated or prompted.
+async fn verify_gas_readiness<P: Provider>(
+    provider: &P,
+    bot: Address,
+) -> anyhow::Result<()> {
+    let gas_price = provider.get_gas_price().await?;
+    let required = U256::from(gas_price)
+        .checked_mul(U256::from(MOVE_RECEIPTS_GAS_CEILING))
+        .ok_or_else(|| {
+            anyhow::anyhow!("gas price {gas_price} overflows the gas budget")
+        })?;
+    let balance = provider.get_balance(bot).await?;
+
+    if balance < required {
+        anyhow::bail!(
+            "bot wallet {bot} holds {balance} wei but the receipt transfer \
+             needs up to {required} wei at the current gas price \
+             ({gas_price}); fund the wallet before moving receipts"
+        );
+    }
 
     Ok(())
 }
@@ -1125,6 +1544,7 @@ fn parse_confirmation(input: &str) -> bool {
 mod tests {
     use alloy::network::EthereumWallet;
     use alloy::primitives::{U256, address, b256};
+    use alloy::providers::ext::AnvilApi;
     use alloy::signers::local::PrivateKeySigner;
     use chrono::Utc;
     use cqrs_es::DomainEvent;
@@ -1961,6 +2381,41 @@ mod tests {
         );
     }
 
+    /// The gas gate's boundary is exact: a balance equal to the fixed
+    /// ceiling at the current gas price passes, one wei below it refuses
+    /// with the funding guidance.
+    #[tokio::test]
+    async fn gas_readiness_boundary_is_exact() {
+        let evm = LocalEvm::with_chain_id(8453).await.unwrap();
+        let provider = alloy::providers::ProviderBuilder::new()
+            .connect(&evm.endpoint)
+            .await
+            .unwrap();
+        let bot = address!("0x00000000000000000000000000000000000000d1");
+
+        let gas_price = provider.get_gas_price().await.unwrap();
+        let required =
+            U256::from(gas_price) * U256::from(MOVE_RECEIPTS_GAS_CEILING);
+
+        provider.anvil_set_balance(bot, required).await.unwrap();
+        verify_gas_readiness(&provider, bot)
+            .await
+            .expect("a balance equal to the ceiling must pass");
+
+        provider
+            .anvil_set_balance(bot, required - U256::from(1u8))
+            .await
+            .unwrap();
+        let error = verify_gas_readiness(&provider, bot).await.unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("fund the wallet before moving receipts"),
+            "one wei below the ceiling must refuse with funding guidance, \
+             got: {error}"
+        );
+    }
+
     /// The full preflight glue against a real orchestrator on Anvil: NOT
     /// READY (non-zero exit) while the approval is missing, READY after it is
     /// executed. Turnkey credentials are parse-only stand-ins — the preflight
@@ -2043,6 +2498,350 @@ mod tests {
         run_orchestrator_preflight(parse_args(&database_url))
             .await
             .expect("preflight must pass once the approval is unlimited");
+    }
+
+    fn move_receipts_args(
+        config_path: &str,
+        destination_flags: &[&str],
+        signer_flags: &[&str],
+    ) -> MoveReceiptsArgs {
+        let mut command_line = vec![
+            "issuer",
+            "move-receipts",
+            "rklb",
+            "--config",
+            config_path,
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            "sqlite::memory:",
+        ];
+        command_line.extend_from_slice(destination_flags);
+        command_line.extend_from_slice(signer_flags);
+
+        let cli =
+            IssuerCli::try_parse_from(command_line).expect("arguments parse");
+        let IssuerCommand::MoveReceipts(args) = cli.command else {
+            panic!("expected the move-receipts subcommand")
+        };
+        *args
+    }
+
+    /// The destination group is clap-required and mutually exclusive:
+    /// stating none or both must fail at parse time, before any code runs.
+    #[test]
+    fn move_receipts_requires_exactly_one_destination() {
+        let base = [
+            "issuer",
+            "move-receipts",
+            "rklb",
+            "--config",
+            "issuance-config.toml",
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+        ];
+
+        let neither = IssuerCli::try_parse_from(base);
+        assert!(neither.is_err(), "a destination must be stated");
+
+        let both = IssuerCli::try_parse_from(base.iter().copied().chain([
+            "--to",
+            "0x00000000000000000000000000000000000000aa",
+            "--to-configured-orchestrator",
+        ]));
+        assert!(both.is_err(), "the two destination flags must conflict");
+
+        let stated = IssuerCli::try_parse_from(
+            base.iter()
+                .copied()
+                .chain(["--to", "0x00000000000000000000000000000000000000aa"]),
+        );
+        assert!(stated.is_ok(), "--to alone must parse: {:?}", stated.err());
+
+        let configured = IssuerCli::try_parse_from(
+            base.iter().copied().chain(["--to-configured-orchestrator"]),
+        );
+        assert!(
+            configured.is_ok(),
+            "--to-configured-orchestrator alone must parse: {:?}",
+            configured.err()
+        );
+    }
+
+    /// A typed orchestrator address must be refused with the config-flag
+    /// alternative named, keeping the never-typed convention: the check runs
+    /// before the signer, hold, database, or network are touched — the
+    /// panicking confirm and unreachable RPC prove it.
+    #[tokio::test]
+    async fn move_receipts_refuses_a_typed_orchestrator_destination() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = move_receipts_args(
+            config_path.to_str().unwrap(),
+            &["--to", "0x1234567890abcdef1234567890abcdef12345678"],
+            &TURNKEY_FLAGS,
+        );
+
+        let error = run_move_receipts(args, directory.path(), |_| {
+            panic!("must refuse the typed orchestrator before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("--to-configured-orchestrator"),
+            "the refusal must name the config-flag alternative, got {error}"
+        );
+    }
+
+    /// `--to-configured-orchestrator` against a config with no
+    /// `[orchestrator]` section must fail actionably, not guess.
+    #[tokio::test]
+    async fn move_receipts_refuses_a_dark_config_without_orchestrator() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = directory.path().join("issuance-config.toml");
+        std::fs::write(&config_path, "").unwrap();
+
+        let args = move_receipts_args(
+            config_path.to_str().unwrap(),
+            &["--to-configured-orchestrator"],
+            &TURNKEY_FLAGS,
+        );
+
+        let error = run_move_receipts(args, directory.path(), |_| {
+            panic!("must refuse the missing section before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("[orchestrator].address"),
+            "the refusal must name the missing section, got {error}"
+        );
+    }
+
+    /// The receipts move from the production Turnkey wallet — the recorded
+    /// custody holder — so a local key is refused outright.
+    #[tokio::test]
+    async fn move_receipts_refuses_a_non_turnkey_signer() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = move_receipts_args(
+            config_path.to_str().unwrap(),
+            &["--to", "0x00000000000000000000000000000000000000aa"],
+            &["--evm-private-key", TEST_SIGNER_KEY],
+        );
+
+        let error = run_move_receipts(args, directory.path(), |_| {
+            panic!("must refuse the signer before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("Turnkey signer configuration"),
+            "the refusal must name the Turnkey requirement, got {error}"
+        );
+    }
+
+    /// An un-armed hold means the service may be running (or a deploy may
+    /// restart it), racing the engine's projection rebuilds — refused before
+    /// the database or network are touched.
+    #[tokio::test]
+    async fn move_receipts_refuses_when_the_hold_is_not_armed() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let args = move_receipts_args(
+            config_path.to_str().unwrap(),
+            &["--to", "0x00000000000000000000000000000000000000aa"],
+            &TURNKEY_FLAGS,
+        );
+
+        let error = run_move_receipts(args, directory.path(), |_| {
+            panic!("must refuse the un-armed hold before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("deployment hold is not armed"),
+            "the refusal must say how to arm the hold, got {error}"
+        );
+    }
+
+    /// A lingering readiness marker lets a concurrent deploy restart the
+    /// service mid-move; armed means hold present AND marker absent.
+    #[tokio::test]
+    async fn move_receipts_refuses_when_the_readiness_marker_remains() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+        std::fs::write(directory.path().join(DEPLOY_HOLD_FILE), "").unwrap();
+        std::fs::write(directory.path().join(DEPLOY_READY_FILE), "").unwrap();
+
+        let args = move_receipts_args(
+            config_path.to_str().unwrap(),
+            &["--to", "0x00000000000000000000000000000000000000aa"],
+            &TURNKEY_FLAGS,
+        );
+
+        let error = run_move_receipts(args, directory.path(), |_| {
+            panic!("must refuse the readiness marker before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("readiness marker"),
+            "the refusal must name the marker, got {error}"
+        );
+    }
+
+    /// The chain-id/network redundancy check runs first, as in every other
+    /// network-scoped subcommand.
+    #[tokio::test]
+    async fn move_receipts_refuses_a_network_chain_mismatch() {
+        let directory = tempfile::tempdir().unwrap();
+        let config_path = write_orchestrator_config(directory.path());
+
+        let cli = IssuerCli::try_parse_from([
+            "issuer",
+            "move-receipts",
+            "rklb",
+            "--config",
+            config_path.to_str().unwrap(),
+            "--network",
+            "base",
+            "--chain-id",
+            "1",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--to-configured-orchestrator",
+        ])
+        .expect("arguments parse");
+        let IssuerCommand::MoveReceipts(args) = cli.command else {
+            panic!("expected the move-receipts subcommand")
+        };
+
+        let error = run_move_receipts(*args, directory.path(), |_| {
+            panic!("must refuse the mismatch before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("--chain-id is 1"),
+            "the refusal must show the mismatch, got {error}"
+        );
+    }
+
+    fn confirm_custody_args(signer_flags: &[&str]) -> ConfirmCustodyArgs {
+        let mut command_line = vec![
+            "issuer",
+            "confirm-custody",
+            "rklb",
+            "--network",
+            "base",
+            "--chain-id",
+            "8453",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+            "--database-url",
+            "sqlite::memory:",
+        ];
+        command_line.extend_from_slice(signer_flags);
+
+        let cli =
+            IssuerCli::try_parse_from(command_line).expect("arguments parse");
+        let IssuerCommand::ConfirmCustody(args) = cli.command else {
+            panic!("expected the confirm-custody subcommand")
+        };
+        *args
+    }
+
+    /// The custody holder is always the Turnkey bot wallet — never typed and
+    /// never a local key — so a local signer is refused outright.
+    #[tokio::test]
+    async fn confirm_custody_refuses_a_non_turnkey_signer() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let args =
+            confirm_custody_args(&["--evm-private-key", TEST_SIGNER_KEY]);
+
+        let error = run_confirm_custody(args, directory.path(), |_| {
+            panic!("must refuse the signer before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("Turnkey signer configuration"),
+            "the refusal must name the Turnkey requirement, got {error}"
+        );
+    }
+
+    /// Confirmation records custody the quiescence gates depend on, so a
+    /// running service (un-armed hold) must be excluded first.
+    #[tokio::test]
+    async fn confirm_custody_refuses_when_the_hold_is_not_armed() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let args = confirm_custody_args(&TURNKEY_FLAGS);
+
+        let error = run_confirm_custody(args, directory.path(), |_| {
+            panic!("must refuse the un-armed hold before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("deployment hold is not armed"),
+            "the refusal must say how to arm the hold, got {error}"
+        );
+    }
+
+    /// The chain-id/network redundancy check runs first, as in every other
+    /// network-scoped subcommand.
+    #[tokio::test]
+    async fn confirm_custody_refuses_a_network_chain_mismatch() {
+        let directory = tempfile::tempdir().unwrap();
+
+        let cli = IssuerCli::try_parse_from([
+            "issuer",
+            "confirm-custody",
+            "rklb",
+            "--network",
+            "base",
+            "--chain-id",
+            "1",
+            "--rpc-url",
+            "http://127.0.0.1:1",
+        ])
+        .expect("arguments parse");
+        let IssuerCommand::ConfirmCustody(args) = cli.command else {
+            panic!("expected the confirm-custody subcommand")
+        };
+
+        let error = run_confirm_custody(*args, directory.path(), |_| {
+            panic!("must refuse the mismatch before prompting")
+        })
+        .await
+        .unwrap_err();
+
+        assert!(
+            error.to_string().contains("--chain-id is 1"),
+            "the refusal must show the mismatch, got {error}"
+        );
     }
 
     fn approve_orchestrator_args(

--- a/tests/receipt_custody.rs
+++ b/tests/receipt_custody.rs
@@ -16,9 +16,11 @@ use st0x_issuance::bindings::OffchainAssetReceiptVault::{
     self, OffchainAssetReceiptVaultInstance,
 };
 use st0x_issuance::bindings::Receipt::ReceiptInstance;
+use st0x_issuance::bindings::ST0xOrchestrator;
 use st0x_issuance::receipt_inventory::migration::{
-    CorroboratedRecipient, MigrationOutcome, VaultIdentity,
-    migrate_vault_receipts, recorded_migration_origin,
+    CorroboratedRecipient, MigrationOutcome, RecipientKind, VaultIdentity,
+    confirm_custody_holder, migrate_vault_receipts, recorded_custody_holder,
+    recorded_migration_origin,
 };
 use st0x_issuance::test_utils::LocalEvm;
 use st0x_issuance::tokenized_asset::UnderlyingSymbol;
@@ -1256,6 +1258,249 @@ async fn test_holder_rotation_without_receipt_transfer_cannot_burn_historical_sh
     );
 
     incoming_client.terminate().await;
+
+    Ok(())
+}
+
+/// Proves the cutover's receipt move end to end against a REAL orchestrator
+/// (RAI-1681): the destination is corroborated as an ERC-1155-receiving
+/// contract via its own ERC-165 answers, the engine moves the receipts, the
+/// orchestrator's burn pointer covers the transferred id (so the burn walk
+/// can reach it without any manual `setBurnIndex`), the recorded origin
+/// supports a later rollback, a re-run submits nothing — and the service
+/// then starts cleanly against the migrated store with its custody record
+/// intact (the expected-elsewhere reconciliation skip, until RAI-1223
+/// retires the subsystem).
+#[tokio::test]
+async fn test_receipt_custody_migrates_into_the_orchestrator()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::with_chain_id(Network::Base.chain_id()).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+    let mock_alpaca = MockServer::start();
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CustodyDatabases::in_directory(temp_dir.path());
+    let bot_wallet = evm.wallet_address;
+
+    let provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+
+    harness::preseed_tokenized_asset(
+        &databases.outgoing_url,
+        evm.vault_address,
+        CUSTODY_UNDERLYING,
+        CUSTODY_TOKEN,
+    )
+    .await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_certify_role(bot_wallet).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    // Run the service only long enough to discover the receipt into
+    // inventory, then restart so production startup reconciliation records
+    // the outgoing holder — the engine refuses unobserved custody.
+    let (config, _subgraph) = harness::create_config_with_db(
+        &databases.outgoing_url,
+        &mock_alpaca,
+        &evm,
+    )?;
+    let client = start_service(config.clone()).await?;
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
+    let receipt_shares = U256::from(40) * U256::from(10).pow(U256::from(18));
+    let share_ratio = U256::from(10).pow(U256::from(18));
+    let deposit = vault
+        .deposit(receipt_shares, bot_wallet, share_ratio, Bytes::new())
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    let receipt_id = deposit
+        .inner
+        .logs()
+        .iter()
+        .find_map(|log| {
+            OffchainAssetReceiptVault::Deposit::decode_log(&log.inner).ok()
+        })
+        .ok_or("deposit must emit a Deposit event")?
+        .id;
+    let receipt_contract: Address = vault.receipt().call().await?.0.into();
+    let receipt = ReceiptInstance::new(receipt_contract, &provider);
+    wait_for_receipt_in_inventory(&databases.outgoing_url).await?;
+    client.terminate().await;
+
+    let client = start_service(config.clone()).await?;
+    client.terminate().await;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(&databases.outgoing_url)
+        .await?;
+
+    let underlying: UnderlyingSymbol = CUSTODY_UNDERLYING.parse()?;
+    let identity = VaultIdentity::verify(
+        &pool,
+        &provider,
+        Network::Base,
+        evm.chain_id,
+        evm.vault_address,
+        &underlying,
+    )
+    .await?;
+
+    // The contract corroboration path: the orchestrator must prove ERC-1155
+    // receiver support through its own ERC-165 answers.
+    let destination = CorroboratedRecipient::verify(
+        &provider,
+        bot_wallet,
+        orchestrator_address,
+    )
+    .await?;
+    assert_eq!(
+        destination.kind(),
+        RecipientKind::Erc1155Receiver,
+        "the orchestrator must corroborate as an ERC-1155-receiving contract"
+    );
+
+    let outcome =
+        migrate_vault_receipts(&pool, &provider, identity, destination).await?;
+    assert!(
+        matches!(outcome, MigrationOutcome::Migrated { receipts, .. } if receipts > 0),
+        "the migration must move receipts into the orchestrator, got \
+         {outcome:?}"
+    );
+
+    assert_eq!(
+        receipt.balanceOf(orchestrator_address, receipt_id).call().await?,
+        receipt_shares,
+        "the orchestrator must hold the full transferred receipt balance"
+    );
+    assert_eq!(
+        receipt.balanceOf(bot_wallet, receipt_id).call().await?,
+        U256::ZERO,
+        "the bot wallet must retain nothing after the move"
+    );
+
+    // The cutover verification from the runbook: the burn pointer must sit
+    // at or below the transferred id, so the transferred receipt is
+    // reachable by the orchestrator's burn walk without manual intervention.
+    let orchestrator = ST0xOrchestrator::new(orchestrator_address, &provider);
+    let burn_pointer =
+        orchestrator.nextBurnReceiptId(evm.vault_address).call().await?;
+    assert!(
+        burn_pointer <= receipt_id,
+        "the burn pointer ({burn_pointer}) must cover the transferred \
+         receipt ({receipt_id})"
+    );
+
+    // The rollback origin derives from the recorded migration, not a typed
+    // address — an EMERGENCY_ROLE withdrawReceipt would return receipts
+    // here.
+    assert_eq!(
+        recorded_migration_origin(&pool, evm.chain_id, evm.vault_address)
+            .await?,
+        bot_wallet,
+        "the recorded origin must support a rollback to the bot wallet"
+    );
+
+    let rerun =
+        migrate_vault_receipts(&pool, &provider, identity, destination).await?;
+    assert!(
+        matches!(rerun, MigrationOutcome::AlreadyMigrated { receipts } if receipts > 0),
+        "re-running a completed move must submit nothing, got {rerun:?}"
+    );
+
+    pool.close().await;
+
+    // The service starts cleanly on the migrated store: startup
+    // reconciliation skips the vault whose custody a recorded migration
+    // moved away (asserted at the log level in the reconciler's unit tests;
+    // here the whole production startup path runs against the real store)
+    // and the custody record survives untouched.
+    let client = start_service(config.clone()).await?;
+    client.terminate().await;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(1)
+        .connect(&databases.outgoing_url)
+        .await?;
+    assert_eq!(
+        recorded_migration_origin(&pool, evm.chain_id, evm.vault_address)
+            .await?,
+        bot_wallet,
+        "post-migration startup must not clobber the recorded custody"
+    );
+    pool.close().await;
+
+    assert_eq!(
+        receipt.balanceOf(orchestrator_address, receipt_id).call().await?,
+        receipt_shares,
+        "the orchestrator's receipts must survive the service restart \
+         untouched"
+    );
+
+    // The rollback leg: an EMERGENCY_ROLE withdrawReceipt returns the
+    // receipts to the bot wallet, and confirm-custody re-records the holder
+    // so reconciliation resumes — the documented recovery a cutover
+    // rollback depends on.
+    let emergency_role = orchestrator.EMERGENCY_ROLE().call().await?;
+    orchestrator
+        .grantRole(emergency_role, bot_wallet)
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+    orchestrator
+        .withdrawReceipt(
+            evm.vault_address,
+            receipt_id,
+            receipt_shares,
+            bot_wallet,
+        )
+        .send()
+        .await?
+        .get_receipt()
+        .await?;
+
+    assert_eq!(
+        receipt.balanceOf(bot_wallet, receipt_id).call().await?,
+        receipt_shares,
+        "the emergency withdrawal must return the receipt to the bot wallet"
+    );
+    assert_eq!(
+        receipt.balanceOf(orchestrator_address, receipt_id).call().await?,
+        U256::ZERO,
+        "the orchestrator must retain nothing after the withdrawal"
+    );
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(&databases.outgoing_url)
+        .await?;
+    let confirmed =
+        confirm_custody_holder(&pool, &provider, identity, bot_wallet).await?;
+    assert_eq!(
+        confirmed, 1,
+        "re-confirmation must verify and record the returned receipt"
+    );
+    // The count above only proves verified balances; the persisted custody
+    // holder is the fact reconciliation actually reads.
+    assert_eq!(
+        recorded_custody_holder(&pool, evm.chain_id, evm.vault_address).await?,
+        bot_wallet,
+        "re-confirmation must record the bot wallet as the current holder"
+    );
+    pool.close().await;
+
+    // With custody re-recorded at the signing wallet, the service resumes
+    // ordinary reconciliation on the same store.
+    let client = start_service(config).await?;
+    client.terminate().await;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

The receipt-moving engine had no operator entry point — it was reusable library code waiting for a driver. Moving receipts to the orchestrator at cutover, or to a new wallet during a rotation, required manual intervention with no CLI surface, no deploy-hold enforcement, no gas readiness check, and no confirmation prompt. Additionally, after a recorded migration moved custody away from the signing wallet, the periodic reconciliation and backfill paths would manufacture `CustodyDisplaced` errors for a state the operator deliberately created, with no way to recover from a rollback without restarting the service and hoping automatic confirmation ran cleanly.

## Solution

Two new `issuer` subcommands drive the custody lifecycle:

**`issuer move-receipts <UNDERLYING>`** is the operator driver for the receipt-moving engine. It resolves the destination through exactly one of two mutually exclusive flags: `--to-configured-orchestrator` reads `[orchestrator].address` from `--config` (the cutover path, keeping the orchestrator address never-typed), while `--to <ADDRESS>` states an explicit destination (the wallet-rotation path). Stating `--to` with the configured orchestrator address is refused — the cutover path must go through the config flag. Before anything is signed, the command verifies the deployment hold is armed (hold file present, readiness marker absent), checks the bot wallet's native balance against the estimated transfer gas, corroborates the destination, and prompts with the asset, vault, holder, destination, its proven kind, and the tracked receipt count. A re-run after a completed move reports the already-migrated state and submits nothing.

**`issuer confirm-custody <UNDERLYING>`** is the rollback counterpart. After an `EMERGENCY_ROLE` `withdrawReceipt` returns receipts to the bot wallet, recorded custody still names the old destination and reconciliation stays skipped. This command verifies on-chain that the Turnkey bot wallet holds exactly every tracked receipt balance, then records it as the custody holder. The holder is always the Turnkey wallet — never typed — and a wallet that does not hold every tracked balance is refused with the first mismatch. It signs nothing and submits nothing on-chain.

The destination corroboration in `CorroboratedRecipient::verify` is extended to be kind-aware. An address with no deployed code is an EOA and must have on-chain history (transaction count or native balance). An address with deployed code must prove ERC-1155 receiver support up front through a consistent ERC-165 responder — affirming `IERC1155Receiver` and passing EIP-165's own consistency checks (`true` for ERC-165 itself, `false` for `0xffffffff`). A contract that answers `false` for receiver support, affirms every interface, or reverts ERC-165 calls is refused before any transfer is attempted. The `ST0xOrchestrator` clears this: it implements the receiver hooks and answers ERC-165. The witness records which kind it corroborated so the confirmation prompt and audit trail state what was proven.

The reconciler and backfiller now skip balance reads for a vault whose recorded custody holder differs from the signing wallet when a recorded `CustodyMigrated` from that wallet explains the mismatch, logging the skip once at INFO. A holder mismatch with no recorded migration explaining it is still treated as displacement and fails loudly at ERROR. `issuer confirm-custody` is the documented recovery: after a rollback, it re-records the bot wallet as holder and reconciliation resumes normally on the next startup.

The SPEC is updated to document both subcommands, the kind-aware corroboration guarantee, the expected-elsewhere skip and its rollback recovery, and the `confirm_custody_holder` manual path.

Closes [RAI-1712](https://linear.app/makeitrain/issue/RAI-1712/move-receipts-to-stated-destination-signed-by-turnkey)

Closes [RAI-1681](https://linear.app/makeitrain/issue/RAI-1681/move-receipts-to-a-stated-destination-signed-by-turnkey)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `move-receipts` and `confirm-custody` commands for controlled migration and custody verification.
  * Added validation for wallet destinations and ERC-1155 receiver contracts.
  * Added gas, deployment, chain, inventory, and confirmation checks, with safe repeat handling.
* **Bug Fixes**
  * Reconciliation now handles recorded custody transfers without false balance mismatches.
  * Added rollback and custody re-confirmation support after emergency withdrawals.
* **Documentation**
  * Documented the new workflows, validation requirements, migration limits, and recovery procedures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->