### PR TITLE
chore: revoke Alex and Jakub server access

### DIFF
--- a/keys.nix
+++ b/keys.nix
@@ -4,8 +4,6 @@ rec {
     juan = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHHNeV3nfiJS0QE2JoW3d0dRw1j6OVKl7rXor24XHvsd";
     # purpose: op sec auditing and manual cli while fixing gaps in automation
     alastair = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJArH3PA+bFIon0JkCVQGs9aWr45lnVjiiTLLO9BPItn";
-    jakub = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIM8D2RLBbEfB0GZKhT7tlT43pkKbrMnOR7cZfXoG9NbH";
-    alex = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIA9MytndYpB/zpdh4kCXE0KF+NoLrpe+ij+zctM3xUCf";
 
     # purpose: deployments from github actions
     ci = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOkrujoBNXILB8Ypv90puKKhmKq161gitlvUFM5n0c+d";
@@ -34,8 +32,6 @@ rec {
       ssh = [
         juan
         alastair
-        jakub
-        alex
         st0x-op
         ci
       ];
@@ -43,8 +39,6 @@ rec {
         st0x-op
         juan
         alastair
-        jakub
-        alex
         host-prod
       ];
     };
@@ -53,8 +47,6 @@ rec {
       ssh = [
         juan
         alastair
-        jakub
-        alex
         st0x-op
         ci
       ];
@@ -62,8 +54,6 @@ rec {
         st0x-op
         juan
         alastair
-        jakub
-        alex
         host-staging
       ];
     };


### PR DESCRIPTION
## Motivation

- Alex and Jakub should no longer have SSH or service access on issuance prod and staging.

## Solution

- Remove both Ed25519 public keys from `keys`.
- Drop both from `prod.ssh`, `prod.service`, `staging.ssh`, and `staging.service`.
- Existing `.age` files still encrypt to their keys until we rekey. SSH access goes away on next deploy. Decrypt access stays until we rekey.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic (no logic changed)
- [x] made this PR as small as possible
- [x] linked any relevant issues or PRs (none)
- [x] evaluated `keys.nix` with `nix-instantiate --eval --strict keys.nix`
