### PR TITLE
feat: chunked receipt migration with crash-safe resume

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1490,9 +1490,13 @@ every vault instead of none. Beyond quiescence, the tracked inventory is
 cross-checked against on-chain balances, the vault's certification and
 owner-freeze gates are re-read immediately before submission, and a completed
 move observed again is recorded idempotently instead of being re-transferred
-(`AlreadyMigrated`). A single transfer is limited to the 14-receipt batch size
-proven in production; larger inventories refuse until resumable chunking exists
-(expected for the full rollout's high-volume assets, not the pilot). The
+(`AlreadyMigrated`). A single transfer transaction is limited to the 14-receipt
+batch size proven in production; larger inventories move as a sequence of
+bounded chunks, each verified per identifier before the next is submitted, with
+the custody migration recorded only on full completion. A run interrupted
+between chunks resumes via a plain re-run: completed chunks have left the source
+on-chain, so reconciliation re-derives exactly the remaining identifiers and can
+never re-select a moved one — no resume bookkeeping is persisted anywhere. The
 `move-receipts` driver performs the outside-the-engine checks before the generic
 engine is invoked: it verifies the deployment hold is armed (hold file present,
 readiness marker absent — see `docs/runbooks/deploy-hold.md`), binds the signing

--- a/docs/runbooks/orchestrator-onboarding.md
+++ b/docs/runbooks/orchestrator-onboarding.md
@@ -1,16 +1,22 @@
-# Orchestrator onboarding: Turnkey policy, role grants, approvals (RAI-1221)
+# Orchestrator onboarding and per-asset cutover (RAI-1221 / RAI-1222)
 
-The ops procedure that must be complete for an asset **before** that asset's
-`vault_mode` flips to `"orchestrator"` (the per-asset cutover itself is
-RAI-1222's runbook; this one establishes its preconditions). Roles and the
-Turnkey policy are orchestrator-wide — done once, before the pilot. Approvals
-are per asset — RKLB's before the pilot cutover, each remaining asset's before
-its own.
+Two ordered procedures in one document. **Onboarding** (steps 1–6) is the ops
+work that must be complete for an asset before its `vault_mode` can flip to
+`"orchestrator"`: roles and the Turnkey policy are orchestrator-wide — done
+once, before the pilot — while approvals are per asset (RKLB's before the pilot
+cutover, each remaining asset's before its own). **Cutover** (steps 7–14) is the
+per-asset procedure that actually moves an asset onto the orchestrator, authored
+for the RKLB pilot (RAI-1222) and reused verbatim for every later asset
+(RAI-1246).
 
 There is no testnet or staging chain for this: every step below runs against
 prod (Base mainnet) and is verified by on-chain reads. The first live end-to-end
-mint/burn through Turnkey is the RKLB pilot's manual exercise, which everything
-here must fully precede.
+mint/burn through Turnkey is the RKLB pilot's manual exercise (step 13), which
+everything before it must fully precede. The full cutover cycle — migrate,
+operate, roll back, resume — is rehearsed by the Anvil end-to-end suite
+(`tests/receipt_custody.rs`,
+`test_receipt_custody_migrates_into_the_orchestrator`), the only pre-prod
+environment.
 
 ## Prerequisites
 
@@ -19,14 +25,23 @@ here must fully precede.
 - The orchestrator is deployed by st0x.deploy (PR #222/#223) and its address is
   known; the permissions scripts have run.
 - The liquidity-bot counterpart (RAI-1243) is tracked separately — it gates the
-  RAI-1222 cutover, not this procedure.
+  RAI-1222 cutover, not this procedure. Its release plumbing, once the issuance
+  orchestrator stack merges to main: cut the `st0x-issuance-client` /
+  `st0x-issuance-dto` tag `0.3.0` from main, swap the liquidity repo's
+  `Cargo.toml` git-branch pin back to that tag (the pin carries a swap-back
+  comment marking the spot), and deploy the liquidity bot from the swapped pin.
+  Step 7's cutover pre-check ("pin is on the release tag") verifies this
+  happened.
 
 All `issuer` subcommands below run on the issuer host (over SSH) with the
 service's own environment; they refuse a local-key signer because every fact
-they verify or establish is keyed to the Turnkey bot wallet. None of them takes
-an address argument — the orchestrator address comes from the TOML config file,
-the bot wallet from `TURNKEY_ADDRESS`, and vault/receipt addresses from the
-listing view and on-chain resolution.
+they verify or establish is keyed to the Turnkey bot wallet. The orchestrator
+address is never typed — it comes from the TOML config file — the bot wallet
+from `TURNKEY_ADDRESS`, and vault/receipt addresses from the listing view and
+on-chain resolution. The one address argument in this document,
+`move-receipts --to`, exists only for the wallet-rotation path, refuses the
+configured orchestrator address, and is guarded by the kind-aware corroboration
+witness (see SPEC "Receipt custody").
 
 ## 1. Ship the orchestrator address in the config (stays dark)
 
@@ -140,6 +155,169 @@ every check passes, so the RAI-1222 pre-checks gate on the exit code for the
 asset being cut over; `Overall: READY` is the human-readable rendering of the
 same verdict.
 
+## 7. Cutover pre-checks (gate on exit codes, not eyeballs)
+
+All of these must hold for the asset being cut over, immediately before its
+window. Every check is a command with an expected exit status — record each
+command's output with the cutover:
+
+- Step 6's preflight exits zero for this asset:
+  `issuer orchestrator-preflight --asset <SYM> …` → exit 0.
+- Step 4's signing proof exits zero for this asset (it covers the ERC-1155
+  `safeBatchTransferFrom` shape the receipt move, step 10, submits):
+  `issuer verify-orchestrator-signing <SYM> …` → exit 0.
+- `$ISSUANCE_URL` is the canonical HTTPS issuer origin before any check sends
+  `X-API-KEY` to it (a plain-`http://` or mistyped origin would leak the key in
+  cleartext or to the wrong host): `[[ "$ISSUANCE_URL" == https://* ]]` →
+  exit 0.
+- No stuck mints or redemptions for this asset:
+
+  ```sh
+  curl -fsS -H "X-API-KEY: $INTERNAL_API_KEY" "$ISSUANCE_URL/admin/stuck" \
+    | jq -e --arg sym <SYM> \
+        '[.stuck[] | select(.underlying == $sym)] | length == 0'
+  ```
+
+  → exit 0 (`jq -e` fails the check if any entry names the asset).
+- The status endpoint the liquidity bot polls serves the mode field, still
+  reading vault-direct pre-flip:
+
+  ```sh
+  curl -fsS -H "X-API-KEY: $INTERNAL_API_KEY" \
+    "$ISSUANCE_URL/tokenized-assets/<SYM>/status" \
+    | jq -e '.vault_mode == "vault_direct"'
+  ```
+
+  → exit 0.
+- The liquidity bot is deployed with MintAuthV1 delivery live (RAI-1243), each
+  fact checked in that repo's checkout at the DEPLOYED revision:
+  - The deployed revision contains RAI-1243:
+    `git merge-base --is-ancestor <rai-1243-merge-commit> <deployed-rev>` →
+    exit 0.
+  - BOTH issuance pins are on the release tag `0.3.0`, and neither is on a
+    branch — one check per dependency, so a single correct pin cannot vouch for
+    the other: `grep -E 'st0x-issuance-client.*tag *= *"0.3.0"' Cargo.toml` →
+    exit 0, `grep -E 'st0x-issuance-dto.*tag *= *"0.3.0"' Cargo.toml` → exit 0,
+    and `! grep -E 'st0x-issuance-(client|dto).*branch' Cargo.toml` → exit 0.
+  - Its deployed plaintext config carries the orchestrator section AND the exact
+    deployed orchestrator address from step 1 (the section existing with a stale
+    address would sign MintAuths for the wrong contract):
+    `grep -F '[orchestrator' <deployed config.toml>` → exit 0, and
+    `grep -iF '<orchestrator address>' <deployed config.toml>` → exit 0.
+  - Its Turnkey policy allows `ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2` (raw-payload
+    signing is a separate policy surface from transaction signing): run that
+    repo's ignored integration test against prod Turnkey,
+    `cargo test turnkey_digest_signing_integration -- --ignored` → exit 0.
+
+## 8. Freeze and drain
+
+Freeze the asset (`issuer freeze <SYM>`): `POST /inkind/issuance` rejects frozen
+assets before Alpaca journals shares, so nothing gets stranded mid-flow. Wait
+for this asset's in-flight mints and redemptions to reach terminal states
+(re-check `/admin/stuck` and step 7's preflight). The freeze-plus-drain is also
+what guarantees no aggregate straddles the mode flip — an operation's mode
+anchors once, at `Initiated` / `RedemptionDetected`.
+
+## 9. Deploy hold and snapshot
+
+Arm the deployment hold and stop the service per `docs/runbooks/deploy-hold.md`
+— `move-receipts` refuses without it, because the engine's projection rebuilds
+and quiescence reads must not race a running service. Then snapshot: record this
+token's per-receipt on-chain balances of BOTH wallets — the bot wallet
+(sanity-checked against `receipt_inventory_view`) and the orchestrator's
+pre-move balances for the same receipt ids (the engine deliberately allows a
+destination with pre-existing balances and verifies per-identifier GAINS, so the
+verification in step 11 needs the before-values) — and investigate any
+discrepancy before proceeding.
+
+## 10. Move the receipts
+
+```
+issuer move-receipts <SYM> \
+  --to-configured-orchestrator \
+  --config "$CONFIG" \
+  --network base --chain-id 8453 --rpc-url "$RPC_URL"
+```
+
+The destination is read from `[orchestrator].address` — never typed — and
+corroborated as an ERC-1155-receiving contract before anything is signed. The
+command prompts with the asset, vault, holder, destination and its corroborated
+kind, and the tracked receipt count. A vault tracking more than 14 receipts
+moves in multiple bounded transactions, each verified before the next. A re-run
+after any interruption is safe: an interrupted move resumes with only the
+remaining receipts, and a completed move reports "already migrated" and submits
+nothing.
+
+## 11. Verify the move
+
+- For every receipt id, the orchestrator's `balanceOf` GAIN over its step-9
+  pre-move balance equals the bot wallet's transferred amount from the same
+  snapshot; the bot wallet reads zero. (Final-balance equality with the bot's
+  snapshot is only correct when the orchestrator started at zero — the gain
+  check is the one the engine itself enforces.)
+- `nextBurnReceiptId(token)` sits at or below the lowest transferred id, so
+  every transferred receipt is reachable by the burn walk with no manual
+  `setBurnIndex` (`BurnIndexLowered` events appear only if the pointer had
+  previously advanced past a transferred id — their absence on a fresh
+  orchestrator is normal).
+- The recorded custody history shows the move bot → orchestrator (this is what a
+  later rollback derives its origin from).
+
+## 12. Flip, deploy, unfreeze
+
+Set `vault_mode = "orchestrator"` in the asset's `[assets.<SYM>]` table of the
+TOML config; release the hold and run the service deployment (the deploy
+activation restarts the unit). Verify `/admin/orchestrator-health` and the
+status endpoint report orchestrator mode for the asset, and that startup
+reconciliation logged the migrated vault as **skipped at INFO** ("custody
+recorded at a migrated destination") — a `CustodyDisplaced` ERROR here is a real
+problem, not cutover noise. Unfreeze.
+
+## 13. Pilot validation (manual, in prod)
+
+RKLB has essentially no organic flow — that is the point — so validation is
+actively driven. Manually trigger a small mint through the liquidity bot's
+rebalancing path (exercising the real MintAuthV1 delivery) and a small
+redemption (send tokens to the redemption wallet), and follow every stage
+end-to-end: authorization delivery, Turnkey signing, orchestrator
+`Minted`/`Burned` events, Alpaca journals/callbacks, `/admin` health. Repeat
+over a soak window (≥1 week with the asset left in orchestrator mode): every
+attempt completes, no unexplained `/admin/stuck` entries, and any transient
+failure exercises a recovery path observably. Record the go/no-go that gates the
+full rollout (RAI-1246).
+
+## 14. Rollback (per asset; rehearsed on Anvil)
+
+Touches only this asset:
+
+1. Freeze the asset and let in-flight work drain (step 8's procedure).
+2. Flip its `vault_mode` back to `"vault_direct"` in the TOML config.
+3. Arm the deployment hold and stop the service (per
+   `docs/runbooks/deploy-hold.md`) — **before** any receipt moves, for the same
+   reason step 9 requires it on the way in: projection rebuilds and custody
+   reads must not race a running service, and a live reconciliation pass must
+   never observe returned balances while persisted custody still names the
+   orchestrator.
+4. Page the `EMERGENCY_ROLE` holder (recorded below):
+   `withdrawReceipt(token, id, amount, bot_wallet)` for every migrated receipt
+   returns them on-chain. Verify bot-wallet `balanceOf` matches the step-9
+   snapshot.
+5. With the hold still armed, re-record custody:
+   `issuer confirm-custody <SYM> --network base --chain-id 8453
+   --rpc-url "$RPC_URL"`.
+   **Before** this command runs, recorded custody is EXPECTED to still name the
+   orchestrator — the on-chain withdrawal (step 4) does not touch the persisted
+   record, so that is not stale data to investigate. **After** it succeeds,
+   recorded custody must name the bot wallet: the command verifies on-chain that
+   the bot wallet holds every tracked balance and only then records it as
+   holder. Reconciliation stays skipped between the two states.
+6. Release the hold, deploy, verify startup reconciliation reads the vault
+   normally again, unfreeze.
+
+Redemptions already burned through the orchestrator keep their persisted
+`burn_mode`; their recovery and verification follow the persisted mode, so they
+stay recoverable after the flip back.
+
 ## Record of prod facts
 
 Fill in as the steps execute; this table is the standing record the acceptance
@@ -159,6 +337,12 @@ Per-asset approvals:
 | Asset | Approval tx hash | Date | Operator |
 | ----- | ---------------- | ---- | -------- |
 | RKLB  |                  |      |          |
+
+Per-asset cutovers (steps 7–13; RAI-1222 acceptance record):
+
+| Asset | Final receipt-move tx | Snapshot ref | Flip deploy | Validation mints/redemptions | Soak end | Go/no-go |
+| ----- | --------------------- | ------------ | ----------- | ---------------------------- | -------- | -------- |
+| RKLB  |                       |              |             |                              |          |          |
 
 ## Shortfall escalation (InsufficientReceipts)
 

--- a/src/receipt_inventory/migration.rs
+++ b/src/receipt_inventory/migration.rs
@@ -52,11 +52,11 @@ use crate::redemption::{
 use crate::tokenized_asset::view::find_vault;
 use crate::tokenized_asset::{Network, TokenizedAsset, UnderlyingSymbol};
 
-/// Largest receipt batch proven to fit the retired production transfer path.
-/// A 240-receipt batch exhausted gas while batches through 14 succeeded. Until
-/// a future driver introduces resumable chunking, refusing above the proven
-/// bound is safer than submitting an irreversible transaction with unverified
-/// gas behaviour.
+/// Largest receipt batch proven to fit a single transfer transaction. A
+/// 240-receipt batch exhausted gas in production while batches through 14
+/// succeeded, so larger inventories move as a sequence of bounded chunks
+/// (see [`MigratableHoldings::transfer_chunks`]) rather than one unverified
+/// oversized submission.
 const MAX_RECEIPTS_PER_TRANSFER: usize = 14;
 
 /// EIP-165 defines an interface's id as the XOR of all its function
@@ -314,6 +314,26 @@ impl MigratableHoldings {
     fn total(&self) -> Result<Shares, SharesOverflow> {
         total_of(self.holdings.iter().map(|held| held.balance))
     }
+
+    /// Splits the holdings into transfer-sized batches of at most
+    /// [`MAX_RECEIPTS_PER_TRANSFER`], preserving their canonical order.
+    ///
+    /// Chunk membership is positional over the sorted holdings, so it is
+    /// deterministic across re-runs — but nothing depends on that for
+    /// safety: an interrupted run's completed chunks have left the source
+    /// on-chain, and the next run's reconciliation re-derives exactly the
+    /// remaining identifiers before anything is submitted.
+    fn transfer_chunks(&self) -> Vec<Self> {
+        self.holdings
+            .chunks(MAX_RECEIPTS_PER_TRANSFER)
+            .map(|chunk| Self {
+                chain_id: self.chain_id,
+                vault: self.vault,
+                holder: self.holder,
+                holdings: chunk.to_vec(),
+            })
+            .collect()
+    }
 }
 
 /// Why a migration must not proceed.
@@ -434,13 +454,6 @@ enum MigrationRefusal {
 
     #[error("vault {vault} owner freeze blocks {from} -> {to} until {until}")]
     OwnerFrozen { vault: Address, from: Address, to: Address, until: U256 },
-
-    #[error(
-        "vault {vault} has {receipts} tracked receipts, exceeding the proven \
-         single-transfer maximum of {maximum}; a resumable chunking driver is \
-         required before custody can move"
-    )]
-    ReceiptBatchTooLarge { vault: Address, receipts: usize, maximum: usize },
 
     #[error(
         "receipt {receipt_id} on vault {vault} diverges: inventory tracks \
@@ -1730,6 +1743,23 @@ async fn reconcile_holdings(
     // transfer construction deterministic across retries.
     unmoved.sort_by_key(|held| held.receipt_id.inner());
 
+    // The third holdings state, made explicit: every tracked balance is
+    // accounted for per identifier across exactly source + destination, so
+    // an interrupted chunked move (or a retired execution path's partial
+    // move) resumes with only the remainder — never re-selecting an
+    // identifier that already left the source.
+    if migrated > 0 {
+        info!(
+            target: "receipt_inventory",
+            %vault,
+            %holder,
+            %recipient,
+            already_at_destination = migrated,
+            remaining = unmoved.len(),
+            "Resuming a partially migrated vault"
+        );
+    }
+
     debug!(
         target: "receipt_inventory",
         %vault,
@@ -1747,11 +1777,20 @@ async fn reconcile_holdings(
     }))
 }
 
-/// Moves one vault's receipts to the incoming wallet.
+/// Moves one vault's receipts to the incoming wallet, in transfer-sized
+/// chunks of at most [`MAX_RECEIPTS_PER_TRANSFER`], verifying each chunk's
+/// per-identifier movement before submitting the next.
 ///
-/// Re-reads the transfer permission immediately before submitting, because
-/// certification is maintained outside this service and can lapse between an
-/// earlier preflight and the transaction landing.
+/// A chunk failure returns immediately: completed chunks have already left
+/// the source on-chain, so a plain re-run reconciles the remainder and never
+/// re-selects a moved identifier — no resume bookkeeping is persisted
+/// anywhere. The caller records the custody migration only on the fully
+/// completed outcome.
+///
+/// Re-reads the transfer permission immediately before each submission,
+/// because certification is maintained outside this service and can lapse
+/// between an earlier preflight — or an earlier chunk — and the transaction
+/// landing.
 async fn migrate_vault_custody(
     custody: &(impl ReceiptCustody + Sync),
     holdings: &MigratableHoldings,
@@ -1763,62 +1802,79 @@ async fn migrate_vault_custody(
     }
 
     let receipts = holdings.holdings().len();
-    if receipts > MAX_RECEIPTS_PER_TRANSFER {
-        return Err(MigrationRefusal::ReceiptBatchTooLarge {
-            vault,
-            receipts,
-            maximum: MAX_RECEIPTS_PER_TRANSFER,
-        });
-    }
+    let chunks = holdings.transfer_chunks();
+    let transfers = chunks.len();
+    let mut last_transaction: Option<B256> = None;
 
-    let permit = match custody
-        .transfer_permission(vault, holdings.holder(), recipient)
-        .await?
-    {
-        TransferPermission::Permitted(permit) => permit,
-        TransferPermission::CertificationExpired => {
-            return Err(MigrationRefusal::CertificationExpired { vault });
-        }
-        TransferPermission::OwnerFrozen { until } => {
-            return Err(MigrationRefusal::OwnerFrozen {
+    for (position, chunk) in chunks.iter().enumerate() {
+        let permit = match custody
+            .transfer_permission(vault, chunk.holder(), recipient)
+            .await?
+        {
+            TransferPermission::Permitted(permit) => permit,
+            TransferPermission::CertificationExpired => {
+                return Err(MigrationRefusal::CertificationExpired { vault });
+            }
+            TransferPermission::OwnerFrozen { until } => {
+                return Err(MigrationRefusal::OwnerFrozen {
+                    vault,
+                    from: chunk.holder(),
+                    to: recipient,
+                    until,
+                });
+            }
+        };
+
+        // Captured before the transfer so the post-condition measures what
+        // this transfer delivered, not the recipient's absolute balance —
+        // which would wrongly pass if the recipient already held some of
+        // these identifiers.
+        let receipt_ids = chunk.receipt_ids();
+        let recipient_before =
+            custody.held_balances(vault, recipient, &receipt_ids).await?;
+
+        // Checked before submitting: a truncated response here would
+        // otherwise only surface in `verify_custody_moved`, after the
+        // irreversible transfer has already gone out.
+        if recipient_before.len() != receipt_ids.len() {
+            return Err(MigrationRefusal::BalanceCountMismatch {
                 vault,
-                from: holdings.holder(),
-                to: recipient,
-                until,
+                requested: receipt_ids.len(),
+                returned: recipient_before.len(),
             });
         }
-    };
 
-    // Captured before the transfer so the post-condition measures what this
-    // transfer delivered, not the recipient's absolute balance — which would
-    // wrongly pass if the recipient already held some of these identifiers.
-    let receipt_ids = holdings.receipt_ids();
-    let recipient_before =
-        custody.held_balances(vault, recipient, &receipt_ids).await?;
+        let expected = chunk.total()?;
+        let transaction = custody.transfer_custody(&permit, chunk).await?;
 
-    // Checked before submitting: a truncated response here would otherwise
-    // only surface in `verify_custody_moved`, after the irreversible
-    // transfer has already gone out.
-    if recipient_before.len() != receipt_ids.len() {
-        return Err(MigrationRefusal::BalanceCountMismatch {
-            vault,
-            requested: receipt_ids.len(),
-            returned: recipient_before.len(),
-        });
+        verify_custody_moved(
+            custody,
+            chunk,
+            recipient,
+            &recipient_before,
+            expected,
+            transaction,
+        )
+        .await?;
+
+        debug!(
+            target: "receipt_inventory",
+            chain_id = chunk.chain_id(),
+            %vault,
+            %transaction,
+            chunk = position + 1,
+            transfers,
+            receipts = chunk.holdings().len(),
+            "Migrated a receipt custody chunk"
+        );
+        last_transaction = Some(transaction);
     }
 
-    let expected = holdings.total()?;
-    let transaction = custody.transfer_custody(&permit, holdings).await?;
-
-    verify_custody_moved(
-        custody,
-        holdings,
-        recipient,
-        &recipient_before,
-        expected,
-        transaction,
-    )
-    .await?;
+    // The loop ran at least once (holdings verified non-empty above), so a
+    // missing hash is unreachable in practice — failed closed rather than
+    // panicking, per the no-panic rule.
+    let transaction = last_transaction
+        .ok_or(ReceiptCustodyError::NothingToTransfer { vault })?;
 
     info!(
         target: "receipt_inventory",
@@ -1826,6 +1882,7 @@ async fn migrate_vault_custody(
         %vault,
         %transaction,
         receipts,
+        transfers,
         holder = %holdings.holder(),
         %recipient,
         "Migrated receipt custody"
@@ -2212,6 +2269,14 @@ mod tests {
         /// Leave the recipient holding less than it did before the transfer,
         /// modelling a corrupt or reorganised observation.
         shrink_recipient_on_settle: bool,
+        /// Fail the transfer whose zero-based position equals this value,
+        /// moving nothing — a crash between chunks. Self-clearing, so the
+        /// same fake then serves the resuming re-run.
+        fail_transfer_at: Mutex<Option<usize>>,
+        /// Report `CertificationExpired` once this many transfers have been
+        /// submitted — a certification lapsing mid-move, between chunks.
+        /// Cleared by the test to model the operator renewing it.
+        expire_certification_after: Mutex<Option<usize>>,
     }
 
     /// The fake's scripted permission, kept separate from
@@ -2251,6 +2316,8 @@ mod tests {
                 truncate_for: None,
                 swap_on_settle: false,
                 shrink_recipient_on_settle: false,
+                fail_transfer_at: Mutex::new(None),
+                expire_certification_after: Mutex::new(None),
             }
         }
 
@@ -2304,6 +2371,17 @@ mod tests {
             from: Address,
             to: Address,
         ) -> Result<TransferPermission, ReceiptCustodyError> {
+            // A scripted mid-move lapse: once the scripted number of
+            // transfers has gone out, the certification reads as expired —
+            // exercising the loop's per-chunk permission re-read.
+            let value =
+                *self.expire_certification_after.lock().expect("expire lock");
+            if let Some(after) = value
+                && self.transfers.lock().expect("transfers lock").len() >= after
+            {
+                return Ok(TransferPermission::CertificationExpired);
+            }
+
             Ok(match self.permission {
                 Permission::Permitted => TransferPermission::Permitted(
                     TransferPermit::granted(vault, from, to),
@@ -2322,6 +2400,19 @@ mod tests {
             permit: &TransferPermit,
             holdings: &MigratableHoldings,
         ) -> Result<B256, ReceiptCustodyError> {
+            let submitted =
+                self.transfers.lock().expect("transfers lock").len();
+            let mut fail_at =
+                self.fail_transfer_at.lock().expect("fail_transfer_at lock");
+            if *fail_at == Some(submitted) {
+                *fail_at = None;
+                return Err(ReceiptCustodyError::Reverted {
+                    vault: permit.vault(),
+                    tx_hash: B256::repeat_byte(9),
+                });
+            }
+            drop(fail_at);
+
             self.transfers
                 .lock()
                 .expect("transfers lock")
@@ -2656,9 +2747,62 @@ mod tests {
         ));
     }
 
+    fn holdings_range(
+        range: std::ops::RangeInclusive<u64>,
+    ) -> MigratableHoldings {
+        MigratableHoldings {
+            chain_id: CHAIN_ID,
+            vault: VAULT,
+            holder: OUTGOING,
+            holdings: range.map(|id| FakeCustody::holding(id, 100)).collect(),
+        }
+    }
+
+    #[test]
+    fn transfer_chunks_pack_to_the_proven_bound_in_canonical_order() {
+        for (receipts, expected_sizes) in [
+            (1u64, vec![1usize]),
+            (14, vec![14]),
+            (15, vec![14, 1]),
+            (30, vec![14, 14, 2]),
+        ] {
+            let holdings = holdings_range(1..=receipts);
+
+            let chunks = holdings.transfer_chunks();
+
+            let sizes: Vec<usize> =
+                chunks.iter().map(|chunk| chunk.holdings().len()).collect();
+            assert_eq!(
+                sizes, expected_sizes,
+                "{receipts} holdings must pack into batches of at most 14"
+            );
+
+            let flattened: Vec<U256> = chunks
+                .iter()
+                .flat_map(MigratableHoldings::receipt_ids)
+                .map(|receipt_id| receipt_id.inner())
+                .collect();
+            let original: Vec<U256> = holdings
+                .receipt_ids()
+                .into_iter()
+                .map(|receipt_id| receipt_id.inner())
+                .collect();
+            assert_eq!(
+                flattened, original,
+                "chunking must preserve the canonical order and cover every \
+                 identifier exactly once"
+            );
+        }
+    }
+
+    /// Above the proven single-transfer bound, the migration submits a
+    /// sequence of bounded chunks instead of refusing — each verified
+    /// per identifier before the next goes out — and reports the full
+    /// receipt count on completion.
+    #[traced_test]
     #[tokio::test]
-    async fn migrate_refuses_more_receipts_than_the_proven_batch_limit() {
-        let source: Vec<(u64, u64)> = (1..=15).map(|id| (id, 100)).collect();
+    async fn migrate_transfers_above_the_batch_bound_in_chunks() {
+        let source: Vec<(u64, u64)> = (1..=30).map(|id| (id, 100)).collect();
         let custody = FakeCustody::at_source(&source);
         let tracked: Vec<ReceiptHolding> = source
             .iter()
@@ -2669,22 +2813,185 @@ mod tests {
         let holdings =
             holdings_of(reconcile(&custody, &tracked).await.unwrap());
 
+        let outcome =
+            migrate_vault_custody(&custody, &holdings, INCOMING).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                transaction: B256::repeat_byte(7),
+                receipts: 30
+            }
+        );
+        assert_eq!(
+            custody.transfers.lock().unwrap().as_slice(),
+            [(INCOMING, 14), (INCOMING, 14), (INCOMING, 2)],
+            "the move must submit bounded batches, largest first"
+        );
+        for held in &tracked {
+            let balances = custody.balances.lock().unwrap();
+            assert_eq!(
+                balances.get(&(INCOMING, held.receipt_id)).copied(),
+                Some(held.balance),
+                "receipt {} must reach the destination exactly once",
+                held.receipt_id
+            );
+            assert_eq!(
+                balances
+                    .get(&(OUTGOING, held.receipt_id))
+                    .copied()
+                    .unwrap_or(Shares::ZERO),
+                Shares::ZERO,
+                "receipt {} must leave the source",
+                held.receipt_id
+            );
+            drop(balances);
+        }
+        assert!(logs_contain_at!(
+            tracing::Level::DEBUG,
+            &["Migrated a receipt custody chunk", "chunk=1", "transfers=3"]
+        ));
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &["Migrated receipt custody", "receipts=30", "transfers=3"]
+        ));
+    }
+
+    /// A failure between chunks is a crash the engine must survive without
+    /// bookkeeping: the completed chunk has left the source on-chain, so a
+    /// plain re-run reconciles only the remainder and moves every balance
+    /// exactly once.
+    #[traced_test]
+    #[tokio::test]
+    async fn interrupted_chunked_migration_resumes_without_duplication() {
+        let source: Vec<(u64, u64)> = (1..=16).map(|id| (id, 100)).collect();
+        let custody = FakeCustody::at_source(&source);
+        let tracked: Vec<ReceiptHolding> = source
+            .iter()
+            .map(|(receipt_id, balance)| {
+                FakeCustody::holding(*receipt_id, *balance)
+            })
+            .collect();
+        *custody.fail_transfer_at.lock().unwrap() = Some(1);
+
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
         let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
             .await
             .unwrap_err();
 
-        assert!(matches!(
-            refusal,
-            MigrationRefusal::ReceiptBatchTooLarge {
-                vault: VAULT,
-                receipts: 15,
-                maximum: 14,
-            }
-        ));
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::Custody(ref boxed)
+                    if matches!(**boxed, ReceiptCustodyError::Reverted { .. })
+            ),
+            "the failing chunk must surface its error, got {refusal:?}"
+        );
         assert_eq!(
-            custody.transfer_count(),
-            0,
-            "an unproven batch size must be refused before submission"
+            custody.transfers.lock().unwrap().as_slice(),
+            [(INCOMING, 14)],
+            "only the first chunk may have been submitted"
+        );
+
+        // The re-run: reconciliation resumes with exactly the remainder.
+        let resumed = holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        assert_eq!(
+            resumed
+                .receipt_ids()
+                .iter()
+                .map(ReceiptId::inner)
+                .collect::<Vec<_>>(),
+            vec![U256::from(15), U256::from(16)],
+            "the resume must select only the identifiers still at the source"
+        );
+
+        let outcome =
+            migrate_vault_custody(&custody, &resumed, INCOMING).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                transaction: B256::repeat_byte(7),
+                receipts: 2
+            }
+        );
+        for held in &tracked {
+            let balances = custody.balances.lock().unwrap();
+            assert_eq!(
+                balances.get(&(INCOMING, held.receipt_id)).copied(),
+                Some(held.balance),
+                "receipt {} must reach the destination exactly once across \
+                 the interrupted run and its resume",
+                held.receipt_id
+            );
+            drop(balances);
+        }
+        assert!(logs_contain_at!(
+            tracing::Level::INFO,
+            &[
+                "Resuming a partially migrated vault",
+                "already_at_destination=14",
+                "remaining=2"
+            ]
+        ));
+    }
+
+    /// Certification is maintained outside this service and can lapse
+    /// between chunks: the loop re-reads the transfer permission before
+    /// every chunk, so a mid-move lapse refuses the remaining chunks after
+    /// the completed one — and a plain re-run after renewal moves exactly
+    /// the remainder.
+    #[tokio::test]
+    async fn chunked_migration_stops_when_certification_lapses_mid_move() {
+        let source: Vec<(u64, u64)> = (1..=16).map(|id| (id, 100)).collect();
+        let custody = FakeCustody::at_source(&source);
+        let tracked: Vec<ReceiptHolding> = source
+            .iter()
+            .map(|(receipt_id, balance)| {
+                FakeCustody::holding(*receipt_id, *balance)
+            })
+            .collect();
+        *custody.expire_certification_after.lock().unwrap() = Some(1);
+
+        let holdings =
+            holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        let refusal = migrate_vault_custody(&custody, &holdings, INCOMING)
+            .await
+            .unwrap_err();
+
+        assert!(
+            matches!(
+                refusal,
+                MigrationRefusal::CertificationExpired { vault: VAULT }
+            ),
+            "the lapsed certification must refuse the second chunk, got \
+             {refusal:?}"
+        );
+        assert_eq!(
+            custody.transfers.lock().unwrap().as_slice(),
+            [(INCOMING, 14)],
+            "only the chunk submitted before the lapse may have gone out"
+        );
+
+        // The operator renews certification; a plain re-run moves exactly
+        // the remainder.
+        *custody.expire_certification_after.lock().unwrap() = None;
+        let resumed = holdings_of(reconcile(&custody, &tracked).await.unwrap());
+        let outcome =
+            migrate_vault_custody(&custody, &resumed, INCOMING).await.unwrap();
+
+        assert_eq!(
+            outcome,
+            MigrationOutcome::Migrated {
+                transaction: B256::repeat_byte(7),
+                receipts: 2
+            }
+        );
+        assert_eq!(
+            custody.transfers.lock().unwrap().as_slice(),
+            [(INCOMING, 14), (INCOMING, 2)],
+            "the renewed re-run must submit exactly the remainder"
         );
     }
 

--- a/tests/receipt_custody.rs
+++ b/tests/receipt_custody.rs
@@ -80,6 +80,17 @@ impl CustodyDatabases {
 async fn wait_for_receipt_in_inventory(
     database_url: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    wait_for_discovered_receipts(database_url, 1).await
+}
+
+/// Waits until the running service has discovered at least `minimum`
+/// receipts into the vault's inventory — the multi-receipt counterpart of
+/// [`wait_for_receipt_in_inventory`], for scenarios seeding more deposits
+/// than one.
+async fn wait_for_discovered_receipts(
+    database_url: &str,
+    minimum: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
     let pool = SqlitePoolOptions::new()
         .max_connections(1)
         .connect(database_url)
@@ -104,7 +115,7 @@ async fn wait_for_receipt_in_inventory(
         .fetch_one(&pool)
         .await?;
 
-        if recorded > 0 {
+        if recorded >= minimum {
             pool.close().await;
             return Ok(());
         }
@@ -113,7 +124,8 @@ async fn wait_for_receipt_in_inventory(
     }
 
     pool.close().await;
-    Err("no receipt ever entered the inventory".into())
+    Err(format!("fewer than {minimum} receipts ever entered the inventory")
+        .into())
 }
 
 /// Waits until the running service has settled a redemption's burn
@@ -1501,6 +1513,368 @@ async fn test_receipt_custody_migrates_into_the_orchestrator()
     // ordinary reconciliation on the same store.
     let client = start_service(config).await?;
     client.terminate().await;
+
+    Ok(())
+}
+
+/// The chunked-migration scenario's tracked receipt count and the engine's
+/// proven per-transaction bound: 17 receipts split into a full chunk of 14
+/// plus a remainder of 3.
+const CHUNKED_TRACKED_RECEIPTS: usize = 17;
+const CHUNK_BOUND: usize = 14;
+
+/// Everything the chunked-migration phases share, so each phase reads as one
+/// focused step of the scenario.
+struct ChunkedMigrationStage<'a, P: Provider> {
+    pool: &'a sqlx::SqlitePool,
+    provider: &'a P,
+    identity: VaultIdentity<'a>,
+    destination: CorroboratedRecipient,
+    receipt_contract: Address,
+    receipt_ids: &'a [U256],
+    receipt_shares: U256,
+    orchestrator_address: Address,
+    bot_wallet: Address,
+    chain_id: u64,
+    vault_address: Address,
+}
+
+impl<P: Provider> ChunkedMigrationStage<'_, P> {
+    /// Phase 1: the full move must cross the bound as multiple bounded batch
+    /// transactions, each verified before the next, recording custody once —
+    /// and a re-run must report `AlreadyMigrated`.
+    async fn full_move_lands_in_bounded_batches(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let outcome = migrate_vault_receipts(
+            self.pool,
+            self.provider,
+            self.identity,
+            self.destination,
+        )
+        .await?;
+        assert!(
+            matches!(
+                outcome,
+                MigrationOutcome::Migrated { receipts, .. }
+                    if receipts == CHUNKED_TRACKED_RECEIPTS
+            ),
+            "the migration must move all {CHUNKED_TRACKED_RECEIPTS} \
+             receipts, got {outcome:?}"
+        );
+
+        let receipt =
+            ReceiptInstance::new(self.receipt_contract, self.provider);
+        let batches =
+            receipt.TransferBatch_filter().from_block(0).query().await?;
+        let engine_batches = batches
+            .iter()
+            .filter(|(event, _)| event.to == self.orchestrator_address)
+            .count();
+        assert_eq!(
+            engine_batches, 2,
+            "{CHUNKED_TRACKED_RECEIPTS} receipts must move as exactly two \
+             bounded batch transactions"
+        );
+
+        self.assert_orchestrator_holds_everything(
+            "the orchestrator must hold every receipt after the move",
+        )
+        .await?;
+        for receipt_id in self.receipt_ids {
+            assert_eq!(
+                receipt.balanceOf(self.bot_wallet, *receipt_id).call().await?,
+                U256::ZERO,
+                "the bot wallet must retain nothing of receipt {receipt_id}"
+            );
+        }
+        assert_eq!(
+            recorded_migration_origin(
+                self.pool,
+                self.chain_id,
+                self.vault_address,
+            )
+            .await?,
+            self.bot_wallet,
+            "custody must be recorded once, with the bot wallet as origin"
+        );
+
+        self.assert_rerun_reports_already_migrated(
+            "re-running the completed move must submit nothing",
+        )
+        .await
+    }
+
+    /// Phase 2: return every receipt (the rollback leg) and re-confirm
+    /// custody at the bot wallet, restoring the pre-migration state for the
+    /// interrupted-run phase.
+    async fn rollback_and_reconfirm_custody(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let orchestrator =
+            ST0xOrchestrator::new(self.orchestrator_address, self.provider);
+        let emergency_role = orchestrator.EMERGENCY_ROLE().call().await?;
+        orchestrator
+            .grantRole(emergency_role, self.bot_wallet)
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        for receipt_id in self.receipt_ids {
+            orchestrator
+                .withdrawReceipt(
+                    self.vault_address,
+                    *receipt_id,
+                    self.receipt_shares,
+                    self.bot_wallet,
+                )
+                .send()
+                .await?
+                .get_receipt()
+                .await?;
+        }
+
+        let confirmed = confirm_custody_holder(
+            self.pool,
+            self.provider,
+            self.identity,
+            self.bot_wallet,
+        )
+        .await?;
+        assert_eq!(
+            confirmed, CHUNKED_TRACKED_RECEIPTS,
+            "re-confirmation must verify every returned receipt"
+        );
+        // The count above only proves verified balances; the persisted
+        // custody holder is the fact reconciliation actually reads.
+        assert_eq!(
+            recorded_custody_holder(
+                self.pool,
+                self.chain_id,
+                self.vault_address,
+            )
+            .await?,
+            self.bot_wallet,
+            "re-confirmation must record the bot wallet as the current holder"
+        );
+
+        Ok(())
+    }
+
+    /// Phase 3: fabricate the exact state a crash between chunks leaves —
+    /// the first bounded batch landed, the rest never submitted — then prove
+    /// a plain re-run resumes with only the remainder and a further re-run
+    /// reports `AlreadyMigrated`.
+    async fn crash_resume_moves_only_remainder(
+        &self,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut sorted_ids = self.receipt_ids.to_vec();
+        sorted_ids.sort();
+        let first_chunk: Vec<U256> =
+            sorted_ids.iter().take(CHUNK_BOUND).copied().collect();
+        let receipt =
+            ReceiptInstance::new(self.receipt_contract, self.provider);
+        receipt
+            .safeBatchTransferFrom(
+                self.bot_wallet,
+                self.orchestrator_address,
+                first_chunk.clone(),
+                vec![self.receipt_shares; first_chunk.len()],
+                Bytes::new(),
+            )
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+
+        let resumed = migrate_vault_receipts(
+            self.pool,
+            self.provider,
+            self.identity,
+            self.destination,
+        )
+        .await?;
+        assert!(
+            matches!(
+                resumed,
+                MigrationOutcome::Migrated { receipts, .. }
+                    if receipts == CHUNKED_TRACKED_RECEIPTS - CHUNK_BOUND
+            ),
+            "the resume must move only the remainder, got {resumed:?}"
+        );
+        self.assert_orchestrator_holds_everything(
+            "every receipt must reach the orchestrator exactly once across \
+             the interrupted run and its resume",
+        )
+        .await?;
+
+        self.assert_rerun_reports_already_migrated(
+            "a further re-run must report the completed migration",
+        )
+        .await
+    }
+
+    async fn assert_orchestrator_holds_everything(
+        &self,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let receipt =
+            ReceiptInstance::new(self.receipt_contract, self.provider);
+        for receipt_id in self.receipt_ids {
+            assert_eq!(
+                receipt
+                    .balanceOf(self.orchestrator_address, *receipt_id)
+                    .call()
+                    .await?,
+                self.receipt_shares,
+                "{message} (receipt {receipt_id})"
+            );
+        }
+        Ok(())
+    }
+
+    async fn assert_rerun_reports_already_migrated(
+        &self,
+        message: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let rerun = migrate_vault_receipts(
+            self.pool,
+            self.provider,
+            self.identity,
+            self.destination,
+        )
+        .await?;
+        assert!(
+            matches!(
+                rerun,
+                MigrationOutcome::AlreadyMigrated { receipts }
+                    if receipts == CHUNKED_TRACKED_RECEIPTS
+            ),
+            "{message}, got {rerun:?}"
+        );
+        Ok(())
+    }
+}
+
+/// RAI-1714: a vault above the proven 14-receipt single-transfer bound
+/// migrates into the orchestrator as a sequence of bounded batch
+/// transactions; a run interrupted between chunks resumes via a plain
+/// re-run, moving only the remainder and recording custody once; a further
+/// re-run reports `AlreadyMigrated` and submits nothing.
+#[tokio::test]
+async fn test_receipt_custody_chunked_migration_resumes_into_the_orchestrator()
+-> Result<(), Box<dyn std::error::Error>> {
+    let evm = LocalEvm::with_chain_id(Network::Base.chain_id()).await?;
+    let orchestrator_address = evm.deploy_orchestrator().await?;
+    let mock_alpaca = MockServer::start();
+    let _mint_callback_mock =
+        harness::alpaca_mocks::setup_mint_mocks(&mock_alpaca);
+    let temp_dir = tempfile::tempdir()?;
+    let databases = CustodyDatabases::in_directory(temp_dir.path());
+    let bot_wallet = evm.wallet_address;
+
+    let provider = create_provider()
+        .wallet(EthereumWallet::from(PrivateKeySigner::from_bytes(
+            &evm.private_key,
+        )?))
+        .connect(&evm.endpoint)
+        .await?;
+
+    harness::preseed_tokenized_asset(
+        &databases.outgoing_url,
+        evm.vault_address,
+        CUSTODY_UNDERLYING,
+        CUSTODY_TOKEN,
+    )
+    .await?;
+    evm.grant_deposit_role(bot_wallet).await?;
+    evm.grant_certify_role(bot_wallet).await?;
+    evm.certify_vault(U256::MAX).await?;
+
+    let (config, _subgraph) = harness::create_config_with_db(
+        &databases.outgoing_url,
+        &mock_alpaca,
+        &evm,
+    )?;
+    let client = start_service(config.clone()).await?;
+
+    let vault =
+        OffchainAssetReceiptVaultInstance::new(evm.vault_address, &provider);
+    let share_ratio = U256::from(10).pow(U256::from(18));
+    let receipt_shares = U256::from(10) * share_ratio;
+    let mut receipt_ids: Vec<U256> =
+        Vec::with_capacity(CHUNKED_TRACKED_RECEIPTS);
+    for _ in 0..CHUNKED_TRACKED_RECEIPTS {
+        let deposit = vault
+            .deposit(receipt_shares, bot_wallet, share_ratio, Bytes::new())
+            .send()
+            .await?
+            .get_receipt()
+            .await?;
+        let receipt_id = deposit
+            .inner
+            .logs()
+            .iter()
+            .find_map(|log| {
+                OffchainAssetReceiptVault::Deposit::decode_log(&log.inner).ok()
+            })
+            .ok_or("deposit must emit a Deposit event")?
+            .id;
+        receipt_ids.push(receipt_id);
+    }
+    let receipt_contract: Address = vault.receipt().call().await?.0.into();
+    wait_for_discovered_receipts(
+        &databases.outgoing_url,
+        i64::try_from(CHUNKED_TRACKED_RECEIPTS)?,
+    )
+    .await?;
+    client.terminate().await;
+
+    // Startup reconciliation records the outgoing holder — the engine
+    // refuses unobserved custody.
+    let client = start_service(config.clone()).await?;
+    client.terminate().await;
+
+    let pool = SqlitePoolOptions::new()
+        .max_connections(5)
+        .connect(&databases.outgoing_url)
+        .await?;
+    let underlying: UnderlyingSymbol = CUSTODY_UNDERLYING.parse()?;
+    let identity = VaultIdentity::verify(
+        &pool,
+        &provider,
+        Network::Base,
+        evm.chain_id,
+        evm.vault_address,
+        &underlying,
+    )
+    .await?;
+    let destination = CorroboratedRecipient::verify(
+        &provider,
+        bot_wallet,
+        orchestrator_address,
+    )
+    .await?;
+
+    let stage = ChunkedMigrationStage {
+        pool: &pool,
+        provider: &provider,
+        identity,
+        destination,
+        receipt_contract,
+        receipt_ids: &receipt_ids,
+        receipt_shares,
+        orchestrator_address,
+        bot_wallet,
+        chain_id: evm.chain_id,
+        vault_address: evm.vault_address,
+    };
+
+    stage.full_move_lands_in_bounded_batches().await?;
+    stage.rollback_and_reconfirm_custody().await?;
+    stage.crash_resume_moves_only_remainder().await?;
+
+    pool.close().await;
 
     Ok(())
 }


### PR DESCRIPTION
## Motivation

Receipt migration was previously limited to a hard refusal when a vault held more than 14 receipts (the proven single-transfer gas bound). This made it impossible to migrate vaults with larger inventories without manual intervention, and blocked the full rollout for high-volume assets.

Additionally, the orchestrator onboarding runbook covered only the precondition steps (roles, policy, approvals) and referenced a separate cutover document that did not exist as a consolidated resource.

## Solution

The 14-receipt ceiling is replaced with chunked transfer logic: `MigratableHoldings::transfer_chunks` splits holdings into bounded batches of at most 14, and `migrate_vault_custody` iterates over them, verifying each chunk's per-identifier movement before submitting the next. The `ReceiptBatchTooLarge` refusal variant is removed entirely.

Interrupted runs are safe without any persisted resume bookkeeping: completed chunks have already left the source on-chain, so a plain re-run's reconciliation re-derives exactly the remaining identifiers and can never re-select a moved one. A partial-migration log line (`Resuming a partially migrated vault`) makes this visible at INFO. Custody is recorded only on full completion; the last chunk's transaction hash is surfaced in the `Migrated` outcome.

The orchestrator onboarding runbook is expanded to fold in the per-asset cutover procedure (previously RAI-1222's separate document) as steps 7–14, covering: cutover pre-checks, freeze-and-drain, deploy hold and snapshot, `move-receipts` invocation, post-move verification, mode flip and deploy, pilot validation, and a step-by-step rollback. The prerequisites section is extended with the liquidity-bot release plumbing needed before cutover. The prod-facts table gains a per-asset cutover record.

Unit tests replace the `migrate_refuses_more_receipts_than_the_proven_batch_limit` test with `migrate_transfers_above_the_batch_bound_in_chunks` (30 receipts, three chunks) and add `interrupted_chunked_migration_resumes_without_duplication` (16 receipts, crash between chunks, re-run moves only the remainder). A `transfer_chunks_pack_to_the_proven_bound_in_canonical_order` test covers the chunking logic directly. The end-to-end suite gains `test_receipt_custody_chunked_migration_resumes_into_the_orchestrator`, which exercises 17 receipts across three legs: full chunked move, rollback and re-confirmation, and fabricated mid-chunk crash followed by a resuming re-run.



Closes [RAI-1714](https://linear.app/makeitrain/issue/RAI-1714/probe-receipt-counts-and-lift-the-14-receipt-bound-with-resumable)  
Part of [RAI-1222](https://linear.app/makeitrain/issue/RAI-1222/7-pilot-cutover-rklb-through-the-orchestrator)

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs

<!-- codesmith:footer -->

---

<picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture> <picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture>
<sup>Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->

<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Receipt custody migrations now support inventories larger than 14 receipts through verified batches.
  - Interrupted migrations resume safely by detecting receipts already transferred.
  - Custody is recorded only after the complete migration succeeds.

- **Bug Fixes**
  - Removed failures for oversized receipt inventories.
  - Improved migration verification, rollback handling, and idempotent reruns.
  - Receipt-inventory polling now reports unmet discovery thresholds on timeout.

- **Documentation**
  - Expanded onboarding and asset cutover guidance with readiness checks, rollback procedures, receipt transfers, and acceptance criteria.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->