### PR TITLE
[RAI-1759] Accept hyperevm as a tokenization network in the redeem callback

### DIFF
--- a/src/alpaca/itn.rs
+++ b/src/alpaca/itn.rs
@@ -15,7 +15,7 @@ pub(crate) const REDEEM_CALLBACK_OPENAPI_REFERENCE: &str =
 /// (`components.schemas.TokenizationNetwork.enum`).
 pub(crate) const TOKENIZATION_NETWORK_WIRE_STRINGS: &[&str] = &[
     "solana", "arbitrum", "ethereum", "binance", "base", "ton", "tron",
-    "mantle",
+    "mantle", "hyperevm",
 ];
 
 /// Returns whether `wire` is a published Alpaca ITN `TokenizationNetwork` value.
@@ -34,7 +34,7 @@ mod tests {
 
     #[test]
     fn issued_network_wire_strings_are_alpaca_itn_values() {
-        for network in [Network::Base, Network::Ethereum] {
+        for network in [Network::Base, Network::Ethereum, Network::HyperEvm] {
             let wire = network.as_str();
             assert!(
                 accepts_network_wire_string(wire),


### PR DESCRIPTION
## Motivation

The redeem callback rejects any network missing from TOKENIZATION_NETWORK_WIRE_STRINGS, and hyperevm is not on it, so a HyperEVM redemption fails inside the bot before Alpaca is called. Alpaca already publishes hyperevm in the TokenizationNetwork OpenAPI enum (verified 2026-08-14, https://docs.alpaca.markets/reference/posttokenizationredeem). Blocks the redeem half of RAI-1743.

Closes RAI-1759.

## Solution

Add "hyperevm" to the allowlist in src/alpaca/itn.rs and extend the test asserting issued networks are published Alpaca values to cover Network::HyperEvm.

## Checks

By submitting this for review, I'm confirming I've done the following:

- [x] added comprehensive test coverage for any changes in logic
- [x] made this PR as small as possible

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ST0x-Technology/codesmith/st0x.issuance/pr/336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789305992&installation_model_id=19370&pr_number=336&repository=ST0x-Technology%2Fst0x.issuance&return_to=https%3A%2F%2Fgithub.com%2FST0x-Technology%2Fst0x.issuance%2Fpull%2F336&signature=0b623a174437f4180d7a48daff606288e00316fc9b83b5a240db414a2de79d91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for recognizing the HyperEVM tokenization network.
  * Updated validation to correctly accept HyperEVM network identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->